### PR TITLE
Update button prop in OrganizationDocumentsPage: Change 'disabled' pr…

### DIFF
--- a/src/app/(workspace)/organization/documents/page.tsx
+++ b/src/app/(workspace)/organization/documents/page.tsx
@@ -137,7 +137,7 @@ export default function OrganizationDocumentsPage() {
 											PDF files only, maximum 10MB
 										</p>
 									</div>
-									<Button disabled={isUploading} className="shrink-0">
+									<Button isDisabled={isUploading} className="shrink-0">
 										<Upload className="h-4 w-4 mr-2" />
 										{isUploading ? "Uploading..." : "Upload PDF"}
 									</Button>


### PR DESCRIPTION
This pull request makes a minor adjustment to the upload button on the organization documents page. The change updates the way the button is disabled during file uploads to use the correct prop for the underlying UI library.

* Changed the `Button` component to use the `isDisabled` prop instead of `disabled` to ensure proper disabling behavior during uploads in `OrganizationDocumentsPage`.