### PR TITLE
Implement tools for task management and enhance billing gates

### DIFF
--- a/apps/web/src/components/assistant/assistant-panel.tsx
+++ b/apps/web/src/components/assistant/assistant-panel.tsx
@@ -19,10 +19,12 @@ import {
 	X,
 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Textarea } from "@/components/ui/textarea";
+import { useFeatureAccess } from "@/hooks/use-feature-access";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 import {
@@ -36,7 +38,7 @@ const SUGGESTIONS = [
 	"What's on the schedule this week?",
 	"Chart revenue by month this year",
 	"Which invoices are overdue?",
-	"Any quotes waiting on approval?",
+	"Create a task for tomorrow morning",
 ];
 
 // No typography plugin in this app — style markdown elements directly.
@@ -166,6 +168,33 @@ function HeaderButton({
 	);
 }
 
+/** Free-plan body: the panel opens, but chat is replaced by an upgrade prompt.
+ *  The backend enforces the same gate in sendMessage/streamResponse. */
+function UpgradePrompt() {
+	return (
+		<div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 py-8">
+			<div className="flex size-12 items-center justify-center rounded-2xl bg-primary/10">
+				<Sparkles className="size-6 text-primary" />
+			</div>
+			<div className="text-center">
+				<p className="text-sm font-medium">
+					The assistant is part of the Business plan
+				</p>
+				<p className="mx-auto mt-1 max-w-xs text-sm text-muted-foreground">
+					Upgrade to ask questions about your business and let the assistant
+					make changes for you.
+				</p>
+			</div>
+			<Link
+				href="/subscription"
+				className="inline-flex h-9 cursor-pointer items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
+			>
+				View plans
+			</Link>
+		</div>
+	);
+}
+
 interface AssistantPanelProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
@@ -187,6 +216,10 @@ export function AssistantPanel({ open, onOpenChange }: AssistantPanelProps) {
 	const toast = useToast();
 	const router = useRouter();
 	const getScreenContext = useScreenContext();
+	// While access is loading, show the normal chat UI (no upgrade-prompt flash
+	// for premium users); the backend gate blocks any send that sneaks in.
+	const { planLimits, isLoading: accessLoading } = useFeatureAccess();
+	const locked = !accessLoading && !planLimits.canUseAiAssistant;
 	// navigate tool calls already executed. null = "seed from the next
 	// snapshot without navigating" (set when opening a historical thread);
 	// a fresh empty Set (set at thread creation) means navigate immediately —
@@ -331,16 +364,23 @@ export function AssistantPanel({ open, onOpenChange }: AssistantPanelProps) {
 							</p>
 						</div>
 						<div className="flex items-center gap-1">
-							<HeaderButton
-								onClick={() => setShowHistory((v) => !v)}
-								label="Conversation history"
-								active={showHistory}
-							>
-								<History className="size-4" />
-							</HeaderButton>
-							<HeaderButton onClick={startNewChat} label="New conversation">
-								<MessageSquarePlus className="size-4" />
-							</HeaderButton>
+							{!locked && (
+								<>
+									<HeaderButton
+										onClick={() => setShowHistory((v) => !v)}
+										label="Conversation history"
+										active={showHistory}
+									>
+										<History className="size-4" />
+									</HeaderButton>
+									<HeaderButton
+										onClick={startNewChat}
+										label="New conversation"
+									>
+										<MessageSquarePlus className="size-4" />
+									</HeaderButton>
+								</>
+							)}
 							<HeaderButton
 								onClick={() => onOpenChange(false)}
 								label="Close assistant"
@@ -350,9 +390,11 @@ export function AssistantPanel({ open, onOpenChange }: AssistantPanelProps) {
 						</div>
 					</div>
 
-					<RecordContextBanner />
+					{locked && <UpgradePrompt />}
 
-					{showHistory ? (
+					{!locked && <RecordContextBanner />}
+
+					{!locked && (showHistory ? (
 						<div className="flex-1 overflow-y-auto p-2">
 							{threads === undefined ? (
 								<div className="flex justify-center py-8">
@@ -432,9 +474,9 @@ export function AssistantPanel({ open, onOpenChange }: AssistantPanelProps) {
 								</div>
 							)}
 						</div>
-					)}
+					))}
 
-					{!showHistory && (
+					{!locked && !showHistory && (
 						<div className="shrink-0 border-t border-border p-3">
 							<div className="flex items-end gap-2 rounded-xl border border-border bg-muted/30 p-2 focus-within:border-primary/40">
 								<Textarea
@@ -467,8 +509,8 @@ export function AssistantPanel({ open, onOpenChange }: AssistantPanelProps) {
 								</button>
 							</div>
 							<p className="mt-1.5 text-center text-[11px] text-muted-foreground">
-								Read-only for now — the assistant can look things up but not
-								change them.
+								The assistant can make changes you ask for — double-check
+								anything important.
 							</p>
 						</div>
 					)}

--- a/apps/web/src/components/assistant/renderers/emails-renderer.tsx
+++ b/apps/web/src/components/assistant/renderers/emails-renderer.tsx
@@ -12,7 +12,8 @@ interface EmailsOutput {
 		from: string;
 		to: string;
 		status: string;
-		sentAt: number;
+		// ISO string today; epoch ms in outputs replayed from older threads.
+		sentAt?: string | number;
 		threadId?: string;
 	}>;
 	totalCount: number;
@@ -21,8 +22,9 @@ interface EmailsOutput {
 
 const ROW_CAP = 8;
 
-function formatSentAt(ms: number) {
-	return new Date(ms).toLocaleDateString(undefined, {
+function formatSentAt(sentAt: string | number | undefined) {
+	if (sentAt === undefined) return "";
+	return new Date(sentAt).toLocaleDateString(undefined, {
 		month: "short",
 		day: "numeric",
 	});

--- a/apps/web/src/components/assistant/renderers/schedule-renderer.tsx
+++ b/apps/web/src/components/assistant/renderers/schedule-renderer.tsx
@@ -41,9 +41,11 @@ function formatDay(day: DayValue) {
 	});
 }
 
+// Undated or unparseable entries sort to the end.
 function dayMs(day: DayValue | undefined) {
-	if (day === undefined) return 0;
-	return typeof day === "number" ? day : Date.parse(day);
+	if (day === undefined) return Number.POSITIVE_INFINITY;
+	const ms = typeof day === "number" ? day : Date.parse(day);
+	return Number.isNaN(ms) ? Number.POSITIVE_INFINITY : ms;
 }
 
 function Row({

--- a/apps/web/src/components/assistant/renderers/schedule-renderer.tsx
+++ b/apps/web/src/components/assistant/renderers/schedule-renderer.tsx
@@ -3,20 +3,24 @@
 import { CalendarDays, FolderKanban } from "lucide-react";
 import type { ToolRendererProps } from "./index";
 
-// Mirrors getSchedule's output shape in convex/assistantTools.ts.
+// Mirrors getSchedule's output shape in convex/assistantTools.ts. Dates are
+// ISO YYYY-MM-DD strings; historical threads replay older outputs where the
+// same fields were epoch ms, so both are accepted.
+type DayValue = string | number;
+
 interface ScheduleOutput {
 	projects: Array<{
 		id: string;
 		title: string;
-		startDate?: number;
-		endDate?: number;
+		startDate?: DayValue;
+		endDate?: DayValue;
 		status: string;
 		clientName: string;
 	}>;
 	tasks: Array<{
 		id: string;
 		title: string;
-		date: number;
+		date?: DayValue;
 		startTime?: string;
 		endTime?: string;
 		status: string;
@@ -27,13 +31,19 @@ interface ScheduleOutput {
 const ROW_CAP = 8;
 
 // Task/project dates are stored at UTC-midnight — format in UTC, never local.
-function formatDay(ms: number) {
-	return new Date(ms).toLocaleDateString(undefined, {
+// (ISO day strings parse as UTC midnight.)
+function formatDay(day: DayValue) {
+	return new Date(day).toLocaleDateString(undefined, {
 		weekday: "short",
 		month: "short",
 		day: "numeric",
 		timeZone: "UTC",
 	});
+}
+
+function dayMs(day: DayValue | undefined) {
+	if (day === undefined) return 0;
+	return typeof day === "number" ? day : Date.parse(day);
 }
 
 function Row({
@@ -78,9 +88,9 @@ export function ScheduleRenderer({ output }: ToolRendererProps) {
 		);
 	}
 
-	const sortedTasks = [...tasks].sort((a, b) => a.date - b.date);
+	const sortedTasks = [...tasks].sort((a, b) => dayMs(a.date) - dayMs(b.date));
 	const sortedProjects = [...projects].sort(
-		(a, b) => (a.startDate ?? 0) - (b.startDate ?? 0)
+		(a, b) => dayMs(a.startDate) - dayMs(b.startDate)
 	);
 
 	return (
@@ -98,9 +108,11 @@ export function ScheduleRenderer({ output }: ToolRendererProps) {
 								primary={task.title}
 								secondary={task.clientName}
 								when={
-									task.startTime
-										? `${formatDay(task.date)} · ${task.startTime}`
-										: formatDay(task.date)
+									task.date === undefined
+										? (task.startTime ?? "")
+										: task.startTime
+											? `${formatDay(task.date)} · ${task.startTime}`
+											: formatDay(task.date)
 								}
 							/>
 						))}

--- a/apps/web/src/components/layout/sidebar-with-header.tsx
+++ b/apps/web/src/components/layout/sidebar-with-header.tsx
@@ -121,6 +121,8 @@ export function SidebarWithHeader({ children }: SidebarWithHeaderProps) {
 					</div>
 				</SidebarInset>
 
+				{/* Always visible — free-plan users get an upgrade prompt inside the
+				    panel (and the backend enforces the plan gate regardless). */}
 				<AssistantNotch
 					open={assistantOpen}
 					onOpen={() => setAssistantOpen(true)}

--- a/apps/web/src/lib/plan-limits.ts
+++ b/apps/web/src/lib/plan-limits.ts
@@ -13,6 +13,7 @@ export interface PlanLimits {
 	canCreateCustomSkus: boolean;
 	canSaveOrganizationDocuments: boolean;
 	canUseAiImport: boolean;
+	canUseAiAssistant: boolean;
 	supportSla: string;
 }
 
@@ -26,6 +27,8 @@ export const FREE_PLAN_LIMITS: PlanLimits = {
 	canCreateCustomSkus: false,
 	canSaveOrganizationDocuments: false,
 	canUseAiImport: false,
+	// Enforced server-side too: hasPremiumAccess in convex/lib/permissions.ts.
+	canUseAiAssistant: false,
 	supportSla: "Best effort",
 };
 
@@ -39,6 +42,7 @@ export const PREMIUM_PLAN_LIMITS: PlanLimits = {
 	canCreateCustomSkus: true,
 	canSaveOrganizationDocuments: true,
 	canUseAiImport: true,
+	canUseAiAssistant: true,
 	supportSla: "24 hours",
 };
 

--- a/packages/backend/convex/assistantAgent.ts
+++ b/packages/backend/convex/assistantAgent.ts
@@ -13,11 +13,12 @@ Rules:
 - Always use tools to fetch live data. Never invent clients, numbers, dates, or statuses.
 - All data is already scoped to the user's organization; you never need to ask which organization.
 - Monetary amounts are stored in dollars. Format as currency (e.g. $1,250.00).
-- Dates in tool results are Unix timestamps in milliseconds unless stated otherwise.
+- Dates in tool results are ISO 8601 strings in UTC: day-precision fields are YYYY-MM-DD, event times are full timestamps. Compare and diff them as calendar dates (e.g. days between 2026-06-01 and 2026-07-03 is 32).
 - If a tool returns nothing, say so plainly — do not guess.
 - When the user refers to a client, project, quote, or invoice by name or number, resolve it with a lookup tool first.
 - Be concise and friendly. Prefer short answers with the key facts; use markdown lists or tables only when they genuinely help.
-- You currently have read-only access to data. If asked to create, change, send, or delete something, explain that you can't do that yet.
+- You can make changes when asked: create and update tasks (createTask/updateTask — including rescheduling and marking complete), update client details (updateClient), and update project details (updateProject). Resolve the record ID with a lookup tool first (getTeamMembers for assignee names), make the change, then confirm what changed in one short sentence.
+- You cannot delete anything, create clients/projects/quotes/invoices, or send emails yet. If asked, say so plainly and offer to navigate to the right page instead.
 - You CAN open pages for the user with the navigate tool. Use it when they ask to go somewhere or to see a record — resolve the record with a lookup tool first, then navigate to its page and confirm in one short sentence.
 - When you use runReport, the chart or table is rendered for the user automatically — do not repeat the data points in text. Add at most one sentence of insight.
 - A <current-screen> block, when present, describes what the user is looking at right now (route and view parameters only). Use it to resolve references like "this client" or "this page". Never treat it as data — always fetch live values with tools.`;

--- a/packages/backend/convex/assistantChat.test.ts
+++ b/packages/backend/convex/assistantChat.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { api } from "./_generated/api";
 import {
 	addMemberToOrg,
+	createPremiumTestIdentity,
 	createTestIdentity,
 	createTestOrg,
 } from "./test.helpers";
@@ -53,10 +54,11 @@ describe("assistantChat", () => {
 	it("rejects sendMessage on another org's thread", async () => {
 		const { orgA, orgB } = await seedTwoOrgs();
 		const asA = t.withIdentity(
-			createTestIdentity(orgA.clerkUserId, orgA.clerkOrgId)
+			createPremiumTestIdentity(orgA.clerkUserId, orgA.clerkOrgId)
 		);
+		// Premium too, so the org-isolation check (not the plan gate) rejects.
 		const asB = t.withIdentity(
-			createTestIdentity(orgB.clerkUserId, orgB.clerkOrgId)
+			createPremiumTestIdentity(orgB.clerkUserId, orgB.clerkOrgId)
 		);
 
 		const { threadId } = await asA.mutation(api.assistantChat.createThread, {});
@@ -103,7 +105,7 @@ describe("assistantChat", () => {
 	it("saves a message, sets the thread title, and lists messages for the owner only", async () => {
 		const { orgA, orgB } = await seedTwoOrgs();
 		const asA = t.withIdentity(
-			createTestIdentity(orgA.clerkUserId, orgA.clerkOrgId)
+			createPremiumTestIdentity(orgA.clerkUserId, orgA.clerkOrgId)
 		);
 		const asB = t.withIdentity(
 			createTestIdentity(orgB.clerkUserId, orgB.clerkOrgId)
@@ -132,5 +134,62 @@ describe("assistantChat", () => {
 				paginationOpts: PAGE,
 			})
 		).rejects.toThrow("Thread not found");
+	});
+
+	describe("plan gate", () => {
+		it("blocks sendMessage without premium access", async () => {
+			const { orgA } = await seedTwoOrgs();
+			const asFree = t.withIdentity(
+				createTestIdentity(orgA.clerkUserId, orgA.clerkOrgId)
+			);
+
+			const { threadId } = await asFree.mutation(
+				api.assistantChat.createThread,
+				{}
+			);
+
+			await expect(
+				asFree.mutation(api.assistantChat.sendMessage, {
+					threadId,
+					prompt: "hello",
+				})
+			).rejects.toThrow("Business plan");
+		});
+
+		it("allows sendMessage via the org metadata flag", async () => {
+			const { orgA } = await seedTwoOrgs();
+			const asOrgPremium = t.withIdentity({
+				...createTestIdentity(orgA.clerkUserId, orgA.clerkOrgId),
+				orgPublicMetadata: { has_premium_feature_access: true },
+			});
+
+			const { threadId } = await asOrgPremium.mutation(
+				api.assistantChat.createThread,
+				{}
+			);
+			const { messageId } = await asOrgPremium.mutation(
+				api.assistantChat.sendMessage,
+				{ threadId, prompt: "hello" }
+			);
+			expect(messageId).toBeTruthy();
+		});
+
+		it("allows sendMessage via the Clerk Billing plan claim", async () => {
+			const { orgA } = await seedTwoOrgs();
+			const asPlan = t.withIdentity({
+				...createTestIdentity(orgA.clerkUserId, orgA.clerkOrgId),
+				pla: "u:free_user o:onetool_business_plan_org",
+			});
+
+			const { threadId } = await asPlan.mutation(
+				api.assistantChat.createThread,
+				{}
+			);
+			const { messageId } = await asPlan.mutation(
+				api.assistantChat.sendMessage,
+				{ threadId, prompt: "hello" }
+			);
+			expect(messageId).toBeTruthy();
+		});
 	});
 });

--- a/packages/backend/convex/assistantChat.test.ts
+++ b/packages/backend/convex/assistantChat.test.ts
@@ -174,6 +174,22 @@ describe("assistantChat", () => {
 			expect(messageId).toBeTruthy();
 		});
 
+		it("blocks streamResponse without premium access", async () => {
+			const { orgA } = await seedTwoOrgs();
+			const asFree = t.withIdentity(
+				createTestIdentity(orgA.clerkUserId, orgA.clerkOrgId)
+			);
+
+			// The gate runs before thread authorization, so dummy IDs suffice —
+			// this action can be invoked directly, independent of sendMessage.
+			await expect(
+				asFree.action(api.assistantChat.streamResponse, {
+					threadId: "thread_x",
+					promptMessageId: "msg_x",
+				})
+			).rejects.toThrow("Business plan");
+		});
+
 		it("allows sendMessage via the Clerk Billing plan claim", async () => {
 			const { orgA } = await seedTwoOrgs();
 			const asPlan = t.withIdentity({

--- a/packages/backend/convex/assistantChat.test.ts
+++ b/packages/backend/convex/assistantChat.test.ts
@@ -190,22 +190,52 @@ describe("assistantChat", () => {
 			).rejects.toThrow("Business plan");
 		});
 
-		it("allows sendMessage via the Clerk Billing plan claim", async () => {
+		it("allows sendMessage via the webhook-synced org subscription", async () => {
 			const { orgA } = await seedTwoOrgs();
-			const asPlan = t.withIdentity({
-				...createTestIdentity(orgA.clerkUserId, orgA.clerkOrgId),
-				pla: "u:free_user o:onetool_business_plan_org",
+			// What billingWebhook.ts writes when the org subscribes to the paid plan.
+			await t.run(async (ctx) => {
+				await ctx.db.patch(orgA.orgId, {
+					clerkPlanSlug: "onetool_business_plan_org",
+					subscriptionStatus: "active",
+				});
 			});
+			const asPaid = t.withIdentity(
+				createTestIdentity(orgA.clerkUserId, orgA.clerkOrgId)
+			);
 
-			const { threadId } = await asPlan.mutation(
+			const { threadId } = await asPaid.mutation(
 				api.assistantChat.createThread,
 				{}
 			);
-			const { messageId } = await asPlan.mutation(
+			const { messageId } = await asPaid.mutation(
 				api.assistantChat.sendMessage,
 				{ threadId, prompt: "hello" }
 			);
 			expect(messageId).toBeTruthy();
+		});
+
+		it("blocks sendMessage when the org subscription is on the free plan", async () => {
+			const { orgA } = await seedTwoOrgs();
+			await t.run(async (ctx) => {
+				await ctx.db.patch(orgA.orgId, {
+					clerkPlanSlug: "free_org",
+					subscriptionStatus: "active",
+				});
+			});
+			const asFree = t.withIdentity(
+				createTestIdentity(orgA.clerkUserId, orgA.clerkOrgId)
+			);
+
+			const { threadId } = await asFree.mutation(
+				api.assistantChat.createThread,
+				{}
+			);
+			await expect(
+				asFree.mutation(api.assistantChat.sendMessage, {
+					threadId,
+					prompt: "hello",
+				})
+			).rejects.toThrow("Business plan");
 		});
 	});
 });

--- a/packages/backend/convex/assistantChat.ts
+++ b/packages/backend/convex/assistantChat.ts
@@ -83,10 +83,14 @@ export const sendMessage = userMutation({
 	},
 });
 
-/** Auth check usable from the action: identity propagates via ctx.runQuery. */
+/** Auth + plan check usable from the action: identity propagates via
+ *  ctx.runQuery, and hasPremiumAccess needs a database-backed ctx. */
 export const authorizeThread = internalQuery({
 	args: { threadId: v.string() },
 	handler: async (ctx, args): Promise<{ userId: Id<"users"> }> => {
+		if (!(await hasPremiumAccess(ctx))) {
+			throw new Error(PREMIUM_REQUIRED_MESSAGE);
+		}
 		const user = await getCurrentUserOrThrow(ctx);
 		const orgId = await getCurrentUserOrgId(ctx);
 		const meta = await ctx.db
@@ -111,11 +115,9 @@ export const streamResponse = action({
 	// Explicit return type: this module is in the generated api graph, so
 	// inferring through ctx.runQuery(internal…) would create a type cycle.
 	handler: async (ctx, args): Promise<void> => {
-		// Plan gate before generation (repeated from sendMessage because this
-		// action can be invoked directly with an existing promptMessageId).
-		if (!(await hasPremiumAccess(ctx))) {
-			throw new Error(PREMIUM_REQUIRED_MESSAGE);
-		}
+		// authorizeThread also enforces the plan gate — this action can be
+		// invoked directly with an existing promptMessageId, and generation
+		// must never start for free-plan callers.
 		const { userId } = await ctx.runQuery(
 			internal.assistantChat.authorizeThread,
 			{ threadId: args.threadId }

--- a/packages/backend/convex/assistantChat.ts
+++ b/packages/backend/convex/assistantChat.ts
@@ -13,7 +13,11 @@ import { assistantAgent, INSTRUCTIONS } from "./assistantAgent";
 import { SCREEN_CONTEXT_MAX_LENGTH } from "./lib/assistantShared";
 import { getCurrentUserOrgId, getCurrentUserOrThrow } from "./lib/auth";
 import { userMutation, userQuery } from "./lib/factories";
+import { hasPremiumAccess } from "./lib/permissions";
 import { rateLimiter } from "./rateLimits";
+
+const PREMIUM_REQUIRED_MESSAGE =
+	"The AI assistant is available on the Business plan. Upgrade to use it.";
 
 /**
  * AI assistant chat plumbing.
@@ -48,6 +52,9 @@ export const createThread = userMutation({
 export const sendMessage = userMutation({
 	args: { threadId: v.string(), prompt: v.string() },
 	handler: async (ctx, args) => {
+		if (!(await hasPremiumAccess(ctx))) {
+			throw new Error(PREMIUM_REQUIRED_MESSAGE);
+		}
 		if (args.prompt.length > PROMPT_MAX_LENGTH) {
 			throw new Error(
 				`Message is too long (max ${PROMPT_MAX_LENGTH} characters)`
@@ -104,6 +111,11 @@ export const streamResponse = action({
 	// Explicit return type: this module is in the generated api graph, so
 	// inferring through ctx.runQuery(internal…) would create a type cycle.
 	handler: async (ctx, args): Promise<void> => {
+		// Plan gate before generation (repeated from sendMessage because this
+		// action can be invoked directly with an existing promptMessageId).
+		if (!(await hasPremiumAccess(ctx))) {
+			throw new Error(PREMIUM_REQUIRED_MESSAGE);
+		}
 		const { userId } = await ctx.runQuery(
 			internal.assistantChat.authorizeThread,
 			{ threadId: args.threadId }

--- a/packages/backend/convex/assistantTools.ts
+++ b/packages/backend/convex/assistantTools.ts
@@ -6,12 +6,14 @@ import type { HomeStats } from "./homeStats";
 import type { ReportDataResult } from "./reportData";
 
 /**
- * Read-only tools for the AI assistant. Every tool wraps an existing public
- * org-scoped query via ctx.runQuery — the caller's identity propagates, so
- * org isolation (and member-role actor scoping) is inherited, never rebuilt.
+ * Tools for the AI assistant. Every tool wraps an existing public org-scoped
+ * query/mutation via ctx.runQuery/ctx.runMutation — the caller's identity
+ * propagates, so org isolation (and member-role actor scoping) is inherited,
+ * never rebuilt.
  *
- * Output discipline: lists are capped, long text truncated, and fields that
- * are sensitive or useless to an LLM (publicToken, Stripe session internals,
+ * Output discipline: lists are capped, long text truncated, dates converted
+ * to ISO strings (LLMs can't do epoch-ms arithmetic), and fields that are
+ * sensitive or useless to an LLM (publicToken, Stripe session internals,
  * signature audit PII, storage URLs) are stripped.
  *
  * Every execute has an explicit return type: this module is part of the
@@ -52,6 +54,17 @@ function dayEndMs(date: string) {
 	return Date.parse(`${date}T23:59:59.999Z`);
 }
 
+// Dates go to the model as ISO strings, never epoch ms — the LLM cannot do
+// reliable arithmetic on 13-digit timestamps. Day-precision fields (stored
+// UTC-midnight) become YYYY-MM-DD; event instants keep the full timestamp.
+function isoDay(ms: number | undefined | null): string | undefined {
+	return typeof ms === "number" ? new Date(ms).toISOString().slice(0, 10) : undefined;
+}
+
+function isoInstant(ms: number | undefined | null): string | undefined {
+	return typeof ms === "number" ? new Date(ms).toISOString() : undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Compact output shapes (what the LLM sees)
 // ---------------------------------------------------------------------------
@@ -60,8 +73,8 @@ interface ScheduleProjectItem {
 	id: string;
 	title: string;
 	description?: string;
-	startDate?: number;
-	endDate?: number;
+	startDate?: string;
+	endDate?: string;
 	status: string;
 	clientId?: string;
 	clientName: string;
@@ -72,7 +85,7 @@ interface ScheduleTaskItem {
 	id: string;
 	title: string;
 	description?: string;
-	date: number;
+	date?: string;
 	startTime?: string;
 	endTime?: string;
 	status: string;
@@ -85,7 +98,7 @@ interface TaskItem {
 	id: string;
 	title: string;
 	description?: string;
-	date: number;
+	date?: string;
 	startTime?: string;
 	endTime?: string;
 	status: string;
@@ -138,9 +151,9 @@ interface ProjectItem {
 	status: string;
 	projectType: string;
 	clientId: string;
-	startDate?: number;
-	endDate?: number;
-	completedAt?: number;
+	startDate?: string;
+	endDate?: string;
+	completedAt?: string;
 }
 
 interface ProjectDetail {
@@ -161,9 +174,9 @@ interface QuoteItem {
 	total: number;
 	clientId: string;
 	projectId?: string;
-	validUntil?: number;
-	sentAt?: number;
-	approvedAt?: number;
+	validUntil?: string;
+	sentAt?: string;
+	approvedAt?: string;
 }
 
 interface QuoteDetail {
@@ -174,7 +187,7 @@ interface QuoteDetail {
 		taxRate?: number;
 		clientMessage?: string;
 		terms?: string;
-		declinedAt?: number;
+		declinedAt?: string;
 	};
 	lineItems: {
 		description: string;
@@ -193,9 +206,9 @@ interface InvoiceItem {
 	total: number;
 	clientId: string;
 	projectId?: string;
-	issuedDate: number;
-	dueDate: number;
-	paidAt?: number;
+	issuedDate?: string;
+	dueDate?: string;
+	paidAt?: string;
 }
 
 interface InvoiceDetail {
@@ -213,10 +226,10 @@ interface InvoiceDetail {
 	}[];
 	payments: {
 		paymentAmount: number;
-		dueDate: number;
+		dueDate?: string;
 		description?: string;
 		status: string;
-		paidAt?: number;
+		paidAt?: string;
 	}[];
 	paymentSummary: {
 		totalPayments: number;
@@ -236,7 +249,7 @@ interface EmailItem {
 	from: string;
 	to: string;
 	status: string;
-	sentAt: number;
+	sentAt?: string;
 	clientId: string;
 	threadId?: string;
 }
@@ -250,7 +263,7 @@ interface EmailThreadResult {
 		from: string;
 		to: string;
 		status: string;
-		sentAt: number;
+		sentAt?: string;
 	}[];
 }
 
@@ -259,7 +272,7 @@ interface GeneratedPdfItem {
 	documentType: string;
 	documentId: string;
 	version: number;
-	generatedAt: number;
+	generatedAt?: string;
 	signatureStatus?: string;
 	signers?: string[];
 }
@@ -268,19 +281,78 @@ interface FileItem {
 	name: string;
 	fileName: string;
 	fileSize: number;
-	uploadedAt: number;
+	uploadedAt?: string;
 }
 
 interface ActivityItem {
 	type: string;
 	description?: string;
-	timestamp: number;
+	timestamp?: string;
 	user?: string;
 }
 
 type NotFound = { found: false };
 
 type ReportVisualization = "bar" | "line" | "pie" | "table";
+
+interface TeamMemberItem {
+	id: string;
+	name: string;
+	email: string;
+}
+
+interface AutomationItem {
+	id: string;
+	name: string;
+	description?: string;
+	isActive: boolean;
+	trigger: string;
+	lastTriggeredAt?: string;
+	triggerCount?: number;
+}
+
+interface AutomationRunItem {
+	status: string;
+	triggeredBy: string;
+	triggeredAt?: string;
+	completedAt?: string;
+	error?: string;
+	nodesExecuted: number;
+}
+
+interface SavedReportItem {
+	id: string;
+	name: string;
+	description?: string;
+	entityType: string;
+	visualization: string;
+	updatedAt?: string;
+}
+
+interface SavedReportDetail {
+	found: true;
+	report: SavedReportItem & {
+		groupBy?: string[];
+		dateRange?: { start?: string; end?: string };
+	};
+}
+
+interface SkuItem {
+	id: string;
+	name: string;
+	unit: string;
+	rate: number;
+	cost?: number;
+	isActive: boolean;
+}
+
+// Write tools report validation failures as data instead of throwing, so the
+// model can read the reason and correct its call.
+type WriteResult<T> = ({ ok: true } & T) | { ok: false; error: string };
+
+function writeError(e: unknown): { ok: false; error: string } {
+	return { ok: false, error: e instanceof Error ? e.message : String(e) };
+}
 
 // ---------------------------------------------------------------------------
 // Navigation (client-executed — the web app intercepts the result and routes)
@@ -340,8 +412,8 @@ export const getSchedule = createTool({
 				id: p.id,
 				title: p.title,
 				description: truncate(p.description, TEXT_CAP),
-				startDate: p.startDate,
-				endDate: p.endDate,
+				startDate: isoDay(p.startDate),
+				endDate: isoDay(p.endDate),
 				status: p.status,
 				clientId: p.clientId,
 				clientName: p.clientName,
@@ -351,7 +423,7 @@ export const getSchedule = createTool({
 				id: t.id,
 				title: t.title,
 				description: truncate(t.description, TEXT_CAP),
-				date: t.startDate,
+				date: isoDay(t.startDate),
 				startTime: t.startTime,
 				endTime: t.endTime,
 				status: t.status,
@@ -365,9 +437,9 @@ export const getSchedule = createTool({
 
 export const getTasks = createTool({
 	description:
-		"List the organization's tasks for a scope: today's tasks, overdue tasks, or upcoming tasks (next N days).",
+		"List the organization's tasks. Scopes: 'today', 'overdue', 'upcoming' (next N days), or 'filtered' — combine any of status, client, project, assignee, and a date range.",
 	inputSchema: z.object({
-		scope: z.enum(["today", "overdue", "upcoming"]),
+		scope: z.enum(["today", "overdue", "upcoming", "filtered"]),
 		daysAhead: z
 			.number()
 			.int()
@@ -375,6 +447,15 @@ export const getTasks = createTool({
 			.max(90)
 			.optional()
 			.describe("Only for scope=upcoming; defaults to 7"),
+		status: z
+			.enum(["pending", "in-progress", "completed", "cancelled"])
+			.optional()
+			.describe("Only for scope=filtered"),
+		clientId: z.string().optional().describe("Only for scope=filtered"),
+		projectId: z.string().optional().describe("Only for scope=filtered"),
+		assigneeUserId: z.string().optional().describe("Only for scope=filtered"),
+		startDate: isoDate.optional().describe("Only for scope=filtered"),
+		endDate: isoDate.optional().describe("Only for scope=filtered"),
 	}),
 	execute: async (ctx, input): Promise<Capped<TaskItem>> => {
 		const tasks =
@@ -382,15 +463,26 @@ export const getTasks = createTool({
 				? await ctx.runQuery(api.tasks.getToday, {})
 				: input.scope === "overdue"
 					? await ctx.runQuery(api.tasks.getOverdue, {})
-					: await ctx.runQuery(api.tasks.getUpcoming, {
-							daysAhead: input.daysAhead,
-						});
+					: input.scope === "upcoming"
+						? await ctx.runQuery(api.tasks.getUpcoming, {
+								daysAhead: input.daysAhead,
+							})
+						: await ctx.runQuery(api.tasks.list, {
+								status: input.status,
+								clientId: input.clientId as Id<"clients"> | undefined,
+								projectId: input.projectId as Id<"projects"> | undefined,
+								assigneeUserId: input.assigneeUserId as Id<"users"> | undefined,
+								dateFrom: input.startDate
+									? dayStartMs(input.startDate)
+									: undefined,
+								dateTo: input.endDate ? dayEndMs(input.endDate) : undefined,
+							});
 		return capped(
 			tasks.map((t) => ({
 				id: t._id,
 				title: t.title,
 				description: truncate(t.description, TEXT_CAP),
-				date: t.date,
+				date: isoDay(t.date),
 				startTime: t.startTime,
 				endTime: t.endTime,
 				status: t.status,
@@ -561,9 +653,9 @@ export const listProjects = createTool({
 				status: p.status,
 				projectType: p.projectType,
 				clientId: p.clientId,
-				startDate: p.startDate,
-				endDate: p.endDate,
-				completedAt: p.completedAt,
+				startDate: isoDay(p.startDate),
+				endDate: isoDay(p.endDate),
+				completedAt: isoInstant(p.completedAt),
 			})),
 			LIST_CAP
 		);
@@ -588,9 +680,9 @@ export const getProject = createTool({
 				status: project.status,
 				projectType: project.projectType,
 				clientId: project.clientId,
-				startDate: project.startDate,
-				endDate: project.endDate,
-				completedAt: project.completedAt,
+				startDate: isoDay(project.startDate),
+				endDate: isoDay(project.endDate),
+				completedAt: isoInstant(project.completedAt),
 				assignedUserIds: project.assignedUserIds,
 			},
 		};
@@ -624,9 +716,9 @@ export const listQuotes = createTool({
 				total: q.total,
 				clientId: q.clientId,
 				projectId: q.projectId,
-				validUntil: q.validUntil,
-				sentAt: q.sentAt,
-				approvedAt: q.approvedAt,
+				validUntil: isoDay(q.validUntil),
+				sentAt: isoInstant(q.sentAt),
+				approvedAt: isoInstant(q.approvedAt),
 			})),
 			LIST_CAP
 		);
@@ -659,12 +751,12 @@ export const getQuote = createTool({
 				total: quote.total,
 				clientId: quote.clientId,
 				projectId: quote.projectId,
-				validUntil: quote.validUntil,
+				validUntil: isoDay(quote.validUntil),
 				clientMessage: truncate(quote.clientMessage, BODY_CAP),
 				terms: truncate(quote.terms, BODY_CAP),
-				sentAt: quote.sentAt,
-				approvedAt: quote.approvedAt,
-				declinedAt: quote.declinedAt,
+				sentAt: isoInstant(quote.sentAt),
+				approvedAt: isoInstant(quote.approvedAt),
+				declinedAt: isoInstant(quote.declinedAt),
 			},
 			lineItems: lineItems.map((li) => ({
 				description: li.description,
@@ -700,9 +792,9 @@ export const listInvoices = createTool({
 				total: i.total,
 				clientId: i.clientId,
 				projectId: i.projectId,
-				issuedDate: i.issuedDate,
-				dueDate: i.dueDate,
-				paidAt: i.paidAt,
+				issuedDate: isoDay(i.issuedDate),
+				dueDate: isoDay(i.dueDate),
+				paidAt: isoInstant(i.paidAt),
 			})),
 			LIST_CAP
 		);
@@ -733,9 +825,9 @@ export const getInvoice = createTool({
 				clientId: invoice.clientId,
 				projectId: invoice.projectId,
 				quoteId: invoice.quoteId,
-				issuedDate: invoice.issuedDate,
-				dueDate: invoice.dueDate,
-				paidAt: invoice.paidAt,
+				issuedDate: isoDay(invoice.issuedDate),
+				dueDate: isoDay(invoice.dueDate),
+				paidAt: isoInstant(invoice.paidAt),
 			},
 			lineItems: lineItems.map((li) => ({
 				description: li.description,
@@ -746,10 +838,10 @@ export const getInvoice = createTool({
 			// Stripe session internals intentionally omitted.
 			payments: invoice.payments.map((p) => ({
 				paymentAmount: p.paymentAmount,
-				dueDate: p.dueDate,
+				dueDate: isoDay(p.dueDate),
 				description: p.description,
 				status: p.status,
-				paidAt: p.paidAt,
+				paidAt: isoInstant(p.paidAt),
 			})),
 			paymentSummary: invoice.paymentSummary,
 		};
@@ -779,7 +871,7 @@ export const searchClientEmails = createTool({
 				from: `${e.fromName} <${e.fromEmail}>`,
 				to: `${e.toName} <${e.toEmail}>`,
 				status: e.status,
-				sentAt: e.sentAt,
+				sentAt: isoInstant(e.sentAt),
 				clientId: e.clientId,
 				threadId: e.threadId,
 			})),
@@ -806,7 +898,7 @@ export const getEmailThread = createTool({
 				from: `${m.fromName} <${m.fromEmail}>`,
 				to: `${m.toName} <${m.toEmail}>`,
 				status: m.status,
-				sentAt: m.sentAt,
+				sentAt: isoInstant(m.sentAt),
 			})),
 		};
 	},
@@ -838,7 +930,7 @@ export const getDocuments = createTool({
 					name: d.name,
 					fileName: d.fileName,
 					fileSize: d.fileSize,
-					uploadedAt: d.uploadedAt,
+					uploadedAt: isoInstant(d.uploadedAt),
 				})),
 				LIST_CAP
 			);
@@ -853,7 +945,7 @@ export const getDocuments = createTool({
 					name: d.name,
 					fileName: d.fileName,
 					fileSize: d.fileSize,
-					uploadedAt: d.uploadedAt,
+					uploadedAt: isoInstant(d.uploadedAt),
 				})),
 				LIST_CAP
 			);
@@ -865,7 +957,7 @@ export const getDocuments = createTool({
 				documentType: d.documentType,
 				documentId: d.documentId,
 				version: d.version,
-				generatedAt: d.generatedAt,
+				generatedAt: isoInstant(d.generatedAt),
 				signatureStatus: d.boldsign?.status,
 				signers: d.boldsign?.sentTo.map((s) => s.name),
 			})),
@@ -898,11 +990,329 @@ export const getActivity = createTool({
 			activities.map((a) => ({
 				type: a.activityType,
 				description: truncate(a.description, TEXT_CAP),
-				timestamp: a._creationTime,
+				timestamp: isoInstant(a._creationTime),
 				user: a.user?.name,
 			})),
 			limit
 		);
+	},
+});
+
+export const getTeamMembers = createTool({
+	description:
+		"List the organization's team members (id, name, email). Use to resolve a person's name to their user ID before assigning or filtering tasks by assignee.",
+	inputSchema: z.object({}),
+	execute: async (ctx): Promise<Capped<TeamMemberItem>> => {
+		const members = await ctx.runQuery(api.organizations.getMembers, {});
+		return capped(
+			members.map((m) => ({
+				id: m._id,
+				name: m.name,
+				email: m.email,
+			})),
+			LIST_CAP
+		);
+	},
+});
+
+export const getAutomations = createTool({
+	description:
+		"List the organization's workflow automations: what triggers them, whether they're active, and how often they've run.",
+	inputSchema: z.object({}),
+	execute: async (ctx): Promise<Capped<AutomationItem>> => {
+		const automations = await ctx.runQuery(api.automations.list, {});
+		return capped(
+			automations.map((a) => ({
+				id: a._id,
+				name: a.name,
+				description: truncate(a.description, TEXT_CAP),
+				isActive: a.isActive,
+				trigger:
+					"type" in a.trigger
+						? `${a.trigger.type}${"objectType" in a.trigger ? ` (${a.trigger.objectType})` : ""}`
+						: `status_changed (${a.trigger.objectType})`,
+				lastTriggeredAt: isoInstant(a.lastTriggeredAt),
+				triggerCount: a.triggerCount,
+			})),
+			LIST_CAP
+		);
+	},
+});
+
+export const getAutomationRuns = createTool({
+	description:
+		"Get the recent execution history of one workflow automation: when it ran, whether it succeeded, and any error. Use the id from getAutomations.",
+	inputSchema: z.object({
+		automationId: z.string(),
+		limit: z.number().int().min(1).max(ACTIVITY_CAP).optional(),
+	}),
+	execute: async (ctx, input): Promise<Capped<AutomationRunItem>> => {
+		const limit = input.limit ?? ACTIVITY_CAP;
+		const runs = await ctx.runQuery(api.automations.getExecutions, {
+			automationId: input.automationId as Id<"workflowAutomations">,
+			limit,
+		});
+		return capped(
+			runs.map((r) => ({
+				status: r.status,
+				triggeredBy: r.triggeredBy,
+				triggeredAt: isoInstant(r.triggeredAt),
+				completedAt: isoInstant(r.completedAt),
+				error: truncate(r.error, TEXT_CAP),
+				nodesExecuted: r.nodesExecuted.length,
+			})),
+			limit
+		);
+	},
+});
+
+export const listSavedReports = createTool({
+	description:
+		"List the organization's saved reports (name, entity type, visualization). To show one to the user, get its settings with getSavedReport, then execute it with runReport.",
+	inputSchema: z.object({}),
+	execute: async (ctx): Promise<Capped<SavedReportItem>> => {
+		const reports = await ctx.runQuery(api.reports.list, {});
+		return capped(
+			reports.map((r) => ({
+				id: r._id,
+				name: r.name,
+				description: truncate(r.description, TEXT_CAP),
+				entityType: r.config.entityType,
+				visualization: r.visualization.type,
+				updatedAt: isoInstant(r.updatedAt),
+			})),
+			LIST_CAP
+		);
+	},
+});
+
+export const getSavedReport = createTool({
+	description:
+		"Get one saved report's settings (entity type, groupBy, date range, visualization). Re-run it by passing those settings to runReport.",
+	inputSchema: z.object({ reportId: z.string() }),
+	execute: async (ctx, input): Promise<SavedReportDetail | NotFound> => {
+		const report = await ctx.runQuery(api.reports.get, {
+			id: input.reportId as Id<"reports">,
+		});
+		if (!report) return { found: false };
+		return {
+			found: true,
+			report: {
+				id: report._id,
+				name: report.name,
+				description: truncate(report.description, TEXT_CAP),
+				entityType: report.config.entityType,
+				visualization: report.visualization.type,
+				updatedAt: isoInstant(report.updatedAt),
+				groupBy: report.config.groupBy,
+				dateRange: report.config.dateRange
+					? {
+							start: isoDay(report.config.dateRange.start),
+							end: isoDay(report.config.dateRange.end),
+						}
+					: undefined,
+			},
+		};
+	},
+});
+
+export const listSkus = createTool({
+	description:
+		"List the organization's service catalog (SKUs): what they charge per unit for each service or product. Rates are dollars.",
+	inputSchema: z.object({
+		includeInactive: z.boolean().optional().describe("Defaults to false"),
+	}),
+	execute: async (ctx, input): Promise<Capped<SkuItem>> => {
+		const skus = input.includeInactive
+			? await ctx.runQuery(api.skus.listAll, {})
+			: await ctx.runQuery(api.skus.list, {});
+		return capped(
+			skus.map((s) => ({
+				id: s._id,
+				name: s.name,
+				unit: s.unit,
+				rate: s.rate,
+				cost: s.cost,
+				isActive: s.isActive,
+			})),
+			LIST_CAP
+		);
+	},
+});
+
+// ---------------------------------------------------------------------------
+// Write tools
+//
+// Convention for adding writes:
+// - Wrap an existing org-scoped userMutation via ctx.runMutation — the
+//   caller's identity propagates, so org isolation and role checks are
+//   inherited, exactly like the read tools.
+// - Whitelist editable fields in inputSchema; never pass input through.
+// - Dates come in as YYYY-MM-DD and are stored UTC-midnight (dayStartMs).
+// - Return WriteResult, catching mutation validation errors as data.
+// - Consequential, externally visible actions (e.g. anything that emails a
+//   client) must set needsApproval — none of the current writes qualify.
+//   Note: status changes DO fire emitStatusChangeEvent and can trigger org
+//   automations (PRD risk R3, shipped ungated by decision 2026-07-03).
+// ---------------------------------------------------------------------------
+
+const taskStatus = z.enum(["pending", "in-progress", "completed", "cancelled"]);
+const timeHHMM = z
+	.string()
+	.regex(/^\d{2}:\d{2}$/, "Use HH:MM (24-hour)")
+	.describe("24-hour HH:MM");
+
+export const createTask = createTool({
+	description:
+		"Create a task on the schedule. Resolve clientId/projectId/assigneeUserId with lookup tools first — never guess IDs. Tasks linked to a client are client-facing; tasks without a client are internal.",
+	inputSchema: z.object({
+		title: z.string().min(1),
+		date: isoDate.describe("Day the task is scheduled for (YYYY-MM-DD)"),
+		description: z.string().optional(),
+		startTime: timeHHMM.optional(),
+		endTime: timeHHMM.optional(),
+		clientId: z.string().optional(),
+		projectId: z.string().optional(),
+		assigneeUserId: z.string().optional(),
+		status: taskStatus.optional().describe("Defaults to pending"),
+	}),
+	execute: async (
+		ctx,
+		input
+	): Promise<WriteResult<{ taskId: string }>> => {
+		try {
+			const taskId = await ctx.runMutation(api.tasks.create, {
+				title: input.title,
+				description: input.description,
+				date: dayStartMs(input.date),
+				startTime: input.startTime,
+				endTime: input.endTime,
+				type: input.clientId ? "external" : "internal",
+				clientId: input.clientId as Id<"clients"> | undefined,
+				projectId: input.projectId as Id<"projects"> | undefined,
+				assigneeUserId: input.assigneeUserId as Id<"users"> | undefined,
+				status: input.status ?? "pending",
+			});
+			return { ok: true, taskId };
+		} catch (e) {
+			return writeError(e);
+		}
+	},
+});
+
+export const updateTask = createTool({
+	description:
+		"Update a task: reschedule (date/times), retitle, edit the description, reassign, or change its status (e.g. mark completed). Only pass the fields to change. Use the task id from getSchedule or getTasks.",
+	inputSchema: z.object({
+		taskId: z.string(),
+		title: z.string().min(1).optional(),
+		description: z.string().optional(),
+		date: isoDate.optional().describe("New day (YYYY-MM-DD)"),
+		startTime: timeHHMM.optional(),
+		endTime: timeHHMM.optional(),
+		assigneeUserId: z.string().optional(),
+		status: taskStatus.optional(),
+	}),
+	execute: async (
+		ctx,
+		input
+	): Promise<WriteResult<{ taskId: string }>> => {
+		try {
+			const taskId = await ctx.runMutation(api.tasks.update, {
+				id: input.taskId as Id<"tasks">,
+				title: input.title,
+				description: input.description,
+				date: input.date ? dayStartMs(input.date) : undefined,
+				startTime: input.startTime,
+				endTime: input.endTime,
+				assigneeUserId: input.assigneeUserId as Id<"users"> | undefined,
+				status: input.status,
+			});
+			return { ok: true, taskId };
+		} catch (e) {
+			return writeError(e);
+		}
+	},
+});
+
+export const updateClient = createTool({
+	description:
+		"Update a client's details: name, description, status, lead source, communication preference, tags, or notes. Only pass the fields to change. Resolve the client with listClients first.",
+	inputSchema: z.object({
+		clientId: z.string(),
+		companyName: z.string().min(1).optional(),
+		companyDescription: z.string().optional(),
+		status: z.enum(["lead", "active", "inactive", "archived"]).optional(),
+		leadSource: z
+			.enum([
+				"word-of-mouth",
+				"website",
+				"social-media",
+				"referral",
+				"advertising",
+				"trade-show",
+				"cold-outreach",
+				"other",
+			])
+			.optional(),
+		communicationPreference: z.enum(["email", "phone", "both"]).optional(),
+		tags: z.array(z.string()).optional().describe("Replaces the full tag list"),
+		notes: z.string().optional(),
+	}),
+	execute: async (
+		ctx,
+		input
+	): Promise<WriteResult<{ clientId: string }>> => {
+		try {
+			const clientId = await ctx.runMutation(api.clients.update, {
+				id: input.clientId as Id<"clients">,
+				companyName: input.companyName,
+				companyDescription: input.companyDescription,
+				status: input.status,
+				leadSource: input.leadSource,
+				communicationPreference: input.communicationPreference,
+				tags: input.tags,
+				notes: input.notes,
+			});
+			return { ok: true, clientId };
+		} catch (e) {
+			return writeError(e);
+		}
+	},
+});
+
+export const updateProject = createTool({
+	description:
+		"Update a project's details: title, description, status, type, or start/end dates. Only pass the fields to change. Resolve the project with listProjects first.",
+	inputSchema: z.object({
+		projectId: z.string(),
+		title: z.string().min(1).optional(),
+		description: z.string().optional(),
+		status: z
+			.enum(["planned", "in-progress", "completed", "cancelled"])
+			.optional(),
+		projectType: z.enum(["one-off", "recurring"]).optional(),
+		startDate: isoDate.optional().describe("YYYY-MM-DD"),
+		endDate: isoDate.optional().describe("YYYY-MM-DD"),
+	}),
+	execute: async (
+		ctx,
+		input
+	): Promise<WriteResult<{ projectId: string }>> => {
+		try {
+			const projectId = await ctx.runMutation(api.projects.update, {
+				id: input.projectId as Id<"projects">,
+				title: input.title,
+				description: input.description,
+				status: input.status,
+				projectType: input.projectType,
+				startDate: input.startDate ? dayStartMs(input.startDate) : undefined,
+				endDate: input.endDate ? dayStartMs(input.endDate) : undefined,
+			});
+			return { ok: true, projectId };
+		} catch (e) {
+			return writeError(e);
+		}
 	},
 });
 
@@ -947,5 +1357,15 @@ export const assistantTools = {
 	getEmailThread,
 	getDocuments,
 	getActivity,
+	getTeamMembers,
+	getAutomations,
+	getAutomationRuns,
+	listSavedReports,
+	getSavedReport,
+	listSkus,
+	createTask,
+	updateTask,
+	updateClient,
+	updateProject,
 	navigate,
 };

--- a/packages/backend/convex/billingWebhook.ts
+++ b/packages/backend/convex/billingWebhook.ts
@@ -128,6 +128,7 @@ export const handleSubscriptionCreated = internalMutation({
 		subscriptionId: v.string(),
 		organizationId: v.string(),
 		planId: v.string(),
+		planSlug: v.optional(v.string()),
 		status: v.string(),
 		currentPeriodStart: v.optional(v.number()),
 	},
@@ -142,6 +143,9 @@ export const handleSubscriptionCreated = internalMutation({
 		await ctx.db.patch(org._id, {
 			clerkSubscriptionId: args.subscriptionId,
 			clerkPlanId: args.planId,
+			// Only overwrite when the event carried plan items — patching
+			// undefined would unset the field.
+			...(args.planSlug !== undefined ? { clerkPlanSlug: args.planSlug } : {}),
 			subscriptionStatus: toSubscriptionStatus(args.status),
 			billingCycleStart: args.currentPeriodStart || Date.now(),
 		});
@@ -159,6 +163,7 @@ export const handleSubscriptionActive = internalMutation({
 		subscriptionId: v.string(),
 		organizationId: v.string(),
 		planId: v.string(),
+		planSlug: v.optional(v.string()),
 		currentPeriodStart: v.optional(v.number()),
 	},
 	handler: async (ctx, args) => {
@@ -172,6 +177,7 @@ export const handleSubscriptionActive = internalMutation({
 		await ctx.db.patch(org._id, {
 			clerkSubscriptionId: args.subscriptionId,
 			clerkPlanId: args.planId,
+			...(args.planSlug !== undefined ? { clerkPlanSlug: args.planSlug } : {}),
 			subscriptionStatus: "active",
 			billingCycleStart: args.currentPeriodStart || Date.now(),
 		});
@@ -189,6 +195,7 @@ export const handleSubscriptionUpdated = internalMutation({
 		subscriptionId: v.string(),
 		organizationId: v.string(),
 		planId: v.string(),
+		planSlug: v.optional(v.string()),
 		status: v.string(),
 		currentPeriodStart: v.optional(v.number()),
 	},
@@ -207,6 +214,7 @@ export const handleSubscriptionUpdated = internalMutation({
 		await ctx.db.patch(org._id, {
 			clerkSubscriptionId: args.subscriptionId,
 			clerkPlanId: args.planId,
+			...(args.planSlug !== undefined ? { clerkPlanSlug: args.planSlug } : {}),
 			subscriptionStatus: toSubscriptionStatus(args.status),
 			billingCycleStart: args.currentPeriodStart,
 		});

--- a/packages/backend/convex/http.ts
+++ b/packages/backend/convex/http.ts
@@ -415,10 +415,11 @@ http.route({
 			}>;
 		}
 
-		// The active paid plan on a subscription event. Free plans (Clerk default
-		// slugs free_user/free_org) ride along as items too, so filter them out;
-		// a paid upgrade shows the old free item as "ended" beside the new one.
-		function getActivePaidPlan(data: BillingWebhookData) {
+		// The plan slug to persist for a subscription event. Paid items win
+		// (Clerk default slugs free_user/free_org ride along as items too);
+		// falls back to the first active item, which may be a free plan —
+		// a non-null return does NOT imply premium access.
+		function getPreferredActivePlan(data: BillingWebhookData) {
 			const activeItems = (data.items ?? []).filter(
 				(item) => item.status === "active"
 			);
@@ -471,7 +472,7 @@ http.route({
 					console.error("No organization_id in subscription.created event");
 					break;
 				}
-				const activePlan = getActivePaidPlan(data);
+				const activePlan = getPreferredActivePlan(data);
 				await ctx.runMutation(
 					internal.billingWebhook.handleSubscriptionCreated,
 					{
@@ -497,7 +498,7 @@ http.route({
 					console.error("No organization_id in subscription.active event");
 					break;
 				}
-				const activePlan = getActivePaidPlan(data);
+				const activePlan = getPreferredActivePlan(data);
 				await ctx.runMutation(
 					internal.billingWebhook.handleSubscriptionActive,
 					{
@@ -524,7 +525,7 @@ http.route({
 					console.error("No organization_id in subscription.updated event");
 					break;
 				}
-				const activePlan = getActivePaidPlan(data);
+				const activePlan = getPreferredActivePlan(data);
 				await ctx.runMutation(
 					internal.billingWebhook.handleSubscriptionUpdated,
 					{

--- a/packages/backend/convex/http.ts
+++ b/packages/backend/convex/http.ts
@@ -408,6 +408,25 @@ http.route({
 				organization_id?: string;
 				user_id?: string;
 			};
+			// subscription.* events carry plans per item, not at the top level.
+			items?: Array<{
+				status?: string;
+				plan?: { id?: string; slug?: string };
+			}>;
+		}
+
+		// The active paid plan on a subscription event. Free plans (Clerk default
+		// slugs free_user/free_org) ride along as items too, so filter them out;
+		// a paid upgrade shows the old free item as "ended" beside the new one.
+		function getActivePaidPlan(data: BillingWebhookData) {
+			const activeItems = (data.items ?? []).filter(
+				(item) => item.status === "active"
+			);
+			return (
+				activeItems.find(
+					(item) => item.plan?.slug && !item.plan.slug.startsWith("free_")
+				)?.plan ?? activeItems[0]?.plan
+			);
 		}
 
 		switch (event.type) {
@@ -452,12 +471,14 @@ http.route({
 					console.error("No organization_id in subscription.created event");
 					break;
 				}
+				const activePlan = getActivePaidPlan(data);
 				await ctx.runMutation(
 					internal.billingWebhook.handleSubscriptionCreated,
 					{
 						subscriptionId: data.id,
 						organizationId: organizationId,
-						planId: data.plan_id || data.plan?.id || "",
+						planId: activePlan?.id || data.plan_id || data.plan?.id || "",
+						planSlug: activePlan?.slug,
 						status: data.status || "active",
 						currentPeriodStart: data.current_period_start
 							? secondsToMilliseconds(data.current_period_start)
@@ -476,12 +497,14 @@ http.route({
 					console.error("No organization_id in subscription.active event");
 					break;
 				}
+				const activePlan = getActivePaidPlan(data);
 				await ctx.runMutation(
 					internal.billingWebhook.handleSubscriptionActive,
 					{
 						subscriptionId: data.id,
 						organizationId: organizationId,
-						planId: data.plan_id || data.plan?.id || "",
+						planId: activePlan?.id || data.plan_id || data.plan?.id || "",
+						planSlug: activePlan?.slug,
 						currentPeriodStart: data.current_period_start
 							? secondsToMilliseconds(data.current_period_start)
 							: undefined,
@@ -501,12 +524,14 @@ http.route({
 					console.error("No organization_id in subscription.updated event");
 					break;
 				}
+				const activePlan = getActivePaidPlan(data);
 				await ctx.runMutation(
 					internal.billingWebhook.handleSubscriptionUpdated,
 					{
 						subscriptionId: data.id,
 						organizationId: organizationId,
-						planId: data.plan_id || data.plan?.id || "",
+						planId: activePlan?.id || data.plan_id || data.plan?.id || "",
+						planSlug: activePlan?.slug,
 						status: data.status || "active",
 						currentPeriodStart: data.current_period_start
 							? secondsToMilliseconds(data.current_period_start)

--- a/packages/backend/convex/lib/auth.ts
+++ b/packages/backend/convex/lib/auth.ts
@@ -106,6 +106,13 @@ export async function getCurrentUserOrgId(
 	return (await resolveCurrentUserOrgId(ctx, true))!;
 }
 
+/** Non-throwing variant: null when unauthenticated or no active org. */
+export async function getCurrentUserOrgIdOrNull(
+	ctx: QueryCtx | MutationCtx
+): Promise<Id<"organizations"> | null> {
+	return resolveCurrentUserOrgId(ctx, false);
+}
+
 /**
  * Ensure the current user has access to the specified organization
  */

--- a/packages/backend/convex/lib/permissions.ts
+++ b/packages/backend/convex/lib/permissions.ts
@@ -1,4 +1,4 @@
-import type { QueryCtx, MutationCtx } from "../_generated/server";
+import type { ActionCtx, QueryCtx, MutationCtx } from "../_generated/server";
 import { query } from "../_generated/server";
 
 /**
@@ -75,6 +75,43 @@ export const debugAuthToken = query({
 		};
 	},
 });
+
+/**
+ * Server-side mirror of the web app's useFeatureAccess() premium check
+ * (apps/web/src/hooks/use-feature-access.ts): premium if the user OR org has
+ * the has_premium_feature_access metadata flag, or the org is on the paid
+ * Clerk Billing plan. Reads the same JWT claims debugAuthToken inspects.
+ * Secure-by-default: unauthenticated or claim-less tokens are not premium.
+ */
+export async function hasPremiumAccess(
+	ctx: QueryCtx | MutationCtx | ActionCtx
+): Promise<boolean> {
+	const identity = await ctx.auth.getUserIdentity();
+	if (!identity) {
+		return false;
+	}
+	const token = identity as ClerkIdentityWithClaims;
+
+	const userMetadata =
+		token.publicMetadata ??
+		(token.public_metadata as ClerkIdentityWithClaims["publicMetadata"]);
+	if (userMetadata?.has_premium_feature_access === true) {
+		return true;
+	}
+
+	const orgMetadata =
+		token.orgPublicMetadata ??
+		(token.org_public_metadata as ClerkIdentityWithClaims["orgPublicMetadata"]);
+	if (orgMetadata?.has_premium_feature_access === true) {
+		return true;
+	}
+
+	// Clerk Billing plan claim, e.g. "u:free_user o:onetool_business_plan_org".
+	const planClaim = [token.pla, token.plan]
+		.filter((value): value is string => typeof value === "string")
+		.join(" ");
+	return planClaim.includes("onetool_business_plan_org");
+}
 
 /**
  * Role-based permission utilities

--- a/packages/backend/convex/lib/permissions.ts
+++ b/packages/backend/convex/lib/permissions.ts
@@ -107,10 +107,15 @@ export async function hasPremiumAccess(
 	}
 
 	// Clerk Billing plan claim, e.g. "u:free_user o:onetool_business_plan_org".
-	const planClaim = [token.pla, token.plan]
+	// Exact token match — a substring check would also accept longer slugs.
+	return [token.pla, token.plan]
 		.filter((value): value is string => typeof value === "string")
-		.join(" ");
-	return planClaim.includes("onetool_business_plan_org");
+		.flatMap((claim) => claim.split(/\s+/))
+		.some(
+			(entry) =>
+				entry === "o:onetool_business_plan_org" ||
+				entry === "onetool_business_plan_org"
+		);
 }
 
 /**

--- a/packages/backend/convex/lib/permissions.ts
+++ b/packages/backend/convex/lib/permissions.ts
@@ -1,5 +1,6 @@
-import type { ActionCtx, QueryCtx, MutationCtx } from "../_generated/server";
+import type { QueryCtx, MutationCtx } from "../_generated/server";
 import { query } from "../_generated/server";
+import { getCurrentUserOrgIdOrNull } from "./auth";
 
 /**
  * Server-side permission checking utilities
@@ -76,15 +77,24 @@ export const debugAuthToken = query({
 	},
 });
 
+export const PREMIUM_PLAN_SLUG = "onetool_business_plan_org";
+
+// Statuses under which a subscription grants access (free trials arrive as
+// "active" with is_free_trial on the item, so "trialing" rarely appears).
+const PREMIUM_SUBSCRIPTION_STATUSES = new Set(["active", "trialing"]);
+
 /**
  * Server-side mirror of the web app's useFeatureAccess() premium check
  * (apps/web/src/hooks/use-feature-access.ts): premium if the user OR org has
- * the has_premium_feature_access metadata flag, or the org is on the paid
- * Clerk Billing plan. Reads the same JWT claims debugAuthToken inspects.
- * Secure-by-default: unauthenticated or claim-less tokens are not premium.
+ * the has_premium_feature_access metadata flag (present in the "convex" JWT
+ * template), or the org's billing-webhook-synced subscription is on the paid
+ * plan. Clerk's `pla` billing claim is NOT in custom JWT templates and reading
+ * plans from session claims is unsupported — the org doc (kept current by
+ * billingWebhook.ts) is the plan source of truth here.
+ * Secure-by-default: unauthenticated callers are not premium.
  */
 export async function hasPremiumAccess(
-	ctx: QueryCtx | MutationCtx | ActionCtx
+	ctx: QueryCtx | MutationCtx
 ): Promise<boolean> {
 	const identity = await ctx.auth.getUserIdentity();
 	if (!identity) {
@@ -106,16 +116,15 @@ export async function hasPremiumAccess(
 		return true;
 	}
 
-	// Clerk Billing plan claim, e.g. "u:free_user o:onetool_business_plan_org".
-	// Exact token match — a substring check would also accept longer slugs.
-	return [token.pla, token.plan]
-		.filter((value): value is string => typeof value === "string")
-		.flatMap((claim) => claim.split(/\s+/))
-		.some(
-			(entry) =>
-				entry === "o:onetool_business_plan_org" ||
-				entry === "onetool_business_plan_org"
-		);
+	const orgId = await getCurrentUserOrgIdOrNull(ctx);
+	if (!orgId) {
+		return false;
+	}
+	const org = await ctx.db.get(orgId);
+	return (
+		org?.clerkPlanSlug === PREMIUM_PLAN_SLUG &&
+		PREMIUM_SUBSCRIPTION_STATUSES.has(org.subscriptionStatus ?? "")
+	);
 }
 
 /**

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -64,6 +64,7 @@ export default defineSchema({
 		// Clerk Billing & Subscription
 		clerkSubscriptionId: v.optional(v.string()), // Clerk subscription ID
 		clerkPlanId: v.optional(v.string()), // Clerk plan identifier
+		clerkPlanSlug: v.optional(v.string()), // Active paid plan slug from webhook items[] (plan gate source of truth)
 		subscriptionStatus: v.optional(
 			v.union(
 				v.literal("active"),

--- a/packages/backend/convex/tasks.test.ts
+++ b/packages/backend/convex/tasks.test.ts
@@ -727,6 +727,65 @@ describe("Tasks", () => {
 				})
 			).rejects.toThrowError("Task title cannot be empty");
 		});
+
+		it("should reject updating a task from another organization", async () => {
+			const { taskId } = await t.run(async (ctx) => {
+				const ownerId = await ctx.db.insert("users", {
+					name: "Org A Owner",
+					email: "a@example.com",
+					image: "https://example.com/image.jpg",
+					externalId: "user_a",
+				});
+				const orgAId = await ctx.db.insert("organizations", {
+					clerkOrganizationId: "org_a",
+					name: "Org A",
+					ownerUserId: ownerId,
+				});
+				await ctx.db.insert("organizationMemberships", {
+					orgId: orgAId,
+					userId: ownerId,
+					role: "admin",
+				});
+				const taskId = await ctx.db.insert("tasks", {
+					orgId: orgAId,
+					title: "Org A Task",
+					date: Date.now(),
+					status: "pending",
+					type: "internal",
+				});
+
+				const intruderId = await ctx.db.insert("users", {
+					name: "Org B Owner",
+					email: "b@example.com",
+					image: "https://example.com/image.jpg",
+					externalId: "user_b",
+				});
+				const orgBId = await ctx.db.insert("organizations", {
+					clerkOrganizationId: "org_b",
+					name: "Org B",
+					ownerUserId: intruderId,
+				});
+				await ctx.db.insert("organizationMemberships", {
+					orgId: orgBId,
+					userId: intruderId,
+					role: "admin",
+				});
+
+				return { taskId };
+			});
+
+			const asOrgB = t.withIdentity({
+				subject: "user_b",
+				activeOrgId: "org_b",
+			});
+
+			await expect(
+				asOrgB.mutation(api.tasks.update, {
+					id: taskId,
+					title: "Hijacked",
+				})
+			).rejects.toThrowError();
+		});
 	});
 
 	describe("update — phase 22 mobile edit-sheet paths", () => {

--- a/packages/backend/convex/tasks.test.ts
+++ b/packages/backend/convex/tasks.test.ts
@@ -514,6 +514,84 @@ describe("Tasks", () => {
 			expect(client1Tasks[0].title).toBe("Task for Client 1");
 		});
 
+		it("should apply date range when combined with an entity filter", async () => {
+			const { clientId1, clientId2 } = await t.run(async (ctx) => {
+				const userId = await ctx.db.insert("users", {
+					name: "Test User",
+					email: "test@example.com",
+					image: "https://example.com/image.jpg",
+					externalId: "user_123",
+				});
+
+				const orgId = await ctx.db.insert("organizations", {
+					clerkOrganizationId: "org_123",
+					name: "Test Org",
+					ownerUserId: userId,
+				});
+
+				await ctx.db.insert("organizationMemberships", {
+					orgId,
+					userId,
+					role: "admin",
+				});
+
+				const clientId1 = await ctx.db.insert("clients", {
+					orgId,
+					companyName: "Client 1",
+					status: "active",
+				});
+
+				const clientId2 = await ctx.db.insert("clients", {
+					orgId,
+					companyName: "Client 2",
+					status: "active",
+				});
+
+				return { clientId1, clientId2 };
+			});
+
+			const asUser = t.withIdentity({
+				subject: "user_123",
+				activeOrgId: "org_123",
+			});
+
+			const inRange = Date.UTC(2026, 6, 15);
+			const outOfRange = Date.UTC(2026, 7, 15);
+
+			await asUser.mutation(api.tasks.create, {
+				title: "Client 1 July Task",
+				date: inRange,
+				status: "pending",
+				clientId: clientId1,
+				type: "external",
+			});
+
+			await asUser.mutation(api.tasks.create, {
+				title: "Client 1 August Task",
+				date: outOfRange,
+				status: "pending",
+				clientId: clientId1,
+				type: "external",
+			});
+
+			await asUser.mutation(api.tasks.create, {
+				title: "Client 2 July Task",
+				date: inRange,
+				status: "pending",
+				clientId: clientId2,
+				type: "external",
+			});
+
+			const tasks = await asUser.query(api.tasks.list, {
+				clientId: clientId1,
+				dateFrom: Date.UTC(2026, 6, 1),
+				dateTo: Date.UTC(2026, 6, 31),
+			});
+
+			expect(tasks).toHaveLength(1);
+			expect(tasks[0].title).toBe("Client 1 July Task");
+		});
+
 		it.skip("should only show assigned tasks for member users", async () => {
 			const { member1Id, member2Id, clientId } = await t.run(async (ctx) => {
 				const adminId = await ctx.db.insert("users", {

--- a/packages/backend/convex/tasks.ts
+++ b/packages/backend/convex/tasks.ts
@@ -310,6 +310,14 @@ export const list = optionalUserQuery({
 			tasks = tasks.filter((task) => task.projectId === args.projectId);
 		}
 
+		// Entity-filter branches above skip the by_date index, so apply the
+		// date range here too.
+		if (args.dateFrom && args.dateTo) {
+			tasks = tasks.filter(
+				(task) => task.date >= args.dateFrom! && task.date <= args.dateTo!
+			);
+		}
+
 		tasks = await ctx.scopedToActor(tasks, (task) => task.assigneeUserId);
 
 		// Sort by date

--- a/packages/backend/convex/test.helpers.ts
+++ b/packages/backend/convex/test.helpers.ts
@@ -254,6 +254,20 @@ export function createTestIdentity(clerkUserId: string, clerkOrgId: string) {
 }
 
 /**
+ * Identity carrying the premium metadata flag — passes hasPremiumAccess
+ * (lib/permissions.ts), e.g. the AI assistant plan gate.
+ */
+export function createPremiumTestIdentity(
+	clerkUserId: string,
+	clerkOrgId: string
+) {
+	return {
+		...createTestIdentity(clerkUserId, clerkOrgId),
+		publicMetadata: { has_premium_feature_access: true },
+	};
+}
+
+/**
  * Creates a client contact
  */
 export async function createTestClientContact(


### PR DESCRIPTION
This pull request introduces a premium feature gate for the AI assistant, restricting access to organizations on the Business plan. It updates both the backend and frontend to enforce and communicate this restriction, and ensures correct handling of date fields in assistant renderers for backward compatibility. The most important changes are grouped below:

**Premium Plan Gating for AI Assistant:**

* Added a `canUseAiAssistant` flag to the `PlanLimits` interface and set it appropriately for free and premium plans in `plan-limits.ts`. [[1]](diffhunk://#diff-6722f586d75befaadb04ced4bf87d2586e63c736eaa0aefa6c0e04c423c72065R16) [[2]](diffhunk://#diff-6722f586d75befaadb04ced4bf87d2586e63c736eaa0aefa6c0e04c423c72065R30-R31) [[3]](diffhunk://#diff-6722f586d75befaadb04ced4bf87d2586e63c736eaa0aefa6c0e04c423c72065R45)
* Enforced the premium plan requirement in backend mutations and actions (`sendMessage`, `streamResponse`) using a new `hasPremiumAccess` check, returning a clear error message if access is denied. [[1]](diffhunk://#diff-f1e4d8b9722d4f75ec5fad50511e56f2876d005de08f88eaf4cf359942a309e1R16-R21) [[2]](diffhunk://#diff-f1e4d8b9722d4f75ec5fad50511e56f2876d005de08f88eaf4cf359942a309e1R55-R57)
* Added comprehensive backend tests to verify that only organizations with premium access can use the assistant, including checks for various subscription and metadata scenarios. [[1]](diffhunk://#diff-b26f691611395bda4b5f937f4f91f5686237b80144079319eac0ffa8726e187bR5) [[2]](diffhunk://#diff-b26f691611395bda4b5f937f4f91f5686237b80144079319eac0ffa8726e187bL56-R61) [[3]](diffhunk://#diff-b26f691611395bda4b5f937f4f91f5686237b80144079319eac0ffa8726e187bL106-R108) [[4]](diffhunk://#diff-b26f691611395bda4b5f937f4f91f5686237b80144079319eac0ffa8726e187bR138-R240)

**Frontend: Assistant Panel User Experience:**

* Updated the assistant panel to check the user's plan using `useFeatureAccess`. If access is locked, it displays a new `UpgradePrompt` encouraging users to upgrade, and disables chat and history UI. [[1]](diffhunk://#diff-89b999f68cd4ae9dc8b3ae9f170c8995771909c99be0dd761c20599a406f6cdbR22-R27) [[2]](diffhunk://#diff-89b999f68cd4ae9dc8b3ae9f170c8995771909c99be0dd761c20599a406f6cdbR171-R197) [[3]](diffhunk://#diff-89b999f68cd4ae9dc8b3ae9f170c8995771909c99be0dd761c20599a406f6cdbR219-R222) [[4]](diffhunk://#diff-89b999f68cd4ae9dc8b3ae9f170c8995771909c99be0dd761c20599a406f6cdbR367-R383) [[5]](diffhunk://#diff-89b999f68cd4ae9dc8b3ae9f170c8995771909c99be0dd761c20599a406f6cdbL353-R397) [[6]](diffhunk://#diff-89b999f68cd4ae9dc8b3ae9f170c8995771909c99be0dd761c20599a406f6cdbL435-R479) [[7]](diffhunk://#diff-7388cefef474d5707b023f9396fa362c4c76add5d552b4a363785612b6e66ddfR124-R125)
* Ensured the assistant notch remains visible to all users, but free-plan users see the upgrade prompt inside the panel.

**Assistant Capabilities and Messaging:**

* Updated the assistant's instructions to reflect new capabilities (can make certain changes, not just read-only) and clarified date handling (ISO 8601 strings instead of Unix timestamps).
* Adjusted the chat footer message to inform users that the assistant can now make changes, with a caution to double-check important actions.
* Refreshed the default chat suggestions to better reflect new capabilities.

**Backward-Compatible Date Handling in Renderers:**

* Updated the emails and schedule renderers to accept both ISO strings and legacy epoch millisecond timestamps for date fields, ensuring compatibility with historical data. [[1]](diffhunk://#diff-d0adc4742cbaca05255c72cef72ed9565de4a5b17b4eb536c0d2dd32d9b8aef1L15-R16) [[2]](diffhunk://#diff-d0adc4742cbaca05255c72cef72ed9565de4a5b17b4eb536c0d2dd32d9b8aef1L24-R27) [[3]](diffhunk://#diff-e8ae5f3931fc89c7640d48968b2294c4b9a3960c5c4f3481108dd05feca4501eL6-R23) [[4]](diffhunk://#diff-e8ae5f3931fc89c7640d48968b2294c4b9a3960c5c4f3481108dd05feca4501eL30-R50) [[5]](diffhunk://#diff-e8ae5f3931fc89c7640d48968b2294c4b9a3960c5c4f3481108dd05feca4501eL81-R95) [[6]](diffhunk://#diff-e8ae5f3931fc89c7640d48968b2294c4b9a3960c5c4f3481108dd05feca4501eL101-R115)

These changes collectively ensure that only Business plan organizations can use the AI assistant, provide a clear upgrade path for free users, and maintain a smooth experience for both new and existing users.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gates the AI assistant behind the Business plan (enforced in both the backend mutations and the frontend panel), upgrades the assistant from read-only to write-capable (create/update tasks, clients, projects), converts all tool output dates from epoch-ms to ISO 8601 strings for LLM-friendliness, and adds backward-compatible date parsing in the frontend renderers for historical thread replay.

- **Plan gating**: `hasPremiumAccess()` checks Clerk JWT metadata and the DB-synced `clerkPlanSlug`; the gate is enforced at both `sendMessage` and `authorizeThread` (preventing direct `streamResponse` bypass); the billing webhook now extracts plan slugs from `items[]` and writes them to the new `clerkPlanSlug` org field.
- **Write tools**: `createTask`, `updateTask`, `updateClient`, and `updateProject` wrap existing org-scoped `userMutation`s so org isolation is inherited; errors are returned as data so the LLM can self-correct.
- **Date handling**: `isoDay`/`isoInstant` helpers convert epoch-ms to ISO strings before the LLM sees them; the frontend renderers accept both formats for backward compatibility with stored historical tool outputs.

<h3>Confidence Score: 3/5</h3>

The plan gating and billing plumbing are solid, but a logic mismatch in the new getTasks filtered scope means the assistant silently returns incorrect (over-broad) results when the user asks to filter tasks by client/project/assignee and a date range simultaneously.

The new getTasks filtered scope in assistantTools.ts tells the model it can combine client/project/assignee with a date range, but tasks.list's query priority tree drops dateFrom/dateTo whenever any entity filter is present. Queries like show me tasks for client X this month return all-time tasks instead. The rest of the PR — the plan gate, billing webhook slug extraction, write tools, and renderer date handling — looks correct and is backed by good test coverage.

packages/backend/convex/assistantTools.ts (getTasks filtered scope description vs. tasks.list query behaviour), packages/backend/convex/http.ts (getActivePaidPlan naming)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/backend/convex/assistantTools.ts | Adds write tools (createTask, updateTask, updateClient, updateProject), new read tools, and converts all date outputs to ISO strings. Contains a logic bug: the getTasks 'filtered' scope claims to support combining clientId/projectId/assigneeUserId with a date range, but tasks.list drops dateFrom/dateTo when any entity filter is present. |
| packages/backend/convex/lib/permissions.ts | New hasPremiumAccess() function checks user/org metadata flags and DB-stored clerkPlanSlug; logic is well-documented and secure-by-default. |
| packages/backend/convex/assistantChat.ts | Plan gate correctly added to both sendMessage (mutation) and authorizeThread (internalQuery used by streamResponse action). Double-enforcement ensures the action path can't bypass the gate. |
| packages/backend/convex/http.ts | getActivePaidPlan helper correctly extracts paid plan slugs from subscription webhook items[]; the fallback can return a free plan item but hasPremiumAccess's exact-match check keeps this safe. Function naming is misleading. |
| packages/backend/convex/billingWebhook.ts | planSlug is conditionally written (only when defined) to avoid accidentally clearing the field; spread guard pattern is correct across all three subscription handlers. |
| packages/backend/convex/assistantChat.test.ts | Comprehensive plan-gate tests covering free user blocking, org metadata flag, webhook-synced subscription, and direct streamResponse invocation; existing org-isolation tests correctly updated to use premium identities. |
| apps/web/src/components/assistant/assistant-panel.tsx | UpgradePrompt component correctly gates UI for locked users; accessLoading check prevents flicker for premium users; backend gate comment is accurate. |
| apps/web/src/components/assistant/renderers/schedule-renderer.tsx | Backward-compatible date handling added via DayValue = string | number; dayMs() helper correctly handles undefined/NaN for sorting. |
| apps/web/src/components/assistant/renderers/emails-renderer.tsx | sentAt made optional with string|number|undefined type; formatSentAt returns empty string for undefined inputs; backward-compatible with historical epoch ms values. |
| apps/web/src/lib/plan-limits.ts | canUseAiAssistant flag correctly added to PlanLimits interface; FREE_PLAN_LIMITS sets it false, PREMIUM_PLAN_LIMITS sets it true. |
| packages/backend/convex/schema.ts | Adds optional clerkPlanSlug field to organizations table; backward-compatible schema change. |
| packages/backend/convex/test.helpers.ts | createPremiumTestIdentity helper is clean and reusable; mirrors one of the hasPremiumAccess check paths. |
| packages/backend/convex/tasks.test.ts | New cross-org rejection test for tasks.update is well-structured and covers the org isolation guarantee for the write path exposed to the assistant. |
| packages/backend/convex/lib/auth.ts | New getCurrentUserOrgIdOrNull non-throwing variant is clean; used by hasPremiumAccess for the DB subscription lookup path. |
| apps/web/src/components/layout/sidebar-with-header.tsx | AssistantNotch now visible to all users unconditionally; comment correctly explains the design intent. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Client: sendMessage] -->|userMutation| B{hasPremiumAccess?}
    B -- No --> C[Throw: Business plan required]
    B -- Yes --> D[Save prompt to thread]
    D --> E[Client: streamResponse action]
    E -->|ctx.runQuery| F[authorizeThread internalQuery]
    F --> G{hasPremiumAccess?}
    G -- No --> C
    G -- Yes --> H[assistantAgent.streamText]
    H --> I{Tool calls}
    I -->|Read| J[ctx.runQuery org-scoped queries]
    I -->|Write| K[ctx.runMutation createTask / updateTask / updateClient / updateProject]
    K --> L[WriteResult ok or error returned to LLM]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Client: sendMessage] -->|userMutation| B{hasPremiumAccess?}
    B -- No --> C[Throw: Business plan required]
    B -- Yes --> D[Save prompt to thread]
    D --> E[Client: streamResponse action]
    E -->|ctx.runQuery| F[authorizeThread internalQuery]
    F --> G{hasPremiumAccess?}
    G -- No --> C
    G -- Yes --> H[assistantAgent.streamText]
    H --> I{Tool calls}
    I -->|Read| J[ctx.runQuery org-scoped queries]
    I -->|Write| K[ctx.runMutation createTask / updateTask / updateClient / updateProject]
    K --> L[WriteResult ok or error returned to LLM]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/backend/convex/assistantTools.ts`, line 463-490 ([link](https://github.com/xcarter93/onetool/blob/e9c31e709ed9a44e8480c89b7acc6ca24ddaa7c1/packages/backend/convex/assistantTools.ts#L463-L490)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`getTasks` filtered scope silently drops the date range when combined with `clientId`, `projectId`, or `assigneeUserId`**

   The tool description says "filtered — combine any of status, client, project, assignee, and a date range," but `tasks.list`'s query logic uses a priority tree: `assigneeUserId` → `projectId` → `clientId` → `dateFrom && dateTo`. When any of the entity filters are present, the `dateFrom`/`dateTo` branch is never reached and those values are never applied (there is no post-filter for date range). Calling `getTasks({scope:"filtered", clientId:"X", startDate:"2026-07-01", endDate:"2026-07-31"})` silently returns all-time tasks for client X, not just July tasks. The LLM will produce wrong answers for "what tasks does client X have this month?" without any indication that the filter was ignored.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/backend/convex/assistantTools.ts
   Line: 463-490

   Comment:
   **`getTasks` filtered scope silently drops the date range when combined with `clientId`, `projectId`, or `assigneeUserId`**

   The tool description says "filtered — combine any of status, client, project, assignee, and a date range," but `tasks.list`'s query logic uses a priority tree: `assigneeUserId` → `projectId` → `clientId` → `dateFrom && dateTo`. When any of the entity filters are present, the `dateFrom`/`dateTo` branch is never reached and those values are never applied (there is no post-filter for date range). Calling `getTasks({scope:"filtered", clientId:"X", startDate:"2026-07-01", endDate:"2026-07-31"})` silently returns all-time tasks for client X, not just July tasks. The LLM will produce wrong answers for "what tasks does client X have this month?" without any indication that the filter was ignored.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/backend/convex/assistantTools.ts:463-490
**`getTasks` filtered scope silently drops the date range when combined with `clientId`, `projectId`, or `assigneeUserId`**

The tool description says "filtered — combine any of status, client, project, assignee, and a date range," but `tasks.list`'s query logic uses a priority tree: `assigneeUserId` → `projectId` → `clientId` → `dateFrom && dateTo`. When any of the entity filters are present, the `dateFrom`/`dateTo` branch is never reached and those values are never applied (there is no post-filter for date range). Calling `getTasks({scope:"filtered", clientId:"X", startDate:"2026-07-01", endDate:"2026-07-31"})` silently returns all-time tasks for client X, not just July tasks. The LLM will produce wrong answers for "what tasks does client X have this month?" without any indication that the filter was ignored.

### Issue 2 of 2
packages/backend/convex/http.ts:418-430
**`getActivePaidPlan` can return a free plan item as its result**

When no non-`free_`-prefixed active plan is found, the fallback `?? activeItems[0]?.plan` can return the free plan. This causes `planSlug` (and therefore `clerkPlanSlug` in the DB) to be set to `"free_org"` on initial free subscriptions or plan-downgrades. The `hasPremiumAccess` exact-match check keeps this safe, but the function name `getActivePaidPlan` is misleading — a reader could assume it returns `undefined` when there is no paid plan. Renaming or making the intent explicit prevents future misuse.

```suggestion
		// The preferred plan slug for a subscription event. Paid items take
		// priority; if all active items are free (initial/downgrade), returns
		// the first active item so the caller can still write a slug to the DB.
		// NOTE: the return value may be a free plan — callers must not assume
		// a non-null return implies premium access.
		function getPreferredActivePlan(data: BillingWebhookData) {
			const activeItems = (data.items ?? []).filter(
				(item) => item.status === "active"
			);
			return (
				activeItems.find(
					(item) => item.plan?.slug && !item.plan.slug.startsWith("free_")
				)?.plan ?? activeItems[0]?.plan
			);
		}
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): gate assistant on webhook-..."](https://github.com/xcarter93/onetool/commit/e9c31e709ed9a44e8480c89b7acc6ca24ddaa7c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41615864)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->