### PR TITLE
Update PropertyTable component: change property name mapping from 'pr…

### DIFF
--- a/src/components/property-table.tsx
+++ b/src/components/property-table.tsx
@@ -73,12 +73,12 @@ export function PropertyTable({
 		console.log("allProperties useMemo:", {
 			savedItems: savedItems.map((p) => ({
 				id: p._id,
-				name: p.propertyName,
+				name: p.streetAddress,
 				isNew: p.isNew,
 			})),
 			localProperties: localProperties.map((p) => ({
 				id: p._id,
-				name: p.propertyName,
+				name: p.streetAddress,
 				isNew: p.isNew,
 			})),
 		});


### PR DESCRIPTION
This pull request makes a small change to the way property names are displayed in the console log output of the `PropertyTable` component. Instead of logging the `propertyName` field, it now logs the `streetAddress` for each property.

* Changed the console log mapping in `PropertyTable` (`src/components/property-table.tsx`) to use `streetAddress` instead of `propertyName` for the displayed property name.