### PR TITLE
Fix task completion events and format workflow.now date/time

### DIFF
--- a/packages/backend/convex/lib/conditionEval.test.ts
+++ b/packages/backend/convex/lib/conditionEval.test.ts
@@ -248,6 +248,34 @@ describe("interpolateTemplate", () => {
 			"no tokens here"
 		);
 	});
+
+	it("renders workflow.now as a readable date/time, not a raw timestamp", () => {
+		// 1_700_000_000_000 = 2023-11-14T22:13:20Z
+		const out = interpolateTemplate("Completed at {{workflow.now}}", {
+			workflow: { now: 1_700_000_000_000, tz: "UTC" },
+		});
+		expect(out).not.toContain("1700000000000");
+		expect(out).toContain("Nov");
+		expect(out).toContain("2023");
+	});
+
+	it("formats date globals in the run timezone", () => {
+		const utc = interpolateTemplate("{{workflow.now}}", {
+			workflow: { now: 1_700_000_000_000, tz: "UTC" },
+		});
+		const la = interpolateTemplate("{{workflow.now}}", {
+			workflow: { now: 1_700_000_000_000, tz: "America/Los_Angeles" },
+		});
+		expect(utc).not.toBe(la);
+	});
+
+	it("does not date-format non-date numeric fields (e.g. large amounts)", () => {
+		expect(
+			interpolateTemplate("Total: {{trigger.record.total}}", {
+				trigger: { record: { total: 1_700_000_000_000 } },
+			})
+		).toBe("Total: 1700000000000");
+	});
 });
 
 describe("evaluateRule", () => {

--- a/packages/backend/convex/lib/conditionEval.ts
+++ b/packages/backend/convex/lib/conditionEval.ts
@@ -220,17 +220,46 @@ function applyFormulaReturnType(
 }
 
 /**
+ * Built-in global paths whose resolved value is an epoch-ms timestamp and
+ * should render as a readable date/time (not the raw number) in templates.
+ */
+const DATE_GLOBAL_PATHS = new Set(["workflow.now"]);
+
+/** Format an epoch-ms timestamp as a readable date/time in the given IANA tz. */
+function formatTimestampForDisplay(ms: number, tz: string): string {
+	try {
+		return new Intl.DateTimeFormat("en-US", {
+			timeZone: tz,
+			year: "numeric",
+			month: "short",
+			day: "numeric",
+			hour: "numeric",
+			minute: "2-digit",
+		}).format(new Date(ms));
+	} catch {
+		// Invalid tz or ms — fall back to a stable ISO string rather than throw.
+		return new Date(ms).toISOString();
+	}
+}
+
+/**
  * Replace `{{path}}` tokens with values resolved from the scope.
- * Missing values (undefined/null) render as an empty string; other
- * non-string values are String()-ified.
+ * Missing values (undefined/null) render as an empty string. Date values and
+ * epoch-ms date globals (e.g. `workflow.now`) render as a readable date/time in
+ * the run's timezone; other non-string values are String()-ified.
  */
 export function interpolateTemplate(
 	template: string,
 	scope: VariableScope
 ): string {
+	const tz = scope.workflow?.tz ?? "UTC";
 	return template.replace(/\{\{\s*([^{}]+?)\s*\}\}/g, (_match, path: string) => {
 		const value = resolvePath(path, scope);
 		if (value === undefined || value === null) return "";
+		if (value instanceof Date) return formatTimestampForDisplay(value.getTime(), tz);
+		if (typeof value === "number" && DATE_GLOBAL_PATHS.has(path)) {
+			return formatTimestampForDisplay(value, tz);
+		}
 		return typeof value === "string" ? value : String(value);
 	});
 }

--- a/packages/backend/convex/tasks.test.ts
+++ b/packages/backend/convex/tasks.test.ts
@@ -1,11 +1,10 @@
-import { convexTest } from "convex-test";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { api } from "./_generated/api";
 import { setupConvexTest } from "./test.setup";
 import { Id } from "./_generated/dataModel";
 
 describe("Tasks", () => {
-	let t: ReturnType<typeof convexTest>;
+	let t: ReturnType<typeof setupConvexTest>;
 
 	beforeEach(() => {
 		t = setupConvexTest();
@@ -1110,6 +1109,80 @@ describe("Tasks", () => {
 			const task = await asUser.query(api.tasks.get, { id: taskId });
 			expect(task?.status).toBe("completed");
 			expect(task?.completedAt).toBeDefined();
+		});
+
+		it("emits status_changed and record_updated events so checkbox completion triggers automations", async () => {
+			const { orgId, taskId } = await t.run(async (ctx) => {
+				const userId = await ctx.db.insert("users", {
+					name: "Test User",
+					email: "test@example.com",
+					image: "https://example.com/image.jpg",
+					externalId: "user_123",
+				});
+
+				const orgId = await ctx.db.insert("organizations", {
+					clerkOrganizationId: "org_123",
+					name: "Test Org",
+					ownerUserId: userId,
+				});
+
+				await ctx.db.insert("organizationMemberships", {
+					orgId,
+					userId,
+					role: "admin",
+				});
+
+				const clientId = await ctx.db.insert("clients", {
+					orgId,
+					companyName: "Test Client",
+					status: "active",
+				});
+
+				const taskId = await ctx.db.insert("tasks", {
+					orgId,
+					clientId,
+					title: "Task to Complete",
+					date: Date.now(),
+					status: "pending",
+					type: "external",
+				});
+
+				return { orgId, taskId };
+			});
+
+			const asUser = t.withIdentity({
+				subject: "user_123",
+				activeOrgId: "org_123",
+			});
+
+			await asUser.mutation(api.tasks.complete, { id: taskId });
+
+			const events = await t.run(async (ctx) => {
+				return await ctx.db
+					.query("domainEvents")
+					.withIndex("by_org_status", (q) =>
+						q.eq("orgId", orgId).eq("status", "pending")
+					)
+					.collect();
+			});
+
+			const statusChanged = events.filter(
+				(e) => e.eventType === "entity.status_changed"
+			);
+			expect(statusChanged).toHaveLength(1);
+			expect(statusChanged[0].eventSource).toBe("tasks.complete");
+			expect(statusChanged[0].payload.entityType).toBe("task");
+			expect(statusChanged[0].payload.entityId).toBe(taskId);
+			expect(statusChanged[0].payload.newValue).toBe("completed");
+
+			const recordUpdated = events.filter(
+				(e) => e.eventType === "entity.record_updated"
+			);
+			expect(recordUpdated).toHaveLength(1);
+			expect(recordUpdated[0].eventSource).toBe("tasks.complete");
+			expect(recordUpdated[0].payload.metadata).toEqual({
+				changedFields: ["status", "completedAt"],
+			});
 		});
 
 		it("should throw error when completing already completed task", async () => {

--- a/packages/backend/convex/tasks.ts
+++ b/packages/backend/convex/tasks.ts
@@ -634,15 +634,37 @@ export const complete = userMutation({
 			throw new Error("Task is already completed");
 		}
 
+		const oldStatus = task.status;
+
 		await ctx.db.patch(args.id, {
 			status: "completed",
 			completedAt: Date.now(),
 		});
 
-		// Log activity
+		// Log activity and emit events (mirror tasks.update so completion via
+		// the quick-complete checkbox also triggers automations)
 		const updatedTask = await ctx.db.get(args.id);
 		if (updatedTask) {
 			await ActivityHelpers.taskCompleted(ctx, updatedTask as TaskDocument);
+
+			await emitStatusChangeEvent(
+				ctx,
+				updatedTask.orgId,
+				"task",
+				updatedTask._id,
+				oldStatus,
+				"completed",
+				"tasks.complete"
+			);
+
+			await emitRecordUpdatedEvent(
+				ctx,
+				updatedTask.orgId,
+				"task",
+				updatedTask._id,
+				["status", "completedAt"],
+				"tasks.complete"
+			);
 		}
 
 		return args.id;


### PR DESCRIPTION
This pull request introduces improvements to template rendering for date/time fields and enhances task completion logic to emit domain events, ensuring better automation support and more user-friendly output. The main changes are grouped below:

**Template Rendering Improvements:**

* Added logic to `interpolateTemplate` in `conditionEval.ts` to render epoch-millisecond timestamp globals (like `workflow.now`) as readable date/time strings in the specified timezone, instead of displaying raw numbers. This includes a fallback to ISO strings for invalid input. Non-date numeric fields are not affected.
* Added and updated tests in `conditionEval.test.ts` to verify date formatting, timezone handling, and correct treatment of non-date numeric fields in templates.

**Task Completion and Automation:**

* Updated the `complete` mutation in `tasks.ts` to emit `entity.status_changed` and `entity.record_updated` domain events when a task is completed, mirroring the behavior of `tasks.update`. This ensures that automations triggered by these events work consistently, including when tasks are completed via the quick-complete checkbox.
* Added a new test in `tasks.test.ts` to verify that completing a task emits the correct domain events with the expected payloads, supporting downstream automations.

**Test Setup Consistency:**

* Updated `tasks.test.ts` to use `setupConvexTest` instead of `convexTest` for test environment setup, ensuring consistency across tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow templates now display `workflow.now` as a human-readable date/time in the workflow’s timezone.
  * Date values are formatted consistently, with a fallback for invalid timezones.

* **Bug Fixes**
  * Non-date numeric values in templates are no longer mistakenly formatted as dates.
  * Completing a task now records the updated completion details more precisely, including status and timestamp changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two gaps in the automation pipeline: `tasks.complete` now emits `entity.status_changed` and `entity.record_updated` domain events (matching `tasks.update`), and `interpolateTemplate` now renders `workflow.now` as a human-readable date/time string instead of a raw epoch-ms number.

- **Task completion events** (`tasks.ts`): `oldStatus` is captured before the patch, then both status-change and record-updated events are emitted inside the same `if (updatedTask)` guard already used for activity logging — keeping the two callsites atomic and consistent with `tasks.update`.
- **Date rendering** (`conditionEval.ts`): A `DATE_GLOBAL_PATHS` set and `formatTimestampForDisplay` helper use `Intl.DateTimeFormat` with the run's timezone; a catch-block falls back to ISO string for invalid timezone values. Non-date numeric fields are intentionally excluded via an exact-path allowlist.
- **Test hygiene** (`tasks.test.ts`): Replaces the raw `convexTest` import with the shared `setupConvexTest` helper and adds a full domain-event assertion test for the new completion path.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the domain-event and date-formatting changes are well-scoped and tested, and no existing behaviour is removed.

Both feature changes are narrow and well-tested. The only notable rough edge is in formatTimestampForDisplay: if the timezone string is invalid and ms is also not a finite number, the catch-block fallback new Date(ms).toISOString() would itself throw — a silent second failure in an already-exceptional path. In practice workflow.now is always a valid Date.now() value, so this is unlikely to surface, but the error path is not fully hardened.

packages/backend/convex/lib/conditionEval.ts — the formatTimestampForDisplay catch block and the value instanceof Date branch deserve a quick look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/lib/conditionEval.ts | Adds formatTimestampForDisplay and DATE_GLOBAL_PATHS to render workflow.now as a human-readable date in templates; catch-block fallback could rethrow for invalid ms values, and the Date-instance branch appears to be unreachable in production. |
| packages/backend/convex/tasks.ts | Adds emitStatusChangeEvent and emitRecordUpdatedEvent calls to the complete mutation, mirroring the existing tasks.update pattern correctly. |
| packages/backend/convex/tasks.test.ts | Adds a well-structured test verifying domain event emission from tasks.complete; also migrates to setupConvexTest for consistency. |
| packages/backend/convex/lib/conditionEval.test.ts | Adds three targeted tests covering date formatting, timezone differentiation, and the non-date numeric field guard; coverage is appropriate for the new behaviour. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant complete as tasks.complete (mutation)
    participant DB as Convex DB
    participant Activity as ActivityHelpers
    participant Bus as eventBus

    Client->>complete: "complete({ id })"
    complete->>DB: orgEntity("tasks", id)
    DB-->>complete: task (or throws if not found/unauthorized)
    complete->>DB: "patch(id, { status: "completed", completedAt: now })"
    complete->>DB: get(id)
    DB-->>complete: updatedTask
    complete->>Activity: taskCompleted(ctx, updatedTask)
    complete->>Bus: emitStatusChangeEvent("entity.status_changed", oldStatus→"completed")
    complete->>Bus: emitRecordUpdatedEvent("entity.record_updated", ["status","completedAt"])
    complete-->>Client: taskId
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant complete as tasks.complete (mutation)
    participant DB as Convex DB
    participant Activity as ActivityHelpers
    participant Bus as eventBus

    Client->>complete: "complete({ id })"
    complete->>DB: orgEntity("tasks", id)
    DB-->>complete: task (or throws if not found/unauthorized)
    complete->>DB: "patch(id, { status: "completed", completedAt: now })"
    complete->>DB: get(id)
    DB-->>complete: updatedTask
    complete->>Activity: taskCompleted(ctx, updatedTask)
    complete->>Bus: emitStatusChangeEvent("entity.status_changed", oldStatus→"completed")
    complete->>Bus: emitRecordUpdatedEvent("entity.record_updated", ["status","completedAt"])
    complete-->>Client: taskId
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/backend/convex/lib/conditionEval.ts:239-242
The catch-block fallback `new Date(ms).toISOString()` can itself throw a `RangeError` when `ms` is `NaN` or `±Infinity` (e.g. if `workflow.now` is somehow never set). A second try/catch around the fallback ensures the function always returns a string rather than propagating an error from the error path.

```suggestion
	} catch {
		// Invalid tz or ms — fall back to a stable ISO string rather than throw.
		try {
			return new Date(ms).toISOString();
		} catch {
			return String(ms);
		}
	}
```

### Issue 2 of 2
packages/backend/convex/lib/conditionEval.ts:259
**`value instanceof Date` branch is unreachable in production**

Convex documents serialise all values to JSON-compatible types, so `resolvePath` always returns epoch-ms numbers for date fields — never a `Date` instance. As written, this branch can only fire in tests or hand-constructed scopes, which may mislead future callers into thinking Date objects flowing through the scope are automatically timezone-formatted. If this is intentional (e.g. for unit-test convenience), a brief comment would clarify intent.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(automations): fire on task checkbox ..."](https://github.com/xcarter93/onetool/commit/5f730a7256a70d826f44f2ed5a5ac02efee78332) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41978995)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->