### PR TITLE
chore(mobile): declare collected data types in iOS privacy manifest

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -21,7 +21,56 @@
       "privacyManifests": {
         "NSPrivacyTracking": false,
         "NSPrivacyTrackingDomains": [],
-        "NSPrivacyCollectedDataTypes": [],
+        "NSPrivacyCollectedDataTypes": [
+          {
+            "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeName",
+            "NSPrivacyCollectedDataTypeLinked": true,
+            "NSPrivacyCollectedDataTypeTracking": false,
+            "NSPrivacyCollectedDataTypePurposes": [
+              "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+            ]
+          },
+          {
+            "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeEmailAddress",
+            "NSPrivacyCollectedDataTypeLinked": true,
+            "NSPrivacyCollectedDataTypeTracking": false,
+            "NSPrivacyCollectedDataTypePurposes": [
+              "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+            ]
+          },
+          {
+            "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypePhoneNumber",
+            "NSPrivacyCollectedDataTypeLinked": true,
+            "NSPrivacyCollectedDataTypeTracking": false,
+            "NSPrivacyCollectedDataTypePurposes": [
+              "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+            ]
+          },
+          {
+            "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeUserID",
+            "NSPrivacyCollectedDataTypeLinked": true,
+            "NSPrivacyCollectedDataTypeTracking": false,
+            "NSPrivacyCollectedDataTypePurposes": [
+              "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+            ]
+          },
+          {
+            "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeDeviceID",
+            "NSPrivacyCollectedDataTypeLinked": true,
+            "NSPrivacyCollectedDataTypeTracking": false,
+            "NSPrivacyCollectedDataTypePurposes": [
+              "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+            ]
+          },
+          {
+            "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeOtherUserContent",
+            "NSPrivacyCollectedDataTypeLinked": true,
+            "NSPrivacyCollectedDataTypeTracking": false,
+            "NSPrivacyCollectedDataTypePurposes": [
+              "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+            ]
+          }
+        ],
         "NSPrivacyAccessedAPITypes": [
           {
             "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",


### PR DESCRIPTION
NSPrivacyCollectedDataTypes was empty, contradicting the App Store Connect privacy label and the published privacy policy. Declare the data the app actually transmits off-device via Clerk/Convex: Name, Email, Phone, User ID, Device ID (push token), and Other User Content — all linked-to-user, not used for tracking, App Functionality purpose. Ships with the next build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS privacy manifest to declare all collected data types, including personal identifiers (name, email address, phone number, user ID, device ID) and user-generated content, ensuring compliance with Apple's privacy requirements and improving transparency about data collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a mismatch between the iOS privacy manifest and the App Store Connect privacy label by populating the previously empty `NSPrivacyCollectedDataTypes` array with the six data types the app actually transmits off-device via Clerk and Convex.

- Six entries are declared — Name, Email, Phone, User ID, Device ID (push token), and Other User Content — each correctly set as linked-to-user (`NSPrivacyCollectedDataTypeLinked: true`), not used for tracking, and scoped to `NSPrivacyCollectedDataTypePurposeAppFunctionality`.
- The key names, value strings, and array structure are all valid Apple privacy manifest identifiers, and the Expo `privacyManifests` configuration block maps directly to `PrivacyInfo.xcprivacy` during the build.
- If Clerk's SDK emits any crash or performance telemetry, `NSPrivacyCollectedDataTypeCrashData` / `NSPrivacyCollectedDataTypePerformanceData` may warrant a future addition, but nothing in the current plugin list indicates those categories are triggered today.

<h3>Confidence Score: 5/5</h3>

A configuration-only change with no runtime impact; it corrects an App Store compliance gap and does not touch any application logic.

The only changed file is app.json, which adds six well-formed entries to the privacy manifest. All Apple-defined key names and purpose strings are correct, the Linked/Tracking flags are consistent with the stated use case, and the structure matches the Expo privacyManifests schema. No logic, data flows, or build configuration are affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/mobile/app.json | Populates NSPrivacyCollectedDataTypes in the iOS privacy manifest with six data types (Name, Email, Phone, UserID, DeviceID, OtherUserContent), all marked as linked-to-user, non-tracking, and App Functionality purpose — aligning the manifest with the App Store Connect privacy label. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[iOS Privacy Manifest\nNSPrivacyCollectedDataTypes] --> B[NSPrivacyCollectedDataTypeName]
    A --> C[NSPrivacyCollectedDataTypeEmailAddress]
    A --> D[NSPrivacyCollectedDataTypePhoneNumber]
    A --> E[NSPrivacyCollectedDataTypeUserID]
    A --> F[NSPrivacyCollectedDataTypeDeviceID]
    A --> G[NSPrivacyCollectedDataTypeOtherUserContent]
    B --> H[Linked: true\nTracking: false\nPurpose: AppFunctionality]
    C --> H
    D --> H
    E --> H
    F --> H
    G --> H
    H --> I[Clerk / Convex\nOff-device transmission]
```

<sub>Reviews (1): Last reviewed commit: ["chore(mobile): declare collected data ty..."](https://github.com/xcarter93/onetool/commit/6c88ccf18707e1be366d836358afbda0e09ffc41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37449110)</sub>

<!-- /greptile_comment -->