### PR TITLE
Enhance UI components and fix review findings for assistant features

### DIFF
--- a/apps/web/src/app/(workspace)/home/components/calendar/calendar-container.tsx
+++ b/apps/web/src/app/(workspace)/home/components/calendar/calendar-container.tsx
@@ -19,6 +19,7 @@ import { format, addMonths, addWeeks, addDays } from "date-fns";
 import { useQuery } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
 import { motion } from "motion/react";
+import { usePublishScreenContext } from "@/components/assistant/use-screen-context";
 
 export function CalendarContainer() {
 	const [currentDate, setCurrentDate] = useState(new Date());
@@ -30,6 +31,16 @@ export function CalendarContainer() {
 		() => getViewDateRange(currentDate, view),
 		[currentDate, view]
 	);
+
+	// Assistant screen context: calendar view + visible range (IDs/params only)
+	usePublishScreenContext(() => ({
+		calendarView: view,
+		visibleRange: {
+			start: format(dateRange.start, "yyyy-MM-dd"),
+			end: format(dateRange.end, "yyyy-MM-dd"),
+		},
+		selectedEventId: selectedEventId ?? undefined,
+	}));
 
 	// Convert date range to UTC midnight timestamps to match how tasks are stored
 	const startDateUTC = useMemo(() => {

--- a/apps/web/src/app/(workspace)/home/page.tsx
+++ b/apps/web/src/app/(workspace)/home/page.tsx
@@ -12,6 +12,7 @@ import { useQuery, useMutation } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
 import { motion } from "motion/react";
 import { useAutoTimezone } from "@/hooks/use-auto-timezone";
+import { usePublishScreenContext } from "@/components/assistant/use-screen-context";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { LayoutDashboard, CalendarDays } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -41,6 +42,9 @@ export default function Page() {
 
 	// Automatically detect and save timezone if not set
 	useAutoTimezone();
+
+	// Let the assistant see which home view is active ("what am I looking at?")
+	usePublishScreenContext(() => ({ homeView: viewMode }));
 
 	// True only after client hydration; gates localStorage reads to avoid mismatch
 	const hydrated = React.useSyncExternalStore(

--- a/apps/web/src/app/(workspace)/layout.tsx
+++ b/apps/web/src/app/(workspace)/layout.tsx
@@ -30,28 +30,10 @@ export default async function WorkspaceLayout({
 					<ConfirmDialogProvider>
 						<div className="workspace-zone min-h-screen flex-1 md:min-h-min">
 							<AnalyticsIdentity />
-							{/* Modern Background with Subtle Texture */}
+							{/* No ambient blobs / grid overlays here: absolutely-positioned
+							    decorations paint over the static picture-frame background
+							    (but under the card and notches), tinting the frame unevenly. */}
 							<div className="relative bg-background min-h-screen">
-								{/* Ambient Light Effects */}
-								<div className="absolute inset-0 overflow-hidden">
-									<div className="absolute -inset-10 opacity-50">
-										<div className="absolute top-0 -left-4 w-72 h-72 bg-primary/10 rounded-full mix-blend-multiply filter blur-xl animate-blob" />
-										<div className="absolute top-0 -right-4 w-72 h-72 bg-primary/10 rounded-full mix-blend-multiply filter blur-xl animate-blob animation-delay-2000" />
-										<div className="absolute -bottom-8 left-20 w-72 h-72 bg-primary/5 rounded-full mix-blend-multiply filter blur-xl animate-blob animation-delay-4000" />
-									</div>
-								</div>
-
-								{/* Subtle Grid Pattern */}
-								<div
-									className="absolute inset-0 bg-[linear-gradient(to_right,var(--color-border)_1px,transparent_1px),linear-gradient(to_bottom,var(--color-border)_1px,transparent_1px)] bg-size-[4rem_4rem] opacity-[0.03] dark:opacity-[0.05]"
-									style={{
-										maskImage:
-											"radial-gradient(ellipse at center, transparent 20%, black)",
-										WebkitMaskImage:
-											"radial-gradient(ellipse at center, transparent 20%, black)",
-									}}
-								/>
-
 								<ScreenContextProvider>
 									<SidebarWithHeader>{children}</SidebarWithHeader>
 								</ScreenContextProvider>

--- a/apps/web/src/app/(workspace)/layout.tsx
+++ b/apps/web/src/app/(workspace)/layout.tsx
@@ -8,6 +8,7 @@ import { ConfirmDialogProvider } from "@/hooks/use-confirm-dialog";
 import { SidebarWithHeader } from "@/components/layout/sidebar-with-header";
 import { AnalyticsIdentity } from "@/components/analytics-identity";
 import { AdminFab } from "@/components/layout/admin-fab";
+import { ScreenContextProvider } from "@/components/assistant/use-screen-context";
 import "./workspace-theme.css";
 
 export default async function WorkspaceLayout({
@@ -51,7 +52,9 @@ export default async function WorkspaceLayout({
 									}}
 								/>
 
-								<SidebarWithHeader>{children}</SidebarWithHeader>
+								<ScreenContextProvider>
+									<SidebarWithHeader>{children}</SidebarWithHeader>
+								</ScreenContextProvider>
 								{hasAdminAccess && <AdminFab />}
 							</div>
 						</div>

--- a/apps/web/src/app/(workspace)/reports/components/report-line-chart.tsx
+++ b/apps/web/src/app/(workspace)/reports/components/report-line-chart.tsx
@@ -125,12 +125,15 @@ export function ReportLineChart({
 						cursor={{ strokeDasharray: "3 3", stroke: PRIMARY_BLUE }}
 						content={<ChartTooltipContent />}
 					/>
-					{/* Area fill under the line */}
+					{/* Area fill under the line — decorative only; without
+					    tooltipType="none" it duplicates the Line's tooltip entry
+					    (two payload rows keyed "value" → React duplicate-key error) */}
 					<Area
 						type="monotone"
 						dataKey="value"
 						stroke="none"
 						fill="url(#lineGradient)"
+						tooltipType="none"
 					/>
 					{/* Main line with connected points */}
 					<Line

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -512,83 +512,68 @@
 	}
 
 	/* ========================================================================
-	   Header border-shape notches & sidebar connector (Chrome 147+)
+	   Header border-shape notches (Chrome 147+)
 	   Each notch outline is a single shape() path, so the sidebar-colored
 	   background follows the geometry. The sides are ogee (S-curve) sweeps —
-	   a cubic with both control points horizontal — that stay tangent to the
-	   rail where they emerge, so the thin rail flows smoothly into the notch
-	   with no kink. Unsupported browsers drop border-shape and fall back to a
-	   plain rounded-b tab / no connector.
+	   a cubic with both control points horizontal. The notches hang from the
+	   picture-frame band above the content card (see SidebarWithHeader):
+	   their top edge fuses with the same-colored frame, so the sweeps start
+	   right at the top corners. Unsupported browsers drop border-shape and
+	   fall back to a plain rounded-b tab.
 
-	   Geometry: sweep 36 (x), depth 40 (y floor), half-sweep 18 (control x).
-	   The notch top sits ~12px above the rail's bottom edge (rail h-5 minus
-	   pt-2), so the outer edges drop straight to y=12 and the ogee is
-	   horizontal there — matching the rail's flat bottom for a seamless join.
-	   36px side padding reserves the sweep region for content.
+	   Geometry: sweep 56 (x), depth 40 (y floor), half-sweep 28 (control x).
+	   The wide sweep keeps the S-curve gentle. 56px side padding (px-14)
+	   reserves the sweep region for content.
 	   ======================================================================== */
-	.header-notch,
-	.header-notch--flush-right {
+	.header-notch {
 		background-color: var(--sidebar);
 		/* Must cover the 40px notch depth so border-shape isn't clipped. */
 		min-height: 40px;
 	}
 
-	/* Header background strip. Without border-shape it's just a 20px bar (no
-	   scoop); with it, the box grows to 44px and the scoop is carved in. */
-	.header-bg {
-		background-color: var(--sidebar);
-		height: 20px;
-	}
-
 	@supports (border-shape: shape(from 0 0, close)) {
-		/* Ogee sweep on both sides. Outer edges drop to y=12 (rail bottom)
-		   where the sweep is tangent-horizontal; sweep→floor is tangent too,
-		   so the whole bottom edge is smooth with no walls or corners. */
+		/* Ogee sweep on both sides, starting at the very top edge — the notch
+		   hangs directly from the picture-frame band above the card (same
+		   color, no strip inside the card), so there are no straight
+		   shoulders: top corners flow immediately into the S-curves, which
+		   land tangent on the floor. */
 		.header-notch {
 			border-shape: shape(
 				from 0 0,
 				hline to 100%,
-				vline to 12px,
-				curve to calc(100% - 36px) 40px with
-					calc(100% - 18px) 12px / calc(100% - 18px) 40px,
-				hline to 36px,
-				curve to 0 12px with 18px 40px / 18px 12px,
+				curve to calc(100% - 56px) 100% with
+					calc(100% - 28px) 0 / calc(100% - 28px) 100%,
+				hline to 56px,
+				curve to 0 0 with 28px 100% / 28px 0,
 				close
 			);
 		}
 
-		/* Ogee sweep on the left only; right edge runs flush to the rail end. */
-		.header-notch--flush-right {
-			border-shape: shape(
-				from 0 0,
-				hline to 100%,
-				vline to 26px,
-				arc to calc(100% - 14px) 40px of 14px 14px cw,
-				hline to 36px,
-				curve to 0 12px with 18px 40px / 18px 12px,
-				close
-			);
-		}
+	}
 
-		/* One continuous header background: a 20px strip across the full width
-		   with a concave quarter-round scoop carved into the bottom-left, so
-		   the sidebar flows into the header as a single solid piece (no
-		   separate connector element, no seam). The element bleeds 2px left
-		   under the sidebar to cover the sidebar↔inset hairline, but the scoop
-		   lands its vertical tangent at x=2px — the real content edge — so the
-		   curve still joins flush (the 2px sliver below stays hidden behind the
-		   sidebar). The 44px box height gives the scoop room; the notches are
-		   siblings on top, so the shape doesn't clip them. */
-		.header-bg {
-			height: 44px;
+	/* ========================================================================
+	   Assistant notch — the header notch mirrored vertically: a tab that
+	   bulges UP from the bottom frame band. Flat floor on top, ogee sweeps
+	   down both sides to the bottom edge (same 56px sweep / 28px half-sweep
+	   geometry). Sits flush on the viewport bottom; the frame behind it is
+	   the same color, so the hover lift stays visually fused. 56px side
+	   padding (px-14) reserves the sweeps. Fallback without border-shape:
+	   plain rounded-t tab.
+	   ======================================================================== */
+	.assistant-notch {
+		background-color: var(--sidebar);
+		min-height: 40px;
+	}
+
+	@supports (border-shape: shape(from 0 0, close)) {
+		/* Exact vertical mirror of .header-notch — same sweep 56 / half-sweep
+		   28 / depth 40, so top and bottom notches read as twins. */
+		.assistant-notch {
 			border-shape: shape(
-				from 0 0,
-				hline to 100%,
-				vline to 20px,
-				hline to 26px,
-				curve to 2px 44px with 12.75px 20px / 2px 30.75px,
-				hline to 0,
-				vline to 0,
+				from 0 100%,
+				curve to 56px 0 with 28px 100% / 28px 0,
+				hline to calc(100% - 56px),
+				curve to 100% 100% with calc(100% - 28px) 0 / calc(100% - 28px) 100%,
 				close
 			);
 		}
@@ -610,6 +595,11 @@
 		);
 		background-size: 22px 22px;
 		background-position: -1px -1px;
+		/* Canvas scrolls inside the picture-frame card — keep its scrollbar
+		   thin and quiet so the frame stays the visual boundary. */
+		scrollbar-width: thin;
+		scrollbar-color: color-mix(in oklch, var(--foreground) 18%, transparent)
+			transparent;
 	}
 }
 

--- a/apps/web/src/components/assistant/assistant-notch.tsx
+++ b/apps/web/src/components/assistant/assistant-notch.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Sparkles } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Bottom-of-viewport trigger for the assistant panel — the header notches
+ * mirrored: a tab bulging up from the bottom frame band (.assistant-notch in
+ * globals.css). The hover lift reveals a sliver of frame beneath it, which is
+ * the same color, so the tab reads as pulling up while staying fused to the
+ * frame. Slides away below the edge while the panel is open.
+ */
+export function AssistantNotch({
+	open,
+	onOpen,
+}: {
+	open: boolean;
+	onOpen: () => void;
+}) {
+	return (
+		<div
+			className={cn(
+				"fixed bottom-0 right-6 z-40 transition-transform duration-300 ease-out sm:right-12 md:right-24",
+				open && "pointer-events-none translate-y-12"
+			)}
+		>
+			<button
+				type="button"
+				onClick={onOpen}
+				aria-label="Open assistant chat"
+				className="assistant-notch flex h-10 min-w-64 cursor-pointer items-center justify-center gap-2 rounded-t-xl px-14 text-sm font-medium text-muted-foreground transition-[transform,color] duration-200 ease-out hover:-translate-y-1 hover:text-foreground focus-visible:-translate-y-1 focus-visible:text-foreground focus-visible:outline-none"
+			>
+				<Sparkles className="size-4 text-primary" />
+				Assistant
+			</button>
+		</div>
+	);
+}

--- a/apps/web/src/components/assistant/assistant-notch.tsx
+++ b/apps/web/src/components/assistant/assistant-notch.tsx
@@ -27,6 +27,9 @@ export function AssistantNotch({
 			<button
 				type="button"
 				onClick={onOpen}
+				disabled={open}
+				tabIndex={open ? -1 : undefined}
+				aria-hidden={open}
 				aria-label="Open assistant chat"
 				className="assistant-notch flex h-10 min-w-64 cursor-pointer items-center justify-center gap-2 rounded-t-xl px-14 text-sm font-medium text-muted-foreground transition-[transform,color] duration-200 ease-out hover:-translate-y-1 hover:text-foreground focus-visible:-translate-y-1 focus-visible:text-foreground focus-visible:outline-none"
 			>

--- a/apps/web/src/components/assistant/assistant-panel.tsx
+++ b/apps/web/src/components/assistant/assistant-panel.tsx
@@ -11,21 +11,17 @@ import { api } from "@onetool/backend/convex/_generated/api";
 import { useAction, useMutation, useQuery } from "convex/react";
 import {
 	ArrowUp,
+	Eye,
 	History,
 	Loader2,
 	MessageSquarePlus,
 	Sparkles,
+	X,
 } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
 import { useRouter } from "next/navigation";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import {
-	Sheet,
-	SheetContent,
-	SheetDescription,
-	SheetHeader,
-	SheetTitle,
-} from "@/components/ui/sheet";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
@@ -33,6 +29,7 @@ import {
 	ToolPartRenderer,
 	type AssistantToolPart,
 } from "./renderers";
+import { useCurrentRecord } from "./use-current-record";
 import { useScreenContext } from "./use-screen-context";
 
 const SUGGESTIONS = [
@@ -108,12 +105,73 @@ function MessageItem({ message }: { message: UIMessage }) {
 	);
 }
 
-interface AssistantSheetProps {
+/** "The page you're on is shared with the assistant" strip for record pages. */
+function RecordContextBanner() {
+	const record = useCurrentRecord();
+	if (!record) return null;
+	return (
+		<div className="flex shrink-0 items-center gap-2 border-b border-border bg-primary/[0.04] px-4 py-2 text-xs">
+			<Eye className="size-3.5 shrink-0 text-primary" />
+			{record.name === undefined ? (
+				<span className="text-muted-foreground">
+					The page you&apos;re viewing is shared as context
+				</span>
+			) : (
+				<>
+					<span className="min-w-0 truncate">
+						<span className="font-medium text-foreground">{record.name}</span>
+						<span className="text-muted-foreground">
+							{" "}
+							· {record.kindLabel}
+						</span>
+						{record.status && (
+							<span className="capitalize text-muted-foreground">
+								{" "}
+								· {record.status}
+							</span>
+						)}
+					</span>
+					<span className="ml-auto shrink-0 text-muted-foreground">
+						In context
+					</span>
+				</>
+			)}
+		</div>
+	);
+}
+
+function HeaderButton({
+	onClick,
+	label,
+	active,
+	children,
+}: {
+	onClick: () => void;
+	label: string;
+	active?: boolean;
+	children: React.ReactNode;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={cn(
+				"inline-flex cursor-pointer items-center justify-center rounded-lg p-2 text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground",
+				active && "bg-foreground/[0.08] text-foreground"
+			)}
+			aria-label={label}
+		>
+			{children}
+		</button>
+	);
+}
+
+interface AssistantPanelProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 }
 
-export function AssistantSheet({ open, onOpenChange }: AssistantSheetProps) {
+export function AssistantPanel({ open, onOpenChange }: AssistantPanelProps) {
 	const [threadId, setThreadId] = useState<string | null>(null);
 	const [showHistory, setShowHistory] = useState(false);
 	const [input, setInput] = useState("");
@@ -159,6 +217,15 @@ export function AssistantSheet({ open, onOpenChange }: AssistantSheetProps) {
 	useEffect(() => {
 		bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
 	}, [messageCount, isResponding]);
+
+	useEffect(() => {
+		if (!open) return;
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.key === "Escape") onOpenChange(false);
+		};
+		window.addEventListener("keydown", onKeyDown);
+		return () => window.removeEventListener("keydown", onKeyDown);
+	}, [open, onOpenChange]);
 
 	// Client-executed navigate tool: the server only validates the path; the
 	// actual routing happens here when a new tool result streams in.
@@ -240,166 +307,172 @@ export function AssistantSheet({ open, onOpenChange }: AssistantSheetProps) {
 	};
 
 	return (
-		<Sheet open={open} onOpenChange={onOpenChange}>
-			<SheetContent
-				side="right"
-				className="flex w-full flex-col gap-0 bg-background p-0 sm:max-w-lg"
-			>
-				<SheetHeader className="shrink-0 border-b border-border px-4 py-3">
-					<div className="flex items-center justify-between pr-8">
+		<AnimatePresence>
+			{open && (
+				<motion.div
+					key="assistant-panel"
+					role="dialog"
+					aria-label="Assistant chat"
+					initial={{ y: "110%" }}
+					animate={{ y: 0 }}
+					exit={{ y: "110%" }}
+					transition={{ type: "tween", duration: 0.25, ease: "easeOut" }}
+					className="fixed inset-x-0 bottom-0 z-50 flex h-[min(85dvh,640px)] flex-col overflow-hidden rounded-t-2xl border border-border bg-background shadow-2xl sm:inset-x-auto sm:right-4 sm:bottom-2 sm:w-[30rem] sm:max-w-[calc(100vw-2rem)] sm:rounded-2xl"
+				>
+					<div className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
 						<div>
-							<SheetTitle className="flex items-center gap-2 text-base">
+							<h2 className="flex items-center gap-2 text-base font-semibold">
 								<Sparkles className="size-4 text-primary" />
 								Assistant
-							</SheetTitle>
-							<SheetDescription className="text-xs">
+							</h2>
+							<p className="text-xs text-muted-foreground">
 								Ask about your clients, schedule, quotes, invoices, and more
-							</SheetDescription>
+							</p>
 						</div>
 						<div className="flex items-center gap-1">
-							<button
-								type="button"
+							<HeaderButton
 								onClick={() => setShowHistory((v) => !v)}
-								className={cn(
-									"inline-flex cursor-pointer items-center justify-center rounded-lg p-2 text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground",
-									showHistory && "bg-foreground/[0.08] text-foreground"
-								)}
-								aria-label="Conversation history"
+								label="Conversation history"
+								active={showHistory}
 							>
 								<History className="size-4" />
-							</button>
-							<button
-								type="button"
-								onClick={startNewChat}
-								className="inline-flex cursor-pointer items-center justify-center rounded-lg p-2 text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
-								aria-label="New conversation"
-							>
+							</HeaderButton>
+							<HeaderButton onClick={startNewChat} label="New conversation">
 								<MessageSquarePlus className="size-4" />
-							</button>
-						</div>
-					</div>
-				</SheetHeader>
-
-				{showHistory ? (
-					<div className="flex-1 overflow-y-auto p-2">
-						{threads === undefined ? (
-							<div className="flex justify-center py-8">
-								<Loader2 className="size-5 animate-spin text-muted-foreground" />
-							</div>
-						) : threads.length === 0 ? (
-							<p className="py-8 text-center text-sm text-muted-foreground">
-								No conversations yet
-							</p>
-						) : (
-							threads.map((t) => (
-								<button
-									key={t.threadId}
-									type="button"
-									onClick={() => {
-										setThreadId(t.threadId);
-										setShowHistory(false);
-										// Historical thread: seed the baseline from its first
-										// snapshot so past navigations never replay.
-										seenNavigationsRef.current = null;
-									}}
-									className={cn(
-										"w-full cursor-pointer rounded-lg px-3 py-2.5 text-left text-sm transition-colors hover:bg-foreground/[0.04]",
-										t.threadId === threadId && "bg-foreground/[0.06]"
-									)}
-								>
-									<span className="line-clamp-1">{t.title}</span>
-									<span className="text-xs text-muted-foreground">
-										{new Date(t.lastMessageAt).toLocaleDateString(undefined, {
-											month: "short",
-											day: "numeric",
-										})}
-									</span>
-								</button>
-							))
-						)}
-					</div>
-				) : (
-					<div className="flex-1 overflow-y-auto px-4 py-4">
-						{!threadId || messageCount === 0 ? (
-							<div className="flex h-full flex-col items-center justify-center gap-4">
-								<div className="flex size-12 items-center justify-center rounded-2xl bg-primary/10">
-									<Sparkles className="size-6 text-primary" />
-								</div>
-								<p className="max-w-xs text-center text-sm text-muted-foreground">
-									Ask anything about your business — I can look at live data
-									across your whole workspace.
-								</p>
-								<div className="flex w-full max-w-sm flex-col gap-2">
-									{SUGGESTIONS.map((s) => (
-										<button
-											key={s}
-											type="button"
-											onClick={() => void handleSend(s)}
-											disabled={isResponding}
-											className="cursor-pointer rounded-xl border border-border px-3.5 py-2.5 text-left text-sm text-foreground/80 transition-colors hover:border-primary/40 hover:bg-primary/[0.04] disabled:cursor-not-allowed disabled:opacity-50"
-										>
-											{s}
-										</button>
-									))}
-								</div>
-							</div>
-						) : (
-							<div className="flex flex-col gap-4">
-								{messages.results.map((message) => (
-									<MessageItem key={message.key} message={message} />
-								))}
-								{isResponding &&
-									messages.results[messages.results.length - 1]?.role ===
-										"user" && (
-										<div className="flex items-center gap-2 text-sm text-muted-foreground">
-											<Loader2 className="size-3.5 animate-spin" />
-											Thinking…
-										</div>
-									)}
-								<div ref={bottomRef} />
-							</div>
-						)}
-					</div>
-				)}
-
-				{!showHistory && (
-					<div className="shrink-0 border-t border-border p-3">
-						<div className="flex items-end gap-2 rounded-xl border border-border bg-muted/30 p-2 focus-within:border-primary/40">
-							<Textarea
-								value={input}
-								onChange={(e) => setInput(e.target.value)}
-								onKeyDown={(e) => {
-									if (
-										e.key === "Enter" &&
-										!e.shiftKey &&
-										!e.nativeEvent.isComposing
-									) {
-										e.preventDefault();
-										void handleSend();
-									}
-								}}
-								placeholder="Ask about your business…"
-								rows={1}
-								maxLength={4000}
-								className="max-h-32 min-h-9 flex-1 resize-none border-0 bg-transparent p-1.5 text-sm shadow-none focus-visible:ring-0"
-							/>
-							<button
-								type="button"
-								onClick={() => void handleSend()}
-								disabled={!input.trim() || isResponding}
-								className="inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-lg bg-primary text-primary-foreground transition-opacity disabled:opacity-40"
-								aria-label="Send message"
+							</HeaderButton>
+							<HeaderButton
+								onClick={() => onOpenChange(false)}
+								label="Close assistant"
 							>
-								<ArrowUp className="size-4" />
-							</button>
+								<X className="size-4" />
+							</HeaderButton>
 						</div>
-						<p className="mt-1.5 text-center text-[11px] text-muted-foreground">
-							Read-only for now — the assistant can look things up but not
-							change them.
-						</p>
 					</div>
-				)}
-			</SheetContent>
-		</Sheet>
+
+					<RecordContextBanner />
+
+					{showHistory ? (
+						<div className="flex-1 overflow-y-auto p-2">
+							{threads === undefined ? (
+								<div className="flex justify-center py-8">
+									<Loader2 className="size-5 animate-spin text-muted-foreground" />
+								</div>
+							) : threads.length === 0 ? (
+								<p className="py-8 text-center text-sm text-muted-foreground">
+									No conversations yet
+								</p>
+							) : (
+								threads.map((t) => (
+									<button
+										key={t.threadId}
+										type="button"
+										onClick={() => {
+											setThreadId(t.threadId);
+											setShowHistory(false);
+											// Historical thread: seed the baseline from its first
+											// snapshot so past navigations never replay.
+											seenNavigationsRef.current = null;
+										}}
+										className={cn(
+											"w-full cursor-pointer rounded-lg px-3 py-2.5 text-left text-sm transition-colors hover:bg-foreground/[0.04]",
+											t.threadId === threadId && "bg-foreground/[0.06]"
+										)}
+									>
+										<span className="line-clamp-1">{t.title}</span>
+										<span className="text-xs text-muted-foreground">
+											{new Date(t.lastMessageAt).toLocaleDateString(undefined, {
+												month: "short",
+												day: "numeric",
+											})}
+										</span>
+									</button>
+								))
+							)}
+						</div>
+					) : (
+						<div className="flex-1 overflow-y-auto px-4 py-4">
+							{!threadId || messageCount === 0 ? (
+								<div className="flex h-full flex-col items-center justify-center gap-4">
+									<div className="flex size-12 items-center justify-center rounded-2xl bg-primary/10">
+										<Sparkles className="size-6 text-primary" />
+									</div>
+									<p className="max-w-xs text-center text-sm text-muted-foreground">
+										Ask anything about your business — I can look at live data
+										across your whole workspace.
+									</p>
+									<div className="flex w-full max-w-sm flex-col gap-2">
+										{SUGGESTIONS.map((s) => (
+											<button
+												key={s}
+												type="button"
+												onClick={() => void handleSend(s)}
+												disabled={isResponding}
+												className="cursor-pointer rounded-xl border border-border px-3.5 py-2.5 text-left text-sm text-foreground/80 transition-colors hover:border-primary/40 hover:bg-primary/[0.04] disabled:cursor-not-allowed disabled:opacity-50"
+											>
+												{s}
+											</button>
+										))}
+									</div>
+								</div>
+							) : (
+								<div className="flex flex-col gap-4">
+									{messages.results.map((message) => (
+										<MessageItem key={message.key} message={message} />
+									))}
+									{isResponding &&
+										messages.results[messages.results.length - 1]?.role ===
+											"user" && (
+											<div className="flex items-center gap-2 text-sm text-muted-foreground">
+												<Loader2 className="size-3.5 animate-spin" />
+												Thinking…
+											</div>
+										)}
+									<div ref={bottomRef} />
+								</div>
+							)}
+						</div>
+					)}
+
+					{!showHistory && (
+						<div className="shrink-0 border-t border-border p-3">
+							<div className="flex items-end gap-2 rounded-xl border border-border bg-muted/30 p-2 focus-within:border-primary/40">
+								<Textarea
+									value={input}
+									onChange={(e) => setInput(e.target.value)}
+									onKeyDown={(e) => {
+										if (
+											e.key === "Enter" &&
+											!e.shiftKey &&
+											!e.nativeEvent.isComposing
+										) {
+											e.preventDefault();
+											void handleSend();
+										}
+									}}
+									placeholder="Ask about your business…"
+									rows={1}
+									maxLength={4000}
+									autoFocus
+									className="max-h-32 min-h-9 flex-1 resize-none border-0 bg-transparent p-1.5 text-sm shadow-none focus-visible:ring-0"
+								/>
+								<button
+									type="button"
+									onClick={() => void handleSend()}
+									disabled={!input.trim() || isResponding}
+									className="inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-lg bg-primary text-primary-foreground transition-opacity disabled:opacity-40"
+									aria-label="Send message"
+								>
+									<ArrowUp className="size-4" />
+								</button>
+							</div>
+							<p className="mt-1.5 text-center text-[11px] text-muted-foreground">
+								Read-only for now — the assistant can look things up but not
+								change them.
+							</p>
+						</div>
+					)}
+				</motion.div>
+			)}
+		</AnimatePresence>
 	);
 }

--- a/apps/web/src/components/assistant/assistant-panel.tsx
+++ b/apps/web/src/components/assistant/assistant-panel.tsx
@@ -293,7 +293,8 @@ export function AssistantPanel({ open, onOpenChange }: AssistantPanelProps) {
 			});
 			pendingRetryRef.current = null;
 		} catch {
-			setInput(prompt);
+			// Restore the failed prompt, but never clobber a newer draft.
+			setInput((current) => (current.trim() ? current : prompt));
 			toast.error("The assistant hit a snag", "Please try that again.");
 		} finally {
 			setIsResponding(false);

--- a/apps/web/src/components/assistant/assistant-sheet.tsx
+++ b/apps/web/src/components/assistant/assistant-sheet.tsx
@@ -129,8 +129,10 @@ export function AssistantSheet({ open, onOpenChange }: AssistantSheetProps) {
 	const toast = useToast();
 	const router = useRouter();
 	const getScreenContext = useScreenContext();
-	// navigate tool calls already executed (or present when the thread loaded —
-	// history must never replay navigation).
+	// navigate tool calls already executed. null = "seed from the next
+	// snapshot without navigating" (set when opening a historical thread);
+	// a fresh empty Set (set at thread creation) means navigate immediately —
+	// a brand-new thread has no history that could replay.
 	const seenNavigationsRef = useRef<Set<string> | null>(null);
 
 	const threads = useQuery(
@@ -157,10 +159,6 @@ export function AssistantSheet({ open, onOpenChange }: AssistantSheetProps) {
 	useEffect(() => {
 		bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
 	}, [messageCount, isResponding]);
-
-	useEffect(() => {
-		seenNavigationsRef.current = null;
-	}, [threadId]);
 
 	// Client-executed navigate tool: the server only validates the path; the
 	// actual routing happens here when a new tool result streams in.
@@ -210,6 +208,8 @@ export function AssistantSheet({ open, onOpenChange }: AssistantSheetProps) {
 				const created = await createThread({});
 				tid = created.threadId;
 				setThreadId(tid);
+				// New thread has no history — navigate calls can run right away.
+				seenNavigationsRef.current = new Set();
 			}
 			const pending = pendingRetryRef.current;
 			let messageId: string;
@@ -236,6 +236,7 @@ export function AssistantSheet({ open, onOpenChange }: AssistantSheetProps) {
 	const startNewChat = () => {
 		setThreadId(null);
 		setShowHistory(false);
+		seenNavigationsRef.current = null;
 	};
 
 	return (
@@ -297,6 +298,9 @@ export function AssistantSheet({ open, onOpenChange }: AssistantSheetProps) {
 									onClick={() => {
 										setThreadId(t.threadId);
 										setShowHistory(false);
+										// Historical thread: seed the baseline from its first
+										// snapshot so past navigations never replay.
+										seenNavigationsRef.current = null;
 									}}
 									className={cn(
 										"w-full cursor-pointer rounded-lg px-3 py-2.5 text-left text-sm transition-colors hover:bg-foreground/[0.04]",

--- a/apps/web/src/components/assistant/assistant-sheet.tsx
+++ b/apps/web/src/components/assistant/assistant-sheet.tsx
@@ -16,6 +16,7 @@ import {
 	MessageSquarePlus,
 	Sparkles,
 } from "lucide-react";
+import { useRouter } from "next/navigation";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import {
@@ -28,42 +29,18 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
-
-const TOOL_LABELS: Record<string, string> = {
-	getSchedule: "Checked the schedule",
-	getTasks: "Looked up tasks",
-	getBusinessStats: "Pulled business stats",
-	runReport: "Ran a report",
-	listClients: "Looked up clients",
-	getClient: "Fetched client details",
-	listProjects: "Looked up projects",
-	getProject: "Fetched project details",
-	listQuotes: "Looked up quotes",
-	getQuote: "Fetched quote details",
-	listInvoices: "Looked up invoices",
-	getInvoice: "Fetched invoice details",
-	searchClientEmails: "Searched emails",
-	getEmailThread: "Read an email thread",
-	getDocuments: "Looked up documents",
-	getActivity: "Checked recent activity",
-};
+import {
+	ToolPartRenderer,
+	type AssistantToolPart,
+} from "./renderers";
+import { useScreenContext } from "./use-screen-context";
 
 const SUGGESTIONS = [
 	"What's on the schedule this week?",
-	"How is revenue tracking this month?",
+	"Chart revenue by month this year",
 	"Which invoices are overdue?",
 	"Any quotes waiting on approval?",
 ];
-
-function ToolChip({ partType }: { partType: string }) {
-	const name = partType.replace(/^tool-/, "");
-	return (
-		<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-			<Sparkles className="size-3" />
-			{TOOL_LABELS[name] ?? `Used ${name}`}
-		</div>
-	);
-}
 
 // No typography plugin in this app — style markdown elements directly.
 const MARKDOWN_CLASS = [
@@ -118,7 +95,12 @@ function MessageItem({ message }: { message: UIMessage }) {
 					);
 				}
 				if (part.type.startsWith("tool-")) {
-					return <ToolChip key={i} partType={part.type} />;
+					return (
+						<ToolPartRenderer
+							key={i}
+							part={part as unknown as AssistantToolPart}
+						/>
+					);
 				}
 				return null;
 			})}
@@ -145,6 +127,11 @@ export function AssistantSheet({ open, onOpenChange }: AssistantSheetProps) {
 	} | null>(null);
 	const bottomRef = useRef<HTMLDivElement>(null);
 	const toast = useToast();
+	const router = useRouter();
+	const getScreenContext = useScreenContext();
+	// navigate tool calls already executed (or present when the thread loaded —
+	// history must never replay navigation).
+	const seenNavigationsRef = useRef<Set<string> | null>(null);
 
 	const threads = useQuery(
 		api.assistantChat.listThreads,
@@ -171,6 +158,47 @@ export function AssistantSheet({ open, onOpenChange }: AssistantSheetProps) {
 		bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
 	}, [messageCount, isResponding]);
 
+	useEffect(() => {
+		seenNavigationsRef.current = null;
+	}, [threadId]);
+
+	// Client-executed navigate tool: the server only validates the path; the
+	// actual routing happens here when a new tool result streams in.
+	useEffect(() => {
+		if (messages.status === "LoadingFirstPage" || !messages.results) return;
+		const navParts = messages.results
+			.filter((m) => m.role === "assistant")
+			.flatMap((m) => m.parts)
+			.map((p) => p as unknown as AssistantToolPart)
+			.filter(
+				(p) =>
+					p.type === "tool-navigate" &&
+					p.state === "output-available" &&
+					typeof p.toolCallId === "string"
+			);
+		// First non-loading snapshot is thread history — record, don't replay.
+		if (seenNavigationsRef.current === null) {
+			seenNavigationsRef.current = new Set(
+				navParts.map((p) => p.toolCallId as string)
+			);
+			return;
+		}
+		for (const part of navParts) {
+			const id = part.toolCallId as string;
+			if (seenNavigationsRef.current.has(id)) continue;
+			seenNavigationsRef.current.add(id);
+			const output = part.output as { ok?: boolean; path?: string };
+			if (
+				output?.ok &&
+				typeof output.path === "string" &&
+				output.path.startsWith("/") &&
+				!output.path.startsWith("//")
+			) {
+				router.push(output.path);
+			}
+		}
+	}, [messages.results, messages.status, router]);
+
 	const handleSend = async (promptOverride?: string) => {
 		const prompt = (promptOverride ?? input).trim();
 		if (!prompt || isResponding) return;
@@ -191,7 +219,11 @@ export function AssistantSheet({ open, onOpenChange }: AssistantSheetProps) {
 				({ messageId } = await sendMessage({ threadId: tid, prompt }));
 				pendingRetryRef.current = { threadId: tid, prompt, messageId };
 			}
-			await streamResponse({ threadId: tid, promptMessageId: messageId });
+			await streamResponse({
+				threadId: tid,
+				promptMessageId: messageId,
+				screenContext: getScreenContext(),
+			});
 			pendingRetryRef.current = null;
 		} catch {
 			setInput(prompt);

--- a/apps/web/src/components/assistant/renderers/emails-renderer.tsx
+++ b/apps/web/src/components/assistant/renderers/emails-renderer.tsx
@@ -40,7 +40,8 @@ export function EmailsRenderer({ output }: ToolRendererProps) {
 		);
 	}
 
-	const hidden = Math.max(result.totalCount, emails.length) - ROW_CAP;
+	const shown = Math.min(emails.length, ROW_CAP);
+	const hidden = Math.max(result.totalCount, emails.length) - shown;
 
 	return (
 		<div className="rounded-xl border border-border bg-card px-3.5 py-1">

--- a/apps/web/src/components/assistant/renderers/emails-renderer.tsx
+++ b/apps/web/src/components/assistant/renderers/emails-renderer.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { ArrowDownLeft, ArrowUpRight } from "lucide-react";
+import type { ToolRendererProps } from "./index";
+
+// Mirrors searchClientEmails' Capped<EmailItem> output in convex/assistantTools.ts.
+interface EmailsOutput {
+	items: Array<{
+		direction: string;
+		subject: string;
+		preview?: string;
+		from: string;
+		to: string;
+		status: string;
+		sentAt: number;
+		threadId?: string;
+	}>;
+	totalCount: number;
+	truncated: boolean;
+}
+
+const ROW_CAP = 8;
+
+function formatSentAt(ms: number) {
+	return new Date(ms).toLocaleDateString(undefined, {
+		month: "short",
+		day: "numeric",
+	});
+}
+
+export function EmailsRenderer({ output }: ToolRendererProps) {
+	const result = output as EmailsOutput;
+	const emails = Array.isArray(result?.items) ? result.items : [];
+
+	if (emails.length === 0) {
+		return (
+			<div className="rounded-xl border border-border bg-muted/20 px-3.5 py-2.5 text-xs text-muted-foreground">
+				No emails found.
+			</div>
+		);
+	}
+
+	const hidden = Math.max(result.totalCount, emails.length) - ROW_CAP;
+
+	return (
+		<div className="rounded-xl border border-border bg-card px-3.5 py-1">
+			<div className="divide-y divide-border/60">
+				{emails.slice(0, ROW_CAP).map((email, i) => {
+					const outbound = email.direction === "outbound";
+					return (
+						<div key={i} className="py-2">
+							<div className="flex items-baseline justify-between gap-3">
+								<div className="flex min-w-0 items-center gap-1.5">
+									{outbound ? (
+										<ArrowUpRight className="size-3 shrink-0 text-muted-foreground" />
+									) : (
+										<ArrowDownLeft className="size-3 shrink-0 text-primary" />
+									)}
+									<p className="truncate text-sm text-foreground">
+										{email.subject || "(no subject)"}
+									</p>
+								</div>
+								<span className="shrink-0 text-xs text-muted-foreground">
+									{formatSentAt(email.sentAt)}
+								</span>
+							</div>
+							<p className="mt-0.5 truncate pl-[18px] text-xs text-muted-foreground">
+								{outbound ? `To ${email.to}` : `From ${email.from}`}
+								{email.preview ? ` — ${email.preview}` : ""}
+							</p>
+						</div>
+					);
+				})}
+			</div>
+			{hidden > 0 && (
+				<p className="pb-2 pt-1 text-xs text-muted-foreground">
+					+{hidden} more
+				</p>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/components/assistant/renderers/index.tsx
+++ b/apps/web/src/components/assistant/renderers/index.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import type { ComponentType } from "react";
+import { AlertCircle, Sparkles } from "lucide-react";
+import { EmailsRenderer } from "./emails-renderer";
+import { NavigateRenderer } from "./navigate-renderer";
+import { ReportRenderer } from "./report-renderer";
+import { ScheduleRenderer } from "./schedule-renderer";
+
+/**
+ * Generative-UI registry: tool results that have a first-party renderer show
+ * as real UI in the transcript; everything else falls back to a ToolChip.
+ */
+
+// Minimal shape of an AI SDK ToolUIPart as surfaced by @convex-dev/agent.
+export interface AssistantToolPart {
+	type: string;
+	toolCallId?: string;
+	state?: string;
+	input?: unknown;
+	output?: unknown;
+}
+
+export interface ToolRendererProps {
+	input: unknown;
+	output: unknown;
+}
+
+const TOOL_RENDERERS: Record<string, ComponentType<ToolRendererProps>> = {
+	runReport: ReportRenderer,
+	getSchedule: ScheduleRenderer,
+	searchClientEmails: EmailsRenderer,
+	navigate: NavigateRenderer,
+};
+
+export const TOOL_LABELS: Record<string, string> = {
+	getSchedule: "Checked the schedule",
+	getTasks: "Looked up tasks",
+	getBusinessStats: "Pulled business stats",
+	runReport: "Ran a report",
+	listClients: "Looked up clients",
+	getClient: "Fetched client details",
+	listProjects: "Looked up projects",
+	getProject: "Fetched project details",
+	listQuotes: "Looked up quotes",
+	getQuote: "Fetched quote details",
+	listInvoices: "Looked up invoices",
+	getInvoice: "Fetched invoice details",
+	searchClientEmails: "Searched emails",
+	getEmailThread: "Read an email thread",
+	getDocuments: "Looked up documents",
+	getActivity: "Checked recent activity",
+	navigate: "Opened a page",
+};
+
+function ToolChip({ name, state }: { name: string; state?: string }) {
+	const failed = state === "output-error";
+	return (
+		<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+			{failed ? (
+				<AlertCircle className="size-3" />
+			) : (
+				<Sparkles className="size-3" />
+			)}
+			{failed
+				? `Hit a snag: ${(TOOL_LABELS[name] ?? name).toLowerCase()}`
+				: (TOOL_LABELS[name] ?? `Used ${name}`)}
+		</div>
+	);
+}
+
+export function ToolPartRenderer({ part }: { part: AssistantToolPart }) {
+	const name = part.type.replace(/^tool-/, "");
+	const Renderer = TOOL_RENDERERS[name];
+	if (
+		Renderer &&
+		part.state === "output-available" &&
+		part.output !== undefined
+	) {
+		return <Renderer input={part.input} output={part.output} />;
+	}
+	return <ToolChip name={name} state={part.state} />;
+}

--- a/apps/web/src/components/assistant/renderers/index.tsx
+++ b/apps/web/src/components/assistant/renderers/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ComponentType } from "react";
+import { Component, type ComponentType, type ReactNode } from "react";
 import { AlertCircle, Sparkles } from "lucide-react";
 import { EmailsRenderer } from "./emails-renderer";
 import { NavigateRenderer } from "./navigate-renderer";
@@ -69,6 +69,21 @@ function ToolChip({ name, state }: { name: string; state?: string }) {
 	);
 }
 
+// Renderers consume untyped tool output — a malformed payload must degrade
+// to the chip, not take down the whole sheet.
+class RendererErrorBoundary extends Component<
+	{ fallback: ReactNode; children: ReactNode },
+	{ failed: boolean }
+> {
+	state = { failed: false };
+	static getDerivedStateFromError() {
+		return { failed: true };
+	}
+	render() {
+		return this.state.failed ? this.props.fallback : this.props.children;
+	}
+}
+
 export function ToolPartRenderer({ part }: { part: AssistantToolPart }) {
 	const name = part.type.replace(/^tool-/, "");
 	const Renderer = TOOL_RENDERERS[name];
@@ -77,7 +92,13 @@ export function ToolPartRenderer({ part }: { part: AssistantToolPart }) {
 		part.state === "output-available" &&
 		part.output !== undefined
 	) {
-		return <Renderer input={part.input} output={part.output} />;
+		return (
+			<RendererErrorBoundary
+				fallback={<ToolChip name={name} state="output-error" />}
+			>
+				<Renderer input={part.input} output={part.output} />
+			</RendererErrorBoundary>
+		);
 	}
 	return <ToolChip name={name} state={part.state} />;
 }

--- a/apps/web/src/components/assistant/renderers/navigate-renderer.tsx
+++ b/apps/web/src/components/assistant/renderers/navigate-renderer.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { AlertCircle, ArrowUpRight } from "lucide-react";
+import type { ToolRendererProps } from "./index";
+
+interface NavigateOutput {
+	ok: boolean;
+	path: string;
+	reason?: string;
+}
+
+// The actual router.push happens in the sheet (useNavigateToolEffect) —
+// this only shows what happened in the transcript.
+export function NavigateRenderer({ output }: ToolRendererProps) {
+	const result = output as NavigateOutput;
+	if (typeof result?.path !== "string") return null;
+	return (
+		<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+			{result.ok ? (
+				<>
+					<ArrowUpRight className="size-3" />
+					Opened <code className="text-foreground/80">{result.path}</code>
+				</>
+			) : (
+				<>
+					<AlertCircle className="size-3" />
+					Couldn&apos;t open <code>{result.path}</code>
+				</>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/components/assistant/renderers/report-renderer.tsx
+++ b/apps/web/src/components/assistant/renderers/report-renderer.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { ReportBarChart } from "@/app/(workspace)/reports/components/report-bar-chart";
+import { ReportLineChart } from "@/app/(workspace)/reports/components/report-line-chart";
+import { ReportPieChart } from "@/app/(workspace)/reports/components/report-pie-chart";
+import { ReportTable } from "@/app/(workspace)/reports/components/report-table";
+import type { ToolRendererProps } from "./index";
+
+// Mirrors ReportDataResult (+ visualization) from convex/assistantTools.ts.
+interface ReportOutput {
+	data: Array<{
+		label: string;
+		value: number;
+		metadata?: Record<string, unknown>;
+	}>;
+	total: number;
+	visualization?: "bar" | "line" | "pie" | "table";
+	metadata?: { entityType?: string; groupBy?: string };
+}
+
+export function ReportRenderer({ input, output }: ToolRendererProps) {
+	const report = output as ReportOutput;
+	if (!Array.isArray(report?.data)) return null;
+
+	const args = (input ?? {}) as { entityType?: string; groupBy?: string };
+	const entityType = report.metadata?.entityType ?? args.entityType ?? "records";
+	const groupBy = report.metadata?.groupBy ?? args.groupBy;
+
+	if (report.data.length === 0) {
+		return (
+			<div className="rounded-xl border border-border bg-muted/20 px-3.5 py-2.5 text-xs text-muted-foreground">
+				No data for that report.
+			</div>
+		);
+	}
+
+	// Same label→name + metadata-spread mapping report-preview.tsx uses.
+	const chartData = report.data.map((point) => ({
+		name: point.label,
+		value: point.value,
+		...point.metadata,
+	}));
+
+	const chartProps = {
+		data: chartData,
+		total: report.total,
+		groupBy,
+		entityType,
+	};
+
+	return (
+		<div className="overflow-hidden rounded-xl border border-border bg-card p-3">
+			{report.visualization === "line" ? (
+				<ReportLineChart {...chartProps} />
+			) : report.visualization === "pie" ? (
+				<ReportPieChart {...chartProps} />
+			) : report.visualization === "table" ? (
+				<ReportTable {...chartProps} />
+			) : (
+				<ReportBarChart {...chartProps} />
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/components/assistant/renderers/report-renderer.tsx
+++ b/apps/web/src/components/assistant/renderers/report-renderer.tsx
@@ -34,11 +34,12 @@ export function ReportRenderer({ input, output }: ToolRendererProps) {
 		);
 	}
 
-	// Same label→name + metadata-spread mapping report-preview.tsx uses.
+	// Same label→name + metadata-spread mapping report-preview.tsx uses;
+	// spread first so metadata keys can never clobber the chart encoding.
 	const chartData = report.data.map((point) => ({
+		...point.metadata,
 		name: point.label,
 		value: point.value,
-		...point.metadata,
 	}));
 
 	const chartProps = {

--- a/apps/web/src/components/assistant/renderers/schedule-renderer.tsx
+++ b/apps/web/src/components/assistant/renderers/schedule-renderer.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { CalendarDays, FolderKanban } from "lucide-react";
+import type { ToolRendererProps } from "./index";
+
+// Mirrors getSchedule's output shape in convex/assistantTools.ts.
+interface ScheduleOutput {
+	projects: Array<{
+		id: string;
+		title: string;
+		startDate?: number;
+		endDate?: number;
+		status: string;
+		clientName: string;
+	}>;
+	tasks: Array<{
+		id: string;
+		title: string;
+		date: number;
+		startTime?: string;
+		endTime?: string;
+		status: string;
+		clientName: string;
+	}>;
+}
+
+const ROW_CAP = 8;
+
+// Task/project dates are stored at UTC-midnight — format in UTC, never local.
+function formatDay(ms: number) {
+	return new Date(ms).toLocaleDateString(undefined, {
+		weekday: "short",
+		month: "short",
+		day: "numeric",
+		timeZone: "UTC",
+	});
+}
+
+function Row({
+	primary,
+	secondary,
+	when,
+}: {
+	primary: string;
+	secondary?: string;
+	when: string;
+}) {
+	return (
+		<div className="flex items-baseline justify-between gap-3 py-1.5">
+			<div className="min-w-0">
+				<p className="truncate text-sm text-foreground">{primary}</p>
+				{secondary && (
+					<p className="truncate text-xs text-muted-foreground">{secondary}</p>
+				)}
+			</div>
+			<span className="shrink-0 text-xs text-muted-foreground">{when}</span>
+		</div>
+	);
+}
+
+function OverflowNote({ hidden }: { hidden: number }) {
+	if (hidden <= 0) return null;
+	return (
+		<p className="pt-1 text-xs text-muted-foreground">+{hidden} more</p>
+	);
+}
+
+export function ScheduleRenderer({ output }: ToolRendererProps) {
+	const schedule = output as ScheduleOutput;
+	const tasks = Array.isArray(schedule?.tasks) ? schedule.tasks : [];
+	const projects = Array.isArray(schedule?.projects) ? schedule.projects : [];
+
+	if (tasks.length === 0 && projects.length === 0) {
+		return (
+			<div className="rounded-xl border border-border bg-muted/20 px-3.5 py-2.5 text-xs text-muted-foreground">
+				Nothing scheduled in that range.
+			</div>
+		);
+	}
+
+	const sortedTasks = [...tasks].sort((a, b) => a.date - b.date);
+	const sortedProjects = [...projects].sort(
+		(a, b) => (a.startDate ?? 0) - (b.startDate ?? 0)
+	);
+
+	return (
+		<div className="rounded-xl border border-border bg-card px-3.5 py-2.5">
+			{sortedTasks.length > 0 && (
+				<div>
+					<div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+						<CalendarDays className="size-3" />
+						Tasks
+					</div>
+					<div className="divide-y divide-border/60">
+						{sortedTasks.slice(0, ROW_CAP).map((task) => (
+							<Row
+								key={task.id}
+								primary={task.title}
+								secondary={task.clientName}
+								when={
+									task.startTime
+										? `${formatDay(task.date)} · ${task.startTime}`
+										: formatDay(task.date)
+								}
+							/>
+						))}
+					</div>
+					<OverflowNote hidden={sortedTasks.length - ROW_CAP} />
+				</div>
+			)}
+			{sortedProjects.length > 0 && (
+				<div className={sortedTasks.length > 0 ? "mt-3" : undefined}>
+					<div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+						<FolderKanban className="size-3" />
+						Projects
+					</div>
+					<div className="divide-y divide-border/60">
+						{sortedProjects.slice(0, ROW_CAP).map((project) => (
+							<Row
+								key={project.id}
+								primary={project.title}
+								secondary={project.clientName}
+								when={
+									project.startDate
+										? project.endDate && project.endDate !== project.startDate
+											? `${formatDay(project.startDate)} – ${formatDay(project.endDate)}`
+											: formatDay(project.startDate)
+										: project.status
+								}
+							/>
+						))}
+					</div>
+					<OverflowNote hidden={sortedProjects.length - ROW_CAP} />
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/components/assistant/use-current-record.ts
+++ b/apps/web/src/components/assistant/use-current-record.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { api } from "@onetool/backend/convex/_generated/api";
+import type { Id } from "@onetool/backend/convex/_generated/dataModel";
+import { useQuery } from "convex/react";
+import { usePathname } from "next/navigation";
+
+/**
+ * Identifies the record detail page the user is on (client/project/quote/
+ * invoice) and fetches just enough to label it in the assistant panel. The
+ * matching page already runs the same `get` query, so this hits the Convex
+ * subscription cache rather than adding real load.
+ */
+
+export interface CurrentRecord {
+	kindLabel: string;
+	/** undefined while loading */
+	name?: string;
+	status?: string;
+}
+
+// Convex IDs are ~32 lowercase alphanumerics; the length bound keeps static
+// segments (new, import) and garbage URLs from being sent to v.id validators.
+const RECORD_PATH = /^\/(clients|projects|quotes|invoices)\/([a-z0-9]{20,40})$/;
+
+export function useCurrentRecord(): CurrentRecord | null {
+	const pathname = usePathname();
+	const match = pathname?.match(RECORD_PATH);
+	const kind = match?.[1];
+	const id = match?.[2];
+
+	const client = useQuery(
+		api.clients.get,
+		kind === "clients" ? { id: id as Id<"clients"> } : "skip"
+	);
+	const project = useQuery(
+		api.projects.get,
+		kind === "projects" ? { id: id as Id<"projects"> } : "skip"
+	);
+	const quote = useQuery(
+		api.quotes.get,
+		kind === "quotes" ? { id: id as Id<"quotes"> } : "skip"
+	);
+	const invoice = useQuery(
+		api.invoices.get,
+		kind === "invoices" ? { id: id as Id<"invoices"> } : "skip"
+	);
+
+	if (!kind || !id) return null;
+
+	switch (kind) {
+		case "clients":
+			if (client === null) return null;
+			return {
+				kindLabel: "Client",
+				name: client?.companyName,
+				status: client?.status,
+			};
+		case "projects":
+			if (project === null) return null;
+			return {
+				kindLabel: "Project",
+				name: project?.title,
+				status: project?.status,
+			};
+		case "quotes":
+			if (quote === null) return null;
+			return {
+				kindLabel: "Quote",
+				name:
+					quote === undefined
+						? undefined
+						: (quote.title ?? quote.quoteNumber ?? "Untitled quote"),
+				status: quote?.status,
+			};
+		case "invoices":
+			if (invoice === null) return null;
+			return {
+				kindLabel: "Invoice",
+				name:
+					invoice === undefined ? undefined : `#${invoice.invoiceNumber}`,
+				status: invoice?.status,
+			};
+		default:
+			return null;
+	}
+}

--- a/apps/web/src/components/assistant/use-screen-context.tsx
+++ b/apps/web/src/components/assistant/use-screen-context.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { SCREEN_CONTEXT_MAX_LENGTH } from "@onetool/backend/convex/lib/assistantShared";
 import {
 	createContext,
 	useCallback,
@@ -62,10 +63,6 @@ export function usePublishScreenContext(getExtras: ExtrasGetter) {
 	}, [ctx]);
 }
 
-// Keep in sync with SCREEN_CONTEXT_MAX_LENGTH in convex/assistantChat.ts —
-// the server drops (not truncates) anything longer.
-const SCREEN_CONTEXT_MAX_LENGTH = 4000;
-
 /** Returns a stable getter that serializes the current screen snapshot. */
 export function useScreenContext(): () => string | undefined {
 	const ctx = useContext(ScreenContextContext);
@@ -82,7 +79,11 @@ export function useScreenContext(): () => string | undefined {
 		}
 		for (const getter of ctx?.getters.current ?? []) {
 			try {
-				Object.assign(snapshot, getter.current?.());
+				const extras = getter.current?.();
+				for (const [key, value] of Object.entries(extras ?? {})) {
+					// path/query are reserved for the real URL above.
+					if (key !== "path" && key !== "query") snapshot[key] = value;
+				}
 			} catch {
 				// A broken publisher must never block sending a message.
 			}

--- a/apps/web/src/components/assistant/use-screen-context.tsx
+++ b/apps/web/src/components/assistant/use-screen-context.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	type ReactNode,
+	type RefObject,
+} from "react";
+
+/**
+ * Screen-context plumbing for the assistant ("agent sees what the user sees").
+ *
+ * Pages publish view state via `usePublishScreenContext`; the assistant sheet
+ * calls the getter from `useScreenContext` at send time and ships the snapshot
+ * with the message. Rule: IDs and view parameters only — never counts or data
+ * values. The model must fetch real data through tools.
+ */
+
+type ExtrasGetter = () => Record<string, unknown> | undefined;
+
+interface ScreenContextValue {
+	register: (getter: RefObject<ExtrasGetter>) => () => void;
+	getters: RefObject<Set<RefObject<ExtrasGetter>>>;
+}
+
+const ScreenContextContext = createContext<ScreenContextValue | null>(null);
+
+export function ScreenContextProvider({ children }: { children: ReactNode }) {
+	const getters = useRef<Set<RefObject<ExtrasGetter>>>(new Set());
+	const register = useCallback((getter: RefObject<ExtrasGetter>) => {
+		getters.current.add(getter);
+		return () => {
+			getters.current.delete(getter);
+		};
+	}, []);
+	const value = useMemo(() => ({ register, getters }), [register]);
+	return (
+		<ScreenContextContext.Provider value={value}>
+			{children}
+		</ScreenContextContext.Provider>
+	);
+}
+
+/**
+ * Publish extra view state (e.g. active view mode, visible date range) for
+ * the lifetime of the calling component. Pass a plain closure — it is read
+ * lazily at snapshot time, so it always sees current state.
+ */
+export function usePublishScreenContext(getExtras: ExtrasGetter) {
+	const ctx = useContext(ScreenContextContext);
+	const getterRef = useRef(getExtras);
+	useEffect(() => {
+		getterRef.current = getExtras;
+	});
+	useEffect(() => {
+		if (!ctx) return;
+		return ctx.register(getterRef);
+	}, [ctx]);
+}
+
+// Keep in sync with SCREEN_CONTEXT_MAX_LENGTH in convex/assistantChat.ts —
+// the server drops (not truncates) anything longer.
+const SCREEN_CONTEXT_MAX_LENGTH = 4000;
+
+/** Returns a stable getter that serializes the current screen snapshot. */
+export function useScreenContext(): () => string | undefined {
+	const ctx = useContext(ScreenContextContext);
+	return useCallback(() => {
+		if (typeof window === "undefined") return undefined;
+		// window.location (not useSearchParams) so the value is read at send
+		// time without subscribing the sheet to every route change.
+		const snapshot: Record<string, unknown> = {
+			path: window.location.pathname,
+		};
+		const search = window.location.search;
+		if (search) {
+			snapshot.query = Object.fromEntries(new URLSearchParams(search));
+		}
+		for (const getter of ctx?.getters.current ?? []) {
+			try {
+				Object.assign(snapshot, getter.current?.());
+			} catch {
+				// A broken publisher must never block sending a message.
+			}
+		}
+		const json = JSON.stringify(snapshot);
+		return json.length <= SCREEN_CONTEXT_MAX_LENGTH
+			? json
+			: JSON.stringify({ path: snapshot.path });
+	}, [ctx]);
+}

--- a/apps/web/src/components/layout/sidebar-with-header.tsx
+++ b/apps/web/src/components/layout/sidebar-with-header.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { ReactNode, useState } from "react";
-import { Sparkles } from "lucide-react";
-import { AssistantSheet } from "@/components/assistant/assistant-sheet";
+import { AssistantNotch } from "@/components/assistant/assistant-notch";
+import { AssistantPanel } from "@/components/assistant/assistant-panel";
 import { AppSidebar } from "@/components/layout/app-sidebar";
 import { NotificationBell } from "@/components/layout/notification-bell";
 import { ServiceStatusBadge } from "@/components/layout/service-status-badge";
@@ -24,54 +24,36 @@ interface SidebarWithHeaderProps {
 }
 
 /**
- * A notch that bulges downward from the navbar. The whole outline — the ogee
- * (S-curve) side sweeps and the floor — is a single `border-shape` path
- * (see .header-notch in globals.css), so the sidebar-colored background
- * follows the geometry. The 36px side padding reserves the sweep region so
- * content sits on the flat floor; `border-shape`-unaware browsers fall back
- * to a plain rounded-b tab.
+ * A notch that bulges downward from the picture-frame band above the content
+ * card. The whole outline — the ogee (S-curve) side sweeps and the floor — is
+ * a single `border-shape` path (see .header-notch in globals.css), so the
+ * sidebar-colored background follows the geometry. The 56px side padding
+ * reserves the sweep region so content sits on the flat floor;
+ * `border-shape`-unaware browsers fall back to a plain rounded-b tab.
  */
 function NotchedItem({
 	children,
 	contentClassName,
-	showRightEar = true,
 }: {
 	children: ReactNode;
 	contentClassName?: string;
-	showRightEar?: boolean;
 }) {
 	return (
 		<div
-			className={`${showRightEar ? "header-notch px-9" : "header-notch--flush-right pl-9 pr-4"} rounded-b-xl flex items-center ${contentClassName ?? ""}`}
+			className={`header-notch px-14 rounded-b-xl flex items-center ${contentClassName ?? ""}`}
 		>
 			{children}
 		</div>
 	);
 }
 
-function AssistantTrigger({ onClick }: { onClick: () => void }) {
-	return (
-		<button
-			type="button"
-			onClick={onClick}
-			className="relative inline-flex cursor-pointer items-center justify-center rounded-lg p-2 text-muted-foreground transition-colors duration-200 hover:bg-foreground/[0.06] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-			aria-label="Open assistant"
-		>
-			<Sparkles className="size-5" />
-		</button>
-	);
-}
-
 /**
  * Floating pill-shaped header for mobile viewports.
- * Two pill groups: left (sidebar toggle) and right (assistant, notifications, settings).
- * Only visible below the md breakpoint.
+ * Two pill groups: left (sidebar toggle) and right (notifications, settings).
+ * Only visible below the md breakpoint. The assistant opens from the bottom
+ * notch instead.
  */
-function MobileFloatingHeader({
-	onOpenAssistant,
-}: {
-	onOpenAssistant: () => void;
-}) {
+function MobileFloatingHeader() {
 	return (
 		<div className="fixed top-2 left-3 right-3 z-40 flex justify-between pointer-events-none md:hidden">
 			{/* Left pill — sidebar toggle */}
@@ -79,9 +61,8 @@ function MobileFloatingHeader({
 				<SidebarTrigger className="h-5 w-5 text-muted-foreground [&_svg]:size-3.5" />
 			</div>
 
-			{/* Right pill — assistant, notifications, settings */}
+			{/* Right pill — notifications, settings */}
 			<div className="pointer-events-auto flex items-center bg-sidebar/90 backdrop-blur-sm rounded-lg border border-border/40 px-1.5 py-1 [&_button]:p-1.5 [&_button]:rounded-md [&_svg]:size-3.5">
-				<AssistantTrigger onClick={onOpenAssistant} />
 				<NotificationBell />
 				<SettingsPopover />
 			</div>
@@ -98,25 +79,22 @@ export function SidebarWithHeader({ children }: SidebarWithHeaderProps) {
 			orderedStepIds={ORDERED_HOME_TOUR}
 		>
 			<SidebarProvider>
-				<AppSidebar />
-				<SidebarInset className="min-w-0">
+				{/* variant="inset" picture-frames the content: the wrapper turns
+				    sidebar-colored and SidebarInset becomes a rounded card floating
+				    inside it, so the assistant notch below has a frame to rise from. */}
+				<AppSidebar variant="inset" />
+				<SidebarInset className="min-w-0 md:h-[calc(100svh-1rem)] md:overflow-hidden">
 					{/* Thin navbar with notched items */}
 					<header className="sticky top-0 z-30">
 						{/* Mobile floating pill header */}
-						<MobileFloatingHeader
-							onOpenAssistant={() => setAssistantOpen(true)}
-						/>
+						<MobileFloatingHeader />
 
-						{/* One solid header background: full-width strip with the
-						    sidebar→header scoop carved into its bottom-left. Sits
-						    behind the rail and bleeds 2px under the sidebar to hide
-						    the sidebar↔inset hairline (the scoop still lands flush
-						    at the content edge). Notches are siblings on top so
-						    they aren't clipped. */}
-						<div className="header-bg absolute -left-0.5 right-0 top-0 z-0 hidden md:block" />
-
-						{/* Thin navbar rail — notched items hang below (desktop only) */}
-						<div className="relative z-10 hidden md:flex items-start justify-between pt-2 h-5">
+						{/* Notch rail (desktop only). The frame band above the card IS
+						    the navbar — no strip inside the card. Notches start at y=0,
+						    fusing with the same-colored frame through the card's top
+						    edge, and their elements hang down from it. pr-6 keeps the
+						    right notch clear of the card's rounded corner. */}
+						<div className="relative z-10 hidden md:flex items-start justify-between h-5 pr-6">
 							{/* Left spacer */}
 							<div className="flex-1" />
 
@@ -128,19 +106,29 @@ export function SidebarWithHeader({ children }: SidebarWithHeaderProps) {
 							{/* Right spacer */}
 							<div className="flex-1" />
 
-							{/* Right side controls notch */}
-							<NotchedItem contentClassName="gap-1" showRightEar={false}>
-								<AssistantTrigger onClick={() => setAssistantOpen(true)} />
+							{/* Right side controls notch — both ears now that it no
+							    longer runs flush to the screen edge */}
+							<NotchedItem contentClassName="gap-1">
 								<NotificationBell />
 								<SettingsPopover />
 							</NotchedItem>
 						</div>
 					</header>
 
-					<div className="workspace-canvas flex flex-1 flex-col gap-4 pt-12 md:pt-0 min-w-0">{children}</div>
-
-					<AssistantSheet open={assistantOpen} onOpenChange={setAssistantOpen} />
+					{/* Card interior scrolls; the frame and notch stay put. */}
+					<div className="workspace-canvas flex flex-1 flex-col gap-4 pt-12 md:pt-0 min-w-0 md:min-h-0 md:overflow-y-auto">
+						{children}
+					</div>
 				</SidebarInset>
+
+				<AssistantNotch
+					open={assistantOpen}
+					onOpen={() => setAssistantOpen(true)}
+				/>
+				<AssistantPanel
+					open={assistantOpen}
+					onOpenChange={setAssistantOpen}
+				/>
 			</SidebarProvider>
 		</TourContextProvider>
 	);

--- a/apps/web/src/components/ui/chart.tsx
+++ b/apps/web/src/components/ui/chart.tsx
@@ -219,7 +219,7 @@ function ChartTooltipContent({
 
 						return (
 							<div
-								key={String(item.dataKey)}
+								key={`${String(item.dataKey)}-${index}`}
 								className={cn(
 									"[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5",
 									indicator === "dot" && "items-center"

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -310,7 +310,9 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
 			data-slot="sidebar-inset"
 			className={cn(
 				"bg-background relative flex w-full flex-1 flex-col",
-				"md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+				// No shadow on the inset card: it tints the picture-frame band
+				// around the card, breaking the color match with the notches.
+				"md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
 				className
 			)}
 			{...props}

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -39,6 +39,7 @@ import type * as invoiceLineItems from "../invoiceLineItems.js";
 import type * as invoices from "../invoices.js";
 import type * as lib_activities from "../lib/activities.js";
 import type * as lib_aggregates from "../lib/aggregates.js";
+import type * as lib_assistantShared from "../lib/assistantShared.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_changeTracking from "../lib/changeTracking.js";
 import type * as lib_crud from "../lib/crud.js";
@@ -138,6 +139,7 @@ declare const fullApi: ApiFromModules<{
   invoices: typeof invoices;
   "lib/activities": typeof lib_activities;
   "lib/aggregates": typeof lib_aggregates;
+  "lib/assistantShared": typeof lib_assistantShared;
   "lib/auth": typeof lib_auth;
   "lib/changeTracking": typeof lib_changeTracking;
   "lib/crud": typeof lib_crud;

--- a/packages/backend/convex/assistantAgent.ts
+++ b/packages/backend/convex/assistantAgent.ts
@@ -17,7 +17,10 @@ Rules:
 - If a tool returns nothing, say so plainly — do not guess.
 - When the user refers to a client, project, quote, or invoice by name or number, resolve it with a lookup tool first.
 - Be concise and friendly. Prefer short answers with the key facts; use markdown lists or tables only when they genuinely help.
-- You currently have read-only access. If asked to create, change, send, or delete something, explain that you can't do that yet.`;
+- You currently have read-only access to data. If asked to create, change, send, or delete something, explain that you can't do that yet.
+- You CAN open pages for the user with the navigate tool. Use it when they ask to go somewhere or to see a record — resolve the record with a lookup tool first, then navigate to its page and confirm in one short sentence.
+- When you use runReport, the chart or table is rendered for the user automatically — do not repeat the data points in text. Add at most one sentence of insight.
+- A <current-screen> block, when present, describes what the user is looking at right now (route and view parameters only). Use it to resolve references like "this client" or "this page". Never treat it as data — always fetch live values with tools.`;
 
 const usageHandler: UsageHandler = async (ctx, args) => {
 	await ctx.runMutation(internal.assistantAgent.recordUsage, {

--- a/packages/backend/convex/assistantChat.ts
+++ b/packages/backend/convex/assistantChat.ts
@@ -10,6 +10,7 @@ import { components, internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { action, internalQuery } from "./_generated/server";
 import { assistantAgent, INSTRUCTIONS } from "./assistantAgent";
+import { SCREEN_CONTEXT_MAX_LENGTH } from "./lib/assistantShared";
 import { getCurrentUserOrgId, getCurrentUserOrThrow } from "./lib/auth";
 import { userMutation, userQuery } from "./lib/factories";
 import { rateLimiter } from "./rateLimits";
@@ -27,7 +28,6 @@ import { rateLimiter } from "./rateLimits";
 const TITLE_MAX_LENGTH = 60;
 // Cost guard: bound what a single message can send to the model.
 const PROMPT_MAX_LENGTH = 4000;
-const SCREEN_CONTEXT_MAX_LENGTH = 4000;
 
 export const createThread = userMutation({
 	args: {},

--- a/packages/backend/convex/assistantChat.ts
+++ b/packages/backend/convex/assistantChat.ts
@@ -27,6 +27,7 @@ import { rateLimiter } from "./rateLimits";
 const TITLE_MAX_LENGTH = 60;
 // Cost guard: bound what a single message can send to the model.
 const PROMPT_MAX_LENGTH = 4000;
+const SCREEN_CONTEXT_MAX_LENGTH = 4000;
 
 export const createThread = userMutation({
 	args: {},
@@ -93,7 +94,13 @@ export const authorizeThread = internalQuery({
 });
 
 export const streamResponse = action({
-	args: { threadId: v.string(), promptMessageId: v.string() },
+	args: {
+		threadId: v.string(),
+		promptMessageId: v.string(),
+		// Client-serialized snapshot of what the user is looking at (route +
+		// view parameters only, never data values — see useScreenContext).
+		screenContext: v.optional(v.string()),
+	},
 	// Explicit return type: this module is in the generated api graph, so
 	// inferring through ctx.runQuery(internal…) would create a type cycle.
 	handler: async (ctx, args): Promise<void> => {
@@ -113,12 +120,18 @@ export const streamResponse = action({
 		// Per-call `system` overrides the agent's static instructions, letting us
 		// anchor relative dates ("this week", "overdue") to the real current date.
 		const today = new Date().toISOString();
+		// Oversized context is dropped, not truncated — cut JSON is worse than none.
+		const screenBlock =
+			args.screenContext &&
+			args.screenContext.length <= SCREEN_CONTEXT_MAX_LENGTH
+				? `\n\n<current-screen>\n${args.screenContext}\n</current-screen>`
+				: "";
 		await assistantAgent.streamText(
 			ctx,
 			{ threadId: args.threadId, userId },
 			{
 				promptMessageId: args.promptMessageId,
-				system: `${INSTRUCTIONS}\n\nThe current date and time is ${today} (UTC).`,
+				system: `${INSTRUCTIONS}\n\nThe current date and time is ${today} (UTC).${screenBlock}`,
 			},
 			{ saveStreamDeltas: true }
 		);

--- a/packages/backend/convex/assistantTools.test.ts
+++ b/packages/backend/convex/assistantTools.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { isAllowedWorkspacePath } from "./assistantTools";
+
+describe("isAllowedWorkspacePath", () => {
+	it("accepts workspace list and detail paths", () => {
+		expect(isAllowedWorkspacePath("/home")).toBe(true);
+		expect(isAllowedWorkspacePath("/clients")).toBe(true);
+		expect(isAllowedWorkspacePath("/clients/new")).toBe(true);
+		expect(isAllowedWorkspacePath("/clients/jd7abc123XYZ_-")).toBe(true);
+		expect(isAllowedWorkspacePath("/projects/jd7abc123")).toBe(true);
+		expect(isAllowedWorkspacePath("/quotes/jd7abc123")).toBe(true);
+		expect(isAllowedWorkspacePath("/invoices/jd7abc123")).toBe(true);
+		expect(isAllowedWorkspacePath("/tasks")).toBe(true);
+		expect(isAllowedWorkspacePath("/reports/new")).toBe(true);
+		expect(isAllowedWorkspacePath("/organization/profile")).toBe(true);
+	});
+
+	it("rejects external, malformed, and unlisted paths", () => {
+		expect(isAllowedWorkspacePath("https://evil.example")).toBe(false);
+		expect(isAllowedWorkspacePath("//evil.example")).toBe(false);
+		expect(isAllowedWorkspacePath("/admin")).toBe(false);
+		expect(isAllowedWorkspacePath("/organization/complete")).toBe(false);
+		expect(isAllowedWorkspacePath("/clients/../admin")).toBe(false);
+		expect(isAllowedWorkspacePath("/clients/id/extra")).toBe(false);
+		expect(isAllowedWorkspacePath("clients")).toBe(false);
+		expect(isAllowedWorkspacePath("/clients?x=1")).toBe(false);
+		expect(isAllowedWorkspacePath("")).toBe(false);
+	});
+});

--- a/packages/backend/convex/assistantTools.ts
+++ b/packages/backend/convex/assistantTools.ts
@@ -280,6 +280,39 @@ interface ActivityItem {
 
 type NotFound = { found: false };
 
+type ReportVisualization = "bar" | "line" | "pie" | "table";
+
+// ---------------------------------------------------------------------------
+// Navigation (client-executed — the web app intercepts the result and routes)
+// ---------------------------------------------------------------------------
+
+const NAVIGATE_ALLOWED_PATHS: RegExp[] = [
+	/^\/home$/,
+	/^\/clients$/,
+	/^\/clients\/new$/,
+	/^\/clients\/import$/,
+	/^\/clients\/[A-Za-z0-9_-]+$/,
+	/^\/projects$/,
+	/^\/projects\/new$/,
+	/^\/projects\/[A-Za-z0-9_-]+$/,
+	/^\/quotes$/,
+	/^\/quotes\/new$/,
+	/^\/quotes\/[A-Za-z0-9_-]+$/,
+	/^\/invoices$/,
+	/^\/invoices\/[A-Za-z0-9_-]+$/,
+	/^\/tasks$/,
+	/^\/reports$/,
+	/^\/reports\/new$/,
+	/^\/reports\/[A-Za-z0-9_-]+$/,
+	/^\/automations$/,
+	/^\/subscription$/,
+	/^\/organization\/profile$/,
+];
+
+export function isAllowedWorkspacePath(path: string): boolean {
+	return NAVIGATE_ALLOWED_PATHS.some((pattern) => pattern.test(path));
+}
+
 // ---------------------------------------------------------------------------
 // Tools
 // ---------------------------------------------------------------------------
@@ -403,9 +436,18 @@ export const runReport = createTool({
 		groupBy: z.string().optional(),
 		startDate: isoDate.optional(),
 		endDate: isoDate.optional(),
+		visualization: z
+			.enum(["bar", "line", "pie", "table"])
+			.optional()
+			.describe(
+				"How the result is shown to the user in chat. Pick 'line' for time series, 'pie' for share-of-total, 'table' for exact values. Defaults to bar."
+			),
 	}),
-	execute: async (ctx, input): Promise<ReportDataResult> => {
-		return await ctx.runQuery(api.reportData.executeReport, {
+	execute: async (
+		ctx,
+		input
+	): Promise<ReportDataResult & { visualization: ReportVisualization }> => {
+		const result = await ctx.runQuery(api.reportData.executeReport, {
 			entityType: input.entityType,
 			groupBy: input.groupBy,
 			dateRange:
@@ -416,6 +458,7 @@ export const runReport = createTool({
 						}
 					: undefined,
 		});
+		return { ...result, visualization: input.visualization ?? "bar" };
 	},
 });
 
@@ -863,6 +906,30 @@ export const getActivity = createTool({
 	},
 });
 
+export const navigate = createTool({
+	description: [
+		"Open a page in the app for the user. Use when they ask to go somewhere, or after resolving the record they want to see.",
+		"Valid paths: /home, /clients, /clients/{clientId}, /clients/new, /clients/import, /projects, /projects/{projectId}, /projects/new, /quotes, /quotes/{quoteId}, /quotes/new, /invoices, /invoices/{invoiceId}, /tasks, /reports, /reports/{reportId}, /reports/new, /automations, /subscription, /organization/profile.",
+		"IDs must come from lookup tools — never guess an ID.",
+	].join("\n"),
+	inputSchema: z.object({
+		path: z.string().describe("Workspace path starting with /"),
+	}),
+	execute: async (
+		_ctx,
+		input
+	): Promise<{ ok: boolean; path: string; reason?: string }> => {
+		if (!isAllowedWorkspacePath(input.path)) {
+			return {
+				ok: false,
+				path: input.path,
+				reason: "Not a valid app path. Use one of the documented paths.",
+			};
+		}
+		return { ok: true, path: input.path };
+	},
+});
+
 export const assistantTools = {
 	getSchedule,
 	getTasks,
@@ -880,4 +947,5 @@ export const assistantTools = {
 	getEmailThread,
 	getDocuments,
 	getActivity,
+	navigate,
 };

--- a/packages/backend/convex/lib/assistantShared.ts
+++ b/packages/backend/convex/lib/assistantShared.ts
@@ -1,0 +1,7 @@
+/**
+ * Assistant constants shared between the Convex backend and web client.
+ * Must stay dependency-free — this module is bundled into the browser.
+ */
+
+// Cost guard: the server drops (not truncates) screen context longer than this.
+export const SCREEN_CONTEXT_MAX_LENGTH = 4000;

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,6 +24,10 @@
     "./convex/emailMessages": {
       "types": "./convex/emailMessages.ts",
       "default": "./convex/emailMessages.ts"
+    },
+    "./convex/lib/assistantShared": {
+      "types": "./convex/lib/assistantShared.ts",
+      "default": "./convex/lib/assistantShared.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
This pull request introduces a new Assistant screen context system to the workspace, enabling the assistant to be aware of the current view and visible content. It also adds a visually distinctive "assistant notch" trigger at the bottom of the viewport for opening the assistant panel, and refines some UI details and comments for clarity. The most important changes are grouped below:

**Assistant context system integration:**

* Added `ScreenContextProvider` to the workspace layout, wrapping the main app content to provide assistant-related context throughout the workspace. [[1]](diffhunk://#diff-364e3e5da96760752aa44fb3634ea6f2d4aeac89cda845bee9b2dabe809bcfb9R11) [[2]](diffhunk://#diff-364e3e5da96760752aa44fb3634ea6f2d4aeac89cda845bee9b2dabe809bcfb9L32-R39)
* Integrated `usePublishScreenContext` into the calendar and home page components, allowing the assistant to track which view is active and the current visible calendar range or home view. [[1]](diffhunk://#diff-017fdb674e1814c4fadd974edcad26f04ffdf5fe4d19f269e9423c78a6ab9556R22) [[2]](diffhunk://#diff-017fdb674e1814c4fadd974edcad26f04ffdf5fe4d19f269e9423c78a6ab9556R35-R44) [[3]](diffhunk://#diff-c1f3ecba23215c124949d22a9c77d1b37e53d548498ef85559aedd24fbaba3bcR15) [[4]](diffhunk://#diff-c1f3ecba23215c124949d22a9c77d1b37e53d548498ef85559aedd24fbaba3bcR46-R48)

**Assistant panel UI:**

* Implemented the `AssistantNotch` component, a bottom-of-viewport tab styled to mirror the header notches, serving as a trigger for the assistant panel.
* Added new `.assistant-notch` CSS, including border-shape geometry for the assistant tab, ensuring visual consistency with the header notches.

**UI and code comments:**

* Improved comments and minor UI details, such as clarifying the removal of decorative overlays in the workspace layout and enhancing chart area fill behavior. [[1]](diffhunk://#diff-364e3e5da96760752aa44fb3634ea6f2d4aeac89cda845bee9b2dabe809bcfb9L32-R39) [[2]](diffhunk://#diff-79513843f65867c5bfd590617815ceb39b013df211bd510ea78f51c86cecaa8dL128-R136)
* Refined scrollbar appearance for the main canvas, making it thinner and less visually intrusive.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the slide-in `AssistantSheet` with a floating `AssistantPanel` triggered by a new bottom-viewport `AssistantNotch`, adds a screen-context system so the assistant can see which view and date range are active at send time, and introduces a `navigate` tool that lets the model route the user to validated workspace pages.

- **Screen-context system** (`use-screen-context.tsx`): `ScreenContextProvider` collects lazy getters from any page component via `usePublishScreenContext`; `useScreenContext` snapshots them at message-send time and forwards the JSON to the backend as a `<current-screen>` system-prompt block.
- **Navigate tool** (`assistantTools.ts`): server-side path allowlist with strict regex patterns; the client intercepts `output-available` parts and calls `router.push` only for previously-unseen tool call IDs, preventing history replays.
- **UI polish**: duplicate React key fix in `ChartTooltipContent`, `tooltipType=\"none\"` on the decorative Area to stop duplicate tooltip payloads, and a thinner scrollbar for the canvas.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the two findings are quality concerns that cannot cause a regression in shipped functionality today.

The screen-context snapshot merges publisher results with Object.assign, which lets a future publisher silently overwrite the path or query keys. No current publisher does this, so there is no immediate breakage, but the contract is implicit and easy to violate. The SCREEN_CONTEXT_MAX_LENGTH constant duplication is a maintenance concern if the server value is ever raised. Both issues are confined to the screen-context module and do not touch auth, data writes, or the navigate path allowlist, which is solid.

apps/web/src/components/assistant/use-screen-context.tsx — snapshot merging and constant duplication.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/assistant/use-screen-context.tsx | New screen-context system; uses Object.assign to merge publisher snapshots which can silently overwrite reserved top-level keys like `path` and `query`. |
| apps/web/src/components/assistant/assistant-panel.tsx | New floating assistant panel replacing the sheet; includes retry-dedup logic, history baseline seeding for navigate tool, and screen-context forwarding at send time. Logic is sound. |
| packages/backend/convex/assistantTools.ts | Adds navigate tool with strict server-side allowlist validation and visualization field to runReport. Path allowlist is well-constructed and tested. |
| packages/backend/convex/assistantChat.ts | Adds optional screenContext arg to streamResponse; injects it as a tagged system-prompt block only when within the size limit. Safe design. |
| apps/web/src/components/layout/sidebar-with-header.tsx | Switches sidebar to variant=inset, moves AssistantNotch and AssistantPanel outside SidebarInset, removes AssistantTrigger from mobile header. |
| apps/web/src/components/ui/chart.tsx | Fixes duplicate React key for tooltip items by appending index — correctly addresses the duplicate-dataKey case. |
| apps/web/src/components/assistant/renderers/index.tsx | New generative-UI registry; wraps each renderer in a class-based ErrorBoundary so malformed tool output degrades gracefully. |
| apps/web/src/components/assistant/use-current-record.ts | New hook deriving current record from pathname; query caching keeps this lightweight. |
| packages/backend/convex/assistantTools.test.ts | Good unit-test coverage for isAllowedWorkspacePath including path traversal, double-slash, query strings, and unlisted paths. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Page as Page Component
    participant Provider as ScreenContextProvider
    participant Panel as AssistantPanel
    participant Convex as assistantChat.streamResponse
    participant Agent as assistantAgent

    Page->>Provider: usePublishScreenContext
    Note over Provider: registers getter ref
    Panel->>Provider: useScreenContext()
    Note over Panel: user types and submits
    Panel->>Panel: getScreenContext() snapshot
    Panel->>Convex: streamResponse with screenContext
    Convex->>Convex: validate screenContext length
    Convex->>Agent: streamText with current-screen block
    Agent-->>Convex: tool calls (navigate, runReport)
    Convex-->>Panel: streaming tool parts
    Panel->>Panel: navigate effect router.push if unseen
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Page as Page Component
    participant Provider as ScreenContextProvider
    participant Panel as AssistantPanel
    participant Convex as assistantChat.streamResponse
    participant Agent as assistantAgent

    Page->>Provider: usePublishScreenContext
    Note over Provider: registers getter ref
    Panel->>Provider: useScreenContext()
    Note over Panel: user types and submits
    Panel->>Panel: getScreenContext() snapshot
    Panel->>Convex: streamResponse with screenContext
    Convex->>Convex: validate screenContext length
    Convex->>Agent: streamText with current-screen block
    Agent-->>Convex: tool calls (navigate, runReport)
    Convex-->>Panel: streaming tool parts
    Panel->>Panel: navigate effect router.push if unseen
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/src/components/assistant/use-screen-context.tsx:83-89
Publisher snapshot can overwrite reserved keys — `Object.assign` merges getter results directly into `snapshot`, so any publisher that accidentally returns `{ path: "..." }` or `{ query: "..." }` silently corrupts the two keys the function already set from `window.location`. A future publisher returning conflicting keys would strip the real URL from the context without any error or warning.

```suggestion
		for (const getter of ctx?.getters.current ?? []) {
			try {
				const extras = getter.current?.();
				if (extras) {
					for (const [k, v] of Object.entries(extras)) {
						if (k !== "path" && k !== "query") {
							snapshot[k] = v;
						}
					}
				}
			} catch {
				// A broken publisher must never block sending a message.
			}
		}
```

### Issue 2 of 2
apps/web/src/components/assistant/use-screen-context.tsx:65-67
The `SCREEN_CONTEXT_MAX_LENGTH` constant is duplicated between this file and `convex/assistantChat.ts` with only a sync comment. If the server value is raised, the client will continue falling back at the old limit and silently send a stripped snapshot instead of the full one. Consider exporting it from a shared location so the two values cannot drift apart silently.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(assistant): address CodeRabbit revie..."](https://github.com/xcarter93/onetool/commit/6dff89faf7cfea0c78f98afa8ce0ffe424c93f4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41529129)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->