### PR TITLE
feat(web): frosted-blue highlight grid + RELATED frame on record pages

### DIFF
--- a/apps/web/src/app/(workspace)/clients/components/tabs/overview-tab.tsx
+++ b/apps/web/src/app/(workspace)/clients/components/tabs/overview-tab.tsx
@@ -3,12 +3,11 @@
 import { Doc, Id } from "@onetool/backend/convex/_generated/dataModel";
 import { api } from "@onetool/backend/convex/_generated/api";
 import { useMutation } from "convex/react";
-import { ProminentStatusBadge } from "@/components/shared/prominent-status-badge";
 import { MentionSection } from "@/components/shared/mention-section";
 import { Separator } from "@/components/ui/separator";
-import { GlassCard, GlassCardContent } from "@/components/shared/glass-card";
-import { FolderOpen, DollarSign, TrendingUp, Pencil, Check, X } from "lucide-react";
-import Link from "next/link";
+import { HighlightMetricGrid } from "@/components/shared/highlight-metric-grid";
+import { RelatedRecordsFrame } from "@/components/shared/related-records-frame";
+import { FolderOpen, DollarSign, TrendingUp, FileText, Receipt, Pencil, Check, X } from "lucide-react";
 import { useState, useRef, useEffect } from "react";
 import { useToast } from "@/hooks/use-toast";
 
