### PR TITLE
Implement full-bleed background and floating card for iPad auth

### DIFF
--- a/apps/mobile/components/auth/AuthScreenShell.tsx
+++ b/apps/mobile/components/auth/AuthScreenShell.tsx
@@ -26,10 +26,13 @@ interface AuthScreenShellProps {
 	children: React.ReactNode;
 }
 
-// Shared auth surface for sign-in and sign-up: bounded-height Home-matching
-// hero + equal-weight Apple/Google provider pair (guideline 4.8) + "or" divider
-// + a form slot. Two font weights only (bold labels, regular body) — the Google
-// StyledButton label is force-overridden to bold (it defaults to semibold).
+// Shared auth surface for sign-in and sign-up. iPhone: bounded-height
+// Home-matching HalftoneBg hero + body column. iPad: full-bleed BG.png +
+// navy scrim + a centered floating white card (logo/tagline header lives
+// inside the card — the illustration is the page, so there's no cropped band).
+// Both share an equal-weight Apple/Google provider pair (guideline 4.8), an
+// "or" divider, and the form slot. Two font weights only (bold labels, regular
+// body) — the Google StyledButton label is force-overridden to bold.
 export function AuthScreenShell({
 	title,
 	subtitle,
@@ -40,8 +43,96 @@ export function AuthScreenShell({
 	onAppleSuccess,
 	children,
 }: AuthScreenShellProps) {
-	const { device } = useDevice();
+	const { device, width, height } = useDevice();
 	const isPad = device === "ipad";
+
+	// Providers + divider + form — identical on both layouts; only the frame
+	// (hero band vs. floating card) differs.
+	const providersAndForm = (
+		<>
+			<View style={styles.providerPair}>
+				<AppleButton
+					type={appleType}
+					disabled={loading}
+					onError={onProviderError}
+					onSuccess={onAppleSuccess}
+				/>
+				<StyledButton
+					intent="outline"
+					size="lg"
+					onPress={onGoogle}
+					isLoading={loading}
+					disabled={loading}
+					showArrow={false}
+					icon={<GoogleIcon size={20} />}
+					textStyle={{ fontFamily: fontFamily.bold }}
+					style={styles.googleButton}
+				>
+					Continue with Google
+				</StyledButton>
+			</View>
+
+			<View style={styles.divider}>
+				<View style={styles.dividerLine} />
+				<Text style={styles.dividerText}>or</Text>
+				<View style={styles.dividerLine} />
+			</View>
+
+			{children}
+		</>
+	);
+
+	if (isPad) {
+		return (
+			<View style={styles.flex}>
+				{/* Full-bleed illustration — sized to the live window (not absoluteFill,
+				    which didn't expand the <Image> here) so cover fills any iPad aspect
+				    and orientation with no gaps and no cropped band. */}
+				<Image
+					source={require("@/assets/BG.png")}
+					style={[styles.bgImage, { width, height }]}
+					resizeMode="cover"
+				/>
+				{/* Navy scrim so the white card + its shadow read cleanly over both
+				    bright sky and dark-green hill regions of the illustration. */}
+				<View
+					pointerEvents="none"
+					style={[styles.bgImage, { width, height }, styles.scrim]}
+				/>
+				{/* Transparent containers so the image + scrim behind them show
+				    through — styles.flex carries the opaque gray page bg. */}
+				<KeyboardAvoidingView
+					style={styles.flexTransparent}
+					behavior={Platform.OS === "ios" ? "padding" : undefined}
+				>
+					<ScrollView
+						style={styles.flexTransparent}
+						contentContainerStyle={styles.scrollContentPad}
+						keyboardShouldPersistTaps="handled"
+					>
+						<View style={styles.card}>
+							<View style={styles.cardHeader}>
+								<Image
+									source={require("@/assets/OneTool.png")}
+									style={styles.logo}
+									resizeMode="contain"
+								/>
+								<Text style={styles.tagline}>
+									Run your business from one place
+								</Text>
+							</View>
+
+							<Text style={styles.title}>{title}</Text>
+							<Text style={styles.subtitle}>{subtitle}</Text>
+
+							{providersAndForm}
+						</View>
+					</ScrollView>
+				</KeyboardAvoidingView>
+			</View>
+		);
+	}
+
 	return (
 		<KeyboardAvoidingView
 			style={styles.flex}
@@ -49,19 +140,12 @@ export function AuthScreenShell({
 		>
 			<ScrollView
 				style={styles.flex}
-				contentContainerStyle={[
-					styles.scrollContent,
-					// iPad: vertically center the ~480pt brand-card column over the wash,
-					// both orientations. iPhone path unchanged.
-					isPad && styles.scrollContentPad,
-				]}
+				contentContainerStyle={styles.scrollContent}
 				keyboardShouldPersistTaps="handled"
 			>
 				{/* Hero — bounded 220 height so HalftoneBg's internal flex:1 neither
-				    collapses nor overgrows inside the scroll/keyboard layout. On iPad
-				    it's constrained to the centered card width (definite box → the
-				    BG wash stays inside the card, no full-screen escape). */}
-				<View style={[styles.hero, isPad && styles.cardWidthPad]}>
+				    collapses nor overgrows inside the scroll/keyboard layout. */}
+				<View style={styles.hero}>
 					<HalftoneBg brand={0.85} imageFit="width" imageOffsetTop={-10}>
 						<View style={styles.heroContent}>
 							<Image
@@ -74,41 +158,11 @@ export function AuthScreenShell({
 					</HalftoneBg>
 				</View>
 
-				<View style={[styles.body, isPad && styles.cardWidthPad]}>
+				<View style={styles.body}>
 					<Text style={styles.title}>{title}</Text>
 					<Text style={styles.subtitle}>{subtitle}</Text>
 
-					{/* Equal-weight provider pair */}
-					<View style={styles.providerPair}>
-						<AppleButton
-							type={appleType}
-							disabled={loading}
-							onError={onProviderError}
-							onSuccess={onAppleSuccess}
-						/>
-						<StyledButton
-							intent="outline"
-							size="lg"
-							onPress={onGoogle}
-							isLoading={loading}
-							disabled={loading}
-							showArrow={false}
-							icon={<GoogleIcon size={20} />}
-							textStyle={{ fontFamily: fontFamily.bold }}
-							style={styles.googleButton}
-						>
-							Continue with Google
-						</StyledButton>
-					</View>
-
-					{/* "or" divider */}
-					<View style={styles.divider}>
-						<View style={styles.dividerLine} />
-						<Text style={styles.dividerText}>or</Text>
-						<View style={styles.dividerLine} />
-					</View>
-
-					{children}
+					{providersAndForm}
 				</View>
 			</ScrollView>
 		</KeyboardAvoidingView>
@@ -120,20 +174,50 @@ const styles = StyleSheet.create({
 		flex: 1,
 		backgroundColor: tokens.bg,
 	},
+	flexTransparent: {
+		flex: 1,
+		backgroundColor: "transparent",
+	},
 	scrollContent: {
 		flexGrow: 1,
 		paddingBottom: spacing.xl,
 	},
-	// iPad: center the card column vertically + horizontally over the wash.
+	// iPad: center the floating card vertically + horizontally over the
+	// full-bleed illustration; outer padding keeps it off the screen edges
+	// (and breathing room in a narrow Split View pane).
 	scrollContentPad: {
+		flexGrow: 1,
 		justifyContent: "center",
 		alignItems: "center",
+		paddingVertical: spacing.xl,
+		paddingHorizontal: spacing.lg,
 	},
-	// iPad: ~480pt centered brand card (hero + body share the same width).
-	cardWidthPad: {
+	// iPad: full-window background layers (illustration + scrim), pinned top-left.
+	bgImage: {
+		position: "absolute",
+		top: 0,
+		left: 0,
+	},
+	// iPad: ~28% navy wash so the white card reads over any region of BG.png.
+	scrim: {
+		backgroundColor: "rgba(13, 27, 42, 0.28)",
+	},
+	// iPad: the floating auth card.
+	card: {
 		width: "100%",
-		maxWidth: 480,
-		alignSelf: "center",
+		maxWidth: 440,
+		backgroundColor: tokens.card,
+		borderRadius: radii["3xl"],
+		paddingHorizontal: spacing.xl,
+		paddingTop: spacing.xl,
+		paddingBottom: spacing.xl,
+		boxShadow: "0 18px 40px -12px rgba(13, 27, 42, 0.45)",
+	},
+	// iPad: logo + tagline header inside the card (replaces the phone hero band).
+	cardHeader: {
+		alignItems: "center",
+		gap: spacing.sm,
+		marginBottom: spacing.sm,
 	},
 	hero: {
 		height: 220,


### PR DESCRIPTION
This pull request refactors the `AuthScreenShell` component to provide a more tailored and visually appealing authentication experience on iPad devices, while keeping the iPhone layout unchanged. The main changes introduce a floating card layout with a full-bleed background illustration and navy scrim on iPad, and restructure the code for better maintainability.

**iPad-specific layout and visual enhancements:**

* On iPad, the authentication screen now features a full-bleed `BG.png` illustration, a navy scrim overlay for contrast, and a centered floating white card containing the logo, tagline, and form elements. This improves visual clarity and aligns with modern design patterns. [[1]](diffhunk://#diff-14cdb86181e59fd9ec4db8fbd6ea5dae8ae9fd47a33f88b5f9eb38429bc614e7L43-R52) [[2]](diffhunk://#diff-14cdb86181e59fd9ec4db8fbd6ea5dae8ae9fd47a33f88b5f9eb38429bc614e7L104-R165)

* New styles were added for the iPad layout, including `bgImage`, `scrim`, `card`, and `cardHeader`, to support the new illustration, scrim, and floating card appearance.

**Code structure improvements:**

* The provider buttons, divider, and form slot are now grouped into a `providersAndForm` variable, reducing duplication and making the code easier to maintain across both device layouts. [[1]](diffhunk://#diff-14cdb86181e59fd9ec4db8fbd6ea5dae8ae9fd47a33f88b5f9eb38429bc614e7L43-R52) [[2]](diffhunk://#diff-14cdb86181e59fd9ec4db8fbd6ea5dae8ae9fd47a33f88b5f9eb38429bc614e7L104-R165)

**Documentation updates:**

* The component documentation was updated to accurately describe the new iPad and iPhone layouts and their differences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/Design Improvements**
  * Redesigned iPad authentication screens with updated background treatment and floating card layout.
  * Unified sign-in and sign-up flows with consistent provider button and form styling.
  * Enhanced visual consistency across authentication screens on different devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors `AuthScreenShell` to deliver a distinct iPad auth experience: a full-bleed `BG.png` illustration with a navy scrim and a centered floating white card, while leaving the iPhone halftone-hero path unchanged. The shared `providersAndForm` variable cleanly de-duplicates the provider buttons, divider, and form slot across both branches.

- **iPad branch** — absolutely-positioned `BG.png` + scrim sit behind a transparent `KeyboardAvoidingView`/`ScrollView` stack; the floating card uses `boxShadow` (supported in RN 0.76+, fine on 0.85.3) and `tokens.card` background with `radii["3xl"]` corner radius.
- **iPhone branch** — all prior conditional styles (`isPad && styles.cardWidthPad`, `isPad && styles.scrollContentPad`) are removed in favour of the simpler single-layout path.
- **`useDevice`** already uses `useWindowDimensions` so `width`/`height` are reactive to orientation changes, keeping the full-bleed background correctly sized on rotate.

<h3>Confidence Score: 4/5</h3>

The change is additive and well-scoped — the iPhone path is structurally unchanged and the iPad branch introduces only new visual layers with no logic side-effects.

Both the decorative image accessibility gap and the iPad mini portrait-width edge case are minor cosmetic/UX issues with no impact on auth functionality. The core layout and keyboard-avoidance logic are sound.

apps/mobile/components/auth/AuthScreenShell.tsx — specifically the BG.png image accessibility attribute and the 768 pt device-detection threshold.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/mobile/components/auth/AuthScreenShell.tsx | Refactors iPad auth layout to full-bleed BG.png + navy scrim + floating card; iPhone path unchanged; two minor accessibility and device-detection edge cases noted |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AuthScreenShell renders] --> B{isPad?}
    B -- "width >= 768" --> C[iPad branch]
    B -- "width < 768" --> D[iPhone branch]

    C --> E[View - flex, tokens.bg]
    E --> F[Image - BG.png, absolute, full-bleed]
    E --> G[View - navy scrim, absolute, pointerEvents=none]
    E --> H[KeyboardAvoidingView - transparent, flex:1]
    H --> I[ScrollView - scrollContentPad, center/center]
    I --> J[card - white card, maxWidth 440, boxShadow]
    J --> K[cardHeader - logo + tagline]
    J --> L[title + subtitle]
    J --> M[providersAndForm]

    D --> N[KeyboardAvoidingView - flex, tokens.bg]
    N --> O[ScrollView - scrollContent]
    O --> P[hero - HalftoneBg 220pt, logo + tagline]
    O --> Q[body - tokens.bg bg]
    Q --> R[title + subtitle]
    Q --> S[providersAndForm]

    M --> T[AppleButton]
    M --> U[Google StyledButton]
    M --> V[or divider]
    M --> W[children / form slot]
    S --> T
    S --> U
    S --> V
    S --> W
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/mobile/components/auth/AuthScreenShell.tsx:46-47
**iPad mini portrait falls through to the iPhone layout**

The width-based threshold (`width >= 768`) classifies the iPad mini 6th generation as `"phone"` in portrait orientation (its logical width is 744 pt). Before this PR the two layouts were visually similar enough that the switch was subtle; now the iPhone path shows the halftone hero band while the iPad path shows a full-bleed photo, so rotating from portrait to landscape on an iPad mini produces an abrupt layout change mid-session. Consider using `expo-device`'s `DeviceType` enum to detect the actual device class, or at least lowering the threshold to `≥ 744`.

### Issue 2 of 2
apps/mobile/components/auth/AuthScreenShell.tsx:91-95
The full-bleed background image is purely decorative, but without `accessible={false}` VoiceOver will focus it and attempt to announce it (likely as an unlabelled image), adding noise to the accessibility tree before the card content is reached.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(mobile): full-bleed auth background..."](https://github.com/xcarter93/onetool/commit/48453efb5b36feeed362ee8c4e10c729f7f59c57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37451316)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->