### PR TITLE
fix(portal): close Convex client before revoke to stop sign-out flash

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,6 @@ name: Test Suite
 on:
   pull_request:
     branches: [main, staging]
-  push:
-    branches: [main, staging]
 
 jobs:
   test:

--- a/apps/web/src/components/portal/__tests__/portal-shell.test.tsx
+++ b/apps/web/src/components/portal/__tests__/portal-shell.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+//
+// PortalShell sign-out teardown coverage.
+//
+// Regression: signing out deletes the portalSessions row server-side. Any live
+// useQuery subscription (e.g. invoice-detail-island's api.portal.invoices.get)
+// reactively re-runs against the now-missing row, hits getPortalSessionOrThrow's
+// `if (!row) throw UNAUTHENTICATED`, and the error is pushed to the still-open
+// socket — flashing the portal error boundary before navigation completes.
+//
+// Fix: tear down the Convex client (clearing all query listeners) BEFORE issuing
+// the revoke, so the reactive transition has no subscriber to notify.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+const order: string[] = [];
+const closeSpy = vi.fn(() => {
+	order.push("close");
+	return Promise.resolve();
+});
+
+vi.mock("convex/react", () => ({
+	useConvex: () => ({ close: closeSpy }),
+}));
+
+vi.mock("next/navigation", () => ({
+	usePathname: () => "/portal/c/abc/invoices/inv_1",
+}));
+
+// Keep the shell light: stub presentational children that pull next-themes /
+// next/image / next/link so the test focuses on sign-out behavior.
+vi.mock("../brand-header", () => ({ BrandHeader: () => <div /> }));
+vi.mock("../powered-by-onetool", () => ({ PoweredByOneTool: () => <div /> }));
+vi.mock("../mobile-tab-bar", () => ({ MobileTabBar: () => <div /> }));
+vi.mock("../portal-theme-switcher", () => ({
+	PortalThemeSwitcher: () => <div />,
+	PortalThemeIconButton: () => <div />,
+}));
+
+import { PortalShell } from "../portal-shell";
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+	order.length = 0;
+});
+
+function renderShell() {
+	return render(
+		<PortalShell clientPortalId="abc" logoUrl={null} businessName="Acme">
+			<div>child</div>
+		</PortalShell>,
+	);
+}
+
+describe("PortalShell sign-out", () => {
+	it("closes the Convex client before navigating away", () => {
+		const assignSpy = vi.fn(() => order.push("assign"));
+		Object.defineProperty(window, "location", {
+			value: { assign: assignSpy },
+			writable: true,
+		});
+		const fetchSpy = vi
+			.fn(() => {
+				order.push("fetch");
+				return Promise.resolve({ ok: true });
+			})
+			.mockName("fetch");
+		vi.stubGlobal("fetch", fetchSpy);
+
+		renderShell();
+		fireEvent.click(screen.getByRole("button", { name: /sign out/i }));
+
+		expect(closeSpy).toHaveBeenCalledTimes(1);
+		expect(assignSpy).toHaveBeenCalledWith(
+			"/portal/c/abc/signed-out",
+		);
+		// Listeners must be cleared before the revoke fetch can delete the row.
+		expect(order.indexOf("close")).toBeLessThan(order.indexOf("fetch"));
+	});
+});

--- a/apps/web/src/components/portal/portal-shell.tsx
+++ b/apps/web/src/components/portal/portal-shell.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useTransition } from "react";
+import { useConvex } from "convex/react";
 import { FileText, Home, ReceiptText, LogOut } from "lucide-react";
 import { BrandHeader } from "./brand-header";
 import { PoweredByOneTool } from "./powered-by-onetool";
