### PR TITLE
Refactor TasksPage and AppSidebar: replace Button components with sty…

### DIFF
--- a/src/app/(workspace)/tasks/page.tsx
+++ b/src/app/(workspace)/tasks/page.tsx
@@ -5,7 +5,6 @@ import { useQuery, useMutation } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
 import { Id } from "../../../../convex/_generated/dataModel";
 import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -490,10 +489,16 @@ export default function TasksPage() {
 				<TaskSheet
 					mode="create"
 					trigger={
-						<Button className="gap-2">
+						<>
 							<Plus className="h-4 w-4" />
-							New Task
-						</Button>
+							<span>New Task</span>
+							<span
+								aria-hidden="true"
+								className="group-hover:translate-x-1 transition-transform duration-200"
+							>
+								→
+							</span>
+						</>
 					}
 				/>
 			</div>
@@ -669,10 +674,16 @@ export default function TasksPage() {
 									<TaskSheet
 										mode="create"
 										trigger={
-											<Button className="gap-2">
+											<>
 												<Plus className="h-4 w-4" />
-												Create Your First Task
-											</Button>
+												<span>Create Your First Task</span>
+												<span
+													aria-hidden="true"
+													className="group-hover:translate-x-1 transition-transform duration-200"
+												>
+													→
+												</span>
+											</>
 										}
 									/>
 								)}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -12,6 +12,7 @@ import {
 	FileText,
 	Receipt,
 	Briefcase,
+	ListCheck,
 } from "lucide-react";
 
 import { NavMain } from "@/components/nav-main";
@@ -24,6 +25,8 @@ import {
 	SidebarHeader,
 	SidebarRail,
 } from "@/components/ui/sidebar";
+import { api } from "../../convex/_generated/api";
+import { useQuery } from "convex/react";
 
 // This is sample data.
 const data = {
@@ -66,6 +69,11 @@ const data = {
 			icon: Briefcase,
 		},
 		{
+			title: "Tasks",
+			url: "/tasks",
+			icon: ListCheck,
+		},
+		{
 			title: "Quotes",
 			url: "/quotes",
 			icon: FileText,
@@ -85,6 +93,8 @@ const data = {
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 	const pathname = usePathname();
+	const taskStats = useQuery(api.tasks.getStats, {});
+	const tasksDueToday = taskStats?.todayTasks ?? 0;
 
 	// Function to determine if a navigation item should be active
 	const isNavItemActive = (navUrl: string, title: string) => {
@@ -102,6 +112,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 			return (
 				pathname.startsWith("/projects") || pathname.startsWith("/project")
 			);
+		}
+
+		if (title === "Tasks") {
+			return pathname.startsWith("/tasks") || pathname.startsWith("/task");
 		}
 
 		if (title === "Quotes") {
@@ -122,6 +136,9 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 	const navigationItems = data.navMain.map((item) => ({
 		...item,
 		isActive: isNavItemActive(item.url, item.title),
+		badgeCount:
+			item.title === "Tasks" && tasksDueToday > 0 ? tasksDueToday : undefined,
+		badgeVariant: item.title === "Tasks" ? "alert" : undefined,
 	}));
 
 	return (

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -24,6 +24,7 @@ import {
 	SidebarMenuSub,
 	SidebarMenuSubButton,
 	SidebarMenuSubItem,
+	SidebarMenuBadge,
 } from "@/components/ui/sidebar";
 import {
 	DropdownMenu,
@@ -33,6 +34,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useIsMobile } from "@/hooks/use-mobile";
 import Link from "next/link";
+import { cn } from "@/lib/utils";
 
 export function NavMain({
 	items,
@@ -42,6 +44,8 @@ export function NavMain({
 		url: string;
 		icon?: LucideIcon;
 		isActive?: boolean;
+		badgeCount?: number;
+		badgeVariant?: "alert";
 		items?: {
 			title: string;
 			url: string;
@@ -181,6 +185,16 @@ export function NavMain({
 										<span>{item.title}</span>
 									</Link>
 								</SidebarMenuButton>
+								{typeof item.badgeCount === "number" && item.badgeCount > 0 && (
+									<SidebarMenuBadge
+										className={cn(
+											item.badgeVariant === "alert" &&
+												"bg-red-500 text-white ring-2 ring-red-300 shadow-[0_0_0_2px_rgba(255,255,255,0.35)]"
+										)}
+									>
+										{item.badgeCount}
+									</SidebarMenuBadge>
+								)}
 							</SidebarMenuItem>
 						);
 					})}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -586,12 +586,12 @@ function SidebarMenuBadge({
 			data-slot="sidebar-menu-badge"
 			data-sidebar="menu-badge"
 			className={cn(
-				"text-sidebar-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums select-none",
+				"text-sidebar-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-[11px] font-semibold tabular-nums select-none",
 				"peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
 				"peer-data-[size=sm]/menu-button:top-1",
 				"peer-data-[size=default]/menu-button:top-1.5",
 				"peer-data-[size=lg]/menu-button:top-2.5",
-				"group-data-[collapsible=icon]:hidden",
+				"group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:absolute group-data-[collapsible=icon]:-right-1.5 group-data-[collapsible=icon]:-top-1 group-data-[collapsible=icon]:scale-90",
 				className
 			)}
 			{...props}


### PR DESCRIPTION
This pull request introduces a new "Tasks" navigation item in the sidebar and enhances its visibility by displaying a badge with the count of tasks due today. It also updates the "New Task" and "Create Your First Task" buttons in the tasks page to improve their appearance and interaction. The sidebar badge styling is refined for better aesthetics and clarity.

**Sidebar Navigation Enhancements:**

* Added a "Tasks" item to the main sidebar navigation, using the `ListCheck` icon.
* The "Tasks" sidebar item now displays a badge showing the number of tasks due today, fetched via a query to `api.tasks.getStats`. The badge uses an "alert" variant when tasks are due. [[1]](diffhunk://#diff-167140c3830943094d6b84a9cdb9155e4c4762762d1d8245330b48be404758a6R96-R97) [[2]](diffhunk://#diff-167140c3830943094d6b84a9cdb9155e4c4762762d1d8245330b48be404758a6R139-R141)
* Updated logic to highlight the "Tasks" navigation item when on `/tasks` or `/task` routes.

**Badge Display and Styling:**

* Integrated `SidebarMenuBadge` into the navigation component to show badge counts for sidebar items, with conditional styling for alert states.
* Improved badge appearance: made it rounded, more prominent, and adjusted its positioning for icon-only sidebar mode.

**Tasks Page UI Improvements:**

* Updated the "New Task" and "Create Your First Task" triggers to use custom markup instead of the default `Button` component, adding a right-arrow animation for better user feedback. [[1]](diffhunk://#diff-bcbe35d20b58bf590bba4620ccdbd06d5a59627cf1c02631b3c974394e3b3e8eL493-R501) [[2]](diffhunk://#diff-bcbe35d20b58bf590bba4620ccdbd06d5a59627cf1c02631b3c974394e3b3e8eL672-R686)

These changes collectively make the "Tasks" feature more visible and interactive in the sidebar, and improve the overall user experience when creating tasks.