### PR TITLE
Add describeSchema tool for live schema introspection and agent cue

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -64,6 +64,7 @@ import type * as lib_permissions from "../lib/permissions.js";
 import type * as lib_queries from "../lib/queries.js";
 import type * as lib_quoteTotals from "../lib/quoteTotals.js";
 import type * as lib_schedule from "../lib/schedule.js";
+import type * as lib_schemaIntrospection from "../lib/schemaIntrospection.js";
 import type * as lib_shared from "../lib/shared.js";
 import type * as lib_storage from "../lib/storage.js";
 import type * as lib_stripe from "../lib/stripe.js";
@@ -176,6 +177,7 @@ declare const fullApi: ApiFromModules<{
   "lib/queries": typeof lib_queries;
   "lib/quoteTotals": typeof lib_quoteTotals;
   "lib/schedule": typeof lib_schedule;
+  "lib/schemaIntrospection": typeof lib_schemaIntrospection;
   "lib/shared": typeof lib_shared;
   "lib/storage": typeof lib_storage;
   "lib/stripe": typeof lib_stripe;

--- a/packages/backend/convex/assistantAgent.ts
+++ b/packages/backend/convex/assistantAgent.ts
@@ -16,6 +16,7 @@ Rules:
 - Dates in tool results are ISO 8601 strings in UTC: day-precision fields are YYYY-MM-DD, event times are full timestamps. Compare and diff them as calendar dates (e.g. days between 2026-06-01 and 2026-07-03 is 32).
 - If a tool returns nothing, say so plainly — do not guess.
 - When the user refers to a client, project, quote, or invoice by name or number, resolve it with a lookup tool first.
+- To answer questions about the data model itself (what fields a record type has, which statuses or values are valid), or when you are unsure of an exact field name or allowed enum value, call describeSchema first — it returns the live schema for clients, projects, tasks, quotes, invoices, and related tables. Never guess field names or statuses.
 - Be concise and friendly. Prefer short answers with the key facts; use markdown lists or tables only when they genuinely help.
 - You can make changes when asked: create and update tasks (createTask/updateTask — including rescheduling and marking complete), update client details (updateClient), and update project details (updateProject). Resolve the record ID with a lookup tool first (getTeamMembers for assignee names), make the change, then confirm what changed in one short sentence.
 - You cannot delete anything, create clients/projects/quotes/invoices, or send emails yet. If asked, say so plainly and offer to navigate to the right page instead.

--- a/packages/backend/convex/assistantTools.ts
+++ b/packages/backend/convex/assistantTools.ts
@@ -3,6 +3,13 @@ import { z } from "zod";
 import { api } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import type { HomeStats } from "./homeStats";
+import {
+	DESCRIBABLE_TABLES,
+	describeTable,
+	listDescribableTables,
+	type TableSchema,
+	type TableSummary,
+} from "./lib/schemaIntrospection";
 import type { ReportDataResult } from "./reportData";
 
 /**
@@ -1340,11 +1347,43 @@ export const navigate = createTool({
 	},
 });
 
+export const describeSchema = createTool({
+	description:
+		"Look up the fields, types, and valid enum values for a business-data table (clients, projects, tasks, quotes, invoices, payments, etc.). Call with no arguments to list the describable tables; call with a table name to get that table's fields. Use it to learn exact field names and allowed status/enum values before interpreting or filtering record data. Derived live from the schema, so it is always current. Returns only the data model — never any organization's actual records.",
+	inputSchema: z.object({
+		table: z
+			.enum([...DESCRIBABLE_TABLES] as [string, ...string[]])
+			.optional()
+			.describe("The table to describe. Omit to list all describable tables."),
+	}),
+	execute: async (
+		_ctx,
+		input
+	): Promise<
+		| { tables: TableSummary[] }
+		| TableSchema
+		| { error: string; availableTables: string[] }
+	> => {
+		if (!input.table) {
+			return { tables: listDescribableTables() };
+		}
+		const described = describeTable(input.table);
+		if (!described) {
+			return {
+				error: `Unknown table "${input.table}".`,
+				availableTables: [...DESCRIBABLE_TABLES],
+			};
+		}
+		return described;
+	},
+});
+
 export const assistantTools = {
 	getSchedule,
 	getTasks,
 	getBusinessStats,
 	runReport,
+	describeSchema,
 	listClients,
 	getClient,
 	listProjects,

--- a/packages/backend/convex/lib/schemaIntrospection.ts
+++ b/packages/backend/convex/lib/schemaIntrospection.ts
@@ -1,0 +1,222 @@
+/**
+ * Runtime schema introspection for the assistant's describeSchema tool.
+ *
+ * Reads field/type/enum info straight off the live Convex schema validators
+ * (schema.tables[name].validator) so it can never drift from schema.ts — there
+ * is no hand-maintained catalog to keep in sync. Table descriptions are the
+ * only hand-written layer, and they are additive: an unannotated table still
+ * describes fine, it just lacks the one-line hint.
+ */
+import schema from "../schema";
+
+// Business-data tables the assistant may describe. Deliberately excludes auth,
+// billing, portal, and internal plumbing tables.
+export const DESCRIBABLE_TABLES = [
+	"clients",
+	"clientContacts",
+	"clientProperties",
+	"projects",
+	"tasks",
+	"quotes",
+	"quoteLineItems",
+	"invoices",
+	"invoiceLineItems",
+	"payments",
+	"activities",
+	"skus",
+	"emailMessages",
+] as const;
+
+export type DescribableTable = (typeof DESCRIBABLE_TABLES)[number];
+
+const TABLE_DESCRIPTIONS: Record<DescribableTable, string> = {
+	clients: "Customers and prospects the organization serves.",
+	clientContacts: "People associated with a client (name, email, phone, role).",
+	clientProperties: "Physical service locations/addresses belonging to a client.",
+	projects: "Jobs/engagements for a client (one-off or recurring).",
+	tasks: "Scheduled work items or visits, optionally tied to a project.",
+	quotes: "Price quotes/proposals sent to clients.",
+	quoteLineItems: "Individual line items on a quote.",
+	invoices: "Invoices issued to clients and their payment status.",
+	invoiceLineItems: "Individual line items on an invoice.",
+	payments: "Payments recorded against invoices.",
+	activities: "Audit-trail log of changes to records.",
+	skus: "Reusable service/product templates (price book).",
+	emailMessages: "Email messages synced or sent for the org, linked to clients.",
+};
+
+// Stop expanding nested objects past this depth to keep output bounded.
+const MAX_DEPTH = 3;
+
+// Structural view of a Convex validator instance. The runtime shape is
+// documented (stack.convex.dev/types-cookbook) but only loosely typed, so we
+// read it structurally and branch on `kind`. `value` is a literal's primitive
+// OR a record's value-validator depending on `kind`.
+interface RawValidator {
+	kind:
+		| "id"
+		| "string"
+		| "float64"
+		| "int64"
+		| "boolean"
+		| "bytes"
+		| "null"
+		| "any"
+		| "object"
+		| "literal"
+		| "array"
+		| "record"
+		| "union";
+	isOptional: "optional" | "required";
+	fields?: Record<string, RawValidator>;
+	members?: RawValidator[];
+	element?: RawValidator;
+	key?: RawValidator;
+	value?: unknown;
+	tableName?: string;
+}
+
+export interface SchemaFieldInfo {
+	type: string;
+	optional: boolean;
+	enumValues?: string[];
+	of?: string;
+	fields?: Record<string, SchemaFieldInfo>;
+	literal?: string;
+}
+
+export interface TableSchema {
+	table: string;
+	description?: string;
+	fields: Record<string, SchemaFieldInfo>;
+}
+
+export interface TableSummary {
+	table: string;
+	description?: string;
+	fieldCount: number;
+}
+
+function scalarType(kind: RawValidator["kind"]): string {
+	return kind === "float64" || kind === "int64" ? "number" : kind;
+}
+
+// Short type label for a union/record member; keeps an id's target table.
+function memberLabel(validator: RawValidator): string {
+	return validator.kind === "id" && validator.tableName
+		? `id(${validator.tableName})`
+		: scalarType(validator.kind);
+}
+
+function literalToString(value: unknown): string {
+	return typeof value === "bigint" ? value.toString() : String(value);
+}
+
+// Returns literal values if every union member is a literal (null members are
+// allowed and skipped); null if the union mixes in non-literal members.
+function unionEnumValues(members: RawValidator[]): string[] | null {
+	const values: string[] = [];
+	for (const m of members) {
+		if (m.kind === "literal") values.push(literalToString(m.value));
+		else if (m.kind === "null") continue;
+		else return null;
+	}
+	return values.length > 0 ? values : null;
+}
+
+function describeValidator(validator: RawValidator, depth: number): SchemaFieldInfo {
+	const optional = validator.isOptional === "optional";
+
+	switch (validator.kind) {
+		case "union": {
+			const members = validator.members ?? [];
+			const enumValues = unionEnumValues(members);
+			if (enumValues) return { type: "enum", optional, enumValues };
+			// A nullable id (id + null) is really an optional foreign key — keep
+			// its target table instead of flattening to "id | null".
+			const nonNull = members.filter((m) => m.kind !== "null");
+			if (nonNull.length === 1 && nonNull[0].kind === "id") {
+				return { type: "id", optional: true, of: nonNull[0].tableName };
+			}
+			const memberTypes = [...new Set(members.map(memberLabel))];
+			return { type: "union", optional, of: memberTypes.join(" | ") };
+		}
+		case "literal":
+			return { type: "literal", optional, literal: literalToString(validator.value) };
+		case "id":
+			return { type: "id", optional, of: validator.tableName };
+		case "array": {
+			const el = validator.element;
+			if (!el) return { type: "array", optional };
+			if (el.kind === "union") {
+				const enumValues = unionEnumValues(el.members ?? []);
+				if (enumValues) return { type: "array", optional, of: "enum", enumValues };
+			}
+			if (el.kind === "object" && depth < MAX_DEPTH) {
+				return {
+					type: "array",
+					optional,
+					of: "object",
+					fields: describeFields(el.fields ?? {}, depth + 1),
+				};
+			}
+			return { type: "array", optional, of: scalarType(el.kind) };
+		}
+		case "object":
+			if (depth >= MAX_DEPTH) return { type: "object", optional };
+			return { type: "object", optional, fields: describeFields(validator.fields ?? {}, depth + 1) };
+		case "record": {
+			// `.value` here is the value-validator (not a literal primitive).
+			const valueValidator = validator.value as RawValidator | undefined;
+			const keyLabel = validator.key ? memberLabel(validator.key) : "string";
+			const valueLabel = valueValidator ? memberLabel(valueValidator) : "any";
+			return { type: "record", optional, of: `${keyLabel} → ${valueLabel}` };
+		}
+		default:
+			return { type: scalarType(validator.kind), optional };
+	}
+}
+
+function describeFields(
+	fields: Record<string, RawValidator>,
+	depth: number
+): Record<string, SchemaFieldInfo> {
+	const out: Record<string, SchemaFieldInfo> = {};
+	for (const [name, validator] of Object.entries(fields)) {
+		out[name] = describeValidator(validator, depth);
+	}
+	return out;
+}
+
+// schema.tables[table].validator is the documented introspection entry point;
+// it is a VObject for object tables and excludes system fields.
+function tableValidator(table: DescribableTable): RawValidator {
+	return schema.tables[table].validator as unknown as RawValidator;
+}
+
+export function isDescribableTable(table: string): table is DescribableTable {
+	return (DESCRIBABLE_TABLES as readonly string[]).includes(table);
+}
+
+export function listDescribableTables(): TableSummary[] {
+	return DESCRIBABLE_TABLES.map((table) => {
+		const root = tableValidator(table);
+		const fieldCount =
+			root.kind === "object" && root.fields ? Object.keys(root.fields).length : 0;
+		return { table, description: TABLE_DESCRIPTIONS[table], fieldCount };
+	});
+}
+
+export function describeTable(table: string): TableSchema | null {
+	if (!isDescribableTable(table)) return null;
+	const root = tableValidator(table);
+	// The validator omits system fields, so add them explicitly.
+	const fields: Record<string, SchemaFieldInfo> = {
+		_id: { type: "id", optional: false, of: table },
+		_creationTime: { type: "number", optional: false },
+	};
+	if (root.kind === "object" && root.fields) {
+		Object.assign(fields, describeFields(root.fields, 1));
+	}
+	return { table, description: TABLE_DESCRIPTIONS[table], fields };
+}

--- a/packages/backend/convex/lib/schemaIntrospection.ts
+++ b/packages/backend/convex/lib/schemaIntrospection.ts
@@ -189,9 +189,11 @@ function describeFields(
 }
 
 // schema.tables[table].validator is the documented introspection entry point;
-// it is a VObject for object tables and excludes system fields.
-function tableValidator(table: DescribableTable): RawValidator {
-	return schema.tables[table].validator as unknown as RawValidator;
+// it is a VObject for object tables and excludes system fields. The optional
+// chain guards the (type-impossible) case of an allowlist entry with no schema
+// table, so the tool degrades to null instead of throwing inside the agent.
+function tableValidator(table: DescribableTable): RawValidator | undefined {
+	return schema.tables[table]?.validator as unknown as RawValidator | undefined;
 }
 
 export function isDescribableTable(table: string): table is DescribableTable {
@@ -200,16 +202,21 @@ export function isDescribableTable(table: string): table is DescribableTable {
 
 export function listDescribableTables(): TableSummary[] {
 	return DESCRIBABLE_TABLES.map((table) => {
-		const root = tableValidator(table);
-		const fieldCount =
-			root.kind === "object" && root.fields ? Object.keys(root.fields).length : 0;
-		return { table, description: TABLE_DESCRIPTIONS[table], fieldCount };
+		// Count from describeTable so the summary can never disagree with the
+		// detail — which also includes the injected _id/_creationTime fields.
+		const described = describeTable(table);
+		return {
+			table,
+			description: TABLE_DESCRIPTIONS[table],
+			fieldCount: described ? Object.keys(described.fields).length : 0,
+		};
 	});
 }
 
 export function describeTable(table: string): TableSchema | null {
 	if (!isDescribableTable(table)) return null;
 	const root = tableValidator(table);
+	if (!root) return null;
 	// The validator omits system fields, so add them explicitly.
 	const fields: Record<string, SchemaFieldInfo> = {
 		_id: { type: "id", optional: false, of: table },

--- a/packages/backend/convex/schemaIntrospection.test.ts
+++ b/packages/backend/convex/schemaIntrospection.test.ts
@@ -13,6 +13,8 @@ describe("schema introspection", () => {
 		for (const t of tables) {
 			expect(t.fieldCount).toBeGreaterThan(0);
 			expect(t.description).toBeTruthy();
+			// Summary count must match the detail's field count (incl. system fields).
+			expect(t.fieldCount).toBe(Object.keys(describeTable(t.table)!.fields).length);
 		}
 	});
 

--- a/packages/backend/convex/schemaIntrospection.test.ts
+++ b/packages/backend/convex/schemaIntrospection.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+	DESCRIBABLE_TABLES,
+	describeTable,
+	isDescribableTable,
+	listDescribableTables,
+} from "./lib/schemaIntrospection";
+
+describe("schema introspection", () => {
+	it("lists every describable table with a non-empty field count", () => {
+		const tables = listDescribableTables();
+		expect(tables.map((t) => t.table).sort()).toEqual([...DESCRIBABLE_TABLES].sort());
+		for (const t of tables) {
+			expect(t.fieldCount).toBeGreaterThan(0);
+			expect(t.description).toBeTruthy();
+		}
+	});
+
+	it("includes system fields on every table", () => {
+		for (const table of DESCRIBABLE_TABLES) {
+			const described = describeTable(table);
+			expect(described).not.toBeNull();
+			expect(described!.fields._id.type).toBe("id");
+			expect(described!.fields._id.of).toBe(table);
+			expect(described!.fields._creationTime.type).toBe("number");
+		}
+	});
+
+	it("derives enum values from union-of-literal fields", () => {
+		const clients = describeTable("clients");
+		expect(clients!.fields.status.type).toBe("enum");
+		expect(clients!.fields.status.enumValues?.slice().sort()).toEqual(
+			["active", "archived", "inactive", "lead"].sort()
+		);
+
+		const quotes = describeTable("quotes");
+		expect(quotes!.fields.status.type).toBe("enum");
+		expect(quotes!.fields.status.enumValues).toEqual(
+			expect.arrayContaining(["draft", "sent", "approved", "declined", "expired"])
+		);
+	});
+
+	it("resolves id references to their target table", () => {
+		const projects = describeTable("projects");
+		expect(projects!.fields.clientId.type).toBe("id");
+		expect(projects!.fields.clientId.of).toBe("clients");
+	});
+
+	it("returns null for tables that are not on the allowlist", () => {
+		expect(describeTable("organizations")).toBeNull();
+		expect(describeTable("stripeWebhookEvents")).toBeNull();
+		expect(describeTable("nonexistentTable")).toBeNull();
+		expect(isDescribableTable("clients")).toBe(true);
+		expect(isDescribableTable("users")).toBe(false);
+	});
+
+	it("produces JSON-serializable output for every table", () => {
+		for (const table of DESCRIBABLE_TABLES) {
+			expect(() => JSON.stringify(describeTable(table))).not.toThrow();
+		}
+	});
+});


### PR DESCRIPTION
This pull request adds a new schema introspection tool for the assistant, enabling it to answer questions about the data model (such as valid fields and enum values) in a robust and up-to-date way. The changes introduce a runtime schema introspection module, a new `describeSchema` tool, and comprehensive tests to ensure correctness. This eliminates the need for hand-maintained schema documentation and prevents drift between documentation and the actual data model.

**New schema introspection capability:**

* Added a new module `schemaIntrospection.ts` that provides runtime introspection of table schemas, including field types, enum values, and references, directly from the live Convex schema validators. This ensures schema information is always accurate and up-to-date.

* Introduced the `describeSchema` tool in `assistantTools.ts`, allowing the assistant to list describable tables or get detailed field/type/enum info for a specific table. This tool is now available to the assistant for answering data model questions.

**Integration and documentation:**

* Updated the assistant's rules in `assistantAgent.ts` to instruct it to use the new `describeSchema` tool when asked about the data model or when unsure about field names or allowed values, rather than guessing.

* Integrated the new schema introspection utilities and types into `assistantTools.ts`, making them available for tool execution.

**Testing and validation:**

* Added comprehensive tests in `schemaIntrospection.test.ts` to verify that all describable tables are listed, system fields are included, enum values are derived correctly, id references are resolved, and output is JSON-serializable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new assistant capability to look up live business-data table schemas, including field types and enum values.
  * The assistant can now list supported tables or return detailed schema info for a selected table.
* **Bug Fixes**
  * Improved reliability when answering about data fields by using the live schema instead of guessing.
  * Better handling for unknown or unsupported table names.
* **Tests**
  * Added automated coverage for schema introspection output, enums, references, and JSON-serializability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a live schema introspection module (`schemaIntrospection.ts`) and a `describeSchema` assistant tool that reads field/type/enum data directly from Convex's validator objects, plus a rule update that instructs the agent to call the tool before guessing field names or enum values.

- `schemaIntrospection.ts` walks the `RawValidator` tree (kind, members, element, fields) to build `SchemaFieldInfo` records for each table in a curated `DESCRIBABLE_TABLES` allowlist, and `assistantTools.ts` wraps it in a `describeSchema` tool with a Zod enum-validated input.
- The test file verifies all describable tables list correctly, system fields are present, enum values are derived, and output is JSON-serializable.
- The assistant's system-prompt rule is updated to call `describeSchema` first rather than guess schema details.

<h3>Confidence Score: 4/5</h3>

The change is well-contained and additive — it adds a read-only schema introspection tool that touches no mutations or data writes. The main rough edges are a fieldCount discrepancy and a dead error-handling branch, neither of which affects correctness at runtime as long as DESCRIBABLE_TABLES stays in sync with the Convex schema.

The implementation is thoughtful: it derives schema info from live validators rather than hand-maintaining a catalog, uses an explicit allowlist to avoid exposing internal tables, and includes good test coverage. The two findings are both quality concerns — a count inconsistency between the summary and full-description APIs, and an unreachable error branch — not runtime failures given the current schema state.

schemaIntrospection.ts warrants a second look on the fieldCount calculation (lines 204-205) and the unguarded tableValidator access (line 194). The describeSchema error fallback in assistantTools.ts (around line 1373) can also be cleaned up.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/lib/schemaIntrospection.ts | New module: runtime schema introspection over Convex validators. Two minor inconsistencies — fieldCount in listDescribableTables omits the 2 system fields that describeTable always includes, and tableValidator has no null guard against DESCRIBABLE_TABLES/schema drift. |
| packages/backend/convex/assistantTools.ts | Adds the describeSchema tool wired to schemaIntrospection helpers. The error fallback branch (if !described) is unreachable because z.enum input validation excludes non-allowlisted values before execute runs. |
| packages/backend/convex/assistantAgent.ts | One-line system-prompt rule addition instructing the agent to call describeSchema before guessing field names or enum values. Clear and well-scoped. |
| packages/backend/convex/schemaIntrospection.test.ts | Comprehensive test suite covering table listing, system fields, enum derivation, id reference resolution, allowlist enforcement, and JSON serializability. |
| packages/backend/convex/_generated/api.d.ts | Auto-generated file updated to import and register schemaIntrospection module. Mechanical change, no issues. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent calls describeSchema] --> B{table provided?}
    B -- No --> C[listDescribableTables]
    C --> D[Iterate DESCRIBABLE_TABLES]
    D --> E[Read schema validator per table]
    E --> F[Count root fields]
    F --> G[Return TableSummary list]

    B -- Yes --> H[z.enum validation]
    H -- Invalid --> I[Zod rejects input]
    H -- Valid --> J[describeTable]
    J --> K{isDescribableTable?}
    K -- false --> L[Return null error response]
    K -- true --> M[Read tableValidator]
    M --> N[Prepend system fields _id + _creationTime]
    N --> O[describeFields recursive up to depth 3]
    O --> P{validator kind?}
    P -- union of literals --> Q[enumValues list]
    P -- nullable id --> R[optional id with target]
    P -- array of objects --> S[nested fields]
    P -- scalar or id --> T[type string]
    Q & R & S & T --> U[Return TableSchema]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Agent calls describeSchema] --> B{table provided?}
    B -- No --> C[listDescribableTables]
    C --> D[Iterate DESCRIBABLE_TABLES]
    D --> E[Read schema validator per table]
    E --> F[Count root fields]
    F --> G[Return TableSummary list]

    B -- Yes --> H[z.enum validation]
    H -- Invalid --> I[Zod rejects input]
    H -- Valid --> J[describeTable]
    J --> K{isDescribableTable?}
    K -- false --> L[Return null error response]
    K -- true --> M[Read tableValidator]
    M --> N[Prepend system fields _id + _creationTime]
    N --> O[describeFields recursive up to depth 3]
    O --> P{validator kind?}
    P -- union of literals --> Q[enumValues list]
    P -- nullable id --> R[optional id with target]
    P -- array of objects --> S[nested fields]
    P -- scalar or id --> T[type string]
    Q & R & S & T --> U[Return TableSchema]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/backend/convex/lib/schemaIntrospection.ts:193-195
`tableValidator` accesses `schema.tables[table].validator` without guarding against a missing entry. If any name in `DESCRIBABLE_TABLES` is ever removed from the Convex schema (or the list is updated before the schema is), both `listDescribableTables()` and `describeTable()` will throw a `TypeError: Cannot read properties of undefined` at the point of the `.validator` access. The no-argument path to `describeSchema` has no zod enum guard, so a single stale entry crashes the entire table listing.

### Issue 2 of 3
packages/backend/convex/assistantTools.ts:1373-1377
The `if (!described)` error branch is unreachable. The `z.enum([...DESCRIBABLE_TABLES])` input schema already rejects any `table` value that isn't in the allowlist before `execute` runs, and `describeTable` only returns `null` when `isDescribableTable` is false — a condition the enum validation has already ruled out. If a table falls out of sync between `DESCRIBABLE_TABLES` and `schema.tables`, `tableValidator` will throw rather than returning `null`, so this branch won't catch that case either.

### Issue 3 of 3
packages/backend/convex/lib/schemaIntrospection.ts:204-205
`fieldCount` in `listDescribableTables` is computed from schema-defined fields only, but `describeTable` always prepends `_id` and `_creationTime`, so the counts are systematically off by 2. Any consumer using `fieldCount` from the summary to predict how many fields the full description contains will be surprised — the summary may say 5 but the description returns 7.

```suggestion
		const fieldCount =
			root.kind === "object" && root.fields ? Object.keys(root.fields).length + 2 : 2; // +2 for system fields _id and _creationTime
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(assistant): cue the agent to consul..."](https://github.com/xcarter93/onetool/commit/c7873693bbad79015c364da1df748b982a1fbcfa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42135660)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->