### PR TITLE
Refactor ProjectDetailPage: replace Button components with styled but…

### DIFF
--- a/src/app/(workspace)/projects/[projectId]/page.tsx
+++ b/src/app/(workspace)/projects/[projectId]/page.tsx
@@ -22,6 +22,7 @@ import {
 	PlayIcon,
 	CheckIcon,
 } from "@heroicons/react/24/outline";
+import { Plus } from "lucide-react";
 import { StickyFormFooter } from "@/components/sticky-form-footer";
 import { useEffect, useMemo, useState } from "react";
 import type { Id } from "../../../../../convex/_generated/dataModel";
@@ -1360,15 +1361,22 @@ export default function ProjectDetailPage() {
 								<CardHeader className="pb-4">
 									<CardTitle className="flex items-center justify-between text-xl font-semibold text-gray-900 dark:text-white">
 										<span>Tasks ({projectTasks?.length || 0})</span>
-										<Button
-											size="sm"
-											intent="outline"
+										<button
+											type="button"
 											onClick={() =>
 												router.push(`/tasks/new?projectId=${projectId}`)
 											}
+											className="group inline-flex items-center gap-2 text-sm font-semibold text-primary hover:text-primary/80 transition-all duration-200 px-4 py-2 rounded-lg bg-primary/10 hover:bg-primary/15 ring-1 ring-primary/30 hover:ring-primary/40 shadow-sm hover:shadow-md backdrop-blur-sm"
 										>
-											+ Add Task
-										</Button>
+											<Plus className="h-4 w-4" />
+											Add Task
+											<span
+												aria-hidden="true"
+												className="group-hover:translate-x-1 transition-transform duration-200"
+											>
+												→
+											</span>
+										</button>
 									</CardTitle>
 								</CardHeader>
 								<CardContent>
@@ -1424,14 +1432,6 @@ export default function ProjectDetailPage() {
 											<p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
 												No tasks created yet
 											</p>
-											<Button
-												size="sm"
-												onClick={() =>
-													router.push(`/tasks/new?projectId=${projectId}`)
-												}
-											>
-												Create First Task
-											</Button>
 										</div>
 									)}
 								</CardContent>
@@ -1442,15 +1442,22 @@ export default function ProjectDetailPage() {
 								<CardHeader className="pb-4">
 									<CardTitle className="flex items-center justify-between text-xl font-semibold text-gray-900 dark:text-white">
 										<span>Quotes ({projectQuotes?.length || 0})</span>
-										<Button
-											size="sm"
-											intent="outline"
+										<button
+											type="button"
 											onClick={() =>
 												router.push(`/quotes/new?projectId=${projectId}`)
 											}
+											className="group inline-flex items-center gap-2 text-sm font-semibold text-primary hover:text-primary/80 transition-all duration-200 px-4 py-2 rounded-lg bg-primary/10 hover:bg-primary/15 ring-1 ring-primary/30 hover:ring-primary/40 shadow-sm hover:shadow-md backdrop-blur-sm"
 										>
-											+ Add Quote
-										</Button>
+											<Plus className="h-4 w-4" />
+											Add Quote
+											<span
+												aria-hidden="true"
+												className="group-hover:translate-x-1 transition-transform duration-200"
+											>
+												→
+											</span>
+										</button>
 									</CardTitle>
 								</CardHeader>
 								<CardContent>
@@ -1509,14 +1516,6 @@ export default function ProjectDetailPage() {
 											<p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
 												No quotes created yet
 											</p>
-											<Button
-												size="sm"
-												onClick={() =>
-													router.push(`/quotes/new?projectId=${projectId}`)
-												}
-											>
-												Create First Quote
-											</Button>
 										</div>
 									)}
 								</CardContent>


### PR DESCRIPTION
This pull request updates the UI for adding tasks and quotes in the `ProjectDetailPage` to use a custom-styled button instead of the previous `Button` component, and removes the "Create First Task/Quote" buttons from empty states. The new buttons use the `Plus` icon from `lucide-react` for a more modern look and consistent styling.

**UI Improvements:**

* Replaced the `Button` component for "Add Task" and "Add Quote" actions with a custom-styled `button` element that includes the `Plus` icon and improved hover effects for better visual feedback. (`src/app/(workspace)/projects/[projectId]/page.tsx`) ([src/app/(workspace)/projects/[projectId]/page.tsxL1363-R1379](diffhunk://#diff-06dee45221aa25ae2144d1c9ba905b8e8472054d5fc8d8df6013472beaa16cf8L1363-R1379), [src/app/(workspace)/projects/[projectId]/page.tsxL1445-R1460](diffhunk://#diff-06dee45221aa25ae2144d1c9ba905b8e8472054d5fc8d8df6013472beaa16cf8L1445-R1460))
* Imported the `Plus` icon from `lucide-react` to support the new button design. (`src/app/(workspace)/projects/[projectId]/page.tsx`) ([src/app/(workspace)/projects/[projectId]/page.tsxR25](diffhunk://#diff-06dee45221aa25ae2144d1c9ba905b8e8472054d5fc8d8df6013472beaa16cf8R25))

**Empty State Cleanup:**

* Removed the "Create First Task" and "Create First Quote" buttons from the empty state sections, leaving only the informational text when there are no tasks or quotes. (`src/app/(workspace)/projects/[projectId]/page.tsx`) ([src/app/(workspace)/projects/[projectId]/page.tsxL1427-L1434](diffhunk://#diff-06dee45221aa25ae2144d1c9ba905b8e8472054d5fc8d8df6013472beaa16cf8L1427-L1434), [src/app/(workspace)/projects/[projectId]/page.tsxL1512-L1519](diffhunk://#diff-06dee45221aa25ae2144d1c9ba905b8e8472054d5fc8d8df6013472beaa16cf8L1512-L1519))