@@ -42,46 +41,6 @@ function sortedByNewest<T extends { _creationTime: number }>(
 ): T[] {
 	if (!items) return [];
 	return [...items].sort((a, b) => b._creationTime - a._creationTime);
-}
-
-function RelatedEntityColumn<T>({
-	label,
-	count,
-	emptyMessage,
-	items,
-	renderItem,
-}: {
-	label: string;
-	count: number;
-	emptyMessage: string;
-	items: T[] | undefined;
-	renderItem: (item: T) => React.ReactNode;
-}) {
-	return (
-		<div className="flex flex-col min-w-0">
-			<div className="flex items-center justify-between mb-2 px-1">
-				<span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-					{label}
-				</span>
-				{count > 0 && (
-					<span className="text-[11px] text-muted-foreground/70 tabular-nums">
-						{count}
-					</span>
-				)}
-			</div>
-			{count === 0 ? (
-				<div className="flex-1 flex items-center justify-center rounded-lg border border-dashed border-border/60 py-8">
-					<p className="text-sm text-muted-foreground/50">
-						{emptyMessage}
-					</p>
-				</div>
-			) : (
-				<div className="overflow-y-auto max-h-[320px] rounded-lg border border-border/60 divide-y divide-border/40">
-					{(items ?? []).map(renderItem)}
-				</div>
-			)}
-		</div>
-	);
 }
 
 export function OverviewTab({
@@ -165,53 +124,28 @@ export function OverviewTab({
 				<h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-3 pb-2 border-b border-border/40">
 					Highlights
 				</h3>
-				<div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-					<GlassCard>
-						<GlassCardContent className="flex items-center gap-3 p-4">
-							<div className="flex items-center justify-center w-10 h-10 rounded-lg bg-primary/10">
-								<FolderOpen className="h-5 w-5 text-primary" />
-							</div>
-							<div>
-								<p className="text-2xl font-bold text-foreground">
-									{activeProjects}
-								</p>
-								<p className="text-xs text-muted-foreground">
-									Active Projects
-								</p>
-							</div>
-						</GlassCardContent>
-					</GlassCard>
-					<GlassCard>
-						<GlassCardContent className="flex items-center gap-3 p-4">
-							<div className="flex items-center justify-center w-10 h-10 rounded-lg bg-primary/10">
-								<DollarSign className="h-5 w-5 text-primary" />
-							</div>
-							<div>
-								<p className="text-2xl font-bold text-foreground">
-									${outstanding.toLocaleString()}
-								</p>
-								<p className="text-xs text-muted-foreground">
-									Outstanding
-								</p>
-							</div>
-						</GlassCardContent>
-					</GlassCard>
-					<GlassCard>
-						<GlassCardContent className="flex items-center gap-3 p-4">
-							<div className="flex items-center justify-center w-10 h-10 rounded-lg bg-primary/10">
-								<TrendingUp className="h-5 w-5 text-primary" />
-							</div>
-							<div>
-								<p className="text-2xl font-bold text-foreground">
-									${totalRevenue.toLocaleString()}
-								</p>
-								<p className="text-xs text-muted-foreground">
-									Total Revenue
-								</p>
-							</div>
-						</GlassCardContent>
-					</GlassCard>
-				</div>
+				<HighlightMetricGrid
+					metrics={[
+						{
+							icon: FolderOpen,
+							label: "Active Projects",
+							value: activeProjects,
+							description: "Projects currently in progress",
+						},
+						{
+							icon: DollarSign,
+							label: "Outstanding",
+							value: formatCurrency(outstanding),
+							description: "Invoiced but not yet paid",
+						},
+						{
+							icon: TrendingUp,
+							label: "Total Revenue",
+							value: formatCurrency(totalRevenue),
+							description: "Lifetime billed to this client",
+						},
+					]}
+				/>
 			</div>
 
 			<Separator className="my-6" />
@@ -277,103 +211,43 @@ export function OverviewTab({
 
 			<Separator className="my-6" />
 
-			{/* Related Entities — 3-column grid with independent scroll */}
-			<div>
-				<h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-3 pb-2 border-b border-border/40">
-					Related
-				</h3>
-				<div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-					{/* Projects */}
-					<RelatedEntityColumn
-						label="Projects"
-						count={projects?.length ?? 0}
-						emptyMessage="No projects yet"
-						items={sortedByNewest(projects)}
-						renderItem={(project) => (
-							<Link
-								key={project._id}
-								href={`/projects/${project._id}`}
-								className="flex flex-col gap-1 px-3 py-2.5 hover:bg-muted/50 transition-colors group"
-							>
-								<div className="flex items-center justify-between gap-2">
-									<span className="text-sm font-medium text-foreground group-hover:text-primary transition-colors truncate">
-										{project.title}
-									</span>
-									<ProminentStatusBadge
-										status={project.status}
-										size="default"
-										showIcon={false}
-										entityType="project"
-									/>
-								</div>
-								<span className="text-[11px] text-muted-foreground/70 tabular-nums">
-									{formatDate(project._creationTime)}
-								</span>
-							</Link>
-						)}
-					/>
-
-					{/* Quotes */}
-					<RelatedEntityColumn
-						label="Quotes"
-						count={quotes?.length ?? 0}
-						emptyMessage="No quotes yet"
-						items={sortedByNewest(quotes)}
-						renderItem={(quote) => (
-							<Link
-								key={quote._id}
-								href={`/quotes/${quote._id}`}
-								className="flex flex-col gap-1 px-3 py-2.5 hover:bg-muted/50 transition-colors group"
-							>
-								<div className="flex items-center justify-between gap-2">
-									<span className="text-sm font-medium text-foreground group-hover:text-primary transition-colors truncate">
-										{quote.quoteNumber || quote.title || "Untitled"}
-									</span>
-									<ProminentStatusBadge
-										status={quote.status}
-										size="default"
-										showIcon={false}
-										entityType="quote"
-									/>
-								</div>
-								<span className="text-[11px] text-muted-foreground/70 tabular-nums">
-									{formatCurrency(quote.total)}
-								</span>
-							</Link>
-						)}
-					/>
-
-					{/* Invoices */}
-					<RelatedEntityColumn
-						label="Invoices"
-						count={invoices?.length ?? 0}
-						emptyMessage="No invoices yet"
-						items={sortedByNewest(invoices)}
-						renderItem={(invoice) => (
-							<Link
-								key={invoice._id}
-								href={`/invoices/${invoice._id}`}
-								className="flex flex-col gap-1 px-3 py-2.5 hover:bg-muted/50 transition-colors group"
-							>
-								<div className="flex items-center justify-between gap-2">
-									<span className="text-sm font-medium text-foreground group-hover:text-primary transition-colors truncate">
-										{invoice.invoiceNumber}
-									</span>
-									<ProminentStatusBadge
-										status={invoice.status}
-										size="default"
-										showIcon={false}
-										entityType="invoice"
-									/>
-								</div>
-								<span className="text-[11px] text-muted-foreground/70 tabular-nums">
-									{formatCurrency(invoice.total)}
-								</span>
-							</Link>
-						)}
-					/>
-				</div>
-			</div>
+			<RelatedRecordsFrame
+				sections={[
+					{
+						title: "Projects",
+						icon: FolderOpen,
+						items: sortedByNewest(projects).map((project) => ({
+							id: project._id,
+							title: project.title,
+							meta: formatDate(project._creationTime),
+							status: project.status,
+							href: `/projects/${project._id}`,
+						})),
+					},
+					{
+						title: "Quotes",
+						icon: FileText,
+						items: sortedByNewest(quotes).map((quote) => ({
+							id: quote._id,
+							title: quote.quoteNumber || quote.title || "Untitled",
+							meta: formatCurrency(quote.total),
+							status: quote.status,
+							href: `/quotes/${quote._id}`,
+						})),
+					},
+					{
+						title: "Invoices",
+						icon: Receipt,
+						items: sortedByNewest(invoices).map((invoice) => ({
+							id: invoice._id,
+							title: invoice.invoiceNumber,
+							meta: formatCurrency(invoice.total),
+							status: invoice.status,
+							href: `/invoices/${invoice._id}`,
+						})),
+					},
+				]}
+			/>
 
 			<Separator className="my-6" />
 

--- a/apps/web/src/app/(workspace)/invoices/[invoiceId]/components/tabs/overview-tab.tsx
+++ b/apps/web/src/app/(workspace)/invoices/[invoiceId]/components/tabs/overview-tab.tsx
@@ -3,7 +3,7 @@
 import { Doc, Id } from "@onetool/backend/convex/_generated/dataModel";
 import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
-import { GlassCard, GlassCardContent } from "@/components/shared/glass-card";
+import { HighlightMetricGrid } from "@/components/shared/highlight-metric-grid";
 import {
 	DataGrid,
 	DataGridContainer,
@@ -82,41 +82,25 @@ export function OverviewTab({
 	return (
 		<div className="space-y-8">
 			{/* Summary Cards */}
-			<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-				<GlassCard>
-					<GlassCardContent className="flex items-center gap-3 p-4">
-						<div className="flex items-center justify-center w-10 h-10 rounded-lg bg-primary/10">
-							<DollarSign className="h-5 w-5 text-primary" />
-						</div>
-						<div>
-							<p className="text-2xl font-bold text-foreground">
-								{formatCurrency(invoice.total)}
-							</p>
-							<p className="text-xs text-muted-foreground">
-								Total Amount
-							</p>
-						</div>
-					</GlassCardContent>
-				</GlassCard>
-
-				<GlassCard>
-					<GlassCardContent className="flex items-center gap-3 p-4">
-						<div className="flex items-center justify-center w-10 h-10 rounded-lg bg-primary/10">
-							<CreditCard className="h-5 w-5 text-primary" />
-						</div>
-						<div>
-							<p className="text-2xl font-bold text-foreground">
-								{paymentSummary?.totalPayments ?? 0}
-							</p>
-							<p className="text-xs text-muted-foreground">
-								Payments{paymentSummary && paymentSummary.totalPayments > 0
-									? ` \u00B7 ${paymentSummary.paidCount} paid`
-									: ""}
-							</p>
-						</div>
-					</GlassCardContent>
-				</GlassCard>
-			</div>
+			<HighlightMetricGrid
+				metrics={[
+					{
+						icon: DollarSign,
+						label: "Total Amount",
+						value: formatCurrency(invoice.total),
+						description: "Invoice grand total",
+					},
+					{
+						icon: CreditCard,
+						label: "Payments",
+						value: paymentSummary?.totalPayments ?? 0,
+						description:
+							paymentSummary && paymentSummary.totalPayments > 0
+								? `${paymentSummary.paidCount} paid`
+								: "No payments yet",
+					},
+				]}
+			/>
 
 			{/* Line Items Section */}
 			<div>

--- a/apps/web/src/app/(workspace)/projects/components/tabs/overview-tab.tsx
+++ b/apps/web/src/app/(workspace)/projects/components/tabs/overview-tab.tsx
@@ -4,14 +4,13 @@ import React, { useState, useRef, useEffect } from "react";
 import { Doc, Id } from "@onetool/backend/convex/_generated/dataModel";
 import { api } from "@onetool/backend/convex/_generated/api";
 import { useMutation } from "convex/react";
-import { ProminentStatusBadge } from "@/components/shared/prominent-status-badge";
 import { MentionSection } from "@/components/shared/mention-section";
 import { Separator } from "@/components/ui/separator";
-import { GlassCard, GlassCardContent } from "@/components/shared/glass-card";
+import { HighlightMetricGrid } from "@/components/shared/highlight-metric-grid";
+import { RelatedRecordsFrame } from "@/components/shared/related-records-frame";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
-import { ClipboardList, DollarSign, CheckCircle, Pencil } from "lucide-react";
-import Link from "next/link";
+import { ClipboardList, DollarSign, CheckCircle, FileText, Receipt, Pencil } from "lucide-react";
 
 interface OverviewTabProps {
 	projectId: Id<"projects">;
@@ -46,46 +45,6 @@ function sortedByNewest<T extends { _creationTime: number }>(
 ): T[] {
 	if (!items) return [];
 	return [...items].sort((a, b) => b._creationTime - a._creationTime);
-}
-
-function RelatedEntityColumn<T>({
-	label,
-	count,
-	emptyMessage,
-	items,
-	renderItem,
-}: {
-	label: string;
-	count: number;
-	emptyMessage: string;
-	items: T[] | undefined;
-	renderItem: (item: T) => React.ReactNode;
-}) {
-	return (
-		<div className="flex flex-col min-w-0">
-			<div className="flex items-center justify-between mb-2 px-1">
-				<span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-					{label}
-				</span>
-				{count > 0 && (
-					<span className="text-[11px] text-muted-foreground/70 tabular-nums">
-						{count}
-					</span>
-				)}
-			</div>
-			{count === 0 ? (
-				<div className="flex-1 flex items-center justify-center rounded-lg border border-dashed border-border/60 py-8">
-					<p className="text-sm text-muted-foreground/50">
-						{emptyMessage}
-					</p>
-				</div>
-			) : (
-				<div className="overflow-y-auto max-h-[320px] rounded-lg border border-border/60 divide-y divide-border/40">
-					{(items ?? []).map(renderItem)}
-				</div>
-			)}
-		</div>
-	);
 }
 
 function getCalendarDays(date: Date) {
@@ -206,53 +165,28 @@ export function OverviewTab({
 				<h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-3">
 					Highlights
 				</h3>
-				<div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-					<GlassCard>
-						<GlassCardContent className="flex items-center gap-3 p-4">
-							<div className="flex items-center justify-center w-10 h-10 rounded-lg bg-primary/10">
-								<ClipboardList className="h-5 w-5 text-primary" />
-							</div>
-							<div>
-								<p className="text-2xl font-bold text-foreground">
-									{activeTasks}
-								</p>
-								<p className="text-xs text-muted-foreground">
-									Active Tasks
-								</p>
-							</div>
-						</GlassCardContent>
-					</GlassCard>
-					<GlassCard>
-						<GlassCardContent className="flex items-center gap-3 p-4">
-							<div className="flex items-center justify-center w-10 h-10 rounded-lg bg-primary/10">
-								<DollarSign className="h-5 w-5 text-primary" />
-							</div>
-							<div>
-								<p className="text-2xl font-bold text-foreground">
-									{formatCurrency(totalQuoted)}
-								</p>
-								<p className="text-xs text-muted-foreground">
-									Total Quoted
-								</p>
-							</div>
-						</GlassCardContent>
-					</GlassCard>
-					<GlassCard>
-						<GlassCardContent className="flex items-center gap-3 p-4">
-							<div className="flex items-center justify-center w-10 h-10 rounded-lg bg-primary/10">
-								<CheckCircle className="h-5 w-5 text-primary" />
-							</div>
-							<div>
-								<p className="text-2xl font-bold text-foreground">
-									{approvedQuotes}
-								</p>
-								<p className="text-xs text-muted-foreground">
-									Approved Quotes
-								</p>
-							</div>
-						</GlassCardContent>
-					</GlassCard>
-				</div>
+				<HighlightMetricGrid
+					metrics={[
+						{
+							icon: ClipboardList,
+							label: "Active Tasks",
+							value: activeTasks,
+							description: "Tasks not yet completed",
+						},
+						{
+							icon: DollarSign,
+							label: "Total Quoted",
+							value: formatCurrency(totalQuoted),
+							description: "Sum of all quotes on this project",
+						},
+						{
+							icon: CheckCircle,
+							label: "Approved Quotes",
+							value: approvedQuotes,
+							description: "Quotes accepted by the client",
+						},
+					]}
+				/>
 			</div>
 
 			<Separator className="my-6" />
@@ -497,73 +431,32 @@ export function OverviewTab({
 
 			<Separator className="my-6" />
 
-			{/* Related Entities — 2-column grid with independent scroll */}
-			<div>
-				<h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-3">
-					Related
-				</h3>
-				<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-					{/* Quotes */}
-					<RelatedEntityColumn
-						label="Quotes"
-						count={quotes?.length ?? 0}
-						emptyMessage="No quotes yet"
-						items={sortedByNewest(quotes)}
-						renderItem={(quote) => (
-							<Link
-								key={quote._id}
-								href={`/quotes/${quote._id}`}
-								className="flex flex-col gap-1 px-3 py-2.5 hover:bg-muted/50 transition-colors group"
-							>
-								<div className="flex items-center justify-between gap-2">
-									<span className="text-sm font-medium text-foreground group-hover:text-primary transition-colors truncate">
-										{quote.quoteNumber || quote.title || "Untitled"}
-									</span>
-									<ProminentStatusBadge
-										status={quote.status}
-										size="default"
-										showIcon={false}
-										entityType="quote"
-									/>
-								</div>
-								<span className="text-[11px] text-muted-foreground/70 tabular-nums">
-									{formatCurrency(quote.total)}
-								</span>
-							</Link>
-						)}
-					/>
-
-					{/* Invoices */}
-					<RelatedEntityColumn
-						label="Invoices"
-						count={invoices?.length ?? 0}
-						emptyMessage="No invoices yet"
-						items={sortedByNewest(invoices)}
-						renderItem={(invoice) => (
-							<Link
-								key={invoice._id}
-								href={`/invoices/${invoice._id}`}
-								className="flex flex-col gap-1 px-3 py-2.5 hover:bg-muted/50 transition-colors group"
-							>
-								<div className="flex items-center justify-between gap-2">
-									<span className="text-sm font-medium text-foreground group-hover:text-primary transition-colors truncate">
-										{invoice.invoiceNumber}
-									</span>
-									<ProminentStatusBadge
-										status={invoice.status}
-										size="default"
-										showIcon={false}
-										entityType="invoice"
-									/>
-								</div>
-								<span className="text-[11px] text-muted-foreground/70 tabular-nums">
-									{formatCurrency(invoice.total)}
-								</span>
-							</Link>
-						)}
-					/>
-				</div>
-			</div>
+			<RelatedRecordsFrame
+				sections={[
+					{
+						title: "Quotes",
+						icon: FileText,
+						items: sortedByNewest(quotes).map((quote) => ({
+							id: quote._id,
+							title: quote.quoteNumber || quote.title || "Untitled",
+							meta: formatCurrency(quote.total),
+							status: quote.status,
+							href: `/quotes/${quote._id}`,
+						})),
+					},
+					{
+						title: "Invoices",
+						icon: Receipt,
+						items: sortedByNewest(invoices).map((invoice) => ({
+							id: invoice._id,
+							title: invoice.invoiceNumber,
+							meta: formatCurrency(invoice.total),
+							status: invoice.status,
+							href: `/invoices/${invoice._id}`,
+						})),
+					},
+				]}
+			/>
 
 			<Separator className="my-6" />
 

--- a/apps/web/src/components/shared/highlight-metric-grid.tsx
+++ b/apps/web/src/components/shared/highlight-metric-grid.tsx
@@ -1,0 +1,163 @@
+import * as React from "react";
+import type { LucideIcon } from "lucide-react";
+
+import { Frame, FramePanel } from "@/components/reui/frame";
+import { cn } from "@/lib/utils";
+
+/**
+ * A single highlight metric. `description` and `trend` are optional — omit the
+ * trend when there's no period-over-period delta to show.
+ */
+export interface HighlightMetric {
+	icon: LucideIcon;
+	label: string;
+	value: React.ReactNode;
+	description?: string;
+	trend?: { value: string; direction: "up" | "down" };
+}
+
+// Diagonal clip-path levels + frosted-blue fills for the decorative area shape.
+// Adapted from ReUI card-29, recolored from indigo to translucent primary.
+const AREA_LEVELS = [
+	{ back: [34, 2], fill: [48, 16] },
+	{ back: [2, 36], fill: [16, 50] },
+	{ back: [36, 0], fill: [50, 10] },
+	{ back: [0, 22], fill: [10, 32] },
+] as const;
+
+const AREA_FILLS = [
+	"from-primary/45 via-primary/30 to-primary/15",
+	"from-primary/50 via-primary/35 to-primary/20",
+	"from-primary/40 via-primary/25 to-primary/10",
+	"from-primary/55 via-primary/40 to-primary/25",
+] as const;
+
+function MetricAreaShape({ index }: { index: number }) {
+	const levels = AREA_LEVELS[index % AREA_LEVELS.length];
+	const fill = AREA_FILLS[index % AREA_FILLS.length];
+	const backClip = `polygon(0 ${levels.back[0]}%, 100% ${levels.back[1]}%, 100% 100%, 0 100%)`;
+	const fillClip = `polygon(0 ${levels.fill[0]}%, 100% ${levels.fill[1]}%, 100% 100%, 0 100%)`;
+
+	return (
+		<div
+			aria-hidden="true"
+			className="relative -mx-4 -mb-4 mt-3 h-14 overflow-hidden"
+		>
+			<div
+				className="absolute inset-x-0 bottom-0 h-full bg-primary/10"
+				style={{ clipPath: backClip }}
+			/>
+			<div
+				className={cn(
+					"absolute inset-x-0 bottom-0 h-full bg-linear-to-br",
+					fill
+				)}
+				style={{ clipPath: fillClip }}
+			/>
+		</div>
+	);
+}
+
+const GRID_COLS: Record<number, string> = {
+	1: "",
+	2: "sm:grid-cols-2",
+	3: "sm:grid-cols-3",
+	4: "sm:grid-cols-4",
+};
+
+function cellBorders(index: number, total: number, cols: number) {
+	const isLast = index === total - 1;
+	const inLastCol = index % cols === cols - 1;
+	const lastRowStart = total - (total % cols || cols);
+	const inLastRow = index >= lastRowStart;
+
+	return cn(
+		"border-border/60",
+		// Stacked (mobile): divider under every card except the last.
+		!isLast && "max-sm:border-b",
+		// Grid (sm+): right divider except the last column…
+		!inLastCol && "sm:border-r",
+		// …and bottom divider except the last row.
+		inLastRow ? "sm:border-b-0" : "sm:border-b"
+	);
+}
+
+/**
+ * Frosted-blue panel of highlight metrics — the record-page "Highlights" row.
+ * Wrapped in a ReUI Frame so the panel edge stays visible in light mode.
+ * card-29-style layout: icon → label → value → description → frosted-blue area
+ * shape. Compact by design.
+ */
+export function HighlightMetricGrid({
+	metrics,
+	columns,
+	className,
+}: {
+	metrics: HighlightMetric[];
+	columns?: 2 | 3 | 4;
+	className?: string;
+}) {
+	const cols = columns ?? Math.min(Math.max(metrics.length, 1), 4);
+
+	return (
+		<Frame className={className}>
+			<FramePanel className="overflow-hidden p-0!">
+				{/* Subtle glass sheen over the solid card panel */}
+				<div className="pointer-events-none absolute inset-0 bg-linear-to-br from-white/10 via-white/5 to-transparent dark:from-white/5 dark:via-white/2 dark:to-transparent" />
+
+				<div
+					className={cn("relative z-10 grid grid-cols-1", GRID_COLS[cols])}
+				>
+					{metrics.map((metric, index) => {
+						const Icon = metric.icon;
+						return (
+							<div
+								key={metric.label}
+								className={cn(
+									"flex min-h-[150px] flex-col overflow-hidden p-4",
+									cellBorders(index, metrics.length, cols)
+								)}
+							>
+								<div className="flex flex-1 flex-col justify-between gap-3">
+									<div className="flex items-center justify-center w-8 h-8 rounded-lg bg-primary/10">
+										<Icon className="h-4 w-4 text-primary" />
+									</div>
+
+									<div className="flex flex-col gap-1">
+										<p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+											{metric.label}
+										</p>
+										<div className="flex items-center gap-1.5">
+											<p className="text-2xl font-bold leading-tight text-foreground">
+												{metric.value}
+											</p>
+											{metric.trend && (
+												<span
+													className={cn(
+														"rounded-md px-1.5 py-0.5 text-xs font-medium",
+														metric.trend.direction === "up"
+															? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+															: "bg-amber-500/10 text-amber-600 dark:text-amber-400"
+													)}
+												>
+													{metric.trend.value}
+												</span>
+											)}
+										</div>
+										{metric.description && (
+											<p className="text-xs leading-relaxed text-muted-foreground">
+												{metric.description}
+											</p>
+										)}
+									</div>
+								</div>
+
+								<MetricAreaShape index={index} />
+							</div>
+						);
+					})}
+				</div>
+			</FramePanel>
+		</Frame>
+	);
+}

--- a/apps/web/src/components/shared/related-records-frame.tsx
+++ b/apps/web/src/components/shared/related-records-frame.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import type { LucideIcon } from "lucide-react";
+
+import {
+	Frame,
+	FrameHeader,
+	FramePanel,
+	FrameTitle,
+} from "@/components/reui/frame";
+import {
+	Item,
+	ItemActions,
+	ItemContent,
+	ItemDescription,
+	ItemMedia,
+	ItemTitle,
+} from "@/components/ui/item";
+import { EmptyState } from "@/components/domain/empty-state";
+import { StatusBadge } from "@/components/domain/status-badge";
+import { cn } from "@/lib/utils";
+
+export interface RelatedRecordItem {
+	id: string;
+	title: React.ReactNode;
+	/** Secondary line under the title (date, amount, …). */
+	meta?: React.ReactNode;
+	/** Domain status string → canonical StatusBadge. */
+	status?: string;
+	href?: string;
+	/** Row icon; defaults to the section icon. */
+	icon?: LucideIcon;
+}
+
+export interface RelatedRecordSection {
+	title: string;
+	icon: LucideIcon;
+	items: RelatedRecordItem[];
+	/** Empty-state title; defaults to "No <title> yet". */
+	emptyLabel?: string;
+}
+
+const COLS: Record<number, string> = {
+	1: "",
+	2: "md:grid-cols-2",
+	3: "md:grid-cols-3",
+};
+
+/** "in-progress" → "In Progress" */
+function formatStatusLabel(status: string) {
+	return status
+		.split(/[-_]/)
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(" ");
+}
+
+/**
+ * "RELATED" frame — one card per related object type. Each card renders a list
+ * of c-item-6-style rows, or a ReUI empty state when the type has no records.
+ */
+export function RelatedRecordsFrame({
+	sections,
+	columns,
+	className,
+}: {
+	sections: RelatedRecordSection[];
+	columns?: 1 | 2 | 3;
+	className?: string;
+}) {
+	const cols = columns ?? Math.min(Math.max(sections.length, 1), 3);
+
+	return (
+		<Frame className={className}>
+			<FrameHeader>
+				<FrameTitle className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+					Related
+				</FrameTitle>
+			</FrameHeader>
+
+			<div className={cn("grid grid-cols-1 gap-3", COLS[cols])}>
+				{sections.map((section) => {
+					const SectionIcon = section.icon;
+					return (
+						<FramePanel key={section.title} className="flex flex-col gap-3">
+							<div className="flex items-center justify-between">
+								<div className="flex items-center gap-2">
+									<SectionIcon className="size-4 text-muted-foreground" />
+									<span className="text-sm font-semibold text-foreground">
+										{section.title}
+									</span>
+								</div>
+								{section.items.length > 0 && (
+									<span className="text-xs text-muted-foreground/70 tabular-nums">
+										{section.items.length}
+									</span>
+								)}
+							</div>
+
+							{section.items.length === 0 ? (
+								<EmptyState
+									size="sm"
+									icon={<SectionIcon />}
+									title={
+										section.emptyLabel ??
+										`No ${section.title.toLowerCase()} yet`
+									}
+								/>
+							) : (
+								<div className="flex max-h-72 flex-col gap-2 overflow-y-auto">
+									{section.items.map((item) => {
+										const RowIcon = item.icon ?? section.icon;
+										return (
+											<Item
+												key={item.id}
+												variant="outline"
+												size="xs"
+												render={
+													item.href ? <Link href={item.href} /> : undefined
+												}
+											>
+												<ItemMedia variant="icon">
+													<RowIcon />
+												</ItemMedia>
+												<ItemContent>
+													<ItemTitle>{item.title}</ItemTitle>
+													{item.meta != null && (
+														<ItemDescription className="tabular-nums">
+															{item.meta}
+														</ItemDescription>
+													)}
+												</ItemContent>
+												{item.status != null && (
+													<ItemActions>
+														<StatusBadge status={item.status} appearance="soft">
+															{formatStatusLabel(item.status)}
+														</StatusBadge>
+													</ItemActions>
+												)}
+											</Item>
+										);
+									})}
+								</div>
+							)}
+						</FramePanel>
+					);
+				})}
+			</div>
+		</Frame>
+	);
+}


### PR DESCRIPTION
Replace the copy-pasted highlight cards and related-entity lists on the client/project/invoice overview tabs with two shared components:

- HighlightMetricGrid (adapted from ReUI card-29): icon → label → value → description → a compact frosted-blue area shape (indigo swapped for translucent primary; min-h-[150px] + h-14 shape vs card-29's 316/144px). Wrapped in a ReUI Frame so the panel edge stays visible in light mode. No trend badge (no delta data). Wired into clients/projects/invoices.

- RelatedRecordsFrame: a "RELATED" Frame (title in FrameHeader) with one card per related object type, rendering c-item-6-style ui/item rows (whole row a Link) or a ReUI EmptyState when empty. Status shown via the canonical domain StatusBadge. Replaces the duplicated RelatedEntityColumn helper + hand-rolled dashed empty states on clients (3-up) and projects (2-up); invoices/quotes have no related-list section.

CodeRabbit: client Outstanding/Total Revenue highlights now use the file's 2-decimal formatCurrency (were inline no-decimal, inconsistent with the rest of the page).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent metric highlight cards across client, project, and invoice overviews.
  * Added shared related-record panels for browsing projects, quotes, invoices, and other records.
  * Related records now show counts, metadata, statuses, and newest-first ordering.
  * Empty related sections display clear contextual messages.

* **UI Improvements**
  * Improved responsive layouts and visual consistency across overview tabs.
  * Invoice payment summaries now clearly indicate when no payments have been recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts two reusable components — `HighlightMetricGrid` and `RelatedRecordsFrame` — that replace copy-pasted `GlassCard` highlight rows and hand-rolled `RelatedEntityColumn` sections across the client, project, and invoice overview tabs. The refactoring is clean, the shared interfaces are well-typed, and the client Outstanding/Total Revenue highlights now consistently use the file's 2-decimal `formatCurrency`.

- **`HighlightMetricGrid`**: A new ReUI-Frame-wrapped card grid with a frosted-blue decorative area shape; adapts column count from `metrics.length`, supports an optional `trend` badge, and handles responsive borders via `cellBorders()`.
- **`RelatedRecordsFrame`**: A new "RELATED" Frame that renders per-entity-type `FramePanel` columns using the canonical `Item`/`StatusBadge` primitives, replacing the duplicated `RelatedEntityColumn` helper and hand-rolled dashed empty states on clients (3-up) and projects (2-up).

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is a straightforward UI refactor with no behavioral regressions; existing runtime guards (sortedByNewest undefined check, item.status != null guard) are preserved in the new components.

The refactoring is clean and the shared components are well-composed. The only non-ideal detail is using metric.label as the React list key, which would produce duplicate-key warnings if a caller ever passes two metrics with the same label string.

highlight-metric-grid.tsx — the key={metric.label} pattern is the only thing worth a second look before broadening reuse of HighlightMetricGrid elsewhere.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/shared/highlight-metric-grid.tsx | New shared component; clean implementation using clamped column count and clip-path area shapes. `key={metric.label}` could produce duplicate-key warnings if callers ever pass two metrics with the same label. |
| apps/web/src/components/shared/related-records-frame.tsx | New shared component; correctly delegates status color to StatusBadge while passing formatted text as children, uses Base UI useRender render-prop pattern for Link items, and guards formatStatusLabel behind a non-null check. |
| apps/web/src/app/(workspace)/clients/components/tabs/overview-tab.tsx | Drops local RelatedEntityColumn and GlassCard usage; sortedByNewest correctly guards against undefined before mapping; Outstanding/Total Revenue now consistently use 2-decimal formatCurrency. |
| apps/web/src/app/(workspace)/projects/components/tabs/overview-tab.tsx | Mirrors the client tab refactor; local RelatedEntityColumn removed cleanly and sortedByNewest undefined guard is in place. |
| apps/web/src/app/(workspace)/invoices/[invoiceId]/components/tabs/overview-tab.tsx | Two GlassCards replaced by HighlightMetricGrid; local formatCurrency continues to use 0-decimal Intl.NumberFormat (pre-existing, unchanged behavior consistent with the line-items table on the same page). |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph "Before (copy-pasted)"
        C1[clients/overview-tab\nGlassCard × 3\nRelatedEntityColumn × 3]
        P1[projects/overview-tab\nGlassCard × 3\nRelatedEntityColumn × 2]
        I1[invoices/overview-tab\nGlassCard × 2]
    end

    subgraph "After (shared components)"
        HMG["HighlightMetricGrid\n(new shared component)\nicon → label → value → description\n+ frosted-blue area shape"]
        RRF["RelatedRecordsFrame\n(new shared component)\nFramePanel per entity type\nItem rows with StatusBadge\nor EmptyState"]
    end

    C2[clients/overview-tab] -->|metrics prop| HMG
    C2 -->|sections prop| RRF
    P2[projects/overview-tab] -->|metrics prop| HMG
    P2 -->|sections prop| RRF
    I2[invoices/overview-tab] -->|metrics prop| HMG

    HMG --> Frame1[ReUI Frame + FramePanel]
    RRF --> Frame2[ReUI Frame + FrameHeader\n+ FramePanel per section]
    RRF --> SB[StatusBadge\n canonical domain colors]
    RRF --> ES[EmptyState\n when items.length === 0]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph "Before (copy-pasted)"
        C1[clients/overview-tab\nGlassCard × 3\nRelatedEntityColumn × 3]
        P1[projects/overview-tab\nGlassCard × 3\nRelatedEntityColumn × 2]
        I1[invoices/overview-tab\nGlassCard × 2]
    end

    subgraph "After (shared components)"
        HMG["HighlightMetricGrid\n(new shared component)\nicon → label → value → description\n+ frosted-blue area shape"]
        RRF["RelatedRecordsFrame\n(new shared component)\nFramePanel per entity type\nItem rows with StatusBadge\nor EmptyState"]
    end

    C2[clients/overview-tab] -->|metrics prop| HMG
    C2 -->|sections prop| RRF
    P2[projects/overview-tab] -->|metrics prop| HMG
    P2 -->|sections prop| RRF
    I2[invoices/overview-tab] -->|metrics prop| HMG

    HMG --> Frame1[ReUI Frame + FramePanel]
    RRF --> Frame2[ReUI Frame + FrameHeader\n+ FramePanel per section]
    RRF --> SB[StatusBadge\n canonical domain colors]
    RRF --> ES[EmptyState\n when items.length === 0]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/components/shared/highlight-metric-grid.tsx:115
**Non-unique list key on metric label**

`key={metric.label}` will produce duplicate-key React warnings if a caller ever passes two metrics with the same label string (e.g., two "Total" cards). Since `label` is a free-form string that the caller controls, prefer a composite key such as `` `${metric.label}-${index}` `` to guarantee uniqueness without relying on caller discipline.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): frosted-blue highlight grid +..."](https://github.com/xcarter93/onetool/commit/0f5058399aa28df6561c2b37f2cf3d5029e27cad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43464683)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->