### PR TITLE
Require name in onboarding and add Apple revocation guidance

### DIFF
--- a/apps/mobile/app/(onboarding)/create-organization.tsx
+++ b/apps/mobile/app/(onboarding)/create-organization.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
-import { useOrganization, useOrganizationList } from "@clerk/expo";
+import { useOrganization, useOrganizationList, useUser } from "@clerk/expo";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
 import { Check } from "lucide-react-native";
@@ -34,7 +34,7 @@ type Step = 1 | 2 | 3;
 type CompanySize = "1-10" | "10-100" | "100+";
 
 const STEP_TITLES: Record<Step, string> = {
-	1: "Name your organization",
+	1: "Your name and business",
 	2: "Business details",
 	3: "How big is your team?",
 };
@@ -56,6 +56,7 @@ export default function CreateOrganizationScreen() {
 	const isPad = device === "ipad";
 
 	// --- Auth / org hooks ---------------------------------------------------
+	const { user } = useUser();
 	const { organization: activeOrg } = useOrganization();
 	const { createOrganization, setActive, userMemberships } =
 		useOrganizationList({ userMemberships: true });
@@ -75,6 +76,9 @@ export default function CreateOrganizationScreen() {
 	const [formError, setFormError] = useState<string | null>(null);
 
 	// Step-1
+	const [firstName, setFirstName] = useState("");
+	const [lastName, setLastName] = useState("");
+	const [nameSeeded, setNameSeeded] = useState(false);
 	const [orgName, setOrgName] = useState("");
 	// Step-2
 	const [address, setAddress] = useState<AddressValue>(EMPTY_ADDRESS);
@@ -105,6 +109,15 @@ export default function CreateOrganizationScreen() {
 	// the durable active org id (createdOrgRef is reset by the remount and is only
 	// read inside handlers, never during render).
 	const metadataReady = canWriteMetadata(convexOrg, activeOrg?.id ?? null);
+
+	// Seed the name inputs once from Clerk (Google / email sign-ups arrive with a
+	// name; Apple returning-auth sign-ups do not). Render-time derivation, guarded
+	// by a flag — the apps/mobile lint forbids setState in an effect.
+	if (!nameSeeded && user) {
+		setNameSeeded(true);
+		if (user.firstName) setFirstName(user.firstName);
+		if (user.lastName) setLastName(user.lastName);
+	}
 
 	// Once an active org exists, the create step is done. setActive() remounts this
 	// screen with step reset to 1; re-derive from the durable active org so we
@@ -181,19 +194,34 @@ export default function CreateOrganizationScreen() {
 		}
 	}
 
-	function handleStep1Continue() {
+	async function handleStep1Continue() {
 		// Org already active (e.g. tapped during the post-create remount): advance,
 		// never create a duplicate.
 		if (activeOrg) {
 			setStep(2);
 			return;
 		}
-		const result = validateStep1({ orgName });
+		const result = validateStep1({ firstName, lastName, orgName });
 		if (!result.valid) {
 			setFieldErrors(result.fields);
 			return;
 		}
 		setFieldErrors([]);
+
+		// Persist the name to Clerk BEFORE org creation: setActive() in runOrgCreate
+		// remounts this screen and wipes step-1 state, so the name must live in Clerk
+		// (which re-syncs to convex users.name via the user.updated webhook) to
+		// survive. Skip the write when nothing changed.
+		const fName = firstName.trim();
+		const lName = lastName.trim();
+		if (user && (user.firstName !== fName || user.lastName !== lName)) {
+			try {
+				await user.update({ firstName: fName, lastName: lName });
+			} catch {
+				setFormError("Couldn't save your name. Try again.");
+				return;
+			}
+		}
 
 		// PRECONDITION: wait for the Convex user row before creating the org —
 		// otherwise createFromClerk's owner lookup throws and organizations.get
@@ -232,7 +260,7 @@ export default function CreateOrganizationScreen() {
 
 	function handleAdvance() {
 		if (step === 1) {
-			handleStep1Continue();
+			void handleStep1Continue();
 			return;
 		}
 		if (step === 2) {
@@ -373,6 +401,26 @@ export default function CreateOrganizationScreen() {
 
 				{step === 1 ? (
 					<View style={styles.stepBody}>
+						<TextInput
+							value={firstName}
+							onChangeText={setFirstName}
+							placeholder="First name"
+							placeholderTextColor={tokens.faint}
+							editable={!submitting}
+							style={styles.input}
+							autoCapitalize="words"
+							textContentType="givenName"
+						/>
+						<TextInput
+							value={lastName}
+							onChangeText={setLastName}
+							placeholder="Last name"
+							placeholderTextColor={tokens.faint}
+							editable={!submitting}
+							style={styles.input}
+							autoCapitalize="words"
+							textContentType="familyName"
+						/>
 						<TextInput
 							value={orgName}
 							onChangeText={setOrgName}

--- a/apps/mobile/app/(onboarding)/create-organization.tsx
+++ b/apps/mobile/app/(onboarding)/create-organization.tsx
@@ -56,7 +56,7 @@ export default function CreateOrganizationScreen() {
 	const isPad = device === "ipad";
 
 	// --- Auth / org hooks ---------------------------------------------------
-	const { user } = useUser();
+	const { user, isLoaded: userLoaded } = useUser();
 	const { organization: activeOrg } = useOrganization();
 	const { createOrganization, setActive, userMemberships } =
 		useOrganizationList({ userMemberships: true });
@@ -115,8 +115,9 @@ export default function CreateOrganizationScreen() {
 	// by a flag — the apps/mobile lint forbids setState in an effect.
 	if (!nameSeeded && user) {
 		setNameSeeded(true);
-		if (user.firstName) setFirstName(user.firstName);
-		if (user.lastName) setLastName(user.lastName);
+		// Only fill empty fields — never clobber input typed before Clerk hydrated.
+		if (user.firstName && !firstName) setFirstName(user.firstName);
+		if (user.lastName && !lastName) setLastName(user.lastName);
 	}
 
 	// Once an active org exists, the create step is done. setActive() remounts this
@@ -201,6 +202,9 @@ export default function CreateOrganizationScreen() {
 			setStep(2);
 			return;
 		}
+		// Block until Clerk has hydrated the user — otherwise user.update() below is
+		// skipped and the name is never persisted before org creation.
+		if (!userLoaded) return;
 		const result = validateStep1({ firstName, lastName, orgName });
 		if (!result.valid) {
 			setFieldErrors(result.fields);

--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -39,6 +39,14 @@ export default function ProfileScreen({
 	// Guard against a double-tap launching the destroy+delete flow twice (no spinner per CONTEXT).
 	const [isDeleting, setIsDeleting] = useState(false);
 
+	// Apple 5.1.1(v): a Sign in with Apple user must be told to revoke the app's
+	// access on Apple's side. Clerk brokers the token (no refresh token exposed),
+	// so we can't revoke server-side — instead we surface the manual step in the
+	// delete confirmation. Match both "apple" and "oauth_apple" provider shapes.
+	const hasAppleLogin = !!user?.externalAccounts?.some((a) =>
+		a.provider?.toLowerCase().includes("apple"),
+	);
+
 	const handleSignOut = () => {
 		Alert.alert("Sign Out", "Are you sure you want to sign out?", [
 			{ text: "Cancel", style: "cancel" },
@@ -66,6 +74,11 @@ export default function ProfileScreen({
 			// Member/co-admin: only their own account is removed; org data stays.
 			message =
 				"This removes your account from the organization and deletes your user. The organization's data remains for the other members. This cannot be undone.";
+		}
+
+		if (hasAppleLogin) {
+			message +=
+				"\n\nYou signed in with Apple. After deleting, open Settings → your name → Sign-In & Security → Sign in with Apple → OneTool → Stop Using Apple ID to fully revoke access.";
 		}
 
 		Alert.alert("Delete Account", message, [

--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -78,7 +78,7 @@ export default function ProfileScreen({
 
 		if (hasAppleLogin) {
 			message +=
-				"\n\nYou signed in with Apple. After deleting, open Settings → your name → Sign-In & Security → Sign in with Apple → OneTool → Stop Using Apple ID to fully revoke access.";
+				"\n\nYou signed in with Apple. After deleting, open Settings → your name → Sign in with Apple → OneTool → Stop Using Apple ID to fully revoke access.";
 		}
 
 		Alert.alert("Delete Account", message, [

--- a/apps/mobile/lib/wizardValidation.test.ts
+++ b/apps/mobile/lib/wizardValidation.test.ts
@@ -28,6 +28,12 @@ describe("validateStep1", () => {
 	});
 
 	it("treats whitespace-only values as empty", () => {
+		expect(validateStep1({ ...full, firstName: "   " }).fields).toContain(
+			"firstName"
+		);
+		expect(validateStep1({ ...full, lastName: "   " }).fields).toContain(
+			"lastName"
+		);
 		expect(validateStep1({ ...full, orgName: "   " }).fields).toContain(
 			"orgName"
 		);

--- a/apps/mobile/lib/wizardValidation.test.ts
+++ b/apps/mobile/lib/wizardValidation.test.ts
@@ -9,22 +9,32 @@ import {
 } from "./wizardValidation";
 
 describe("validateStep1", () => {
-	it("is invalid for an empty org name", () => {
-		expect(validateStep1({ orgName: "" })).toEqual({
+	const full = { firstName: "Ada", lastName: "Lovelace", orgName: "Acme" };
+
+	it("lists every missing required field", () => {
+		expect(
+			validateStep1({ firstName: "", lastName: "", orgName: "" })
+		).toEqual({
 			valid: false,
-			fields: ["orgName"],
+			fields: ["firstName", "lastName", "orgName"],
 		});
 	});
 
-	it("is invalid for whitespace-only org name", () => {
-		expect(validateStep1({ orgName: "   " }).valid).toBe(false);
+	it("is invalid when the name is missing even with an org name", () => {
+		const result = validateStep1({ ...full, firstName: "", lastName: "" });
+		expect(result.valid).toBe(false);
+		expect(result.fields).toContain("firstName");
+		expect(result.fields).toContain("lastName");
 	});
 
-	it("is valid for a real org name", () => {
-		expect(validateStep1({ orgName: "Acme" })).toEqual({
-			valid: true,
-			fields: [],
-		});
+	it("treats whitespace-only values as empty", () => {
+		expect(validateStep1({ ...full, orgName: "   " }).fields).toContain(
+			"orgName"
+		);
+	});
+
+	it("is valid when name and org name are all present", () => {
+		expect(validateStep1(full)).toEqual({ valid: true, fields: [] });
 	});
 });
 

--- a/apps/mobile/lib/wizardValidation.ts
+++ b/apps/mobile/lib/wizardValidation.ts
@@ -14,8 +14,19 @@ function isEmpty(value: string | undefined): boolean {
 	return !value || value.trim() === "";
 }
 
-export function validateStep1(v: { orgName: string }): StepValidation {
-	const fields = isEmpty(v.orgName) ? ["orgName"] : [];
+// firstName/lastName are required HERE (the onboarding wizard), not at the Clerk
+// sign-up step. The Clerk instance keeps them optional so Sign in with Apple can
+// complete on returning auth (Apple only returns the name on first authorization);
+// the wizard backfills the name into Clerk before org creation.
+export function validateStep1(v: {
+	firstName: string;
+	lastName: string;
+	orgName: string;
+}): StepValidation {
+	const fields: string[] = [];
+	if (isEmpty(v.firstName)) fields.push("firstName");
+	if (isEmpty(v.lastName)) fields.push("lastName");
+	if (isEmpty(v.orgName)) fields.push("orgName");
 	return { valid: fields.length === 0, fields };
 }
 

--- a/apps/web/src/app/(workspace)/organization/complete/page.tsx
+++ b/apps/web/src/app/(workspace)/organization/complete/page.tsx
@@ -44,7 +44,7 @@ interface FormData {
 }
 
 export default function CompleteOrganizationMetadata() {
-	const { user } = useUser();
+	const { user, isLoaded: userLoaded } = useUser();
 	const { organization: clerkOrganization, isLoaded: clerkOrgLoaded } =
 		useOrganization();
 	const { resolvedTheme } = useTheme();
@@ -134,8 +134,9 @@ export default function CompleteOrganizationMetadata() {
 	// by a flag — the eslint config forbids setState inside an effect.
 	if (!nameSeeded && user) {
 		setNameSeeded(true);
-		if (user.firstName) setFirstName(user.firstName);
-		if (user.lastName) setLastName(user.lastName);
+		// Only fill empty fields — never clobber input typed before Clerk hydrated.
+		if (user.firstName && !firstName) setFirstName(user.firstName);
+		if (user.lastName && !lastName) setLastName(user.lastName);
 	}
 
 	// Whether we're creating a new organization (from query param)
@@ -433,21 +434,32 @@ export default function CompleteOrganizationMetadata() {
 			hasError = true;
 		}
 		if (hasError) return;
-		// Guard: hook still initializing
-		if (!orgListLoaded || !createOrganization) return;
+		// Guard: hooks still initializing. userLoaded gates the name write below —
+		// without it, user is null and the name is never persisted before org create.
+		if (!orgListLoaded || !createOrganization || !userLoaded) return;
 
 		setCreateSubmitting(true);
 		try {
 			// Persist the user's name to Clerk before org creation (re-syncs to
 			// convex users.name via the user.updated webhook). Skip when unchanged.
+			// Own try/catch so a name-write failure reports accurately instead of the
+			// org-creation error below.
 			if (
 				user &&
 				(user.firstName !== trimmedFirst || user.lastName !== trimmedLast)
 			) {
-				await user.update({
-					firstName: trimmedFirst,
-					lastName: trimmedLast,
-				});
+				try {
+					await user.update({
+						firstName: trimmedFirst,
+						lastName: trimmedLast,
+					});
+				} catch {
+					toast.warning(
+						"Couldn't save your name",
+						"Please try again."
+					);
+					return;
+				}
 			}
 
 			// 1. Create org — or reuse one from a prior failed attempt with the same

--- a/apps/web/src/app/(workspace)/organization/complete/page.tsx
+++ b/apps/web/src/app/(workspace)/organization/complete/page.tsx
@@ -87,6 +87,19 @@ export default function CompleteOrganizationMetadata() {
 		setActive,
 	} = useOrganizationList();
 	const [orgName, setOrgName] = useState("");
+	// First/last name are required HERE, not at the Clerk sign-up step: the Clerk
+	// instance keeps name optional so Sign in with Apple completes on returning
+	// auth (Apple returns the name only on first authorization). Captured here and
+	// written to Clerk before org creation. Mirrors the mobile onboarding wizard.
+	const [firstName, setFirstName] = useState("");
+	const [lastName, setLastName] = useState("");
+	const [createFirstNameError, setCreateFirstNameError] = useState<
+		string | null
+	>(null);
+	const [createLastNameError, setCreateLastNameError] = useState<string | null>(
+		null
+	);
+	const [nameSeeded, setNameSeeded] = useState(false);
 	const [logoFile, setLogoFile] = useState<File | null>(null);
 	const [logoPreviewUrl, setLogoPreviewUrl] = useState<string | null>(null);
 	const [createSubmitting, setCreateSubmitting] = useState(false);
@@ -116,6 +129,14 @@ export default function CompleteOrganizationMetadata() {
 		logoInvertInDarkMode: true,
 	});
 
+	// Seed the name inputs once from Clerk (Google / email sign-ups arrive with a
+	// name; Apple returning-auth sign-ups do not). Render-time derivation, guarded
+	// by a flag — the eslint config forbids setState inside an effect.
+	if (!nameSeeded && user) {
+		setNameSeeded(true);
+		if (user.firstName) setFirstName(user.firstName);
+		if (user.lastName) setLastName(user.lastName);
+	}
 
 	// Whether we're creating a new organization (from query param)
 	const isCreatingNew = searchParams.get("creating") === "true";
@@ -392,17 +413,43 @@ export default function CompleteOrganizationMetadata() {
 	> = async (e) => {
 		e.preventDefault();
 		setCreateNameError(null);
+		setCreateFirstNameError(null);
+		setCreateLastNameError(null);
 
+		const trimmedFirst = firstName.trim();
+		const trimmedLast = lastName.trim();
 		const trimmedName = orgName.trim();
+		let hasError = false;
+		if (!trimmedFirst) {
+			setCreateFirstNameError("First name is required");
+			hasError = true;
+		}
+		if (!trimmedLast) {
+			setCreateLastNameError("Last name is required");
+			hasError = true;
+		}
 		if (!trimmedName) {
 			setCreateNameError("Organization name is required");
-			return;
+			hasError = true;
 		}
+		if (hasError) return;
 		// Guard: hook still initializing
 		if (!orgListLoaded || !createOrganization) return;
 
 		setCreateSubmitting(true);
 		try {
+			// Persist the user's name to Clerk before org creation (re-syncs to
+			// convex users.name via the user.updated webhook). Skip when unchanged.
+			if (
+				user &&
+				(user.firstName !== trimmedFirst || user.lastName !== trimmedLast)
+			) {
+				await user.update({
+					firstName: trimmedFirst,
+					lastName: trimmedLast,
+				});
+			}
+
 			// 1. Create org — or reuse one from a prior failed attempt with the same
 			// name to avoid orphaning + duplicating on retry.
 			const cached = createdOrgRef.current;
@@ -459,6 +506,75 @@ export default function CompleteOrganizationMetadata() {
 						className="space-y-6"
 						noValidate
 					>
+						<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+							<div>
+								<label
+									htmlFor="first-name"
+									className="block text-sm font-semibold text-foreground mb-3 tracking-wide"
+								>
+									First Name
+								</label>
+								<Input
+									id="first-name"
+									value={firstName}
+									onChange={(e) => {
+										setFirstName(e.target.value);
+										if (createFirstNameError)
+											setCreateFirstNameError(null);
+									}}
+									disabled={createSubmitting}
+									placeholder="Jane"
+									autoComplete="given-name"
+									aria-invalid={createFirstNameError ? true : undefined}
+									aria-describedby={
+										createFirstNameError ? "first-name-error" : undefined
+									}
+									className="w-full border-border dark:border-border bg-background dark:bg-background focus:bg-background dark:focus:bg-background transition-colors shadow-sm ring-1 ring-border/10"
+								/>
+								{createFirstNameError && (
+									<p
+										id="first-name-error"
+										className="mt-2 text-sm text-destructive"
+									>
+										{createFirstNameError}
+									</p>
+								)}
+							</div>
+							<div>
+								<label
+									htmlFor="last-name"
+									className="block text-sm font-semibold text-foreground mb-3 tracking-wide"
+								>
+									Last Name
+								</label>
+								<Input
+									id="last-name"
+									value={lastName}
+									onChange={(e) => {
+										setLastName(e.target.value);
+										if (createLastNameError)
+											setCreateLastNameError(null);
+									}}
+									disabled={createSubmitting}
+									placeholder="Doe"
+									autoComplete="family-name"
+									aria-invalid={createLastNameError ? true : undefined}
+									aria-describedby={
+										createLastNameError ? "last-name-error" : undefined
+									}
+									className="w-full border-border dark:border-border bg-background dark:bg-background focus:bg-background dark:focus:bg-background transition-colors shadow-sm ring-1 ring-border/10"
+								/>
+								{createLastNameError && (
+									<p
+										id="last-name-error"
+										className="mt-2 text-sm text-destructive"
+									>
+										{createLastNameError}
+									</p>
+								)}
+							</div>
+						</div>
+
 						<div>
 							<label
 								htmlFor="org-name"


### PR DESCRIPTION
This pull request enhances the onboarding and organization creation flows on both mobile and web by requiring users to provide their first and last names, not just organization name, during setup. The changes ensure that names are collected and validated, persisted to Clerk before organization creation, and improve the user experience for special sign-in cases (like Apple). Test coverage and validation logic are also updated to match the new requirements.

**Onboarding and Organization Creation Flow Improvements**

* The onboarding wizard on mobile now collects and validates first and last names in addition to organization name. Names are seeded from Clerk if available and written back to Clerk before organization creation to ensure persistence, especially for sign-in methods (like Apple) that may not always provide names. [[1]](diffhunk://#diff-82cb946c55b72f740069e72b6971af51e26d625ef9d315259c6f01fa6d6a182eL37-R37) [[2]](diffhunk://#diff-82cb946c55b72f740069e72b6971af51e26d625ef9d315259c6f01fa6d6a182eR79-R81) [[3]](diffhunk://#diff-82cb946c55b72f740069e72b6971af51e26d625ef9d315259c6f01fa6d6a182eR113-R121) [[4]](diffhunk://#diff-82cb946c55b72f740069e72b6971af51e26d625ef9d315259c6f01fa6d6a182eL184-R225) [[5]](diffhunk://#diff-82cb946c55b72f740069e72b6971af51e26d625ef9d315259c6f01fa6d6a182eR404-R423)
* The web organization completion form mirrors the mobile flow: first and last names are required, validated, seeded from Clerk, and written back to Clerk before organization creation. Validation errors are surfaced to the user. [[1]](diffhunk://#diff-219ee5e668359c9981c3d1ce1175607f4f125735750ea55e76b6e62d81aab9f0R90-R102) [[2]](diffhunk://#diff-219ee5e668359c9981c3d1ce1175607f4f125735750ea55e76b6e62d81aab9f0R132-R139) [[3]](diffhunk://#diff-219ee5e668359c9981c3d1ce1175607f4f125735750ea55e76b6e62d81aab9f0R416-R452) [[4]](diffhunk://#diff-219ee5e668359c9981c3d1ce1175607f4f125735750ea55e76b6e62d81aab9f0R509-R577)

**Validation and Test Updates**

* The `validateStep1` function now requires `firstName` and `lastName` in addition to `orgName`, and treats whitespace-only values as empty. Corresponding tests are updated to cover these cases. [[1]](diffhunk://#diff-828d6e4e6c7ec2e352f790b743a33fafc65077878d73a0427b2e0361e3784c29L12-R37) [[2]](diffhunk://#diff-33212fc9a8e1cc95e140aad43e43a22eec37ac2a3c950177996223b81f38f191L17-R29)

**User Experience Improvements**

* For users who sign in with Apple, the profile deletion flow now informs them about the manual Apple ID revocation step, improving clarity and compliance with Apple’s requirements. [[1]](diffhunk://#diff-1df85d0a829b178db20cd9bdda02c49b8df11d50acf00d469f2c02f71730f2b8R42-R49) [[2]](diffhunk://#diff-1df85d0a829b178db20cd9bdda02c49b8df11d50acf00d469f2c02f71730f2b8R79-R83)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Onboarding/organization setup now collects **first name** and **last name** alongside the business/organization name.
  * These names are saved to the user profile before organization creation.

* **Bug Fixes**
  * Improved name prefill behavior and submission flow to handle delayed profile hydration, including Apple return-auth scenarios.
  * Organization creation now prevents progress if any required name fields are missing.

* **Tests**
  * Updated step-1 validation tests to require **first name**, **last name**, and **organization name** together.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR requires first and last names during onboarding on both mobile and web, persists them to Clerk before organization creation (ensuring Apple Sign In users — who only receive a name on first authorization — have their name captured), and adds a manual Apple ID revocation step to the delete-account confirmation.

- `validateStep1` now requires `firstName` and `lastName` in addition to `orgName`, with whitespace-only rejection and updated tests covering all cases.
- Both the mobile wizard and the web completion form seed name inputs from Clerk, validate them inline, and call `user.update()` before `createOrganization()` so the name survives the `setActive()` remount.
- `profile.tsx` detects the `oauth_apple` provider and appends Apple's revocation instructions to the delete confirmation alert.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the core name-capture and Clerk persistence logic is correct on both platforms, and org creation is properly guarded against duplicates.

The Clerk update and org-creation flow is well-guarded. The main gaps are UX-level: the mobile step-1 Continue button stays active during the async name write (allowing concurrent taps), the generic error message does not identify which of the three fields is empty, and the web toast says organization when the Clerk name update failed. None of these affect data integrity.

apps/mobile/app/(onboarding)/create-organization.tsx (step-1 loading guard) and apps/web/src/app/(workspace)/organization/complete/page.tsx (error message scoping)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/mobile/app/(onboarding)/create-organization.tsx | Adds firstName/lastName inputs and Clerk name persistence before org creation; has minor UX gaps: no per-field error styling and no loading guard on the new async step-1 path. |
| apps/mobile/app/(tabs)/profile.tsx | Adds Apple Sign In detection and surfaces the manual revocation step in the delete-account confirmation; clean and correct. |
| apps/mobile/lib/wizardValidation.ts | Extends validateStep1 to require firstName and lastName with whitespace handling; straightforward and correct. |
| apps/mobile/lib/wizardValidation.test.ts | Tests updated to cover all three required fields and whitespace-only values; coverage is thorough. |
| apps/web/src/app/(workspace)/organization/complete/page.tsx | Mirrors mobile: adds name fields, render-time Clerk seeding, and name persistence before org creation; error message when user.update() fails incorrectly reads as an org-creation failure. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant Form as Onboarding Form
    participant Clerk as Clerk SDK
    participant Convex as Convex Backend

    U->>Form: Fill firstName, lastName, orgName
    Form->>Form: validateStep1() all three required
    alt validation fails
        Form-->>U: Show field errors
    else validation passes
        Form->>Clerk: user.update firstName lastName
        alt update fails
            Clerk-->>Form: Error
            Form-->>U: Couldnt save your name
        else update succeeds
            Form->>Clerk: createOrganization name orgName
            Clerk-->>Form: org created
            Form->>Clerk: setActive organization org.id
            Note over Form: Screen remounts name safely in Clerk
            Form->>Convex: webhook user.updated sync name
            Convex-->>Form: convexUser ready
            Form->>Convex: completeMetadata
            Convex-->>Form: metadata saved
            Form-->>U: Navigate to app
        end
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/mobile/app/(onboarding)/create-organization.tsx`, line 502-504 ([link](https://github.com/xcarter93/onetool/blob/698d498b0c32ae074364e8c572cfa4d008985d14/apps/mobile/app/(onboarding)/create-organization.tsx#L502-L504)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Generic error message doesn't distinguish missing fields**

   `fieldErrors` now contains field names (`firstName`, `lastName`, `orgName`), but the single "This field is required." message doesn't tell the user which of the three new fields is empty. Before this change only one field was required, so the ambiguity was minimal; with three required fields a user who fills in one or two will receive no indication of which one is still missing. Consider at least mapping `fieldErrors` to human-readable labels, or adding a `borderColor` change to the failing inputs.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/mobile/app/(onboarding)/create-organization.tsx
   Line: 502-504

   Comment:
   **Generic error message doesn't distinguish missing fields**

   `fieldErrors` now contains field names (`firstName`, `lastName`, `orgName`), but the single "This field is required." message doesn't tell the user which of the three new fields is empty. Before this change only one field was required, so the ambiguity was minimal; with three required fields a user who fills in one or two will receive no indication of which one is still missing. Consider at least mapping `fieldErrors` to human-readable labels, or adding a `borderColor` change to the failing inputs.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


2. `apps/mobile/app/(onboarding)/create-organization.tsx`, line 197-236 ([link](https://github.com/xcarter93/onetool/blob/698d498b0c32ae074364e8c572cfa4d008985d14/apps/mobile/app/(onboarding)/create-organization.tsx#L197-L236)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No loading guard on step-1 async operations**

   `handleStep1Continue` is now async (Clerk `user.update()` + `runOrgCreate()`) but the Continue button's `isLoading` prop is wired to `submitting`, which is only set to `true` during the step-3 `handleSubmit()`. A double-tap before the Clerk update resolves triggers a second concurrent call. The second call passes validation, fires another `user.update()`, and proceeds; `creatingRef` blocks a second org creation, but two concurrent Clerk writes still go out. Setting a step-1-specific loading flag on entry to `handleStep1Continue` (cleared on error) would close this window.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/mobile/app/(onboarding)/create-organization.tsx
   Line: 197-236

   Comment:
   **No loading guard on step-1 async operations**

   `handleStep1Continue` is now async (Clerk `user.update()` + `runOrgCreate()`) but the Continue button's `isLoading` prop is wired to `submitting`, which is only set to `true` during the step-3 `handleSubmit()`. A double-tap before the Clerk update resolves triggers a second concurrent call. The second call passes validation, fires another `user.update()`, and proceeds; `creatingRef` blocks a second org creation, but two concurrent Clerk writes still go out. Setting a step-1-specific loading flag on entry to `handleStep1Continue` (cleared on error) would close this window.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/mobile/app/(onboarding)/create-organization.tsx:502-504
**Generic error message doesn't distinguish missing fields**

`fieldErrors` now contains field names (`firstName`, `lastName`, `orgName`), but the single "This field is required." message doesn't tell the user which of the three new fields is empty. Before this change only one field was required, so the ambiguity was minimal; with three required fields a user who fills in one or two will receive no indication of which one is still missing. Consider at least mapping `fieldErrors` to human-readable labels, or adding a `borderColor` change to the failing inputs.

### Issue 2 of 3
apps/mobile/app/(onboarding)/create-organization.tsx:197-236
**No loading guard on step-1 async operations**

`handleStep1Continue` is now async (Clerk `user.update()` + `runOrgCreate()`) but the Continue button's `isLoading` prop is wired to `submitting`, which is only set to `true` during the step-3 `handleSubmit()`. A double-tap before the Clerk update resolves triggers a second concurrent call. The second call passes validation, fires another `user.update()`, and proceeds; `creatingRef` blocks a second org creation, but two concurrent Clerk writes still go out. Setting a step-1-specific loading flag on entry to `handleStep1Continue` (cleared on error) would close this window.

### Issue 3 of 3
apps/web/src/app/(workspace)/organization/complete/page.tsx:440-451
**Misleading toast when `user.update()` fails**

If the Clerk name update throws, the outer `catch` block shows `toast.warning("Couldn't create organization", ...)`. At that point, org creation was never attempted — the failure was in persisting the user's name. Showing an "organization" error confuses the user about what actually went wrong. A dedicated `try/catch` around `user.update()` (separate from the org-creation catch) would allow a more accurate message such as "Couldn't save your name — please try again."


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(auth): require name in onboarding; ..."](https://github.com/xcarter93/onetool/commit/698d498b0c32ae074364e8c572cfa4d008985d14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37440834)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->