### PR TITLE
Enhance UI feedback with persistent 'Thinking...' indicator

### DIFF
--- a/apps/web/src/components/assistant/assistant-panel.tsx
+++ b/apps/web/src/components/assistant/assistant-panel.tsx
@@ -251,6 +251,32 @@ export function AssistantPanel({ open, onOpenChange }: AssistantPanelProps) {
 		bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
 	}, [messageCount, isResponding]);
 
+	// The assistant runs multi-step (reason → call tools → answer) and
+	// streamResponse stays open for the whole run, so isResponding is true
+	// start-to-finish. Show a generic "Thinking…" line whenever it's working but
+	// nothing else already signals activity — i.e. not while a tool chip shows
+	// its own spinner and not while answer text is streaming in. Without this,
+	// the indicator vanished the instant the first assistant part arrived and the
+	// UI looked idle through the (often long) tool-calling phase.
+	const results = messages.results ?? [];
+	const lastMessage = results[results.length - 1];
+	const runningToolPart =
+		lastMessage?.role === "assistant"
+			? (lastMessage.parts as unknown as AssistantToolPart[]).find(
+					(p) =>
+						p.type.startsWith("tool-") &&
+						p.state !== "output-available" &&
+						p.state !== "output-error"
+				)
+			: undefined;
+	const isStreamingText =
+		lastMessage?.role === "assistant" &&
+		lastMessage.status === "streaming" &&
+		lastMessage.parts.some(
+			(p) => p.type === "text" && (p as { text: string }).text.length > 0
+		);
+	const showThinking = isResponding && !runningToolPart && !isStreamingText;
+
 	useEffect(() => {
 		if (!open) return;
 		const onKeyDown = (event: KeyboardEvent) => {
@@ -462,14 +488,12 @@ export function AssistantPanel({ open, onOpenChange }: AssistantPanelProps) {
 									{messages.results.map((message) => (
 										<MessageItem key={message.key} message={message} />
 									))}
-									{isResponding &&
-										messages.results[messages.results.length - 1]?.role ===
-											"user" && (
-											<div className="flex items-center gap-2 text-sm text-muted-foreground">
-												<Loader2 className="size-3.5 animate-spin" />
-												Thinking…
-											</div>
-										)}
+									{showThinking && (
+										<div className="flex items-center gap-2 text-sm text-muted-foreground">
+											<Loader2 className="size-3.5 animate-spin" />
+											Thinking…
+										</div>
+									)}
 									<div ref={bottomRef} />
 								</div>
 							)}

--- a/apps/web/src/components/assistant/renderers/index.tsx
+++ b/apps/web/src/components/assistant/renderers/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Component, type ComponentType, type ReactNode } from "react";
-import { AlertCircle, Sparkles } from "lucide-react";
+import { AlertCircle, Loader2, Sparkles } from "lucide-react";
 import { EmailsRenderer } from "./emails-renderer";
 import { NavigateRenderer } from "./navigate-renderer";
 import { ReportRenderer } from "./report-renderer";
@@ -53,18 +53,46 @@ export const TOOL_LABELS: Record<string, string> = {
 	navigate: "Opened a page",
 };
 
+// Present-tense labels shown while a tool is still executing (state is
+// input-streaming / input-available). Falls back to a generic label below.
+const TOOL_LABELS_ACTIVE: Record<string, string> = {
+	getSchedule: "Checking the schedule…",
+	getTasks: "Looking up tasks…",
+	getBusinessStats: "Pulling business stats…",
+	runReport: "Running a report…",
+	listClients: "Looking up clients…",
+	getClient: "Fetching client details…",
+	listProjects: "Looking up projects…",
+	getProject: "Fetching project details…",
+	listQuotes: "Looking up quotes…",
+	getQuote: "Fetching quote details…",
+	listInvoices: "Looking up invoices…",
+	getInvoice: "Fetching invoice details…",
+	searchClientEmails: "Searching emails…",
+	getEmailThread: "Reading an email thread…",
+	getDocuments: "Looking up documents…",
+	getActivity: "Checking recent activity…",
+	navigate: "Opening a page…",
+};
+
 function ToolChip({ name, state }: { name: string; state?: string }) {
 	const failed = state === "output-error";
+	// Anything that isn't a terminal state is still executing.
+	const running = state !== "output-available" && state !== "output-error";
 	return (
 		<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
 			{failed ? (
 				<AlertCircle className="size-3" />
+			) : running ? (
+				<Loader2 className="size-3 animate-spin" />
 			) : (
 				<Sparkles className="size-3" />
 			)}
 			{failed
 				? `Hit a snag: ${(TOOL_LABELS[name] ?? name).toLowerCase()}`
-				: (TOOL_LABELS[name] ?? `Used ${name}`)}
+				: running
+					? (TOOL_LABELS_ACTIVE[name] ?? `Working on ${name}…`)
+					: (TOOL_LABELS[name] ?? `Used ${name}`)}
 		</div>
 	);
 }

