### PR TITLE
feat(automations): turbo-flow-inspired restyle with dual-mode contrast

### DIFF
--- a/apps/web/src/app/(workspace)/automations/components/flow/action-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/action-node-rf.tsx
@@ -63,7 +63,7 @@ function getSummary(config: ActionNodeConfig | undefined): {
 	}
 }
 
-export const ActionNodeRF = memo(({ data, selected }: NodeProps) => {
+export const ActionNodeRF = memo(({ data }: NodeProps) => {
 	const config = (data as Record<string, unknown>)?.config as ActionNodeConfig | undefined;
 	const { title, description, isConfigured } = getSummary(config);
 	const meta = config ? ACTION_META[config.action.type] : undefined;
@@ -74,10 +74,8 @@ export const ActionNodeRF = memo(({ data, selected }: NodeProps) => {
 			className={cn(
 				"w-[280px]",
 				isConfigured
-					? "border-border shadow-sm"
+					? meta && `border-l-4 ${meta.accent}`
 					: "border-dashed border-muted-foreground/30",
-				"hover:border-primary/30 transition-colors",
-				selected && "ring-2 ring-primary/50",
 			)}
 			aria-label={`Action: ${title} - ${description}`}
 		>

--- a/apps/web/src/app/(workspace)/automations/components/flow/adjust-time-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/adjust-time-node-rf.tsx
@@ -29,7 +29,7 @@ function getSummary(config: AdjustTimeNodeConfig | undefined): {
 	};
 }
 
-export const AdjustTimeNodeRF = memo(({ data, selected }: NodeProps) => {
+export const AdjustTimeNodeRF = memo(({ data }: NodeProps) => {
 	const config = (data as Record<string, unknown>)?.config as AdjustTimeNodeConfig | undefined;
 	const { title, description, isConfigured } = getSummary(config);
 
@@ -38,17 +38,15 @@ export const AdjustTimeNodeRF = memo(({ data, selected }: NodeProps) => {
 			className={cn(
 				"w-[280px]",
 				isConfigured
-					? "border-border shadow-sm"
+					? "border-l-4 border-l-cyan-500 dark:border-l-cyan-400"
 					: "border-dashed border-muted-foreground/30",
-				"hover:border-primary/30 transition-colors",
-				selected && "ring-2 ring-primary/50",
 			)}
 			aria-label={`Adjust time: ${title} - ${description}`}
 		>
 			<BaseHandle type="target" position={Position.Top} />
 			<BaseNodeContent className="p-3">
 				<div className="flex items-center gap-3">
-					<div className="w-8 h-8 rounded-lg bg-cyan-50 text-cyan-600 dark:bg-cyan-950/40 dark:text-cyan-400 flex items-center justify-center shrink-0">
+					<div className="w-8 h-8 rounded-lg bg-cyan-100 text-cyan-700 dark:bg-cyan-400/15 dark:text-cyan-300 flex items-center justify-center shrink-0">
 						<Clock3 className="h-4 w-4" />
 					</div>
 					<div className="min-w-0 flex-1">

--- a/apps/web/src/app/(workspace)/automations/components/flow/after-last-edge.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/after-last-edge.tsx
@@ -9,6 +9,7 @@ import { Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getAfterLastGeometry } from "./edge-geometry";
 import { NextItemMarker } from "./next-item-marker";
+import { LOOP_EDGE_STYLE } from "./edge-style";
 
 /**
  * Custom edge for the "After Last" branch of loop nodes.
@@ -44,7 +45,7 @@ export function AfterLastEdge({
 		<>
 			<BaseEdge
 				path={geometry.edgePath}
-				style={{ ...style, strokeWidth: 1.5, stroke: "var(--color-orange-300)", strokeDasharray: "6 3" }}
+				style={{ ...style, ...LOOP_EDGE_STYLE }}
 			/>
 			<EdgeLabelRenderer>
 				<div

--- a/apps/web/src/app/(workspace)/automations/components/flow/aggregate-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/aggregate-node-rf.tsx
@@ -30,7 +30,7 @@ function getSummary(config: AggregateNodeConfig | undefined): {
 	};
 }
 
-export const AggregateNodeRF = memo(({ data, selected }: NodeProps) => {
+export const AggregateNodeRF = memo(({ data }: NodeProps) => {
 	const config = (data as Record<string, unknown>)?.config as AggregateNodeConfig | undefined;
 	const { title, description, isConfigured } = getSummary(config);
 
@@ -39,17 +39,15 @@ export const AggregateNodeRF = memo(({ data, selected }: NodeProps) => {
 			className={cn(
 				"w-[280px]",
 				isConfigured
-					? "border-border shadow-sm"
+					? "border-l-4 border-l-orange-500 dark:border-l-orange-400"
 					: "border-dashed border-muted-foreground/30",
-				"hover:border-primary/30 transition-colors",
-				selected && "ring-2 ring-primary/50",
 			)}
 			aria-label={`Aggregate: ${title} - ${description}`}
 		>
 			<BaseHandle type="target" position={Position.Top} />
 			<BaseNodeContent className="p-3">
 				<div className="flex items-center gap-3">
-					<div className="w-8 h-8 rounded-lg bg-orange-50 text-orange-600 dark:bg-orange-950/40 dark:text-orange-400 flex items-center justify-center shrink-0">
+					<div className="w-8 h-8 rounded-lg bg-orange-100 text-orange-700 dark:bg-orange-400/15 dark:text-orange-300 flex items-center justify-center shrink-0">
 						<Sigma className="h-4 w-4" />
 					</div>
 					<div className="min-w-0 flex-1">

--- a/apps/web/src/app/(workspace)/automations/components/flow/automation-flow.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/automation-flow.tsx
@@ -28,6 +28,7 @@ import {
 } from "../../lib/derived-layout";
 import type { AppEdge, AppNode } from "../../lib/node-types";
 import "@xyflow/react/dist/style.css";
+import "./flow-theme.css";
 import { TriggerNodeRF } from "./trigger-node-rf";
 import { ConditionNodeRF } from "./condition-node-rf";
 import { ActionNodeRF } from "./action-node-rf";

--- a/apps/web/src/app/(workspace)/automations/components/flow/branch-label-edge.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/branch-label-edge.tsx
@@ -10,17 +10,7 @@ import { ButtonEdge as RFButtonEdge } from "@/components/button-edge";
 import { Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { NextItemMarker } from "./next-item-marker";
-
-const EDGE_STYLE = {
-	stroke: "color-mix(in oklch, var(--muted-foreground) 40%, transparent)",
-	strokeWidth: 1.5,
-};
-
-const LOOP_EDGE_STYLE = {
-	stroke: "var(--color-orange-300)",
-	strokeWidth: 1.5,
-	strokeDasharray: "6 3",
-};
+import { EDGE_STYLE, LOOP_EDGE_STYLE } from "./edge-style";
 
 /** Map raw branch labels to user-friendly text */
 function displayLabel(label: string | undefined, branchType: string): string {

--- a/apps/web/src/app/(workspace)/automations/components/flow/condition-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/condition-node-rf.tsx
@@ -39,7 +39,7 @@ function getSummary(
 	return { title, description, isConfigured: true };
 }
 
-export const ConditionNodeRF = memo(({ data, selected }: NodeProps) => {
+export const ConditionNodeRF = memo(({ data }: NodeProps) => {
 	const config = (data as Record<string, unknown>)?.config as ConditionNodeConfig | undefined;
 	const triggerObjectType = data?.triggerObjectType as AutomationObjectType | null;
 	const { title, description, isConfigured } = getSummary(config, triggerObjectType ?? null);
@@ -59,18 +59,17 @@ export const ConditionNodeRF = memo(({ data, selected }: NodeProps) => {
 			className={cn(
 				"w-[280px]",
 				isConfigured
-					? "border-border shadow-sm"
+					? "border-l-4 border-l-violet-500 dark:border-l-violet-400"
 					: "border-dashed border-muted-foreground/30",
-				isFieldInvalid && "border-yellow-400",
-				"hover:border-primary/30 transition-colors",
-				selected && "ring-2 ring-primary/50",
+				// dark: variant needed so tw-merge drops the dark accent class too
+				isFieldInvalid && "border-yellow-400 dark:border-yellow-400",
 			)}
 			aria-label={`Condition: ${description}`}
 		>
 			<BaseHandle type="target" position={Position.Top} />
 			<BaseNodeContent className="p-3">
 				<div className="flex items-center gap-3">
-					<div className="w-8 h-8 rounded-lg bg-purple-50 text-purple-600 flex items-center justify-center shrink-0">
+					<div className="w-8 h-8 rounded-lg bg-violet-100 text-violet-700 dark:bg-violet-400/15 dark:text-violet-300 flex items-center justify-center shrink-0">
 						<GitBranch className="h-4 w-4" />
 					</div>
 					<div className="min-w-0 flex-1">
@@ -85,7 +84,7 @@ export const ConditionNodeRF = memo(({ data, selected }: NodeProps) => {
 							<div className="relative group">
 								<AlertTriangle className="h-3.5 w-3.5 text-yellow-500" />
 								<div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 hidden group-hover:block z-10">
-									<div className="bg-yellow-50 border border-yellow-200 rounded-md px-2 py-1 text-xs font-semibold text-yellow-700 whitespace-nowrap">
+									<div className="bg-yellow-100 dark:bg-yellow-500/15 border border-yellow-300 dark:border-yellow-500/30 rounded-md px-2 py-1 text-xs font-semibold text-yellow-800 dark:text-yellow-300 whitespace-nowrap">
 										Field may not match current trigger type
 									</div>
 								</div>

--- a/apps/web/src/app/(workspace)/automations/components/flow/delay-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/delay-node-rf.tsx
@@ -27,7 +27,7 @@ function getSummary(config: DelayNodeConfig | undefined): {
 	};
 }
 
-export const DelayNodeRF = memo(({ data, selected }: NodeProps) => {
+export const DelayNodeRF = memo(({ data }: NodeProps) => {
 	const config = (data as Record<string, unknown>)?.config as DelayNodeConfig | undefined;
 	const { title, description, isConfigured } = getSummary(config);
 
@@ -36,17 +36,15 @@ export const DelayNodeRF = memo(({ data, selected }: NodeProps) => {
 			className={cn(
 				"w-[280px]",
 				isConfigured
-					? "border-border shadow-sm"
+					? "border-l-4 border-l-cyan-500 dark:border-l-cyan-400"
 					: "border-dashed border-muted-foreground/30",
-				"hover:border-primary/30 transition-colors",
-				selected && "ring-2 ring-primary/50",
 			)}
 			aria-label={`Delay: ${title} - ${description}`}
 		>
 			<BaseHandle type="target" position={Position.Top} />
 			<BaseNodeContent className="p-3">
 				<div className="flex items-center gap-3">
-					<div className="w-8 h-8 rounded-lg bg-cyan-50 text-cyan-600 flex items-center justify-center shrink-0">
+					<div className="w-8 h-8 rounded-lg bg-cyan-100 text-cyan-700 dark:bg-cyan-400/15 dark:text-cyan-300 flex items-center justify-center shrink-0">
 						<Timer className="h-4 w-4" />
 					</div>
 					<div className="min-w-0 flex-1">

--- a/apps/web/src/app/(workspace)/automations/components/flow/delay-until-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/delay-until-node-rf.tsx
@@ -22,7 +22,7 @@ function getSummary(config: DelayUntilNodeConfig | undefined): {
 	return { title: "Wait until a date", description, isConfigured: true };
 }
 
-export const DelayUntilNodeRF = memo(({ data, selected }: NodeProps) => {
+export const DelayUntilNodeRF = memo(({ data }: NodeProps) => {
 	const config = (data as Record<string, unknown>)?.config as DelayUntilNodeConfig | undefined;
 	const { title, description, isConfigured } = getSummary(config);
 
@@ -31,17 +31,15 @@ export const DelayUntilNodeRF = memo(({ data, selected }: NodeProps) => {
 			className={cn(
 				"w-[280px]",
 				isConfigured
-					? "border-border shadow-sm"
+					? "border-l-4 border-l-cyan-500 dark:border-l-cyan-400"
 					: "border-dashed border-muted-foreground/30",
-				"hover:border-primary/30 transition-colors",
-				selected && "ring-2 ring-primary/50",
 			)}
 			aria-label={`Delay until: ${title} - ${description}`}
 		>
 			<BaseHandle type="target" position={Position.Top} />
 			<BaseNodeContent className="p-3">
 				<div className="flex items-center gap-3">
-					<div className="w-8 h-8 rounded-lg bg-cyan-50 text-cyan-600 flex items-center justify-center shrink-0">
+					<div className="w-8 h-8 rounded-lg bg-cyan-100 text-cyan-700 dark:bg-cyan-400/15 dark:text-cyan-300 flex items-center justify-center shrink-0">
 						<CalendarClock className="h-4 w-4" />
 					</div>
 					<div className="min-w-0 flex-1">

--- a/apps/web/src/app/(workspace)/automations/components/flow/edge-style.ts
+++ b/apps/web/src/app/(workspace)/automations/components/flow/edge-style.ts
@@ -1,0 +1,20 @@
+import type { CSSProperties } from "react";
+
+/**
+ * Shared connector styling for the automations flow. Single source of truth so
+ * every edge type stays consistent. Colors resolve from design tokens (or
+ * Tailwind color vars) so they read with good contrast in light and dark.
+ */
+
+/** Default sequential connector — mid-tone gray, legible on both canvases. */
+export const EDGE_STYLE: CSSProperties = {
+	stroke: "color-mix(in oklch, var(--muted-foreground) 60%, transparent)",
+	strokeWidth: 1.5,
+};
+
+/** Loop iteration lanes (each / loop-back / after-last) — dashed orange, dark-safe. */
+export const LOOP_EDGE_STYLE: CSSProperties = {
+	stroke: "var(--color-orange-400)",
+	strokeWidth: 1.5,
+	strokeDasharray: "6 3",
+};

--- a/apps/web/src/app/(workspace)/automations/components/flow/end-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/end-node-rf.tsx
@@ -1,19 +1,17 @@
 "use client";
 
 import { memo } from "react";
-import { Position, type NodeProps } from "@xyflow/react";
+import { Position } from "@xyflow/react";
 import { CircleStop } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { BaseNode, BaseNodeContent } from "@/components/base-node";
 import { BaseHandle } from "@/components/base-handle";
 
-export const EndNodeRF = memo(({ selected }: NodeProps) => {
+export const EndNodeRF = memo(() => {
 	return (
 		<BaseNode
 			className={cn(
-				"w-[280px] border-border shadow-sm",
-				"hover:border-primary/30 transition-colors",
-				selected && "ring-2 ring-primary/50",
+				"w-[280px] border-l-4 border-l-muted-foreground/40",
 			)}
 			aria-label="End: Workflow stops here"
 		>

--- a/apps/web/src/app/(workspace)/automations/components/flow/fetch-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/fetch-node-rf.tsx
@@ -27,7 +27,7 @@ function getSummary(config: FetchNodeConfig | undefined): {
 	return { title: `Fetch ${entityLabel}`, description, isConfigured: true };
 }
 
-export const FetchNodeRF = memo(({ data, selected }: NodeProps) => {
+export const FetchNodeRF = memo(({ data }: NodeProps) => {
 	const config = (data as Record<string, unknown>)?.config as FetchNodeConfig | undefined;
 	const { title, description, isConfigured } = getSummary(config);
 
@@ -36,17 +36,15 @@ export const FetchNodeRF = memo(({ data, selected }: NodeProps) => {
 			className={cn(
 				"w-[280px]",
 				isConfigured
-					? "border-border shadow-sm"
+					? "border-l-4 border-l-blue-500 dark:border-l-blue-400"
 					: "border-dashed border-muted-foreground/30",
-				"hover:border-primary/30 transition-colors",
-				selected && "ring-2 ring-primary/50",
 			)}
 			aria-label={`Fetch: ${title} - ${description}`}
 		>
 			<BaseHandle type="target" position={Position.Top} />
 			<BaseNodeContent className="p-3">
 				<div className="flex items-center gap-3">
-					<div className="w-8 h-8 rounded-lg bg-blue-50 text-blue-600 flex items-center justify-center shrink-0">
+					<div className="w-8 h-8 rounded-lg bg-blue-100 text-blue-700 dark:bg-blue-400/15 dark:text-blue-300 flex items-center justify-center shrink-0">
 						<Database className="h-4 w-4" />
 					</div>
 					<div className="min-w-0 flex-1">

--- a/apps/web/src/app/(workspace)/automations/components/flow/flow-theme.css
+++ b/apps/web/src/app/(workspace)/automations/components/flow/flow-theme.css
@@ -1,0 +1,60 @@
+/*
+ * React Flow theme overrides for the automations editor.
+ * Imported after `@xyflow/react/dist/style.css` in automation-flow.tsx so these
+ * win the cascade. Every value resolves from the app's design tokens (or
+ * Tailwind color vars), so the canvas, edges, handles and selection all flip
+ * automatically between light and dark.
+ */
+
+.react-flow {
+	/* Canvas paint. In light this matches the workspace paper; nodes lift via
+	   their own lighter card + border. */
+	background-color: var(--background);
+
+	/* Edges managed by React Flow. Custom edges set their own inline stroke
+	   (see edge-style.ts); this covers anything that falls through. */
+	--xy-edge-stroke-default: color-mix(in oklch, var(--muted-foreground) 60%, transparent);
+	--xy-edge-stroke-width-default: 1.5;
+	--xy-edge-stroke-selected-default: var(--primary);
+
+	/* Drag-to-connect line (unused today — connections are derived — themed for
+	   consistency in case it is ever enabled). */
+	--xy-connectionline-stroke-default: var(--primary);
+	--xy-connectionline-stroke-width-default: 1.5;
+
+	/* Handles: BaseHandle paints the visible dot; these theme any default. */
+	--xy-handle-background-color-default: var(--secondary);
+	--xy-handle-border-color-default: var(--border);
+
+	/* Marquee / box selection. */
+	--xy-selection-background-color-default: color-mix(in oklch, var(--primary) 8%, transparent);
+	--xy-selection-border-default: 1px dashed color-mix(in oklch, var(--primary) 55%, transparent);
+
+	/* Dot grid color is set via className on <Background /> in
+	   automation-flow.tsx (dual-mode there), not via --xy-* vars. */
+
+	/* Node hover/selected treatment is owned by BaseNode (a single brand ring);
+	   neutralize React Flow's built-in node shadows so they don't compete. */
+	--xy-node-boxshadow-hover-default: none;
+	--xy-node-boxshadow-selected-default: none;
+}
+
+/* Light: a slightly darker hairline than the workspace default so cards read
+   cleanly against the near-white paper. */
+html:not(.dark) .react-flow {
+	--border: oklch(0.85 0.007 265);
+}
+
+/* Dark: the default card and canvas are near-identical in lightness, so nodes
+   vanish into the background. Deepen the canvas AND raise the card to a clearly
+   lighter "raised surface", with a crisper border — scoped to the flow so the
+   rest of the workspace is untouched. `bg-card` / `border-border` on the node
+   cards resolve these overrides (Tailwind v4 `@theme inline`). */
+.dark .react-flow {
+	/* Override the token itself (not just background-color) so on-canvas
+	   maskers using bg-background (trigger eyebrow, branch-label pills,
+	   plus buttons) keep matching the deepened canvas. */
+	--background: oklch(0.125 0.022 264);
+	--card: oklch(0.205 0.009 264);
+	--border: oklch(0.32 0.012 270);
+}

--- a/apps/web/src/app/(workspace)/automations/components/flow/loop-back-edge.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/loop-back-edge.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { BaseEdge, type EdgeProps } from "@xyflow/react";
+import { LOOP_EDGE_STYLE } from "./edge-style";
 
 export function LoopBackEdge({
 	sourceX,
@@ -39,12 +40,7 @@ export function LoopBackEdge({
 		<BaseEdge
 			path={edgePath}
 			markerEnd={markerEnd}
-			style={{
-				...style,
-				strokeWidth: 1.5,
-				stroke: "var(--color-orange-300)",
-				strokeDasharray: "6 3",
-			}}
+			style={{ ...style, ...LOOP_EDGE_STYLE }}
 		/>
 	);
 }

--- a/apps/web/src/app/(workspace)/automations/components/flow/loop-container-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/loop-container-node-rf.tsx
@@ -14,7 +14,7 @@ export const LoopContainerNodeRF = memo(({ data }: NodeProps) => {
 	return (
 		<div
 			aria-hidden
-			className="pointer-events-none rounded-2xl border-2 border-dashed border-orange-300/60 bg-orange-50/25 dark:border-orange-700/40 dark:bg-orange-950/10"
+			className="pointer-events-none rounded-2xl border-2 border-dashed border-orange-300/60 bg-orange-50/25 dark:border-orange-400/35 dark:bg-orange-400/5"
 			style={{ width, height }}
 		/>
 	);

--- a/apps/web/src/app/(workspace)/automations/components/flow/loop-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/loop-node-rf.tsx
@@ -23,7 +23,7 @@ function getSummary(config: LoopNodeConfig | undefined): {
 	};
 }
 
-export const LoopNodeRF = memo(({ data, selected }: NodeProps) => {
+export const LoopNodeRF = memo(({ data }: NodeProps) => {
 	const config = (data as Record<string, unknown>)?.config as LoopNodeConfig | undefined;
 	const { title, description, isConfigured } = getSummary(config);
 
@@ -32,17 +32,15 @@ export const LoopNodeRF = memo(({ data, selected }: NodeProps) => {
 			className={cn(
 				"w-[280px]",
 				isConfigured
-					? "border-border shadow-sm"
+					? "border-l-4 border-l-orange-500 dark:border-l-orange-400"
 					: "border-dashed border-muted-foreground/30",
-				"hover:border-primary/30 transition-colors",
-				selected && "ring-2 ring-primary/50",
 			)}
 			aria-label={`Loop: ${title} - ${description}`}
 		>
 			<BaseHandle type="target" position={Position.Top} />
 			<BaseNodeContent className="p-3">
 				<div className="flex items-center gap-3">
-					<div className="w-8 h-8 rounded-lg bg-orange-50 text-orange-600 flex items-center justify-center shrink-0">
+					<div className="w-8 h-8 rounded-lg bg-orange-100 text-orange-700 dark:bg-orange-400/15 dark:text-orange-300 flex items-center justify-center shrink-0">
 						<Repeat className="h-4 w-4" />
 					</div>
 					<div className="min-w-0 flex-1">

--- a/apps/web/src/app/(workspace)/automations/components/flow/next-item-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/next-item-node-rf.tsx
@@ -1,19 +1,17 @@
 "use client";
 
 import { memo } from "react";
-import { Position, type NodeProps } from "@xyflow/react";
+import { Position } from "@xyflow/react";
 import { SkipForward } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { BaseNode, BaseNodeContent } from "@/components/base-node";
 import { BaseHandle } from "@/components/base-handle";
 
-export const NextItemNodeRF = memo(({ selected }: NodeProps) => {
+export const NextItemNodeRF = memo(() => {
 	return (
 		<BaseNode
 			className={cn(
-				"w-[280px] border-border shadow-sm",
-				"hover:border-primary/30 transition-colors",
-				selected && "ring-2 ring-primary/50",
+				"w-[280px] border-l-4 border-l-muted-foreground/40",
 			)}
 			aria-label="Next item: skips to the loop's next record"
 		>

--- a/apps/web/src/app/(workspace)/automations/components/flow/placeholder-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/placeholder-node-rf.tsx
@@ -9,13 +9,11 @@ import { BaseHandle } from "@/components/base-handle";
 import type { PlaceholderRFNode } from "../../lib/node-types";
 
 export const PlaceholderNodeRF = memo(
-	({ selected }: NodeProps<PlaceholderRFNode>) => {
+	(_props: NodeProps<PlaceholderRFNode>) => {
 		return (
 			<BaseNode
 				className={cn(
 					"w-[280px] border-dashed border-muted-foreground/30",
-					"hover:border-primary/30 transition-colors",
-					selected && "ring-2 ring-primary/50",
 				)}
 				aria-label="Empty step -- click to configure"
 			>

--- a/apps/web/src/app/(workspace)/automations/components/flow/plus-button-edge.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/plus-button-edge.tsx
@@ -10,11 +10,7 @@ import { ButtonEdge as RFButtonEdge } from "@/components/button-edge";
 import { Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { NextItemMarker } from "./next-item-marker";
-
-const EDGE_STYLE = {
-	stroke: "color-mix(in oklch, var(--muted-foreground) 40%, transparent)",
-	strokeWidth: 1.5,
-};
+import { EDGE_STYLE } from "./edge-style";
 
 export function PlusButtonEdge(props: EdgeProps) {
 	const {

--- a/apps/web/src/app/(workspace)/automations/components/flow/trigger-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/trigger-node-rf.tsx
@@ -76,26 +76,24 @@ function getSummary(trigger: TriggerConfig | undefined): {
 	}
 }
 
-export const TriggerNodeRF = memo(({ data, selected }: NodeProps) => {
+export const TriggerNodeRF = memo(({ data }: NodeProps) => {
 	const trigger = (data as Record<string, unknown>)?.trigger as TriggerConfig | undefined;
 	const { title, description } = getSummary(trigger);
 
 	return (
 		<div className="relative mt-4">
-			<span className="absolute -top-2.5 left-3 bg-background px-2 text-[10px] font-semibold uppercase tracking-wider text-amber-600 z-10">
+			<span className="absolute -top-2.5 left-3 bg-background px-2 text-[10px] font-semibold uppercase tracking-wider text-amber-700 dark:text-amber-300 z-10">
 				Trigger
 			</span>
 			<BaseNode
 				className={cn(
-					"w-[280px] border-amber-200 shadow-sm",
-					"hover:border-primary/30 transition-colors",
-					selected && "ring-2 ring-primary/50",
+					"w-[280px] border-l-4 border-l-amber-500 dark:border-l-amber-400",
 				)}
 				aria-label={`Trigger: ${title} - ${description}`}
 			>
 				<BaseNodeContent className="p-3">
 					<div className="flex items-center gap-3">
-						<div className="w-8 h-8 rounded-lg bg-amber-50 text-amber-600 flex items-center justify-center shrink-0">
+						<div className="w-8 h-8 rounded-lg bg-amber-100 text-amber-700 dark:bg-amber-400/15 dark:text-amber-300 flex items-center justify-center shrink-0">
 							<Zap className="h-4 w-4" />
 						</div>
 						<div className="min-w-0 flex-1">

--- a/apps/web/src/app/(workspace)/automations/components/flow/trigger-placeholder-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/trigger-placeholder-node-rf.tsx
@@ -1,29 +1,27 @@
 "use client";
 
 import { memo } from "react";
-import { type NodeProps } from "@xyflow/react";
 import { Zap } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { BaseNode, BaseNodeContent } from "@/components/base-node";
 
-export const TriggerPlaceholderNodeRF = memo(({ selected }: NodeProps) => {
+export const TriggerPlaceholderNodeRF = memo(() => {
 	return (
 		<div className="relative mt-4">
-			<span className="absolute -top-2.5 left-3 bg-background px-2 text-[10px] font-semibold uppercase tracking-wider text-amber-400 z-10">
+			<span className="absolute -top-2.5 left-3 bg-background px-2 text-[10px] font-semibold uppercase tracking-wider text-amber-400 dark:text-amber-300 z-10">
 				Trigger
 			</span>
 			<BaseNode
 				className={cn(
-					"w-[280px] border-dashed border-amber-300/50",
+					"w-[280px] border-dashed border-amber-300/50 dark:border-amber-400/30",
 					"cursor-pointer hover:border-amber-400 transition-colors",
-					selected && "ring-2 ring-primary/50",
 				)}
 				aria-label="Trigger placeholder -- click to configure"
 			>
 				<BaseNodeContent className="p-3">
 					<div className="flex items-center gap-3">
-						<div className="w-8 h-8 rounded-lg bg-amber-50/50 flex items-center justify-center shrink-0">
-							<Zap className="h-4 w-4 text-amber-400" />
+						<div className="w-8 h-8 rounded-lg bg-amber-100/50 dark:bg-amber-400/10 flex items-center justify-center shrink-0">
+							<Zap className="h-4 w-4 text-amber-400 dark:text-amber-300" />
 						</div>
 						<span className="text-sm text-muted-foreground">
 							Choose a trigger

--- a/apps/web/src/app/(workspace)/automations/lib/action-meta.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/action-meta.ts
@@ -16,8 +16,12 @@ export const ACTION_META: Record<
 	ActionNodeConfig["action"]["type"],
 	{
 		icon: LucideIcon;
+		/** Icon-chip background (dual-mode). */
 		bg: string;
+		/** Icon-chip foreground (dual-mode). */
 		fg: string;
+		/** Left-accent border classes (dual-mode) for the node card. */
+		accent: string;
 		badge: string;
 		name: string;
 		description: string;
@@ -25,32 +29,36 @@ export const ACTION_META: Record<
 > = {
 	update_field: {
 		icon: Play,
-		bg: "bg-green-50 dark:bg-green-950/40",
-		fg: "text-green-600 dark:text-green-400",
+		bg: "bg-green-100 dark:bg-green-400/15",
+		fg: "text-green-700 dark:text-green-300",
+		accent: "border-l-green-500 dark:border-l-green-400",
 		badge: "Actions",
 		name: "Update Record",
 		description: "Set a field on the record in scope.",
 	},
 	create_task: {
 		icon: ListTodo,
-		bg: "bg-green-50 dark:bg-green-950/40",
-		fg: "text-green-600 dark:text-green-400",
+		bg: "bg-green-100 dark:bg-green-400/15",
+		fg: "text-green-700 dark:text-green-300",
+		accent: "border-l-green-500 dark:border-l-green-400",
 		badge: "Actions",
 		name: "Create Task",
 		description: "Add a task to your workspace.",
 	},
 	send_notification: {
 		icon: Bell,
-		bg: "bg-pink-50 dark:bg-pink-950/40",
-		fg: "text-pink-600 dark:text-pink-400",
+		bg: "bg-pink-100 dark:bg-pink-400/15",
+		fg: "text-pink-700 dark:text-pink-300",
+		accent: "border-l-pink-500 dark:border-l-pink-400",
 		badge: "Communication",
 		name: "Send Notification",
 		description: "Notify an admin, the record owner, or a teammate.",
 	},
 	send_team_message: {
 		icon: MessagesSquare,
-		bg: "bg-pink-50 dark:bg-pink-950/40",
-		fg: "text-pink-600 dark:text-pink-400",
+		bg: "bg-pink-100 dark:bg-pink-400/15",
+		fg: "text-pink-700 dark:text-pink-300",
+		accent: "border-l-pink-500 dark:border-l-pink-400",
 		badge: "Communication",
 		name: "Send Team Message",
 		description: "Broadcast a message to your team.",

--- a/apps/web/src/components/base-node.tsx
+++ b/apps/web/src/components/base-node.tsx
@@ -6,15 +6,17 @@ export function BaseNode({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "bg-card text-card-foreground relative rounded-md border",
-        "hover:ring-1",
-        // React Flow displays node elements inside of a `NodeWrapper`
-        // component, which compiles down to a div with the class
-        // `react-flow__node`. When a node is selected, the class `selected` is
-        // added to the `react-flow__node` element. This allows us to style the
-        // node when it is selected.
-        "in-[.selected]:border-muted-foreground",
-        "in-[.selected]:shadow-lg",
+        "bg-card text-card-foreground relative rounded-md border border-border",
+        // Resting elevation so cards lift off the canvas in both themes.
+        "shadow-sm transition-[border-color,box-shadow] duration-150",
+        // Tint top/right/bottom only — the full `border-color` shorthand would
+        // override the per-type `border-l-*` accent bar on hover.
+        "hover:border-t-primary/30 hover:border-r-primary/30 hover:border-b-primary/30 hover:shadow-md",
+        // React Flow wraps every node in a `.react-flow__node` div and adds the
+        // class `selected` to it when selected, so `in-[.selected]` targets the
+        // selected state from inside. This is the single selection treatment —
+        // a brand-colored ring — so individual node cards must not add their own.
+        "in-[.selected]:ring-2 in-[.selected]:ring-primary/60 in-[.selected]:shadow-md",
         className,
       )}
       tabIndex={0}

--- a/apps/web/src/components/zoom-slider.tsx
+++ b/apps/web/src/components/zoom-slider.tsx
@@ -30,7 +30,7 @@ export function ZoomSlider({
   return (
     <Panel
       className={cn(
-        "bg-primary-foreground text-foreground flex gap-1 rounded-md p-1",
+        "bg-card/95 text-foreground border-border flex gap-1 rounded-xl border p-1 shadow-lg backdrop-blur-sm",
         orientation === "horizontal" ? "flex-row" : "flex-col",
         className,
       )}


### PR DESCRIPTION
Higher-contrast, more engaging automations editor in both light and dark, inspired by React Flow's turbo-flow example (kept calm — no gradients/glow).

Nodes:
- Fix broken dark mode: replace light-only chips (bg-*-50/text-*-600) with contrast-tuned dual-mode tokens across all node types.
- Add a 4px per-type left accent bar for at-a-glance scannability.
- Elevate cards (resting shadow + border) and consolidate selection into a single brand ring, owned by BaseNode; remove per-node duplicate rings.

Theme layer (new flow-theme.css, scoped to .react-flow):
- Token-driven --xy-* overrides for edges/handles/selection.
- Dark mode: deepen the canvas and raise the card to a clearly lighter raised surface with a crisper border so nodes separate from the background; override --background so on-canvas bg-background maskers track.

Edges: centralize styling (edge-style.ts), bump default stroke contrast, make the loop-lane orange dark-safe.

Zoom control: theme-aware raised panel instead of an always-white slab.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restyles the automations flow editor toward a turbo-flow–inspired aesthetic: per-type left accent bars on node cards, dual-mode contrast tokens throughout, centralized edge styles, and a new scoped `flow-theme.css` that overrides React Flow's CSS variables and local design tokens for the canvas in both light and dark.

- **BaseNode consolidation** — selection rings and hover states are unified in `BaseNode` (hover applies only to t/r/b borders to preserve the left accent bar); all per-node duplicate rings are removed.
- **Edge / handle theming** — `edge-style.ts` centralises `EDGE_STYLE` and `LOOP_EDGE_STYLE`; opacity bumped from 40% → 60% for better contrast; loop orange updated from `--color-orange-300` to the dark-safe `--color-orange-400`.
- **`flow-theme.css`** — scoped to `.react-flow` / `.dark .react-flow` so canvas token overrides (`--background`, `--card`, `--border`) don't bleed into the rest of the workspace.

<h3>Confidence Score: 3/5</h3>

Safe to merge after fixing the invalid-field border override in ConditionNode; all other changes are low-risk visual updates.

The invalid-field warning indicator in ConditionNode is likely broken: tailwind-merge keeps both border-l-violet-500 and border-yellow-400 because they belong to different conflict groups, and the CSS cascade may leave the left border violet while the other three sides go yellow — a mixed-color border rather than a uniform warning. This is a present defect on an existing user-visible validation path. The action-node fallthrough is theoretical with current types but indicates fragility if a new action type is added without updating ACTION_META.

condition-node-rf.tsx — the isFieldInvalid border override needs a reliable fix; action-node-rf.tsx — the meta fallback path should be hardened.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/(workspace)/automations/components/flow/condition-node-rf.tsx | Removes per-node selection ring (delegated to BaseNode), upgrades dark-mode tokens, adds left accent bar — but the isFieldInvalid border override likely fails to clear the new border-l-violet-500 class due to tailwind-merge conflict group mismatch. |
| apps/web/src/app/(workspace)/automations/components/flow/action-node-rf.tsx | Replaces flat border with per-type accent bar via ACTION_META; has a silent fallthrough (no border class) when isConfigured is true but meta is absent, and stale fallback tokens on the icon chip in that same path. |
| apps/web/src/components/base-node.tsx | Consolidates selection ring and hover into BaseNode; correctly limits hover to t/r/b sides to preserve the per-type left accent bar; removes duplicate per-node rings. |
| apps/web/src/app/(workspace)/automations/components/flow/flow-theme.css | New file that scopes --xy-* React Flow token overrides and dark-mode --background/--card/--border overrides to .react-flow, cleanly keeping changes off the rest of the workspace. |
| apps/web/src/app/(workspace)/automations/components/flow/edge-style.ts | Centralises EDGE_STYLE and LOOP_EDGE_STYLE constants; bumps opacity from 40% to 60% for better contrast; loop orange changed from --color-orange-300 to --color-orange-400 for dark-mode safety. |
| apps/web/src/app/(workspace)/automations/lib/action-meta.ts | Adds accent field to all ACTION_META entries with proper dual-mode Tailwind classes; updates bg/fg tokens to higher-contrast equivalents. |
| apps/web/src/components/zoom-slider.tsx | Replaces always-white bg-primary-foreground with theme-aware bg-card/95 + border + shadow + backdrop-blur; straightforward and correct. |
| apps/web/src/app/(workspace)/automations/components/flow/trigger-node-rf.tsx | Drops selected prop, updates to dual-mode amber accent bar and improved contrast tokens; clean change. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Node renders] --> B{config defined?}
    B -- No --> C[meta = undefined
isConfigured = false]
    B -- Yes --> D[meta = ACTION_META lookup
getSummary runs switch]
    D --> E{action type known?}
    E -- No --> F[default branch
isConfigured = false]
    E -- Yes --> G{sub-conditions met?}
    G -- No --> H[isConfigured = false]
    G -- Yes --> I[isConfigured = true]
    C --> J[border-dashed border-muted-foreground/30]
    F --> J
    H --> J
    I --> K{meta defined?}
    K -- Yes --> L[border-l-4 + meta.accent]
    K -- No --> M[no border class applied — visual fallthrough]
    L --> N{isFieldInvalid? — ConditionNode only}
    N -- No --> O[Final: accent bar visible]
    N -- Yes --> P[border-yellow-400 added — tw-merge may NOT drop border-l-violet-500]
    style M fill:#fca5a5,color:#000
    style P fill:#fca5a5,color:#000
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Node renders] --> B{config defined?}
    B -- No --> C[meta = undefined
isConfigured = false]
    B -- Yes --> D[meta = ACTION_META lookup
getSummary runs switch]
    D --> E{action type known?}
    E -- No --> F[default branch
isConfigured = false]
    E -- Yes --> G{sub-conditions met?}
    G -- No --> H[isConfigured = false]
    G -- Yes --> I[isConfigured = true]
    C --> J[border-dashed border-muted-foreground/30]
    F --> J
    H --> J
    I --> K{meta defined?}
    K -- Yes --> L[border-l-4 + meta.accent]
    K -- No --> M[no border class applied — visual fallthrough]
    L --> N{isFieldInvalid? — ConditionNode only}
    N -- No --> O[Final: accent bar visible]
    N -- Yes --> P[border-yellow-400 added — tw-merge may NOT drop border-l-violet-500]
    style M fill:#fca5a5,color:#000
    style P fill:#fca5a5,color:#000
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/src/app/(workspace)/automations/components/flow/condition-node-rf.tsx:59-66
**Invalid-field border may silently fail to override the accent bar**

`tailwind-merge` treats `border-{color}` (shorthand, all sides) and `border-l-{color}` (left-only) as **separate conflict groups**, so when both `"border-l-violet-500"` and `"border-yellow-400"` reach the DOM, neither is dropped — both classes end up in the rendered `className`. The final left-border color is then decided by CSS cascade order in the generated stylesheet. If Tailwind v4 generates `border-left-color` utilities after `border-color` shorthands (which is the conventional ordering), `border-l-violet-500` wins for the left side and the warning yellow only applies to the three other sides: a 4 px violet left rail alongside 1 px yellow top/right/bottom borders.

The old code used `"border-border shadow-sm"` for the configured state, and `border-border` sits in the same `border-color` conflict group as `border-yellow-400`, so tw-merge reliably dropped it and the warning was always fully yellow. The new `border-l-{color}` class breaks that assumption.

A reliable fix is to pair the invalid override with an explicit left reset so there is no ambiguity about which color wins on the left side.

### Issue 2 of 2
apps/web/src/app/(workspace)/automations/components/flow/action-node-rf.tsx:74-79
**Silent visual fallthrough when `isConfigured && !meta`**

When `isConfigured` is `true` but `meta` is `undefined`, `meta && \`border-l-4 ${meta.accent}\`` evaluates to `undefined`, so neither the accent bar nor the old `border-border shadow-sm` fallback is applied. The node renders as a plain-bordered card indistinguishable from neither state. The icon chip fallback (`meta?.bg ?? "bg-green-50 dark:bg-green-950/40"`) also still uses pre-restyle tokens, so dark mode contrast for that path would be lower than the new standard. Adding `meta?.accent ?? "border-l-primary/40"` as a guard keeps the component robust as new action types are added.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(automations): turbo-flow-inspired r..."](https://github.com/xcarter93/onetool/commit/586c03e1e8e8c6295254ddc2fe5a8b7c7539fc7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42756974)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->