### PR TITLE
feat(automations): expose record _id as a referenceable variable

### DIFF
--- a/apps/web/src/app/(workspace)/automations/lib/condition-sentence.test.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/condition-sentence.test.ts
@@ -70,6 +70,24 @@ describe("conditionSentence", () => {
 		);
 	});
 
+	it("renders trigger.record._id as a plain-English record ID reference", () => {
+		const groups: ConditionGroup[] = [
+			{
+				logic: "and",
+				rules: [
+					{
+						field: "clientId",
+						operator: "equals" as const,
+						value: { kind: "var", path: "trigger.record._id" },
+					},
+				],
+			},
+		];
+		expect(conditionSentence("and", groups, "task")).toBe(
+			"Client equals Trigger record ID"
+		);
+	});
+
 	it("skips incomplete rules and empty groups", () => {
 		const groups: ConditionGroup[] = [
 			{ logic: "and", rules: [rule("", "equals", "x")] },

--- a/apps/web/src/app/(workspace)/automations/lib/condition-sentence.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/condition-sentence.ts
@@ -57,6 +57,7 @@ function describeVarPath(
 	const prefix = "trigger.record.";
 	if (path.startsWith(prefix)) {
 		const field = path.slice(prefix.length);
+		if (field === "_id") return "Trigger record ID"; // not in the field registry
 		const label = objectType ? getFieldDefinition(objectType, field)?.label : undefined;
 		return label ?? field;
 	}

--- a/apps/web/src/app/(workspace)/automations/lib/variables.test.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/variables.test.ts
@@ -71,6 +71,27 @@ describe("getAvailableVariables", () => {
 		expect(companyName?.group).toBe("Trigger");
 	});
 
+	it("offers trigger.record._id first, labeled with the trigger's entity type", () => {
+		const target = actionNode("a1");
+		const options = getAvailableVariables([target], statusChangedTrigger, "a1");
+		const triggerOptions = options.filter((o) => o.group === "Trigger");
+		expect(triggerOptions[0]).toEqual({
+			path: "trigger.record._id",
+			label: "Trigger → Client ID",
+			group: "Trigger",
+			fieldType: "id",
+		});
+	});
+
+	it("suffixes id-type FK field labels with ' ID' to disambiguate from the related record", () => {
+		const target = actionNode("a1");
+		const taskTrigger: TriggerConfig = { type: "record_created", objectType: "task" };
+		const options = getAvailableVariables([target], taskTrigger, "a1");
+		const clientId = options.find((o) => o.path === "trigger.record.clientId");
+		expect(clientId?.label).toBe("Trigger → Client ID");
+		expect(clientId?.fieldType).toBe("id");
+	});
+
 	it("includes trigger.event.oldValue/newValue only for status_changed triggers", () => {
 		const target = actionNode("a1");
 		const statusChangedOptions = getAvailableVariables(
@@ -132,6 +153,14 @@ describe("getAvailableVariables", () => {
 		expect(item).toBeDefined();
 		expect(item?.label).toBe("Loop item → Title");
 		expect(insideBody.some((o) => o.path === "loop.loop1.index")).toBe(true);
+
+		const loopItemId = insideBody.find((o) => o.path === "loop.loop1.item._id");
+		expect(loopItemId).toEqual({
+			path: "loop.loop1.item._id",
+			label: "Loop item → Project ID",
+			group: "Loop item",
+			fieldType: "id",
+		});
 
 		const outsideBody = getAvailableVariables(nodes, statusChangedTrigger, "after1");
 		expect(outsideBody.some((o) => o.path.startsWith("loop.loop1."))).toBe(false);

--- a/apps/web/src/app/(workspace)/automations/lib/variables.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/variables.ts
@@ -160,6 +160,11 @@ const GLOBAL_VARIABLE_OPTIONS: VariableOption[] = [
 	},
 ];
 
+/** " ID" suffix for id-type fields (e.g. "Client" -> "Client ID") disambiguates FK references. */
+function fieldOptionLabel(prefix: string, field: { label: string; type: FieldType }): string {
+	return `${prefix} → ${field.label}${field.type === "id" ? " ID" : ""}`;
+}
+
 /** trigger.record.<field> + trigger.event.oldValue/newValue — shared by both functions. */
 function triggerVariableOptions(
 	trigger: TriggerConfig | AutomationTrigger
@@ -168,10 +173,17 @@ function triggerVariableOptions(
 	const triggerObjectType = trigger.objectType as AutomationObjectType | undefined;
 
 	if (triggerObjectType) {
+		// Runtime resolves _id by raw property lookup on the record; offer it explicitly.
+		options.push({
+			path: "trigger.record._id",
+			label: `Trigger → ${OBJECT_TYPE_LABELS[triggerObjectType]} ID`,
+			group: "Trigger",
+			fieldType: "id",
+		});
 		for (const field of getFilterableFields(triggerObjectType)) {
 			options.push({
 				path: `trigger.record.${field.key}`,
-				label: `Trigger → ${field.label}`,
+				label: fieldOptionLabel("Trigger", field),
 				group: "Trigger",
 				fieldType: field.type,
 			});
@@ -292,10 +304,17 @@ export function getAvailableVariables(
 			?.objectType;
 		if (!sourceObjectType) continue;
 
+		// Runtime resolves _id by raw property lookup on the loop item; offer it explicitly.
+		options.push({
+			path: `loop.${node.id}.item._id`,
+			label: `Loop item → ${OBJECT_TYPE_LABELS[sourceObjectType]} ID`,
+			group: "Loop item",
+			fieldType: "id",
+		});
 		for (const field of getFilterableFields(sourceObjectType)) {
 			options.push({
 				path: `loop.${node.id}.item.${field.key}`,
-				label: `Loop item → ${field.label}`,
+				label: fieldOptionLabel("Loop item", field),
 				group: "Loop item",
 				fieldType: field.type,
 			});
@@ -387,10 +406,16 @@ export function getAllVariableOptions(
 			?.objectType;
 		if (!sourceObjectType) continue;
 
+		options.push({
+			path: `loop.${node.id}.item._id`,
+			label: `Loop item → ${OBJECT_TYPE_LABELS[sourceObjectType]} ID`,
+			group: "Loop item",
+			fieldType: "id",
+		});
 		for (const field of getFilterableFields(sourceObjectType)) {
 			options.push({
 				path: `loop.${node.id}.item.${field.key}`,
-				label: `Loop item → ${field.label}`,
+				label: fieldOptionLabel("Loop item", field),
 				group: "Loop item",
 				fieldType: field.type,
 			});

--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -1287,10 +1287,25 @@ describe("automationExecutor (v2 engine)", () => {
 			};
 		}
 
+		/** Like filterGroup, but the value resolves from scope (e.g. trigger.record._id). */
+		function varFilterGroup(field: string, operator: string, path: string) {
+			return {
+				logic: "and" as const,
+				rules: [
+					{
+						field,
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						operator: operator as any,
+						value: { kind: "var" as const, path },
+					},
+				],
+			};
+		}
+
 		function fetchNode(
 			id: string,
 			objectType: "client" | "project" | "quote" | "invoice" | "task",
-			filters: ReturnType<typeof filterGroup>[] = [],
+			filters: (ReturnType<typeof filterGroup> | ReturnType<typeof varFilterGroup>)[] = [],
 			opts: { nextNodeId?: string; limit?: number } = {}
 		) {
 			return {
@@ -1577,6 +1592,95 @@ describe("automationExecutor (v2 engine)", () => {
 			);
 			expect(keep?.status).toBe("in-progress");
 			expect(skip?.status).toBe("planned");
+
+			const executions = await t.run(async (ctx) =>
+				ctx.db.query("workflowExecutions").collect()
+			);
+			expect(executions).toHaveLength(1);
+			expect(executions[0].status).toBe("completed");
+			const loopEntry = executions[0].nodesExecuted.find(
+				(n) => n.nodeId === "loop-1"
+			);
+			expect(loopEntry?.recordsProcessed).toBe(2);
+		});
+
+		it("var-kind fetch filter: cancel client cascades to only its own tasks", async () => {
+			const { asUser } = await setupUser();
+
+			const clientId = await asUser.mutation(api.clients.create, {
+				portalAccessId: crypto.randomUUID(),
+				companyName: "Acme Co",
+				status: "active",
+			});
+			const otherClientId = await asUser.mutation(api.clients.create, {
+				portalAccessId: crypto.randomUUID(),
+				companyName: "Other Co",
+				status: "active",
+			});
+
+			const task1 = await asUser.mutation(api.tasks.create, {
+				clientId,
+				title: "Task 1",
+				date: Date.now(),
+				status: "pending",
+			});
+			const task2 = await asUser.mutation(api.tasks.create, {
+				clientId,
+				title: "Task 2",
+				date: Date.now(),
+				status: "pending",
+			});
+			const otherTask = await asUser.mutation(api.tasks.create, {
+				clientId: otherClientId,
+				title: "Other client's task",
+				date: Date.now(),
+				status: "pending",
+			});
+
+			await asUser.mutation(api.automations.create, {
+				name: "Cancel client's tasks on archive",
+				trigger: {
+					type: "status_changed",
+					objectType: "client",
+					toStatus: "archived",
+				},
+				nodes: [
+					// clientId resolves via a var-kind value against trigger.record._id,
+					// not a static id — the case under test.
+					fetchNode(
+						"fetch-1",
+						"task",
+						[varFilterGroup("clientId", "equals", "trigger.record._id")],
+						{ nextNodeId: "loop-1" }
+					),
+					loopNode("loop-1", "fetch-1", {
+						bodyStartNodeId: "body-act",
+						nextNodeId: "end-1",
+					}),
+					updateFieldActionNode("body-act", "status", "cancelled", {
+						target: "self",
+					}),
+					endNode("end-1"),
+				],
+				isActive: true,
+			});
+
+			await asUser.mutation(api.clients.update, {
+				id: clientId,
+				status: "archived",
+			});
+			await drainEvents();
+
+			const [t1, t2, t3] = await t.run(async (ctx) =>
+				Promise.all([
+					ctx.db.get(task1),
+					ctx.db.get(task2),
+					ctx.db.get(otherTask),
+				])
+			);
+			expect(t1?.status).toBe("cancelled");
+			expect(t2?.status).toBe("cancelled");
+			expect(t3?.status).toBe("pending");
 
 			const executions = await t.run(async (ctx) =>
 				ctx.db.query("workflowExecutions").collect()


### PR DESCRIPTION
The engine already resolved trigger.record._id in fetch filters, but the variable picker never offered it (FIELD_REGISTRY has no self-_id entry), so flows like "client cancelled -> cancel its tasks" couldn't be built.

- variables.ts: offer trigger.record._id and loop.<id>.item._id, labeled with the entity type; suffix FK id-field labels with " ID" so "Trigger -> Client" (the clientId FK) is no longer ambiguous
- condition-sentence.ts: render _id refs as "Trigger record ID"
- automationExecutor.test.ts: e2e regression for a var-kind fetch filter (first coverage of var refs in fetch filters)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automation variables now include record ID values for trigger records and loop items.
  * Record fields with ID-type values now display with a clearer “ID” label in automation conditions and variable pickers.

* **Bug Fixes**
  * Automation filters can now compare against a value from another variable, improving matching across trigger-driven workflows.
  * Archived-client automations now correctly cancel only the related tasks, leaving unrelated tasks unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a gap in the automation variable picker: `trigger.record._id` and `loop.<id>.item._id` are now offered as selectable variables, and FK field labels gain an \" ID\" suffix to reduce ambiguity (e.g. \"Client\" → \"Client ID\").

- **`variables.ts`**: exposes `_id` first in both `getAvailableVariables` and `getAllVariableOptions`, and applies `fieldOptionLabel` to all id-type fields.
- **`condition-sentence.ts`**: renders `trigger.record._id` as \"Trigger record ID\", but the parallel `loop.<id>.item._id` path is not handled and falls back to a raw `{loop.loop1.item._id}` display.
- **`automationExecutor.test.ts`**: new e2e test verifies the \"cancel client → cancel its tasks\" cascade using a var-kind fetch filter, including cross-client isolation.

<h3>Confidence Score: 4/5</h3>

The core engine change is sound and well-tested end-to-end; the only gap is a display-only inconsistency in condition sentence rendering for loop item IDs.

The var-picker and executor changes are correct and covered by both unit tests and a new e2e regression. The only issue is that `describeVarPath` in `condition-sentence.ts` handles `trigger.record._id` but not `loop.<id>.item._id`, which this PR also adds to the picker. Any condition using a loop item `_id` as its value will render the raw path string in the condition card UI.

condition-sentence.ts — the `describeVarPath` function needs a branch for `loop.<id>.item._id` to match the new trigger-_id handling.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/(workspace)/automations/lib/variables.ts | Adds `trigger.record._id` and `loop.<id>.item._id` to the variable picker, and applies an " ID" suffix to id-type FK field labels. Logic is symmetric between `getAvailableVariables` and `getAllVariableOptions`. |
| apps/web/src/app/(workspace)/automations/lib/condition-sentence.ts | Adds `_id` handling to `describeVarPath` for `trigger.record._id`, but the symmetrical `loop.<loopId>.item._id` path — also newly offered in the picker — falls through to the raw `{path}` fallback. |
| apps/web/src/app/(workspace)/automations/lib/variables.test.ts | Adds three new tests: `_id` is first in trigger group, FK field labels get " ID" suffix, and loop item `_id` is offered with the correct entity label. Coverage is thorough. |
| apps/web/src/app/(workspace)/automations/lib/condition-sentence.test.ts | Adds a test for `trigger.record._id` rendering as "Trigger record ID". No test for the loop item `_id` path (which would reveal the raw-path fallback). |
| packages/backend/convex/automationExecutor.test.ts | Adds a well-structured e2e regression covering the "cancel client's tasks" cascade using a var-kind fetch filter, verifying cross-client isolation and correct `recordsProcessed` count. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Variable Picker] --> B{Path type}
    B -->|trigger.record._id| C["Label: 'Trigger → {EntityType} ID'"]
    B -->|loop.id.item._id| D["Label: 'Loop item → {EntityType} ID'"]
    B -->|trigger.record.field| E["fieldOptionLabel: 'Trigger → {label}[ ID]'"]
    B -->|loop.id.item.field| F["fieldOptionLabel: 'Loop item → {label}[ ID]'"]
    C --> G[Condition sentence: describeVarPath]
    D --> G
    E --> G
    F --> G
    G --> H{Path prefix?}
    H -->|trigger.record._id| I["✅ 'Trigger record ID'"]
    H -->|trigger.record.field| J["✅ Field registry label"]
    H -->|loop.id.item._id| K["⚠️ Raw: '{loop.loop1.item._id}'"]
    H -->|other| L["Raw: '{path}'"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Variable Picker] --> B{Path type}
    B -->|trigger.record._id| C["Label: 'Trigger → {EntityType} ID'"]
    B -->|loop.id.item._id| D["Label: 'Loop item → {EntityType} ID'"]
    B -->|trigger.record.field| E["fieldOptionLabel: 'Trigger → {label}[ ID]'"]
    B -->|loop.id.item.field| F["fieldOptionLabel: 'Loop item → {label}[ ID]'"]
    C --> G[Condition sentence: describeVarPath]
    D --> G
    E --> G
    F --> G
    G --> H{Path prefix?}
    H -->|trigger.record._id| I["✅ 'Trigger record ID'"]
    H -->|trigger.record.field| J["✅ Field registry label"]
    H -->|loop.id.item._id| K["⚠️ Raw: '{loop.loop1.item._id}'"]
    H -->|other| L["Raw: '{path}'"]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/app/(workspace)/automations/lib/condition-sentence.ts`, line 57-65 ([link](https://github.com/xcarter93/onetool/blob/9b4f0749cd3cffe3b9121ea6e37b6bf059d95c27/apps/web/src/app/(workspace)/automations/lib/condition-sentence.ts#L57-L65)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`loop.<id>.item._id` renders as a raw path in condition sentences**

   `describeVarPath` now handles `trigger.record._id` with a human-readable label, but doesn't cover the symmetrical `loop.<loopId>.item._id` path that this PR also adds to the variable picker. When a user selects that path as a condition value, `describeVarPath` falls through to the `return \`{${path}}\`` branch and the condition sentence card displays the raw `{loop.loop1.item._id}` string instead of something like "Loop item ID".

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/app/(workspace)/automations/lib/condition-sentence.ts
   Line: 57-65

   Comment:
   **`loop.<id>.item._id` renders as a raw path in condition sentences**

   `describeVarPath` now handles `trigger.record._id` with a human-readable label, but doesn't cover the symmetrical `loop.<loopId>.item._id` path that this PR also adds to the variable picker. When a user selects that path as a condition value, `describeVarPath` falls through to the `return \`{${path}}\`` branch and the condition sentence card displays the raw `{loop.loop1.item._id}` string instead of something like "Loop item ID".

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/app/(workspace)/automations/lib/condition-sentence.ts:57-65
**`loop.<id>.item._id` renders as a raw path in condition sentences**

`describeVarPath` now handles `trigger.record._id` with a human-readable label, but doesn't cover the symmetrical `loop.<loopId>.item._id` path that this PR also adds to the variable picker. When a user selects that path as a condition value, `describeVarPath` falls through to the `return \`{${path}}\`` branch and the condition sentence card displays the raw `{loop.loop1.item._id}` string instead of something like "Loop item ID".


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(automations): expose record \_id as ..."](https://github.com/xcarter93/onetool/commit/9b4f0749cd3cffe3b9121ea6e37b6bf059d95c27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42727450)</sub>

<!-- /greptile_comment -->