### PR TITLE
feat(workspace): custom create-organization flow with auth-rotation hardening

### DIFF
--- a/apps/web/src/app/(workspace)/organization/complete/page.tsx
+++ b/apps/web/src/app/(workspace)/organization/complete/page.tsx
@@ -1266,13 +1266,7 @@ export default function CompleteOrganizationMetadata() {
 		}
 	};
 
-	// Show loading state while webhook is processing organization creation.
-	// Scoped to step 1 only — once the user has advanced into the wizard, let them
-	// keep filling out business info while the webhook syncs in the background.
-	// This prevents the post-create transition from flashing a full-page spinner
-	// (which felt like a page reload) when stepping from 1 → 2.
-	// completeMetadata at step 5 still needs a real Convex org; that path waits on
-	// `organization` separately if needed.
+	// Step-1 only: avoids flashing a full-page spinner when advancing 1 → 2 while the webhook syncs.
 	if (
 		currentStep === 1 &&
 		clerkOrganization &&

--- a/apps/web/src/app/(workspace)/organization/complete/page.tsx
+++ b/apps/web/src/app/(workspace)/organization/complete/page.tsx
@@ -1266,12 +1266,15 @@ export default function CompleteOrganizationMetadata() {
 		}
 	};
 
-	// Show loading state while webhook is processing organization creation
-	// Show loading if:
-	// 1. User has created a Clerk org AND
-	// 2. Either needsCompletion or organization data hasn't loaded yet (undefined) OR
-	// 3. Organization doesn't exist in Convex yet (null) - waiting for webhook
+	// Show loading state while webhook is processing organization creation.
+	// Scoped to step 1 only — once the user has advanced into the wizard, let them
+	// keep filling out business info while the webhook syncs in the background.
+	// This prevents the post-create transition from flashing a full-page spinner
+	// (which felt like a page reload) when stepping from 1 → 2.
+	// completeMetadata at step 5 still needs a real Convex org; that path waits on
+	// `organization` separately if needed.
 	if (
+		currentStep === 1 &&
 		clerkOrganization &&
 		(needsCompletion === undefined ||
 			organization === undefined ||

--- a/apps/web/src/app/(workspace)/organization/complete/page.tsx
+++ b/apps/web/src/app/(workspace)/organization/complete/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useMemo, useState, useEffect } from "react";
-import { useUser, useOrganization, CreateOrganization } from "@clerk/nextjs";
+import { useUser, useOrganization, useOrganizationList } from "@clerk/nextjs";
 import { PricingTable } from "@clerk/nextjs";
 import { useTheme } from "next-themes";
 import { useMutation, useQuery } from "convex/react";
@@ -71,6 +71,20 @@ export default function CompleteOrganizationMetadata() {
 	// Track the initial org ID when in "creating new" mode to detect when a new org is created
 	const initialOrgIdRef = React.useRef<string | null>(null);
 	const hasInitializedRef = React.useRef(false);
+
+	// Step 1: custom create-org form state (replaces Clerk's <CreateOrganization>)
+	const {
+		isLoaded: orgListLoaded,
+		createOrganization,
+		setActive,
+	} = useOrganizationList();
+	const [orgName, setOrgName] = useState("");
+	const [logoFile, setLogoFile] = useState<File | null>(null);
+	const [logoPreviewUrl, setLogoPreviewUrl] = useState<string | null>(null);
+	const [createSubmitting, setCreateSubmitting] = useState(false);
+	const [createNameError, setCreateNameError] = useState<string | null>(null);
+	const [createLogoError, setCreateLogoError] = useState<string | null>(null);
+
 	const [formData, setFormData] = useState<FormData>({
 		email: user?.primaryEmailAddress?.emailAddress || "",
 		website: "",
@@ -379,6 +393,68 @@ export default function CompleteOrganizationMetadata() {
 		}
 	};
 
+	// Revoke any object URL created for the logo preview to avoid blob retention.
+	useEffect(() => {
+		return () => {
+			if (logoPreviewUrl) URL.revokeObjectURL(logoPreviewUrl);
+		};
+	}, [logoPreviewUrl]);
+
+	const handleLogoSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+		setCreateLogoError(null);
+		const file = e.target.files?.[0] ?? null;
+		if (!file) return;
+		if (file.size > 10 * 1024 * 1024) {
+			setCreateLogoError("Logo must be 10 MB or smaller");
+			// Reset so re-selecting the same file refires onChange
+			e.target.value = "";
+			return;
+		}
+		if (logoPreviewUrl) URL.revokeObjectURL(logoPreviewUrl);
+		setLogoFile(file);
+		setLogoPreviewUrl(URL.createObjectURL(file));
+	};
+
+	const handleCreateOrganization: React.FormEventHandler<
+		HTMLFormElement
+	> = async (e) => {
+		e.preventDefault();
+		setCreateNameError(null);
+
+		const trimmedName = orgName.trim();
+		if (!trimmedName) {
+			setCreateNameError("Organization name is required");
+			return;
+		}
+		// Guard: hook still initializing
+		if (!orgListLoaded || !createOrganization) return;
+
+		setCreateSubmitting(true);
+		try {
+			// 1. Create org (slug omitted = preserves prior hideSlug behavior)
+			const newOrg = await createOrganization({ name: trimmedName });
+
+			// 2. Upload logo BEFORE setActive so step 2's preview tiles see imageUrl on first render
+			if (logoFile) {
+				await newOrg.setLogo({ file: logoFile });
+			}
+
+			// 3. Mark as active session org
+			await setActive({ organization: newOrg.id });
+
+			// 4. Advance wizard in-place — no router.push, no router.refresh, no reload
+			setCurrentStep(2);
+		} catch (err) {
+			const message =
+				(err as { errors?: Array<{ message: string }> })?.errors?.[0]
+					?.message ??
+				(err instanceof Error ? err.message : "Failed to create organization");
+			toast.warning("Couldn't create organization", message);
+		} finally {
+			setCreateSubmitting(false);
+		}
+	};
+
 	const renderStep1 = () => (
 		<div className="space-y-8 flex flex-col items-center">
 			<div className="w-full max-w-2xl text-center">
@@ -393,165 +469,105 @@ export default function CompleteOrganizationMetadata() {
 				</p>
 			</div>
 
-			{/* Clerk Create Organization Component */}
 			<div className="mt-6 w-full max-w-2xl">
-				<CreateOrganization
-					appearance={{
-						elements: {
-							rootBox: {
-								width: "100%",
-								margin: "0 auto",
-							},
-							card: {
-								backgroundColor: "transparent",
-								border: "none",
-								boxShadow: "none",
-								padding: "0",
-								width: "100%",
-							},
-							cardBox: {
-								padding: "0",
-								width: "100%",
-							},
-							headerTitle: {
-								display: "none", // Hide default header since we have our own
-							},
-							headerSubtitle: {
-								display: "none", // Hide default subtitle
-							},
-							form: {
-								gap: "1.5rem",
-								width: "100%",
-							},
-							formFieldRow: {
-								width: "100%",
-							},
-							formContainer: {
-								width: "100%",
-								height: "100%",
-								display: "flex",
-								justifyContent: "center",
-								padding: "5px",
-							},
+				{!orgListLoaded ? (
+					<div className="flex items-center justify-center py-12">
+						<div className="animate-spin rounded-full h-10 w-10 border-b-2 border-primary" />
+					</div>
+				) : (
+					<form
+						onSubmit={handleCreateOrganization}
+						className="space-y-6"
+						noValidate
+					>
+						<div>
+							<label
+								htmlFor="org-name"
+								className="block text-sm font-semibold text-foreground mb-3 tracking-wide"
+							>
+								Organization Name
+							</label>
+							<Input
+								id="org-name"
+								value={orgName}
+								onChange={(e) => {
+									setOrgName(e.target.value);
+									if (createNameError) setCreateNameError(null);
+								}}
+								disabled={createSubmitting}
+								placeholder="Acme Cleaning Co."
+								autoComplete="organization"
+								aria-invalid={createNameError ? true : undefined}
+								aria-describedby={
+									createNameError ? "org-name-error" : undefined
+								}
+								className="w-full border-border dark:border-border bg-background dark:bg-background focus:bg-background dark:focus:bg-background transition-colors shadow-sm ring-1 ring-border/10"
+							/>
+							{createNameError && (
+								<p
+									id="org-name-error"
+									className="mt-2 text-sm text-destructive"
+								>
+									{createNameError}
+								</p>
+							)}
+						</div>
 
-							// Form styling
-							formButtonPrimary: {
-								backgroundColor: "rgb(0, 166, 244)",
-								color: "white",
-								borderRadius: "var(--radius-md)",
-								padding: "0.625rem 3rem",
-								fontSize: "1rem",
-								fontWeight: "500",
-								transition: "all 0.2s",
-								border: "none",
-								"&:hover": {
-									opacity: "0.9",
-									transform: "translateY(-1px)",
-								},
-								"&:focus": {
-									outline: "2px solid rgb(0, 166, 244)",
-									outlineOffset: "2px",
-								},
-								width: "100%",
-							},
-							formFieldInput: {
-								backgroundColor: isDark
-									? "oklch(0.32 0.013 285.805)"
-									: "oklch(0.871 0.006 286.286)",
-								color: isDark
-									? "oklch(0.985 0 0)"
-									: "oklch(0.141 0.005 285.823)",
-								border: `1px solid ${
-									isDark
-										? "oklch(0.27 0.013 285.805)"
-										: "oklch(0.911 0.006 286.286)"
-								}`,
-								borderRadius: "var(--radius-md)",
-								padding: "0.625rem 1rem",
-								width: "100%",
-							},
-							formFieldLabel: {
-								color: isDark
-									? "oklch(0.985 0 0)"
-									: "oklch(0.141 0.005 285.823)",
-								fontSize: "0.875rem",
-								fontWeight: "500",
-								marginBottom: "0.5rem",
-							},
+						<div>
+							<label className="block text-sm font-semibold text-foreground mb-3 tracking-wide">
+								Organization Logo{" "}
+								<span className="text-muted-foreground font-normal">
+									(optional)
+								</span>
+							</label>
+							<div className="flex items-center gap-4">
+								{logoPreviewUrl ? (
+									<Image
+										src={logoPreviewUrl}
+										alt="Logo preview"
+										width={64}
+										height={64}
+										className="h-16 w-16 rounded-lg border border-border object-contain bg-white"
+										unoptimized
+									/>
+								) : (
+									<div className="h-16 w-16 rounded-lg border border-dashed border-border flex items-center justify-center bg-muted/20">
+										<Upload className="h-5 w-5 text-muted-foreground" />
+									</div>
+								)}
+								<input
+									type="file"
+									accept="image/*"
+									onChange={handleLogoSelect}
+									disabled={createSubmitting}
+									className="text-sm text-foreground file:mr-3 file:rounded-md file:border-0 file:bg-primary/10 file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-primary hover:file:bg-primary/20 file:cursor-pointer"
+								/>
+							</div>
+							{createLogoError && (
+								<p className="mt-2 text-sm text-destructive">
+									{createLogoError}
+								</p>
+							)}
+							<p className="mt-2 text-xs text-muted-foreground">
+								PNG, JPG, or SVG up to 10 MB.
+							</p>
+						</div>
 
-							// Footer styling
-							footer: "mt-8 pt-6 border-t border-border dark:border-border",
-							footerActionText:
-								"text-xs text-muted-foreground dark:text-muted-foreground",
-							footerActionLink:
-								"text-primary hover:text-primary/80 dark:text-primary dark:hover:text-primary/80 font-medium text-xs",
-
-							// Error and success styling
-							formFieldSuccessText:
-								"text-green-600 dark:text-green-400 text-sm",
-							formFieldErrorText: "text-red-600 dark:text-red-400 text-sm",
-							formFieldWarningText:
-								"text-yellow-600 dark:text-yellow-400 text-sm",
-
-							// Loading states
-							formFieldInputPlaceholder:
-								"text-muted-foreground dark:text-muted-foreground",
-							spinner: "text-primary dark:text-primary",
-
-							// Modal/popover styling (if any)
-							modalContent:
-								"bg-card dark:bg-card border-border dark:border-border shadow-xl dark:shadow-xl",
-							modalCloseButton:
-								"text-muted-foreground hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground",
-
-							// Additional dark mode elements
-							identityPreview:
-								"bg-background dark:bg-card border-border dark:border-border",
-							identityPreviewText: "text-foreground dark:text-foreground",
-							identityPreviewEditButton:
-								"text-primary hover:text-primary/80 dark:text-primary dark:hover:text-primary/80",
-						},
-						variables: {
-							// Color system that works in both light and dark mode
-							colorPrimary: "rgb(0, 166, 244)",
-							colorDanger: "hsl(var(--destructive))",
-							colorSuccess: "hsl(var(--green-600))",
-							colorWarning: "hsl(var(--yellow-600))",
-							colorNeutral: "hsl(var(--muted-foreground))",
-
-							// Background colors
-							colorBackground: "transparent",
-							colorInputBackground: "hsl(var(--background))",
-
-							// Text colors
-							colorText: "hsl(var(--foreground))",
-							colorTextSecondary: "hsl(var(--muted-foreground))",
-							colorInputText: "hsl(var(--foreground))",
-							colorTextOnPrimaryBackground: "hsl(var(--primary-foreground))",
-
-							// Typography
-							fontFamily: "inherit",
-							fontFamilyButtons: "inherit",
-							fontSize: "0.875rem",
-							fontWeight: {
-								normal: "400",
-								medium: "500",
-								semibold: "600",
-								bold: "700",
-							},
-
-							// Spacing and shapes
-							borderRadius: "0.5rem",
-							spacingUnit: "1rem",
-						},
-					}}
-					afterCreateOrganizationUrl="/organization/complete"
-					skipInvitationScreen={true}
-					hideSlug={true}
-				/>
+						<div className="pt-2">
+							<StyledButton
+								intent="primary"
+								type="submit"
+								isLoading={createSubmitting}
+								disabled={createSubmitting || !orgListLoaded}
+								showArrow={false}
+							>
+								Create Organization
+							</StyledButton>
+						</div>
+					</form>
+				)}
 			</div>
 
-			{/* Help Text */}
 			<div className="mt-6 text-center">
 				<p className="text-xs text-muted-foreground">
 					After creating your organization, you&apos;ll continue to the next

--- a/apps/web/src/app/(workspace)/organization/complete/page.tsx
+++ b/apps/web/src/app/(workspace)/organization/complete/page.tsx
@@ -85,6 +85,14 @@ export default function CompleteOrganizationMetadata() {
 	const [createNameError, setCreateNameError] = useState<string | null>(null);
 	const [createLogoError, setCreateLogoError] = useState<string | null>(null);
 
+	// Holds the org created on a prior attempt so retries (after setLogo/setActive
+	// fail) reuse it instead of creating a duplicate. Invalidated when the name
+	// changes, since a new name means a new org.
+	const createdOrgRef = React.useRef<{
+		org: Awaited<ReturnType<NonNullable<typeof createOrganization>>>;
+		name: string;
+	} | null>(null);
+
 	const [formData, setFormData] = useState<FormData>({
 		email: user?.primaryEmailAddress?.emailAddress || "",
 		website: "",
@@ -431,8 +439,14 @@ export default function CompleteOrganizationMetadata() {
 
 		setCreateSubmitting(true);
 		try {
-			// 1. Create org (slug omitted = preserves prior hideSlug behavior)
-			const newOrg = await createOrganization({ name: trimmedName });
+			// 1. Create org — or reuse one from a prior failed attempt with the same
+			// name to avoid orphaning + duplicating on retry.
+			const cached = createdOrgRef.current;
+			const newOrg =
+				cached && cached.name === trimmedName
+					? cached.org
+					: await createOrganization({ name: trimmedName });
+			createdOrgRef.current = { org: newOrg, name: trimmedName };
 
 			// 2. Upload logo BEFORE setActive so step 2's preview tiles see imageUrl on first render
 			if (logoFile) {
@@ -443,6 +457,7 @@ export default function CompleteOrganizationMetadata() {
 			await setActive({ organization: newOrg.id });
 
 			// 4. Advance wizard in-place — no router.push, no router.refresh, no reload
+			createdOrgRef.current = null;
 			setCurrentStep(2);
 		} catch (err) {
 			const message =

--- a/apps/web/src/app/(workspace)/organization/complete/page.tsx
+++ b/apps/web/src/app/(workspace)/organization/complete/page.tsx
@@ -410,7 +410,7 @@ export default function CompleteOrganizationMetadata() {
 			e.target.value = "";
 			return;
 		}
-		if (logoPreviewUrl) URL.revokeObjectURL(logoPreviewUrl);
+		// Old URL is revoked by the useEffect cleanup when logoPreviewUrl changes.
 		setLogoFile(file);
 		setLogoPreviewUrl(URL.createObjectURL(file));
 	};
@@ -514,7 +514,10 @@ export default function CompleteOrganizationMetadata() {
 						</div>
 
 						<div>
-							<label className="block text-sm font-semibold text-foreground mb-3 tracking-wide">
+							<label
+								htmlFor="org-logo"
+								className="block text-sm font-semibold text-foreground mb-3 tracking-wide"
+							>
 								Organization Logo{" "}
 								<span className="text-muted-foreground font-normal">
 									(optional)
@@ -536,6 +539,7 @@ export default function CompleteOrganizationMetadata() {
 									</div>
 								)}
 								<input
+									id="org-logo"
 									type="file"
 									accept="image/*"
 									onChange={handleLogoSelect}

--- a/apps/web/src/components/layout/theme-switcher.tsx
+++ b/apps/web/src/components/layout/theme-switcher.tsx
@@ -2,22 +2,22 @@
 
 import { IconMoon, IconSun } from "@intentui/icons";
 import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 
 export function ThemeSwitcher({
 	...props
 }: React.ComponentProps<typeof Button>) {
 	const { resolvedTheme, setTheme } = useTheme();
+	const [mounted, setMounted] = useState(false);
+	useEffect(() => setMounted(true), []);
 
 	const toggleTheme = () => {
 		const nextTheme = resolvedTheme === "light" ? "dark" : "light";
 		setTheme(nextTheme);
 	};
 
-	// Don't render until theme is resolved to prevent hydration mismatch
-	if (!resolvedTheme) {
-		return null;
-	}
+	if (!mounted) return null;
 
 	return (
 		<Button

--- a/apps/web/src/components/ui/address-autocomplete.tsx
+++ b/apps/web/src/components/ui/address-autocomplete.tsx
@@ -1,11 +1,19 @@
 "use client";
 
 import * as React from "react";
-import { AddressAutofill } from "@mapbox/search-js-react";
+import dynamic from "next/dynamic";
+import type { AddressAutofill as AddressAutofillType } from "@mapbox/search-js-react";
 import { useTheme } from "next-themes";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { env } from "@/env";
+
+// @mapbox/search-js-react touches `document` at module init, so it can't be statically imported in an RSC graph.
+const AddressAutofill = dynamic<
+	React.ComponentProps<typeof AddressAutofillType>
+>(() => import("@mapbox/search-js-react").then((m) => m.AddressAutofill), {
+	ssr: false,
+});
 
 /**
  * Structured address data returned from Mapbox Address Autofill.

--- a/apps/web/src/hooks/use-feature-access.ts
+++ b/apps/web/src/hooks/use-feature-access.ts
@@ -29,7 +29,7 @@ export function useFeatureAccess(): FeatureAccess {
 	const { has, isLoaded, orgId } = useAuth();
 	const { user, isLoaded: isUserLoaded } = useUser();
 	const { organization, isLoaded: isOrgLoaded } = useOrganization();
-	const usage = useQuery(api.usage.getCurrentUsage);
+	const usage = useQuery(api.usage.getCurrentUsage, isLoaded ? {} : "skip");
 
 	// Check if user has an organization - use orgId instead of role check
 	// This works for all roles (admin, member, owner, etc.)

--- a/apps/web/src/providers/ConvexClientProvider.tsx
+++ b/apps/web/src/providers/ConvexClientProvider.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { ReactNode } from "react";
-import { ConvexReactClient } from "convex/react";
+import {
+	Authenticated,
+	AuthLoading,
+	ConvexReactClient,
+	Unauthenticated,
+} from "convex/react";
 import { ConvexProviderWithClerk } from "convex/react-clerk";
 import { useAuth } from "@clerk/nextjs";
 import { env } from "@/env";
@@ -13,9 +18,14 @@ export default function ConvexClientProvider({
 }: {
 	children: ReactNode;
 }) {
+	// AuthLoading branch keeps the subtree mounted while Clerk rotates tokens
+	// (e.g., during setActive); without it, neither Authenticated nor Unauthenticated
+	// matched and the workspace tree unmounted mid-flow.
 	return (
 		<ConvexProviderWithClerk client={convex} useAuth={useAuth}>
-			{children}
+			<Authenticated>{children}</Authenticated>
+			<AuthLoading>{children}</AuthLoading>
+			<Unauthenticated>{children}</Unauthenticated>
 		</ConvexProviderWithClerk>
 	);
 }

--- a/apps/web/src/providers/ConvexClientProvider.tsx
+++ b/apps/web/src/providers/ConvexClientProvider.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import { ReactNode } from "react";
-import {
-	Authenticated,
-	ConvexReactClient,
-	Unauthenticated,
-} from "convex/react";
+import { ConvexReactClient } from "convex/react";
 import { ConvexProviderWithClerk } from "convex/react-clerk";
 import { useAuth } from "@clerk/nextjs";
 import { env } from "@/env";
@@ -17,10 +13,15 @@ export default function ConvexClientProvider({
 }: {
 	children: ReactNode;
 }) {
+	// Render children directly. Previously this wrapped them in <Authenticated>{children}</Authenticated>
+	// and <Unauthenticated>{children}</Unauthenticated>. Neither branch matches during the brief
+	// AuthLoading transition that fires when Clerk's setActive() rotates the session (e.g., right
+	// after createOrganization), so the workspace subtree was unmounting and resetting all client
+	// state — visually indistinguishable from a page reload. Both branches rendered the same
+	// children, so the swap served no purpose.
 	return (
 		<ConvexProviderWithClerk client={convex} useAuth={useAuth}>
-			<Authenticated>{children}</Authenticated>
-			<Unauthenticated>{children}</Unauthenticated>
+			{children}
 		</ConvexProviderWithClerk>
 	);
 }

--- a/apps/web/src/providers/ConvexClientProvider.tsx
+++ b/apps/web/src/providers/ConvexClientProvider.tsx
@@ -13,12 +13,6 @@ export default function ConvexClientProvider({
 }: {
 	children: ReactNode;
 }) {
-	// Render children directly. Previously this wrapped them in <Authenticated>{children}</Authenticated>
-	// and <Unauthenticated>{children}</Unauthenticated>. Neither branch matches during the brief
-	// AuthLoading transition that fires when Clerk's setActive() rotates the session (e.g., right
-	// after createOrganization), so the workspace subtree was unmounting and resetting all client
-	// state — visually indistinguishable from a page reload. Both branches rendered the same
-	// children, so the swap served no purpose.
 	return (
 		<ConvexProviderWithClerk client={convex} useAuth={useAuth}>
 			{children}

--- a/packages/backend/convex/calendar.test.ts
+++ b/packages/backend/convex/calendar.test.ts
@@ -34,14 +34,14 @@ describe("Calendar", () => {
 			expect(result).toEqual({ projects: [], tasks: [] });
 		});
 
-		it("should throw error when user is not authenticated", async () => {
+		it("should return empty result when user is not authenticated", async () => {
 			const now = Date.now();
-			await expect(
-				t.query(api.calendar.getCalendarEvents, {
-					startDate: now,
-					endDate: now + 7 * 24 * 60 * 60 * 1000,
-				})
-			).rejects.toThrowError("User not authenticated");
+			const result = await t.query(api.calendar.getCalendarEvents, {
+				startDate: now,
+				endDate: now + 7 * 24 * 60 * 60 * 1000,
+			});
+
+			expect(result).toEqual({ projects: [], tasks: [] });
 		});
 
 		it("should return tasks within the date range", async () => {

--- a/packages/backend/convex/lib/auth.test.ts
+++ b/packages/backend/convex/lib/auth.test.ts
@@ -107,6 +107,17 @@ describe("Auth Helpers", () => {
 			).rejects.toThrowError("No active organization found in user session");
 		});
 
+		it("should return null when require: false and no identity", async () => {
+			const result = await t.run(async (ctx) => {
+				(ctx.auth as any).getUserIdentity = async () => null;
+
+				const { getCurrentUserOrgId } = await import("../lib/auth");
+				return await getCurrentUserOrgId(ctx, { require: false });
+			});
+
+			expect(result).toBeNull();
+		});
+
 		it("should return null when require: false and no org", async () => {
 			await t.run(async (ctx) => {
 				const userId = await ctx.db.insert("users", {

--- a/packages/backend/convex/lib/auth.ts
+++ b/packages/backend/convex/lib/auth.ts
@@ -77,6 +77,12 @@ export async function getCurrentUserOrgId(
 	const requireOrg = options.require !== false;
 	const identity = await ctx.auth.getUserIdentity();
 	if (!identity) {
+		// require:false callers (~30 sites) already handle null by returning
+		// empty data; throwing here surfaces during Clerk setActive() token
+		// rotation when Convex briefly sees no identity.
+		if (!requireOrg) {
+			return null;
+		}
 		throw new Error("User not authenticated");
 	}
 

--- a/packages/backend/convex/users.test.ts
+++ b/packages/backend/convex/users.test.ts
@@ -102,10 +102,9 @@ describe("Users", () => {
 			expect(users).toEqual([]);
 		});
 
-		it("should throw error for unauthenticated user", async () => {
-			await expect(t.query(api.users.listByOrg, {})).rejects.toThrowError(
-				"User not authenticated"
-			);
+		it("should return empty list for unauthenticated user", async () => {
+			const users = await t.query(api.users.listByOrg, {});
+			expect(users).toEqual([]);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Replaces Clerk's `<CreateOrganization>` component with a custom in-page form on `/organization/complete`, then hardens the surrounding auth + SSR paths that surfaced as bugs once the wizard kept users on the same route through `setActive()` instead of redirecting.

- **Custom create-org form** — replaces the Clerk-rendered component with a name + logo form that calls `createOrganization()` → `setLogo()` → `setActive()` and advances the wizard in-place (no router.push, no reload).
- **Auth-rotation handling** — `ConvexClientProvider` renders children across `Authenticated` / `AuthLoading` / `Unauthenticated` so the workspace subtree stays mounted while Clerk rotates the JWT during `setActive()`.
- **`getCurrentUserOrgId({ require: false })` fix** — the helper now returns `null` when no identity is present (instead of throwing "User not authenticated"), aligning with the contract its ~30 callers already assume. This silences the sporadic errors users were hitting during the brief Convex auth gap on the create-org screen. `useFeatureAccess` also passes `"skip"` until Clerk's `useAuth` is loaded as defense-in-depth.
- **SSR/hydration fixes** — `AddressAutocomplete` is now loaded via `next/dynamic` with `ssr: false` (Mapbox SDK references `window`); `ThemeSwitcher` defers theme-dependent rendering until after mount to avoid hydration mismatch.
- **Misc** — scope the post-create loader to step 1 only so users don't see a full-page spinner mid-wizard, and trim verbose explanatory comments.

## Test plan

- [x] `pnpm test:once` in `packages/backend` — 385 passing, 15 pre-existing skips
- [x] `pnpm tsc --noEmit` in `apps/web` — clean
- [ ] Manual: sign up a new user, complete the org via the custom form, verify no "User not authenticated" errors in Convex logs and the wizard advances 1→2 without remounting
- [ ] Manual: refresh `/organization/complete` mid-wizard — confirm no SSR errors from AddressAutocomplete or ThemeSwitcher hydration warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-page organization creation with logo upload and preview
  * Address autocomplete now loads safely on the client

* **Bug Fixes**
  * Prevented spinner flash during org setup transition
  * Resolved theme switcher hydration/rendering issues
  * Kept workspace mounted during auth token rotation
  * Usage checks now wait for auth state before running
  * Auth helpers/queries return empty/null instead of throwing during brief unauthenticated states

* **Tests**
  * Updated unauthenticated tests to expect empty/null results instead of errors

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xCarter93/onetool/pull/192)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->