@@ -37,6 +38,7 @@ export function PortalShell({
 	children: React.ReactNode;
 }) {
 	const pathname = usePathname();
+	const convex = useConvex();
 	const [pending, startTransition] = useTransition();
 
 	// Gap 4 (Plan 14-08): suppress MobileTabBar on /portal/c/{id}/quotes/{quoteId}
@@ -53,12 +55,15 @@ export function PortalShell({
 	const suppressTabBar = isQuoteDetail || isInvoiceDetail;
 
 	function handleSignOut() {
+		// Synchronously tear down the Convex client first: close() clears every
+		// query listener before the revoke below deletes the portalSessions row.
+		// Otherwise the row delete reactively re-runs live subscriptions (e.g.
+		// invoices.get), which throw UNAUTHENTICATED and flash the error boundary
+		// before navigation. Hard navigation alone can't win this race — it's
+		// async, so the socket stays live until the new document commits.
+		void convex.close();
 		startTransition(() => {
 			// keepalive lets the revoke survive the hard navigation below.
-			// Hard-navigate (not router.push) so all portal useQuery subscribers
-			// tear down before the session row is revoked; a soft transition
-			// keeps the source page mounted long enough for an in-flight refetch
-			// to hit the revoked session and throw UNAUTHENTICATED.
 			void fetch("/api/portal/logout", {
 				method: "POST",
 				credentials: "same-origin",


### PR DESCRIPTION
This pull request addresses a regression in the portal sign-out flow that could cause a flash of the error boundary due to live subscriptions reacting to a deleted session row. The main fix is to synchronously tear down the Convex client—clearing all query listeners—before issuing the sign-out request. This ensures no live subscription will react to the session deletion, improving user experience and preventing unwanted errors. The changes include both the implementation and a targeted regression test.

**Sign-out Flow Fixes:**

* Updated `PortalShell` to synchronously call `convex.close()` before starting the sign-out transition, ensuring all Convex query listeners are cleared before the session row is deleted. This prevents live subscriptions from reacting to the deleted session and avoids flashing the error boundary.
* Added the `useConvex` hook import and usage in `PortalShell` to access the Convex client instance. [[1]](diffhunk://#diff-3468edc5e87de7e7e1e9d307a8e6959eebbade0fd24f3b47bae6cb0d631684bbR6) [[2]](diffhunk://#diff-3468edc5e87de7e7e1e9d307a8e6959eebbade0fd24f3b47bae6cb0d631684bbR41)

**Testing and Regression Coverage:**

* Added a dedicated test (`portal-shell.test.tsx`) that verifies the Convex client is closed before navigation and the sign-out request, ensuring the regression is covered and the intended teardown order is maintained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-out flow to prevent error messages during navigation by ensuring connections are cleanly closed before redirecting.

* **Tests**
  * Added a regression test validating sign-out ordering and reliable completion of the flow.

* **Chores**
  * Adjusted CI test trigger to run on pull requests targeting main and staging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a sign-out regression in `PortalShell` where live Convex query subscriptions could react to the deleted `portalSessions` row (thrown as `UNAUTHENTICATED`) and flash the error boundary before navigation completed. The fix calls `convex.close()` synchronously before issuing the logout fetch, ensuring all query listeners are cleared before the server-side row deletion.

- **`portal-shell.tsx`**: Adds `useConvex()` hook and inserts `void convex.close()` as the first statement in `handleSignOut`, ahead of `startTransition`/fetch/navigate. The comment explains why hard navigation alone can't win the race.
- **`portal-shell.test.tsx`**: New regression test that tracks call order via an `order` array and asserts `close` is recorded before `fetch`, directly covering the teardown sequence.

<h3>Confidence Score: 4/5</h3>

The change is small and narrowly scoped to the sign-out handler; the core logic is correct and the regression test directly covers the intended teardown order.

The fix is straightforward — one new hook call and one new line before startTransition. Minor test hygiene issues exist around window.location cleanup and a missing fetchSpy call assertion.

The test file deserves a second look for the window.location teardown gap and the missing fetchSpy call-count assertion.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/portal/portal-shell.tsx | Adds `useConvex` hook and calls `convex.close()` before `startTransition` in `handleSignOut`, ensuring all Convex query listeners are torn down before the logout fetch deletes the session row. |
| apps/web/src/components/portal/__tests__/portal-shell.test.tsx | New regression test verifying teardown order (close → fetch → navigate). Minor gaps: `window.location` is replaced via `Object.defineProperty` but never restored in `afterEach`, and there is no explicit assertion that `fetchSpy` was called. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant PortalShell
    participant ConvexClient
    participant FetchAPI
    participant Browser

    User->>PortalShell: "click Sign out"
    PortalShell->>ConvexClient: "close() clears all query listeners"
    PortalShell->>PortalShell: "startTransition(...)"
    PortalShell->>FetchAPI: "POST /api/portal/logout (keepalive: true)"
    PortalShell->>Browser: "window.location.assign signed-out page"
    Browser-->>User: "hard navigate to signed-out page"
    FetchAPI-->>ConvexClient: "server deletes portalSessions row"
    Note over ConvexClient: "No live subscribers remain"
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/web/src/components/portal/__tests__/portal-shell.test.tsx:61-64
**`window.location` not restored between tests**

`Object.defineProperty` replaces the entire `window.location` object with `{ assign: assignSpy }`, but `afterEach` never restores it — `vi.clearAllMocks()` clears call counts but not globals set via `defineProperty`. Any test added later in this file that reads `window.location.href`, `.pathname`, or any other standard property would silently receive `undefined`. Using `vi.stubGlobal("location", { assign: assignSpy })` instead would let `vi.unstubAllGlobals()` in `afterEach` do the teardown automatically.

### Issue 2 of 3
apps/web/src/components/portal/__tests__/portal-shell.test.tsx:76-81
The test verifies `close` was called before `fetch`, but never asserts that `fetch` itself was called. If a future refactor removes the revoke fetch entirely, `order.indexOf("fetch")` returns `-1` and `order.indexOf("close") < -1` evaluates to `false` — the test would still catch a missing fetch, but the failure message would be confusing. A companion `expect(fetchSpy).toHaveBeenCalledTimes(1)` alongside the existing `closeSpy` assertion would make the intent clearer.

```suggestion
		expect(closeSpy).toHaveBeenCalledTimes(1);
		expect(fetchSpy).toHaveBeenCalledTimes(1);
		expect(assignSpy).toHaveBeenCalledWith(
			"/portal/c/abc/signed-out",
		);
		// Listeners must be cleared before the revoke fetch can delete the row.
		expect(order.indexOf("close")).toBeLessThan(order.indexOf("fetch"));
```

### Issue 3 of 3
apps/web/src/components/portal/portal-shell.tsx:64
**Silent discard of `close()` rejection**

`void convex.close()` discards the returned Promise entirely — if `close()` rejects, the error becomes an unhandled rejection that is swallowed silently. The parallel `fetch` call below at least appends `.catch(() => {})` to be explicit about swallowing. Applying the same pattern here (e.g. `convex.close().catch(() => {})`) would keep error handling consistent.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: run test suite on pull\_request only,..."](https://github.com/xcarter93/onetool/commit/38dde919812cea692e1100d950b6cfae868addfb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36046280)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->