### PR TITLE
fix(service-status): repair Convex status check, add Stripe, harden m…

### DIFF
--- a/packages/backend/convex/migrations/seedServiceStatus.ts
+++ b/packages/backend/convex/migrations/seedServiceStatus.ts
@@ -4,11 +4,11 @@ export const seedServiceStatus = internalMutation({
 	handler: async (ctx) => {
 		const now = Date.now();
 		const services = [
-			{ serviceName: "convex_database", provider: "convex" },
-			{ serviceName: "convex_functions", provider: "convex" },
+			{ serviceName: "convex", provider: "convex" },
 			{ serviceName: "clerk_auth", provider: "clerk" },
 			{ serviceName: "clerk_billing", provider: "clerk" },
 			{ serviceName: "boldsign_esignature", provider: "boldsign" },
+			{ serviceName: "stripe", provider: "stripe" },
 		];
 
 		for (const service of services) {

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -792,8 +792,8 @@ export default defineSchema({
 
 	// Service Status - monitoring for external service health
 	serviceStatus: defineTable({
-		serviceName: v.string(), // "convex_database", "convex_functions", "clerk_auth", "clerk_billing"
-		provider: v.string(), // "convex" or "clerk"
+		serviceName: v.string(), // "convex", "clerk_auth", "clerk_billing", "boldsign_esignature", "stripe"
+		provider: v.string(), // "convex", "clerk", "boldsign", or "stripe"
 		status: v.union(
 			v.literal("operational"),
 			v.literal("degraded"),

--- a/packages/backend/convex/serviceStatus.ts
+++ b/packages/backend/convex/serviceStatus.ts
@@ -24,6 +24,7 @@ export const updateStatuses = internalMutation({
 
 			if (existing) {
 				await ctx.db.patch(existing._id, {
+					provider: service.provider,
 					status: service.status as
 						| "operational"
 						| "degraded"

--- a/packages/backend/convex/serviceStatus.ts
+++ b/packages/backend/convex/serviceStatus.ts
@@ -52,6 +52,16 @@ export const updateStatuses = internalMutation({
 				});
 			}
 		}
+
+		// Remove rows no longer reported (e.g. the retired convex_database /
+		// convex_functions entries) so the UI doesn't show stale services.
+		const validNames = new Set(args.services.map((s) => s.name));
+		const all = await ctx.db.query("serviceStatus").collect();
+		for (const row of all) {
+			if (!validNames.has(row.serviceName)) {
+				await ctx.db.delete(row._id);
+			}
+		}
 	},
 });
 

--- a/packages/backend/convex/serviceStatusActions.ts
+++ b/packages/backend/convex/serviceStatusActions.ts
@@ -2,76 +2,148 @@
 import { internalAction } from "./_generated/server";
 import { internal } from "./_generated/api";
 
+type ServiceStatus =
+	| "operational"
+	| "degraded"
+	| "partial_outage"
+	| "major_outage"
+	| "unknown";
+
+type StatuspageSummary = {
+	status: { indicator: string; description: string };
+	page?: { updated_at?: string };
+	components: Array<{
+		name: string;
+		group?: boolean;
+		status: string;
+		updated_at?: string;
+	}>;
+};
+
+// Stripe uses its own status API shape, not statuspage.io.
+type StripeStatus = {
+	largestatus?: string;
+	statuses?: Record<string, string>;
+};
+
+// Maps provider status strings (statuspage.io components + page-level
+// indicators, and Stripe's up/degraded/down) to our enum.
+function normalizeStatus(raw: string | undefined): ServiceStatus {
+	switch (raw) {
+		case "operational":
+		case "none":
+		case "up":
+			return "operational";
+		case "degraded_performance":
+		case "under_maintenance":
+		case "minor":
+		case "maintenance":
+		case "degraded":
+			return "degraded";
+		case "partial_outage":
+		case "major":
+			return "partial_outage";
+		case "major_outage":
+		case "critical":
+		case "down":
+			return "major_outage";
+		default:
+			return "unknown";
+	}
+}
+
+// Prefer the matched component; fall back to the page-level indicator if the
+// component was renamed or removed, so a status-page restructure degrades
+// gracefully instead of silently reporting an outage.
+function resolve(
+	component: { status: string; updated_at?: string } | undefined,
+	pageIndicator: string | undefined
+): { status: ServiceStatus; updated?: string } {
+	return component
+		? { status: normalizeStatus(component.status), updated: component.updated_at }
+		: { status: normalizeStatus(pageIndicator), updated: undefined };
+}
+
 export const checkServiceStatus = internalAction({
 	handler: async (ctx) => {
 		try {
-			// Fetch all three APIs in parallel for better performance
-			const [convexResponse, clerkResponse, boldsignResponse] =
+			const [convexResponse, clerkResponse, boldsignResponse, stripeResponse] =
 				await Promise.all([
 					fetch("https://status.convex.dev/api/v2/summary.json"),
 					fetch("https://status.clerk.com/api/v2/summary.json"),
 					fetch("https://status.boldsign.com/api/v2/summary.json"),
+					fetch("https://status.stripe.com/current"),
 				]);
 
-			const [convexData, clerkData, boldsignData] = (await Promise.all([
-				convexResponse.json(),
-				clerkResponse.json(),
-				boldsignResponse.json(),
-			])) as [
-				{ components: Array<{ name: string; status: string; updated_at?: string }> },
-				{ components: Array<{ name: string; status: string; updated_at?: string }> },
-				{ components: Array<{ name: string; group?: boolean; status: string; updated_at?: string }> },
-			];
+			const [convexData, clerkData, boldsignData, stripeData] =
+				(await Promise.all([
+					convexResponse.json(),
+					clerkResponse.json(),
+					boldsignResponse.json(),
+					stripeResponse.json(),
+				])) as [
+					StatuspageSummary,
+					StatuspageSummary,
+					StatuspageSummary,
+					StripeStatus,
+				];
 
-			// Extract specific service statuses
-			const convexDatabase = convexData.components.find(
-				(c: { name: string }) => c.name === "Database Services"
+			// Convex no longer exposes per-subsystem components (Database/Functions);
+			// its summary now groups by plan tier, so use the page-level indicator.
+			const convex = {
+				status: normalizeStatus(convexData.status?.indicator),
+				updated: convexData.page?.updated_at,
+			};
+
+			const clerkAuth = resolve(
+				clerkData.components.find((c) => c.name === "User and authentication"),
+				clerkData.status?.indicator
 			);
-			const convexFunctions = convexData.components.find(
-				(c: { name: string }) => c.name === "Function Runtime"
+			const clerkBilling = resolve(
+				clerkData.components.find((c) => c.name === "Billing"),
+				clerkData.status?.indicator
 			);
-			const clerkAuth = clerkData.components.find(
-				(c: { name: string }) => c.name === "User and authentication"
-			);
-			const clerkBilling = clerkData.components.find(
-				(c: { name: string }) => c.name === "Billing"
-			);
-			const boldsignAPI = boldsignData.components.find(
-				(c) => c.name === "API" && c.group === true
+			const boldsign = resolve(
+				boldsignData.components.find((c) => c.name === "API" && c.group === true),
+				boldsignData.status?.indicator
 			);
 
-			// Update database with results (with error handling for missing data)
+			// Stripe's overall indicator; fall back to its payments API component.
+			const stripe = normalizeStatus(
+				stripeData.largestatus ?? stripeData.statuses?.api
+			);
+
 			await ctx.runMutation(internal.serviceStatus.updateStatuses, {
 				services: [
 					{
-						name: "convex_database",
+						name: "convex",
 						provider: "convex",
-						status: convexDatabase?.status || "unknown",
-						updated: convexDatabase?.updated_at,
-					},
-					{
-						name: "convex_functions",
-						provider: "convex",
-						status: convexFunctions?.status || "unknown",
-						updated: convexFunctions?.updated_at,
+						status: convex.status,
+						updated: convex.updated,
 					},
 					{
 						name: "clerk_auth",
 						provider: "clerk",
-						status: clerkAuth?.status || "unknown",
-						updated: clerkAuth?.updated_at,
+						status: clerkAuth.status,
+						updated: clerkAuth.updated,
 					},
 					{
 						name: "clerk_billing",
 						provider: "clerk",
-						status: clerkBilling?.status || "unknown",
-						updated: clerkBilling?.updated_at,
+						status: clerkBilling.status,
+						updated: clerkBilling.updated,
 					},
 					{
 						name: "boldsign_esignature",
 						provider: "boldsign",
-						status: boldsignAPI?.status || "unknown",
-						updated: boldsignAPI?.updated_at,
+						status: boldsign.status,
+						updated: boldsign.updated,
+					},
+					{
+						name: "stripe",
+						provider: "stripe",
+						status: stripe,
+						updated: undefined,
 					},
 				],
 				checkedAt: Date.now(),
@@ -81,36 +153,16 @@ export const checkServiceStatus = internalAction({
 			// Mark all services as unknown if the check fails
 			await ctx.runMutation(internal.serviceStatus.updateStatuses, {
 				services: [
-					{
-						name: "convex_database",
-						provider: "convex",
-						status: "unknown",
-						updated: undefined,
-					},
-					{
-						name: "convex_functions",
-						provider: "convex",
-						status: "unknown",
-						updated: undefined,
-					},
-					{
-						name: "clerk_auth",
-						provider: "clerk",
-						status: "unknown",
-						updated: undefined,
-					},
-					{
-						name: "clerk_billing",
-						provider: "clerk",
-						status: "unknown",
-						updated: undefined,
-					},
+					{ name: "convex", provider: "convex", status: "unknown", updated: undefined },
+					{ name: "clerk_auth", provider: "clerk", status: "unknown", updated: undefined },
+					{ name: "clerk_billing", provider: "clerk", status: "unknown", updated: undefined },
 					{
 						name: "boldsign_esignature",
 						provider: "boldsign",
 						status: "unknown",
 						updated: undefined,
 					},
+					{ name: "stripe", provider: "stripe", status: "unknown", updated: undefined },
 				],
 				checkedAt: Date.now(),
 			});

--- a/packages/backend/convex/serviceStatusActions.ts
+++ b/packages/backend/convex/serviceStatusActions.ts
@@ -64,108 +64,89 @@ function resolve(
 		: { status: normalizeStatus(pageIndicator), updated: undefined };
 }
 
+function fulfilled<T>(result: PromiseSettledResult<unknown>): T | undefined {
+	return result.status === "fulfilled" ? (result.value as T) : undefined;
+}
+
+// Canonical service list — the single source of truth for both the mapping
+// below and updateStatuses' row pruning. Adding a service here is enough.
+const SERVICES = [
+	{ name: "convex", provider: "convex" },
+	{ name: "clerk_auth", provider: "clerk" },
+	{ name: "clerk_billing", provider: "clerk" },
+	{ name: "boldsign_esignature", provider: "boldsign" },
+	{ name: "stripe", provider: "stripe" },
+] as const;
+
 export const checkServiceStatus = internalAction({
 	handler: async (ctx) => {
 		try {
-			const [convexResponse, clerkResponse, boldsignResponse, stripeResponse] =
-				await Promise.all([
-					fetch("https://status.convex.dev/api/v2/summary.json"),
-					fetch("https://status.clerk.com/api/v2/summary.json"),
-					fetch("https://status.boldsign.com/api/v2/summary.json"),
-					fetch("https://status.stripe.com/current"),
+			// Per-provider isolation: one unreachable status page only marks its
+			// own services unknown, not all of them.
+			const [convexResult, clerkResult, boldsignResult, stripeResult] =
+				await Promise.allSettled([
+					fetch("https://status.convex.dev/api/v2/summary.json").then((r) =>
+						r.json()
+					),
+					fetch("https://status.clerk.com/api/v2/summary.json").then((r) =>
+						r.json()
+					),
+					fetch("https://status.boldsign.com/api/v2/summary.json").then((r) =>
+						r.json()
+					),
+					fetch("https://status.stripe.com/current").then((r) => r.json()),
 				]);
 
-			const [convexData, clerkData, boldsignData, stripeData] =
-				(await Promise.all([
-					convexResponse.json(),
-					clerkResponse.json(),
-					boldsignResponse.json(),
-					stripeResponse.json(),
-				])) as [
-					StatuspageSummary,
-					StatuspageSummary,
-					StatuspageSummary,
-					StripeStatus,
-				];
+			const convexData = fulfilled<StatuspageSummary>(convexResult);
+			const clerkData = fulfilled<StatuspageSummary>(clerkResult);
+			const boldsignData = fulfilled<StatuspageSummary>(boldsignResult);
+			const stripeData = fulfilled<StripeStatus>(stripeResult);
 
-			// Convex no longer exposes per-subsystem components (Database/Functions);
-			// its summary now groups by plan tier, so use the page-level indicator.
-			const convex = {
-				status: normalizeStatus(convexData.status?.indicator),
-				updated: convexData.page?.updated_at,
+			// Any missing/undefined field flows through normalizeStatus(undefined)
+			// → "unknown", so a failed provider degrades cleanly.
+			const statuses: Record<string, { status: ServiceStatus; updated?: string }> = {
+				// Convex no longer exposes per-subsystem components (Database/Functions);
+				// its summary groups by plan tier, so use the page-level indicator.
+				convex: {
+					status: normalizeStatus(convexData?.status?.indicator),
+					updated: convexData?.page?.updated_at,
+				},
+				clerk_auth: resolve(
+					clerkData?.components?.find((c) => c.name === "User and authentication"),
+					clerkData?.status?.indicator
+				),
+				clerk_billing: resolve(
+					clerkData?.components?.find((c) => c.name === "Billing"),
+					clerkData?.status?.indicator
+				),
+				boldsign_esignature: resolve(
+					boldsignData?.components?.find(
+						(c) => c.name === "API" && c.group === true
+					),
+					boldsignData?.status?.indicator
+				),
+				// Stripe's overall indicator; fall back to its payments API component.
+				stripe: {
+					status: normalizeStatus(
+						stripeData?.largestatus ?? stripeData?.statuses?.api
+					),
+					updated: undefined,
+				},
 			};
 
-			const clerkAuth = resolve(
-				clerkData.components.find((c) => c.name === "User and authentication"),
-				clerkData.status?.indicator
-			);
-			const clerkBilling = resolve(
-				clerkData.components.find((c) => c.name === "Billing"),
-				clerkData.status?.indicator
-			);
-			const boldsign = resolve(
-				boldsignData.components.find((c) => c.name === "API" && c.group === true),
-				boldsignData.status?.indicator
-			);
-
-			// Stripe's overall indicator; fall back to its payments API component.
-			const stripe = normalizeStatus(
-				stripeData.largestatus ?? stripeData.statuses?.api
-			);
-
 			await ctx.runMutation(internal.serviceStatus.updateStatuses, {
-				services: [
-					{
-						name: "convex",
-						provider: "convex",
-						status: convex.status,
-						updated: convex.updated,
-					},
-					{
-						name: "clerk_auth",
-						provider: "clerk",
-						status: clerkAuth.status,
-						updated: clerkAuth.updated,
-					},
-					{
-						name: "clerk_billing",
-						provider: "clerk",
-						status: clerkBilling.status,
-						updated: clerkBilling.updated,
-					},
-					{
-						name: "boldsign_esignature",
-						provider: "boldsign",
-						status: boldsign.status,
-						updated: boldsign.updated,
-					},
-					{
-						name: "stripe",
-						provider: "stripe",
-						status: stripe,
-						updated: undefined,
-					},
-				],
+				services: SERVICES.map((s) => ({
+					name: s.name,
+					provider: s.provider,
+					status: statuses[s.name].status,
+					updated: statuses[s.name].updated,
+				})),
 				checkedAt: Date.now(),
 			});
 		} catch (error) {
+			// Reached only if the mutation itself fails; per-provider fetch errors
+			// are already handled above. Leave existing rows untouched.
 			console.error("Failed to check service status:", error);
-			// Mark all services as unknown if the check fails
-			await ctx.runMutation(internal.serviceStatus.updateStatuses, {
-				services: [
-					{ name: "convex", provider: "convex", status: "unknown", updated: undefined },
-					{ name: "clerk_auth", provider: "clerk", status: "unknown", updated: undefined },
-					{ name: "clerk_billing", provider: "clerk", status: "unknown", updated: undefined },
-					{
-						name: "boldsign_esignature",
-						provider: "boldsign",
-						status: "unknown",
-						updated: undefined,
-					},
-					{ name: "stripe", provider: "stripe", status: "unknown", updated: undefined },
-				],
-				checkedAt: Date.now(),
-			});
 		}
 	},
 });


### PR DESCRIPTION
This pull request updates the external service health monitoring system to reflect changes in upstream APIs and adds support for Stripe status monitoring. It removes the now-obsolete `convex_database` and `convex_functions` services, consolidates them into a single `convex` service, and ensures that the service status table stays in sync with the current set of monitored services. The Stripe status API is now queried and normalized alongside other providers.

**Service monitoring updates:**

* Replaced `convex_database` and `convex_functions` with a single `convex` service, matching changes in the Convex status API. [[1]](diffhunk://#diff-37987942092124742528883f3388385490dcfcd59ed6e9d74917db32d5e1198aR5-R146) [[2]](diffhunk://#diff-8ca2f0e011edc02b5911355c6a42ce7fb1b65e12ad846219217b013e2cf6ad35L7-R11) [[3]](diffhunk://#diff-20d4ecb3659e62d405693b67febb0e900b6c0e58ecfbd28add939a4cb27d36abL795-R796) [[4]](diffhunk://#diff-37987942092124742528883f3388385490dcfcd59ed6e9d74917db32d5e1198aL84-R165)
* Added support for monitoring Stripe service status, including fetching and normalizing its custom status API. [[1]](diffhunk://#diff-37987942092124742528883f3388385490dcfcd59ed6e9d74917db32d5e1198aR5-R146) [[2]](diffhunk://#diff-8ca2f0e011edc02b5911355c6a42ce7fb1b65e12ad846219217b013e2cf6ad35L7-R11) [[3]](diffhunk://#diff-20d4ecb3659e62d405693b67febb0e900b6c0e58ecfbd28add939a4cb27d36abL795-R796) [[4]](diffhunk://#diff-37987942092124742528883f3388385490dcfcd59ed6e9d74917db32d5e1198aL84-R165)

**Data consistency improvements:**

* Implemented logic to remove stale service status rows from the database when services are retired or removed from monitoring, preventing outdated entries from appearing in the UI.

**Schema and type updates:**

* Updated the `serviceStatus` table schema and comments to reflect the new set of monitored services and providers.
* Introduced new TypeScript types and normalization functions to handle status data from different providers, including Stripe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Stripe service status monitoring
  * Separately monitor Clerk Auth and Clerk Billing services
  * Unified/normalized status reporting across providers for consistent displays
  * Convex status now reflects page-level health for clearer reporting

* **Bug Fixes**
  * Automatic cleanup of retired service entries to prevent stale data
  * Partial provider failures no longer force global "unknown" — unavailable providers degrade individually
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the external service health monitoring system by consolidating the two Convex sub-services (`convex_database`/`convex_functions`) into a single `convex` entry, adding Stripe status monitoring, and hardening the fetch layer so a single provider failure no longer marks all services unknown. It also adds a cleanup pass that deletes retired DB rows after each successful update cycle.

- **Per-provider isolation**: Switches from `Promise.all` to `Promise.allSettled` so each provider's fetch failure degrades only its own service row to "unknown".
- **Stripe monitoring**: Adds `https://status.stripe.com/current` with a custom `StripeStatus` type and `normalizeStatus` to unify provider-specific status strings into the internal enum.
- **Stale-row cleanup**: After every successful mutation, `updateStatuses` deletes any DB rows whose `serviceName` is not in the current `args.services` list, preventing retired entries from surfacing in the UI.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one comment worth addressing before the next service is added.

The SERVICES constant carries a comment saying 'Adding a service here is enough,' but the manually-constructed statuses object at line 107 must also be updated for each new entry. If a developer follows the comment literally, statuses[s.name] returns undefined and the .status access throws a TypeError at runtime. The catch block only logs without sending a fallback mutation, so all service rows would remain stale.

packages/backend/convex/serviceStatusActions.ts — the SERVICES comment and the statuses object need to be kept in sync.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/serviceStatusActions.ts | Rewrites status fetching to use Promise.allSettled for per-provider isolation, adds Stripe monitoring, and extracts a SERVICES canonical list — but the SERVICES comment falsely promises "Adding a service here is enough" while the statuses object at line 107 must also be updated, otherwise a runtime TypeError leaves all status rows stale. |
| packages/backend/convex/serviceStatus.ts | Adds provider field patching on update and a cleanup loop to prune stale rows after every write cycle; logic is correct. |
| packages/backend/convex/migrations/seedServiceStatus.ts | Replaces convex_database/convex_functions with convex and adds stripe to the seed list, matching the updated service topology. |
| packages/backend/convex/schema.ts | Comment-only update to serviceStatus table reflecting the new service names and providers; schema itself is unchanged. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/backend/convex/serviceStatusActions.ts:71-80
**Misleading "Adding a service here is enough" comment**

The comment on `SERVICES` says *"Adding a service here is enough"*, but the `statuses` object at line 107 must also be updated when a new service is added. If a developer follows the comment and only adds to `SERVICES`, `statuses[s.name]` at line 141 will return `undefined`, and the `.status` access will throw a `TypeError` at runtime. The `catch` block now only logs without sending any mutation update, so all service rows would be left stale — silently serving outdated status in the UI until the next successful run.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(service-status): per-provider i..."](https://github.com/xcarter93/onetool/commit/a4ce712f73ccae5b74e6034e34d464a8aa3a1e54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36001533)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->