### PR TITLE
fixing branch issue and updating and removing references to old auth …

### DIFF
--- a/convex/activities.ts
+++ b/convex/activities.ts
@@ -1,7 +1,7 @@
 import { query } from "./_generated/server";
 import { v } from "convex/values";
 import { Doc } from "./_generated/dataModel";
-import { getCurrentUserOrThrow, getCurrentUserOrgIdOptional } from "./lib/auth";
+import { getCurrentUserOrThrow, getCurrentUserOrgId } from "./lib/auth";
 
 /**
  * Activity operations for activity feed

--- a/convex/homeStats.ts
+++ b/convex/homeStats.ts
@@ -1,5 +1,5 @@
 import { query } from "./_generated/server";
-import { getCurrentUserOrgIdOptional } from "./lib/auth";
+import { getCurrentUserOrgId } from "./lib/auth";
 import { DateUtils } from "./lib/shared";
 
 /**

--- a/convex/lib/auth.ts
+++ b/convex/lib/auth.ts
@@ -109,11 +109,7 @@ export async function getCurrentUserOrgId(
  * Get the current user's organization ID, returning null if not found (new user-friendly version)
  */
 export async function getCurrentUserOrgIdOptional(ctx: QueryCtx | MutationCtx) {
-	const user = await getCurrentUser(ctx);
-	if (!user || !user.organizationId) {
-		return null;
-	}
-	return user.organizationId;
+	return getCurrentUserOrgId(ctx, { require: false });
 }
 
 /**
@@ -121,8 +117,7 @@ export async function getCurrentUserOrgIdOptional(ctx: QueryCtx | MutationCtx) {
  */
 export async function getCurrentUserOrgIdSafe(ctx: QueryCtx | MutationCtx) {
 	try {
-		const user = await getCurrentUser(ctx);
-		return user?.organizationId || null;
+		return await getCurrentUserOrgId(ctx, { require: false });
 	} catch {
 		return null;
 	}

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -1,7 +1,7 @@
 import { query, mutation, QueryCtx, MutationCtx } from "./_generated/server";
 import { v } from "convex/values";
 import { Doc, Id } from "./_generated/dataModel";
-import { getCurrentUserOrgIdOptional, getCurrentUserOrgId } from "./lib/auth";
+import { getCurrentUserOrgId } from "./lib/auth";
 import { ActivityHelpers } from "./lib/activities";
 import { DateUtils } from "./lib/shared";
 import { requireMembership } from "./lib/memberships";
@@ -21,8 +21,7 @@ async function getProjectWithOrgValidation(
 	id: Id<"projects">,
 	existingOrgId?: Id<"organizations">
 ): Promise<Doc<"projects"> | null> {
-	const userOrgId =
-		existingOrgId ?? (await getCurrentUserOrgId(ctx));
+	const userOrgId = existingOrgId ?? (await getCurrentUserOrgId(ctx));
 	const project = await ctx.db.get(id);
 
 	if (!project) {
@@ -58,8 +57,7 @@ async function validateClientAccess(
 	clientId: Id<"clients">,
 	existingOrgId?: Id<"organizations">
 ): Promise<void> {
-	const userOrgId =
-	existingOrgId ?? (await getCurrentUserOrgId(ctx));
+	const userOrgId = existingOrgId ?? (await getCurrentUserOrgId(ctx));
 	const client = await ctx.db.get(clientId);
 
 	if (!client) {
@@ -79,8 +77,7 @@ async function validateUserAccess(
 	userIds: Id<"users">[],
 	existingOrgId?: Id<"organizations">
 ): Promise<void> {
-	const userOrgId =
-	existingOrgId ?? (await getCurrentUserOrgId(ctx));
+	const userOrgId = existingOrgId ?? (await getCurrentUserOrgId(ctx));
 
 	for (const userId of userIds) {
 		const user = await ctx.db.get(userId);

--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -1,7 +1,7 @@
 import { query, mutation, QueryCtx, MutationCtx } from "./_generated/server";
 import { v } from "convex/values";
 import { Doc, Id } from "./_generated/dataModel";
-import { getCurrentUserOrgIdOptional, getCurrentUserOrgId } from "./lib/auth";
+import { getCurrentUserOrgId } from "./lib/auth";
 import { ActivityHelpers } from "./lib/activities";
 import { DateUtils } from "./lib/shared";
 import { requireMembership } from "./lib/memberships";
@@ -21,8 +21,7 @@ async function getTaskWithOrgValidation(
 	id: Id<"tasks">,
 	existingOrgId?: Id<"organizations">
 ): Promise<Doc<"tasks"> | null> {
-	const userOrgId =
-		existingOrgId ?? (await getCurrentUserOrgId(ctx));
+	const userOrgId = existingOrgId ?? (await getCurrentUserOrgId(ctx));
 	const task = await ctx.db.get(id);
 
 	if (!task) {
@@ -58,8 +57,7 @@ async function validateClientAccess(
 	clientId: Id<"clients">,
 	existingOrgId?: Id<"organizations">
 ): Promise<void> {
-	const userOrgId =
-	existingOrgId ?? (await getCurrentUserOrgId(ctx));
+	const userOrgId = existingOrgId ?? (await getCurrentUserOrgId(ctx));
 	const client = await ctx.db.get(clientId);
 
 	if (!client) {
@@ -79,8 +77,7 @@ async function validateProjectAccess(
 	projectId: Id<"projects">,
 	existingOrgId?: Id<"organizations">
 ): Promise<void> {
-	const userOrgId =
-	existingOrgId ?? (await getCurrentUserOrgId(ctx));
+	const userOrgId = existingOrgId ?? (await getCurrentUserOrgId(ctx));
 	const project = await ctx.db.get(projectId);
 
 	if (!project) {
@@ -100,8 +97,7 @@ async function validateUserAccess(
 	userId: Id<"users">,
 	existingOrgId?: Id<"organizations">
 ): Promise<void> {
-	const userOrgId =
-	existingOrgId ?? (await getCurrentUserOrgId(ctx));
+	const userOrgId = existingOrgId ?? (await getCurrentUserOrgId(ctx));
 	const user = await ctx.db.get(userId);
 
 	if (!user) {
@@ -831,7 +827,7 @@ export const getByUser = query({
 		if (!userOrgId) {
 			return [];
 		}
-		
+
 		// Validate the user exists and belongs to the same org
 		await validateUserAccess(ctx, args.userId, userOrgId);
 


### PR DESCRIPTION
This pull request refactors organization ID retrieval logic across several modules by removing usage of the legacy `getCurrentUserOrgIdOptional` function and replacing it with the newer, unified `getCurrentUserOrgId`. The changes improve consistency and simplify authentication code, ensuring all organization ID checks use the same underlying implementation.

**Authentication logic refactor:**

* Deprecated `getCurrentUserOrgIdOptional` in favor of `getCurrentUserOrgId`, updating all imports and usages in `activities.ts`, `homeStats.ts`, `projects.ts`, and `tasks.ts` to use the new function. [[1]](diffhunk://#diff-2a315113a62a05dcb9d69196376e67925f56563dfb9b548e7f14cefdca2e36b9L4-R4) [[2]](diffhunk://#diff-49f45a8fa276a4b262bde903b0822320b6147233ad51f3a5ccc67695af5027deL2-R2) [[3]](diffhunk://#diff-84c5f3d481558316f72aaef42d338dd9925be86036a37bacb18d25241f6c94d7L4-R4) [[4]](diffhunk://#diff-5e33afee3b933bec3e497e1894110d799ededad92ca67ee58aafbe37d8a44098L4-R4)
* Refactored the implementation of `getCurrentUserOrgIdOptional` and `getCurrentUserOrgIdSafe` in `lib/auth.ts` to delegate to `getCurrentUserOrgId`, ensuring consistent behavior and reducing code duplication.

**Code consistency improvements:**

* Updated organization ID retrieval logic in validation functions (`getProjectWithOrgValidation`, `validateClientAccess`, `validateUserAccess` in `projects.ts`; `getTaskWithOrgValidation`, `validateClientAccess`, `validateProjectAccess`, `validateUserAccess` in `tasks.ts`) to use the new unified approach. [[1]](diffhunk://#diff-84c5f3d481558316f72aaef42d338dd9925be86036a37bacb18d25241f6c94d7L24-R24) [[2]](diffhunk://#diff-84c5f3d481558316f72aaef42d338dd9925be86036a37bacb18d25241f6c94d7L61-R60) [[3]](diffhunk://#diff-84c5f3d481558316f72aaef42d338dd9925be86036a37bacb18d25241f6c94d7L82-R80) [[4]](diffhunk://#diff-5e33afee3b933bec3e497e1894110d799ededad92ca67ee58aafbe37d8a44098L24-R24) [[5]](diffhunk://#diff-5e33afee3b933bec3e497e1894110d799ededad92ca67ee58aafbe37d8a44098L61-R60) [[6]](diffhunk://#diff-5e33afee3b933bec3e497e1894110d799ededad92ca67ee58aafbe37d8a44098L82-R80) [[7]](diffhunk://#diff-5e33afee3b933bec3e497e1894110d799ededad92ca67ee58aafbe37d8a44098L103-R100)