--- a/apps/web/src/components/assistant/renderers/index.tsx
+++ b/apps/web/src/components/assistant/renderers/index.tsx
@@ -33,52 +33,43 @@ const TOOL_RENDERERS: Record<string, ComponentType<ToolRendererProps>> = {
 	navigate: NavigateRenderer,
 };
 
-export const TOOL_LABELS: Record<string, string> = {
-	getSchedule: "Checked the schedule",
-	getTasks: "Looked up tasks",
-	getBusinessStats: "Pulled business stats",
-	runReport: "Ran a report",
-	listClients: "Looked up clients",
-	getClient: "Fetched client details",
-	listProjects: "Looked up projects",
-	getProject: "Fetched project details",
-	listQuotes: "Looked up quotes",
-	getQuote: "Fetched quote details",
-	listInvoices: "Looked up invoices",
-	getInvoice: "Fetched invoice details",
-	searchClientEmails: "Searched emails",
-	getEmailThread: "Read an email thread",
-	getDocuments: "Looked up documents",
-	getActivity: "Checked recent activity",
-	navigate: "Opened a page",
-};
-
-// Present-tense labels shown while a tool is still executing (state is
-// input-streaming / input-available). Falls back to a generic label below.
-const TOOL_LABELS_ACTIVE: Record<string, string> = {
-	getSchedule: "Checking the schedule…",
-	getTasks: "Looking up tasks…",
-	getBusinessStats: "Pulling business stats…",
-	runReport: "Running a report…",
-	listClients: "Looking up clients…",
-	getClient: "Fetching client details…",
-	listProjects: "Looking up projects…",
-	getProject: "Fetching project details…",
-	listQuotes: "Looking up quotes…",
-	getQuote: "Fetching quote details…",
-	listInvoices: "Looking up invoices…",
-	getInvoice: "Fetching invoice details…",
-	searchClientEmails: "Searching emails…",
-	getEmailThread: "Reading an email thread…",
-	getDocuments: "Looking up documents…",
-	getActivity: "Checking recent activity…",
-	navigate: "Opening a page…",
+// One entry per tool holds both label forms so the two can never drift:
+// `active` shows while the tool is executing (state input-streaming /
+// input-available), `done` once it has finished.
+export const TOOL_LABELS: Record<string, { done: string; active: string }> = {
+	getSchedule: { done: "Checked the schedule", active: "Checking the schedule…" },
+	getTasks: { done: "Looked up tasks", active: "Looking up tasks…" },
+	getBusinessStats: {
+		done: "Pulled business stats",
+		active: "Pulling business stats…",
+	},
+	runReport: { done: "Ran a report", active: "Running a report…" },
+	listClients: { done: "Looked up clients", active: "Looking up clients…" },
+	getClient: { done: "Fetched client details", active: "Fetching client details…" },
+	listProjects: { done: "Looked up projects", active: "Looking up projects…" },
+	getProject: {
+		done: "Fetched project details",
+		active: "Fetching project details…",
+	},
+	listQuotes: { done: "Looked up quotes", active: "Looking up quotes…" },
+	getQuote: { done: "Fetched quote details", active: "Fetching quote details…" },
+	listInvoices: { done: "Looked up invoices", active: "Looking up invoices…" },
+	getInvoice: { done: "Fetched invoice details", active: "Fetching invoice details…" },
+	searchClientEmails: { done: "Searched emails", active: "Searching emails…" },
+	getEmailThread: {
+		done: "Read an email thread",
+		active: "Reading an email thread…",
+	},
+	getDocuments: { done: "Looked up documents", active: "Looking up documents…" },
+	getActivity: { done: "Checked recent activity", active: "Checking recent activity…" },
+	navigate: { done: "Opened a page", active: "Opening a page…" },
 };
 
 function ToolChip({ name, state }: { name: string; state?: string }) {
 	const failed = state === "output-error";
 	// Anything that isn't a terminal state is still executing.
 	const running = state !== "output-available" && state !== "output-error";
+	const label = TOOL_LABELS[name];
 	return (
 		<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
 			{failed ? (
@@ -89,10 +80,10 @@ function ToolChip({ name, state }: { name: string; state?: string }) {
 				<Sparkles className="size-3" />
 			)}
 			{failed
-				? `Hit a snag: ${(TOOL_LABELS[name] ?? name).toLowerCase()}`
+				? `Hit a snag: ${(label?.done ?? name).toLowerCase()}`
 				: running
-					? (TOOL_LABELS_ACTIVE[name] ?? `Working on ${name}…`)
-					: (TOOL_LABELS[name] ?? `Used ${name}`)}
+					? (label?.active ?? `Working on ${name}…`)
+					: (label?.done ?? `Used ${name}`)}
 		</div>
 	);
 }


### PR DESCRIPTION
This pull request improves the user experience of the assistant panel by making activity indicators more accurate and informative during multi-step assistant operations. The changes ensure that users always see a clear indication when the assistant is working, especially during tool execution phases, and provide more descriptive, present-tense labels for tool activities.

**User interface improvements for assistant activity:**

* Added logic in `assistant-panel.tsx` to ensure a "Thinking…" indicator is shown whenever the assistant is working but not already displaying a tool spinner or streaming answer text. This prevents the UI from appearing idle during long-running tool calls. [[1]](diffhunk://#diff-89b999f68cd4ae9dc8b3ae9f170c8995771909c99be0dd761c20599a406f6cdbR254-R279) [[2]](diffhunk://#diff-89b999f68cd4ae9dc8b3ae9f170c8995771909c99be0dd761c20599a406f6cdbL465-R491)
* Updated the display condition for the activity indicator to use the new logic, replacing the previous check that only showed "Thinking…" after user messages.

**Tool activity labeling enhancements:**

* Introduced `TOOL_LABELS_ACTIVE` in `renderers/index.tsx` to provide present-tense, descriptive labels for tools while they are still executing, and updated the `ToolChip` component to show these labels with a spinner icon during tool execution.
* Improved the visual feedback in `ToolChip` by showing a spinning loader icon (`Loader2`) when a tool is running, in addition to success and error icons. [[1]](diffhunk://#diff-36b8897c76e4b324d51162880b9e009a31dd9a1ab87a5a3e70b069869650f69aR56-R94) [[2]](diffhunk://#diff-36b8897c76e4b324d51162880b9e009a31dd9a1ab87a5a3e70b069869650f69aL4-R4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved assistant status feedback during longer replies and tool usage.
  * Added clearer in-progress labels and a loading indicator for active tool actions.
* **Bug Fixes**
  * The “Thinking…” indicator now remains visible throughout multi-step assistant responses instead of disappearing too early.
  * Tool status chips now better distinguish between ongoing work, successful completion, and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the assistant panel's activity indicators during multi-step AI runs, preventing the UI from appearing idle between the tool-calling and reasoning phases.

- **`assistant-panel.tsx`**: Replaces the old `isResponding && lastMessage.role === \"user\"` condition with a `showThinking` flag that hides the \"Thinking…\" indicator precisely when a tool chip is already showing its own spinner (`runningToolPart`) or when answer text is streaming in (`isStreamingText`), and shows it again during the silent gap between tool calls.
- **`renderers/index.tsx`**: Adds `TOOL_LABELS_ACTIVE` with present-tense labels (e.g., \"Checking the schedule…\") and updates `ToolChip` to display a `Loader2` spinner for all non-terminal tool states, with `failed` taking priority over `running` in the icon/label ternary.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the changes are additive UI logic with no data mutations or network calls.

The showThinking three-way guard (isResponding, !runningToolPart, !isStreamingText) prevents double-indicator scenarios, and the terminal-state predicate in ToolChip matches the one in runningToolPart exactly, keeping both components in sync. The one maintenance concern is that TOOL_LABELS and TOOL_LABELS_ACTIVE are parallel tables that must be updated together when new tools are registered.

renderers/index.tsx deserves a quick look if new tools are added in the future, to ensure both label tables are updated together.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/assistant/assistant-panel.tsx | Adds showThinking logic that coordinates with ToolChip spinners to display 'Thinking…' only during genuinely idle phases of multi-step runs; replaces the previous role-based condition that hid the indicator too early |
| apps/web/src/components/assistant/renderers/index.tsx | Introduces TOOL_LABELS_ACTIVE for present-tense active labels and updates ToolChip to show a Loader2 spinner during non-terminal tool states; creates a parallel label table that must stay in sync with TOOL_LABELS |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[isResponding = true] --> B{lastMessage role?}
    B -- user --> C[showThinking = true
'Thinking… shown']
    B -- assistant --> D{running tool part
in lastMessage?}
    D -- yes --> E[showThinking = false
ToolChip Loader2 shown]
    D -- no --> F{isStreamingText?}
    F -- yes --> G[showThinking = false
Text streams in UI]
    F -- no --> C
    E --> I[Tool state → output-available]
    I --> D
    G --> J[Stream ends
isResponding = false]
    J --> K[All indicators hidden]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[isResponding = true] --> B{lastMessage role?}
    B -- user --> C[showThinking = true
'Thinking… shown']
    B -- assistant --> D{running tool part
in lastMessage?}
    D -- yes --> E[showThinking = false
ToolChip Loader2 shown]
    D -- no --> F{isStreamingText?}
    F -- yes --> G[showThinking = false
Text streams in UI]
    F -- no --> C
    E --> I[Tool state → output-available]
    I --> D
    G --> J[Stream ends
isResponding = false]
    J --> K[All indicators hidden]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/components/assistant/renderers/index.tsx`, line 36-76 ([link](https://github.com/xcarter93/onetool/blob/da0da5cd47900c03e41b1136b95277f85a7bbc04/apps/web/src/components/assistant/renderers/index.tsx#L36-L76)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `TOOL_LABELS` and `TOOL_LABELS_ACTIVE` are parallel structures with the same key set. Any new tool added to one but missed in the other will silently fall back to a different label (`Used foo` vs `Working on foo…`). Consider adding a `satisfies` annotation to `TOOL_LABELS_ACTIVE` to let TypeScript catch drift between the two tables at compile time.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/components/assistant/renderers/index.tsx
   Line: 36-76

   Comment:
   `TOOL_LABELS` and `TOOL_LABELS_ACTIVE` are parallel structures with the same key set. Any new tool added to one but missed in the other will silently fall back to a different label (`Used foo` vs `Working on foo…`). Consider adding a `satisfies` annotation to `TOOL_LABELS_ACTIVE` to let TypeScript catch drift between the two tables at compile time.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/components/assistant/renderers/index.tsx:36-76
`TOOL_LABELS` and `TOOL_LABELS_ACTIVE` are parallel structures with the same key set. Any new tool added to one but missed in the other will silently fall back to a different label (`Used foo` vs `Working on foo…`). Consider adding a `satisfies` annotation to `TOOL_LABELS_ACTIVE` to let TypeScript catch drift between the two tables at compile time.

```suggestion
export const TOOL_LABELS: Record<string, string> = {
	getSchedule: "Checked the schedule",
	getTasks: "Looked up tasks",
	getBusinessStats: "Pulled business stats",
	runReport: "Ran a report",
	listClients: "Looked up clients",
	getClient: "Fetched client details",
	listProjects: "Looked up projects",
	getProject: "Fetched project details",
	listQuotes: "Looked up quotes",
	getQuote: "Fetched quote details",
	listInvoices: "Looked up invoices",
	getInvoice: "Fetched invoice details",
	searchClientEmails: "Searched emails",
	getEmailThread: "Read an email thread",
	getDocuments: "Looked up documents",
	getActivity: "Checked recent activity",
	navigate: "Opened a page",
};

// Present-tense labels shown while a tool is still executing (state is
// input-streaming / input-available). Falls back to a generic label below.
// Keyed to the same tool names as TOOL_LABELS so they stay in sync.
const TOOL_LABELS_ACTIVE: Record<string, string> = {
	getSchedule: "Checking the schedule…",
	getTasks: "Looking up tasks…",
	getBusinessStats: "Pulling business stats…",
	runReport: "Running a report…",
	listClients: "Looking up clients…",
	getClient: "Fetching client details…",
	listProjects: "Looking up projects…",
	getProject: "Fetching project details…",
	listQuotes: "Looking up quotes…",
	getQuote: "Fetching quote details…",
	listInvoices: "Looking up invoices…",
	getInvoice: "Fetching invoice details…",
	searchClientEmails: "Searching emails…",
	getEmailThread: "Reading an email thread…",
	getDocuments: "Looking up documents…",
	getActivity: "Checking recent activity…",
	navigate: "Opening a page…",
} satisfies Partial<Record<keyof typeof TOOL_LABELS, string>>;
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(assistant): keep a working indicator..."](https://github.com/xcarter93/onetool/commit/da0da5cd47900c03e41b1136b95277f85a7bbc04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42064385)</sub>

<!-- /greptile_comment -->