### PR TITLE
Enhance automation

### DIFF
--- a/apps/web/src/app/(workspace)/automations/components/editor/automation-editor-screen.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/editor/automation-editor-screen.tsx
@@ -26,7 +26,7 @@ function toSidebarType(t: string): NodeConfigType {
 export function AutomationEditorScreen({ automationId }: { automationId: string | null }) {
 	const router = useRouter();
 	const editor = useAutomationEditor(automationId);
-	const sidebar = useSidebarState(editor.hasPlaceholders);
+	const sidebar = useSidebarState();
 	const navigateFnRef = useRef<((nodeId: string) => void) | null>(null);
 
 	const handleNavigateReady = useCallback((fn: (nodeId: string) => void) => {
@@ -110,10 +110,16 @@ export function AutomationEditorScreen({ automationId }: { automationId: string 
 	);
 
 	const selectedNode = useMemo(() => {
-		if (sidebar.mode?.mode !== "node-config") return null;
-		return sidebar.mode.nodeType === "trigger"
-			? { type: "trigger" }
-			: { type: sidebar.mode.nodeType, id: sidebar.mode.nodeId };
+		if (sidebar.mode?.mode === "node-config") {
+			return sidebar.mode.nodeType === "trigger"
+				? { type: "trigger" }
+				: { type: sidebar.mode.nodeType, id: sidebar.mode.nodeId };
+		}
+		// Include placeholders so Backspace can delete them
+		if (sidebar.mode?.mode === "step-picker") {
+			return { type: "placeholder", id: sidebar.mode.placeholderNodeId };
+		}
+		return null;
 	}, [sidebar.mode]);
 
 	useKeyboardShortcuts({
@@ -173,6 +179,7 @@ export function AutomationEditorScreen({ automationId }: { automationId: string 
 						onPaneClick={handlePaneClick}
 						onNodeDragStop={editor.handleNodeDragStop}
 						onNavigateReady={handleNavigateReady}
+						onDeleteNode={handleDeleteNode}
 					/>
 					{editor.undoBanner && (
 						<UndoBanner title={editor.undoBanner.title} message={editor.undoBanner.message} onUndo={editor.handleUndo} />

--- a/apps/web/src/app/(workspace)/automations/components/flow/add-step-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/add-step-node-rf.tsx
@@ -5,7 +5,7 @@ import { Handle, Position, type NodeProps } from "@xyflow/react";
 
 /**
  * Invisible terminal node — serves as the target for terminal "+" edges.
- * Renders only a tiny target handle so dagre can position it. The visible
+ * Renders only a tiny target handle so the layout engine can position it. The visible
  * interaction is the "+" button on the edge, not this node.
  */
 export const TerminalNodeRF = memo((_props: NodeProps) => {

--- a/apps/web/src/app/(workspace)/automations/components/flow/automation-flow.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/automation-flow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	ReactFlow,
 	Background,
@@ -13,7 +13,9 @@ import {
 	type Edge,
 	type NodeMouseHandler,
 } from "@xyflow/react";
+import { Trash2 } from "lucide-react";
 import { ZoomSlider } from "@/components/zoom-slider";
+import { isTerminalId } from "../../lib/flow-adapter";
 import "@xyflow/react/dist/style.css";
 import { TriggerNodeRF } from "./trigger-node-rf";
 import { ConditionNodeRF } from "./condition-node-rf";
@@ -55,8 +57,15 @@ interface AutomationFlowProps {
 	onNodeClick?: (nodeId: string) => void;
 	onPaneClick?: () => void;
 	onNodeDragStop?: (nodeId: string, position: { x: number; y: number }) => void;
+	onDeleteNode?: (nodeId: string) => void;
 	/** Callback ref that receives a navigate function once React Flow is ready */
 	onNavigateReady?: (navigateFn: (nodeId: string) => void) => void;
+}
+
+interface ContextMenuState {
+	nodeId: string;
+	x: number;
+	y: number;
 }
 
 function AutomationFlowInner({
@@ -65,12 +74,14 @@ function AutomationFlowInner({
 	onNodeClick,
 	onPaneClick,
 	onNodeDragStop,
+	onDeleteNode,
 	onNavigateReady,
 }: AutomationFlowProps) {
 	const { fitView, setCenter } = useReactFlow();
 	const prevCountRef = useRef(incomingNodes.length);
 	const [nodes, setNodes, onNodesChange] = useNodesState(incomingNodes);
 	const [edges, setEdges, onEdgesChange] = useEdgesState(incomingEdges);
+	const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
 
 	useEffect(() => {
 		setNodes(incomingNodes);
@@ -118,37 +129,90 @@ function AutomationFlowInner({
 		[onNodeDragStop]
 	);
 
+	// Close context menu on any click outside or scroll
+	useEffect(() => {
+		if (!contextMenu) return;
+		const close = () => setContextMenu(null);
+		window.addEventListener("click", close);
+		window.addEventListener("scroll", close, true);
+		return () => {
+			window.removeEventListener("click", close);
+			window.removeEventListener("scroll", close, true);
+		};
+	}, [contextMenu]);
+
+	// Right-click context menu
+	const handleNodeContextMenu = useCallback(
+		(event: React.MouseEvent, node: Node) => {
+			event.preventDefault();
+			// Don't show context menu for terminal stubs
+			if (isTerminalId(node.id)) return;
+			setContextMenu({ nodeId: node.id, x: event.clientX, y: event.clientY });
+		},
+		[]
+	);
+
+	const handleContextMenuDelete = useCallback(() => {
+		if (contextMenu) {
+			onDeleteNode?.(contextMenu.nodeId);
+			setContextMenu(null);
+		}
+	}, [contextMenu, onDeleteNode]);
+
+	const handlePaneClickInternal = useCallback(() => {
+		setContextMenu(null);
+		onPaneClick?.();
+	}, [onPaneClick]);
+
 	return (
-		<ReactFlow
-			nodes={nodes}
-			edges={edges}
-			onNodesChange={onNodesChange}
-			onEdgesChange={onEdgesChange}
-			onNodeClick={handleNodeClick}
-			onNodeDragStop={handleNodeDragStop}
-			onPaneClick={onPaneClick}
-			nodeTypes={nodeTypes}
-			edgeTypes={edgeTypes}
-			fitView
-			fitViewOptions={{ padding: 0.2, duration: 300 }}
-			nodesDraggable={true}
-			nodesConnectable={false}
-			elementsSelectable={true}
-			panOnDrag={true}
-			zoomOnScroll={true}
-			deleteKeyCode={null}
-			minZoom={0.3}
-			maxZoom={2}
-			proOptions={{ hideAttribution: true }}
-		>
-			<Background
-				variant={BackgroundVariant.Dots}
-				gap={20}
-				size={1}
-				className="text-muted-foreground/15! dark:text-muted-foreground/10!"
-			/>
-			<ZoomSlider position="bottom-left" orientation="vertical" />
-		</ReactFlow>
+		<>
+			<ReactFlow
+				nodes={nodes}
+				edges={edges}
+				onNodesChange={onNodesChange}
+				onEdgesChange={onEdgesChange}
+				onNodeClick={handleNodeClick}
+				onNodeDragStop={handleNodeDragStop}
+				onPaneClick={handlePaneClickInternal}
+				onNodeContextMenu={handleNodeContextMenu}
+				nodeTypes={nodeTypes}
+				edgeTypes={edgeTypes}
+				fitView
+				fitViewOptions={{ padding: 0.2, duration: 300 }}
+				nodesDraggable={true}
+				nodesConnectable={false}
+				elementsSelectable={true}
+				panOnDrag={true}
+				zoomOnScroll={true}
+				deleteKeyCode={null}
+				minZoom={0.3}
+				maxZoom={2}
+				proOptions={{ hideAttribution: true }}
+			>
+				<Background
+					variant={BackgroundVariant.Dots}
+					gap={20}
+					size={1}
+					className="text-muted-foreground/15! dark:text-muted-foreground/10!"
+				/>
+				<ZoomSlider position="bottom-left" orientation="vertical" />
+			</ReactFlow>
+			{contextMenu && (
+				<div
+					className="fixed z-50 min-w-[160px] rounded-md border border-border bg-popover p-1 shadow-md animate-in fade-in-0 zoom-in-95"
+					style={{ top: contextMenu.y, left: contextMenu.x }}
+				>
+					<button
+						type="button"
+						className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-destructive hover:bg-destructive/10 cursor-pointer"
+						onClick={handleContextMenuDelete}
+					>
+						<Trash2 className="h-4 w-4" />
+						Delete node
+					</button>
+				</div>
+			)}
+		</>
 	);
 }
 

--- a/apps/web/src/app/(workspace)/automations/hooks/use-automation-editor.ts
+++ b/apps/web/src/app/(workspace)/automations/hooks/use-automation-editor.ts
@@ -730,34 +730,11 @@ export function useAutomationEditor(automationId: string | null) {
 
 	const handlePaneClick = useCallback(() => {
 		clearUndoState();
-		setNodes((prev) => {
-			// Find placeholder IDs that are branch children of condition/loop nodes
-			const branchPlaceholderIds = new Set<string>();
-			for (const node of prev) {
-				if (node.type === "condition" || node.type === "loop") {
-					if (node.nextNodeId) branchPlaceholderIds.add(node.nextNodeId);
-					if (node.elseNodeId) branchPlaceholderIds.add(node.elseNodeId);
-				}
-			}
-			return prev.filter(
-				(node) =>
-					(node as unknown as { type: string }).type !== "placeholder" ||
-					branchPlaceholderIds.has(node.id)
-			);
-		});
 	}, [clearUndoState]);
 
 	// Positions are now computed inside automationToReactFlow (initial-placement.ts)
 	const layoutedNodes = rawFlow.nodes;
 	const layoutedEdges = rawFlow.edges;
-
-	const hasPlaceholders = useMemo(
-		() =>
-			layoutedNodes.some(
-				(node) => (node.data as Record<string, unknown> | undefined)?.nodeType === "placeholder"
-			),
-		[layoutedNodes]
-	);
 
 	const handleSave = useCallback(async () => {
 		const validation = validateWorkflowForSave(trigger, layoutedNodes);
@@ -857,7 +834,6 @@ export function useAutomationEditor(automationId: string | null) {
 		handleConfirmClear,
 		handleCancelClear,
 		showClearConfirm,
-		hasPlaceholders,
 		canUndo: !!deletedNodeState,
 		undoBanner: deletedNodeState
 			? {

--- a/apps/web/src/app/(workspace)/automations/hooks/use-sidebar-state.ts
+++ b/apps/web/src/app/(workspace)/automations/hooks/use-sidebar-state.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import type { SidebarMode } from "../components/sidebar/automation-sidebar";
 
 type ConfigurableNodeType = Exclude<
@@ -8,7 +8,7 @@ type ConfigurableNodeType = Exclude<
 	"trigger"
 >;
 
-export function useSidebarState(hasPlaceholders: boolean) {
+export function useSidebarState() {
 	const [isOpen, setIsOpen] = useState(false);
 	const [mode, setMode] = useState<SidebarMode | null>(null);
 
@@ -59,12 +59,6 @@ export function useSidebarState(hasPlaceholders: boolean) {
 		},
 		[]
 	);
-
-	useEffect(() => {
-		if (!hasPlaceholders && mode?.mode === "step-picker") {
-			closeSidebar();
-		}
-	}, [closeSidebar, hasPlaceholders, mode]);
 
 	return {
 		isOpen,

--- a/apps/web/src/app/(workspace)/automations/lib/flow-adapter.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/flow-adapter.ts
@@ -304,22 +304,25 @@ export function automationToReactFlow(
 		}
 	}
 
-	// Apply positions: use persisted position if available, otherwise compute
-	const triggerId = trigger ? TRIGGER_NODE_ID : TRIGGER_PLACEHOLDER_ID;
-	const computedPositions = computeAllPositions(rfNodes, rfEdges, triggerId);
-
+	// Collect persisted positions (from drag or DB) so computeAllPositions
+	// places children relative to actual parent positions, not computed ones
+	const persistedPositions = new Map<string, { x: number; y: number }>();
 	for (const rfNode of rfNodes) {
-		// Check if the source DB node had a persisted position
 		const dbNode = rfNode.data?._dbNode as
 			| (WorkflowNode & { position?: { x: number; y: number } })
 			| undefined;
 		if (dbNode?.position) {
-			rfNode.position = { x: dbNode.position.x, y: dbNode.position.y };
-		} else {
-			const computed = computedPositions.get(rfNode.id);
-			if (computed) {
-				rfNode.position = computed;
-			}
+			persistedPositions.set(rfNode.id, dbNode.position);
+		}
+	}
+
+	const triggerId = trigger ? TRIGGER_NODE_ID : TRIGGER_PLACEHOLDER_ID;
+	const computedPositions = computeAllPositions(rfNodes, rfEdges, triggerId, persistedPositions);
+
+	for (const rfNode of rfNodes) {
+		const pos = computedPositions.get(rfNode.id);
+		if (pos) {
+			rfNode.position = pos;
 		}
 	}
 

--- a/apps/web/src/app/(workspace)/automations/lib/initial-placement.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/initial-placement.ts
@@ -77,11 +77,16 @@ export function computeInitialPosition(
  * Uses DFS to ensure each subtree branch is fully placed (including terminal
  * stubs) before sibling branches. Critical for loop nodes: the "each" body
  * must be fully placed so the "after" branch's maxY scan includes all body nodes.
+ *
+ * persistedPositions: map of node ID -> saved position from drag/DB.
+ * When a node has a persisted position, we use it instead of computing,
+ * so child nodes are placed relative to the actual (dragged) parent position.
  */
 export function computeAllPositions(
-  nodes: Array<{ id: string }>,
+  _nodes: Array<{ id: string }>,
   edges: Array<{ source: string; target: string; data?: { branchType?: string } }>,
-  triggerId: string
+  triggerId: string,
+  persistedPositions?: Map<string, { x: number; y: number }>
 ): Map<string, { x: number; y: number }> {
   const ctx = createPlacementContext();
   const visited = new Set<string>();
@@ -94,7 +99,14 @@ export function computeAllPositions(
     if (visited.has(nodeId)) return;
     visited.add(nodeId);
 
-    computeInitialPosition(nodeId, parentId, branchType, ctx);
+    // Use persisted (dragged) position if available, so children are placed
+    // relative to the actual parent position rather than the computed one
+    const persisted = persistedPositions?.get(nodeId);
+    if (persisted) {
+      ctx.positions.set(nodeId, persisted);
+    } else {
+      computeInitialPosition(nodeId, parentId, branchType, ctx);
+    }
 
     // Find child edges (exclude loop_back)
     const childEdges = edges.filter(

--- a/apps/web/src/app/(workspace)/automations/lib/initial-placement.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/initial-placement.ts
@@ -1,6 +1,6 @@
 /**
  * Hybrid positioning: compute initial node positions for new/unpositioned nodes.
- * Replaces the 730-line dagre-layout.ts with simple parent-relative placement.
+ * Uses simple parent-relative placement (BFS-based).
  *
  * Rules:
  * - Trigger: top center (0, 0)


### PR DESCRIPTION
This pull request introduces improved support for node deletion and context menus in the automation editor, and refines the logic for node positioning and sidebar state management. The most important changes are summarized below.

**Context menu and node deletion enhancements:**

* Added a right-click context menu to nodes in the automation flow (`automation-flow.tsx`), allowing users to delete nodes directly from the canvas. The menu is not shown for terminal nodes. [[1]](diffhunk://#diff-8a05f3afa5dc71917c09d55987363289a8b1406d45c40a4f44a56f0ebeacac78R16-R18) [[2]](diffhunk://#diff-8a05f3afa5dc71917c09d55987363289a8b1406d45c40a4f44a56f0ebeacac78R60-R84) [[3]](diffhunk://#diff-8a05f3afa5dc71917c09d55987363289a8b1406d45c40a4f44a56f0ebeacac78R132-R177) [[4]](diffhunk://#diff-8a05f3afa5dc71917c09d55987363289a8b1406d45c40a4f44a56f0ebeacac78R200-R215)
* Introduced an `onDeleteNode` callback, wiring it from the flow component up to the editor screen, so node deletions can be handled appropriately. [[1]](diffhunk://#diff-8a05f3afa5dc71917c09d55987363289a8b1406d45c40a4f44a56f0ebeacac78R60-R84) [[2]](diffhunk://#diff-8a05f3afa5dc71917c09d55987363289a8b1406d45c40a4f44a56f0ebeacac78R132-R177) [[3]](diffhunk://#diff-3392f4a7564b6621673229c2ae9f2e68322f8bf03a525a42072d968150fbfb0bR182)

**Sidebar and selection logic simplification:**

* Removed the `hasPlaceholders` prop from `useSidebarState` and related logic, simplifying sidebar state management. The sidebar now closes only based on direct interactions, not placeholder state. [[1]](diffhunk://#diff-3392f4a7564b6621673229c2ae9f2e68322f8bf03a525a42072d968150fbfb0bL29-R29) [[2]](diffhunk://#diff-e7c31ebdc3e7ce3514a9c335287d96910c0397e6cf2201ab01c02fa05a0b92ceL3-R11) [[3]](diffhunk://#diff-e7c31ebdc3e7ce3514a9c335287d96910c0397e6cf2201ab01c02fa05a0b92ceL63-L68) [[4]](diffhunk://#diff-e3ab58d202efc7863fbaec52908884bf53e4a4170c325fca046f2765c5b6abdfL860)
* Improved selection logic so that placeholder nodes are included as selectable when the step picker is open, enabling keyboard shortcuts (like Backspace) to delete them.

**Node positioning improvements:**

* Enhanced the node positioning algorithm to respect persisted (dragged or database) positions for nodes, ensuring that child nodes are placed relative to actual parent positions rather than always using computed positions. This change affects both the flow adapter and the placement logic. [[1]](diffhunk://#diff-8d2ac3c95c980795c35d5094c3673b513c074129ddba08ed91eca6568c2307c5L307-R325) [[2]](diffhunk://#diff-6aa7bdfea427f478a019bcf6b09bbcd627e743edf3137841b1d0d0795189fc7fR80-R89) [[3]](diffhunk://#diff-6aa7bdfea427f478a019bcf6b09bbcd627e743edf3137841b1d0d0795189fc7fR102-R109)

**Other improvements:**

* Minor documentation and code comments were updated for clarity, including replacing references to "dagre" with "layout engine" and updating descriptions in the placement logic. [[1]](diffhunk://#diff-58efbb9b6f4a3eb95648969d949668055baac2ef9257ea8cda340dcc766110d4L8-R8) [[2]](diffhunk://#diff-6aa7bdfea427f478a019bcf6b09bbcd627e743edf3137841b1d0d0795189fc7fL3-R3)

These changes collectively improve the usability and maintainability of the automation editor, especially in terms of node management and layout behavior.