### PR TITLE
fix(tasks): treat cancelled tasks as terminal; fix phantom sidebar badge

### DIFF
--- a/apps/web/src/app/(workspace)/tasks/page.tsx
+++ b/apps/web/src/app/(workspace)/tasks/page.tsx
@@ -40,6 +40,7 @@ import {
 	X,
 } from "lucide-react";
 import { Task } from "@/types/task";
+import { isTerminalStatus } from "@/lib/tasks";
 import DeleteConfirmationModal from "@/components/ui/delete-confirmation-modal";
 
 // --- Grouping logic ---
@@ -48,11 +49,6 @@ interface TaskGroup {
 	label: string;
 	tasks: Task[];
 	variant: "destructive" | "default" | "secondary" | "outline";
-}
-
-// Task in terminal state (completed or cancelled) needs no action.
-function isTerminalStatus(status: Task["status"]): boolean {
-	return status === "completed" || status === "cancelled";
 }
 
 function groupTasks(tasks: Task[]): TaskGroup[] {

--- a/apps/web/src/app/(workspace)/tasks/page.tsx
+++ b/apps/web/src/app/(workspace)/tasks/page.tsx
@@ -30,6 +30,7 @@ import {
 	Plus,
 	CheckCircle2,
 	Circle,
+	XCircle,
 	Search,
 	Building2,
 	FolderOpen,
@@ -49,6 +50,11 @@ interface TaskGroup {
 	variant: "destructive" | "default" | "secondary" | "outline";
 }
 
+// Task in terminal state (completed or cancelled) needs no action.
+function isTerminalStatus(status: Task["status"]): boolean {
+	return status === "completed" || status === "cancelled";
+}
+
 function groupTasks(tasks: Task[]): TaskGroup[] {
 	const now = new Date();
 	const todayStart = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
@@ -64,9 +70,12 @@ function groupTasks(tasks: Task[]): TaskGroup[] {
 	const thisWeek: Task[] = [];
 	const upcoming: Task[] = [];
 	const completed: Task[] = [];
+	const cancelled: Task[] = [];
 
 	for (const task of tasks) {
-		if (task.status === "completed") {
+		if (task.status === "cancelled") {
+			cancelled.push(task);
+		} else if (task.status === "completed") {
 			completed.push(task);
 		} else if (task.date < todayStart) {
 			overdue.push(task);
@@ -85,6 +94,7 @@ function groupTasks(tasks: Task[]): TaskGroup[] {
 		{ label: "This Week", tasks: thisWeek, variant: "secondary" as const },
 		{ label: "Upcoming", tasks: upcoming, variant: "outline" as const },
 		{ label: "Completed", tasks: completed, variant: "outline" as const },
+		{ label: "Cancelled", tasks: cancelled, variant: "outline" as const },
 	].filter((g) => g.tasks.length > 0);
 }
 
@@ -115,7 +125,7 @@ function formatRelativeDate(timestamp: number): string {
 function isOverdue(task: Task): boolean {
 	const now = new Date();
 	const todayStart = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
-	return task.date < todayStart && task.status !== "completed";
+	return task.date < todayStart && !isTerminalStatus(task.status);
 }
 
 // --- Columns ---
@@ -142,7 +152,7 @@ function createColumns(
 				return (
 					<button
 						onClick={() => onToggleComplete(task)}
-						disabled={isUpdating}
+						disabled={isUpdating || task.status === "cancelled"}
 						className={cn(
 							"p-0.5 rounded-full transition-colors",
 							"hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
@@ -151,6 +161,8 @@ function createColumns(
 					>
 						{task.status === "completed" ? (
 							<CheckCircle2 className="h-5 w-5 text-green-600" />
+						) : task.status === "cancelled" ? (
+							<XCircle className="h-5 w-5 text-muted-foreground" />
 						) : (
 							<Circle className="h-5 w-5 text-muted-foreground hover:text-foreground" />
 						)}
@@ -169,7 +181,7 @@ function createColumns(
 							<span
 								className={cn(
 									"font-medium text-foreground truncate",
-									task.status === "completed" &&
+									isTerminalStatus(task.status) &&
 										"line-through text-muted-foreground"
 								)}
 							>
@@ -337,7 +349,7 @@ function GroupTable({
 				recordCount={group.tasks.length}
 				tableLayout={{ width: "auto", headerBackground: true }}
 				rowClassName={(task) =>
-					task.status === "completed" ? "opacity-60" : undefined
+					isTerminalStatus(task.status) ? "opacity-60" : undefined
 				}
 			>
 				<DataGridContainer className="rounded-lg border">
@@ -528,6 +540,7 @@ export default function TasksPage() {
 
 	// Handlers
 	const handleToggleComplete = async (task: Task) => {
+		if (task.status === "cancelled") return;
 		setUpdatingTasks((prev) => new Set(prev).add(task._id));
 		try {
 			if (task.status === "completed") {
@@ -585,7 +598,7 @@ export default function TasksPage() {
 		allTasks?.filter((t) => t.status === "completed").length || 0;
 	const overdueTasks =
 		allTasks?.filter(
-			(t) => t.date < todayStart && t.status !== "completed"
+			(t) => t.date < todayStart && !isTerminalStatus(t.status)
 		).length || 0;
 
 	// Columns

--- a/apps/web/src/components/shared/record-tasks-tab.tsx
+++ b/apps/web/src/components/shared/record-tasks-tab.tsx
@@ -27,6 +27,7 @@ import {
 	Plus,
 	CheckCircle2,
 	Circle,
+	XCircle,
 	Search,
 	Building2,
 	FolderOpen,
@@ -44,6 +45,11 @@ interface TaskGroup {
 	variant: "destructive" | "default" | "secondary" | "outline";
 }
 
+// Task in terminal state (completed or cancelled) needs no action.
+function isTerminalStatus(status: Task["status"]): boolean {
+	return status === "completed" || status === "cancelled";
+}
+
 function groupTasks(tasks: Task[]): TaskGroup[] {
 	const now = new Date();
 	const todayStart = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
@@ -58,9 +64,12 @@ function groupTasks(tasks: Task[]): TaskGroup[] {
 	const thisWeek: Task[] = [];
 	const upcoming: Task[] = [];
 	const completed: Task[] = [];
+	const cancelled: Task[] = [];
 
 	for (const task of tasks) {
-		if (task.status === "completed") {
+		if (task.status === "cancelled") {
+			cancelled.push(task);
+		} else if (task.status === "completed") {
 			completed.push(task);
 		} else if (task.date < todayStart) {
 			overdue.push(task);
@@ -79,6 +88,7 @@ function groupTasks(tasks: Task[]): TaskGroup[] {
 		{ label: "This Week", tasks: thisWeek, variant: "secondary" as const },
 		{ label: "Upcoming", tasks: upcoming, variant: "outline" as const },
 		{ label: "Completed", tasks: completed, variant: "outline" as const },
+		{ label: "Cancelled", tasks: cancelled, variant: "outline" as const },
 	].filter((g) => g.tasks.length > 0);
 }
 
@@ -109,7 +119,7 @@ function formatRelativeDate(timestamp: number): string {
 function isOverdue(task: Task): boolean {
 	const now = new Date();
 	const todayStart = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
-	return task.date < todayStart && task.status !== "completed";
+	return task.date < todayStart && !isTerminalStatus(task.status);
 }
 
 // --- Columns ---
@@ -137,7 +147,7 @@ function createColumns(
 				return (
 					<button
 						onClick={() => onToggleComplete(task)}
-						disabled={isUpdating}
+						disabled={isUpdating || task.status === "cancelled"}
 						className={cn(
 							"p-0.5 rounded-full transition-colors",
 							"hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
@@ -146,6 +156,8 @@ function createColumns(
 					>
 						{task.status === "completed" ? (
 							<CheckCircle2 className="h-5 w-5 text-green-600" />
+						) : task.status === "cancelled" ? (
+							<XCircle className="h-5 w-5 text-muted-foreground" />
 						) : (
 							<Circle className="h-5 w-5 text-muted-foreground hover:text-foreground" />
 						)}
@@ -164,7 +176,7 @@ function createColumns(
 							<span
 								className={cn(
 									"font-medium text-foreground truncate",
-									task.status === "completed" &&
+									isTerminalStatus(task.status) &&
 										"line-through text-muted-foreground"
 								)}
 							>
@@ -344,7 +356,7 @@ function GroupTable({
 				recordCount={group.tasks.length}
 				tableLayout={{ width: "auto", headerBackground: true }}
 				rowClassName={(task) =>
-					task.status === "completed" ? "opacity-60" : undefined
+					isTerminalStatus(task.status) ? "opacity-60" : undefined
 				}
 			>
 				<DataGridContainer className="rounded-lg border">
@@ -409,6 +421,7 @@ export function RecordTasksTab({
 
 	// Handlers
 	const handleToggleComplete = async (task: Task) => {
+		if (task.status === "cancelled") return;
 		setUpdatingTasks((prev) => new Set(prev).add(task._id));
 		try {
 			if (task.status === "completed") {

--- a/apps/web/src/components/shared/record-tasks-tab.tsx
+++ b/apps/web/src/components/shared/record-tasks-tab.tsx
@@ -36,6 +36,7 @@ import {
 	ClipboardList,
 } from "lucide-react";
 import { Task } from "@/types/task";
+import { isTerminalStatus } from "@/lib/tasks";
 
 // --- Grouping logic (matches tasks page) ---
 
@@ -43,11 +44,6 @@ interface TaskGroup {
 	label: string;
 	tasks: Task[];
 	variant: "destructive" | "default" | "secondary" | "outline";
-}
-
-// Task in terminal state (completed or cancelled) needs no action.
-function isTerminalStatus(status: Task["status"]): boolean {
-	return status === "completed" || status === "cancelled";
 }
 
 function groupTasks(tasks: Task[]): TaskGroup[] {

--- a/apps/web/src/lib/tasks.ts
+++ b/apps/web/src/lib/tasks.ts
@@ -1,0 +1,6 @@
+import type { Task } from "@/types/task";
+
+// Task in terminal state (completed or cancelled) needs no action.
+export function isTerminalStatus(status: Task["status"]): boolean {
+	return status === "completed" || status === "cancelled";
+}

--- a/packages/backend/convex/tasks.test.ts
+++ b/packages/backend/convex/tasks.test.ts
@@ -1315,6 +1315,92 @@ describe("Tasks", () => {
 			expect(stats.byStatus.completed).toBe(1);
 			expect(stats.byStatus.cancelled).toBe(0);
 		});
+
+		it("excludes completed and cancelled tasks from sidebar badge counts", async () => {
+			const { clientId } = await t.run(async (ctx) => {
+				const userId = await ctx.db.insert("users", {
+					name: "Badge User",
+					email: "badge@example.com",
+					image: "https://example.com/image.jpg",
+					externalId: "user_badge",
+				});
+
+				const orgId = await ctx.db.insert("organizations", {
+					clerkOrganizationId: "org_badge",
+					name: "Badge Org",
+					ownerUserId: userId,
+				});
+
+				await ctx.db.insert("organizationMemberships", {
+					orgId,
+					userId,
+					role: "admin",
+				});
+
+				const clientId = await ctx.db.insert("clients", {
+					orgId,
+					companyName: "Badge Client",
+					status: "active",
+				});
+
+				return { clientId };
+			});
+
+			const asUser = t.withIdentity({
+				subject: "user_badge",
+				activeOrgId: "org_badge",
+			});
+
+			const twoDaysAgo = Date.now() - 2 * 24 * 60 * 60 * 1000;
+
+			// Actionable, due today -> counts toward todayTasks
+			await asUser.mutation(api.tasks.create, {
+				title: "Actionable today",
+				date: Date.now(),
+				status: "pending",
+				clientId,
+				type: "external",
+			});
+			// Completed today -> must NOT count
+			await asUser.mutation(api.tasks.create, {
+				title: "Completed today",
+				date: Date.now(),
+				status: "completed",
+				clientId,
+				type: "external",
+			});
+			// Cancelled today -> must NOT count
+			await asUser.mutation(api.tasks.create, {
+				title: "Cancelled today",
+				date: Date.now(),
+				status: "cancelled",
+				clientId,
+				type: "external",
+			});
+			// Actionable, overdue -> counts toward overdue
+			await asUser.mutation(api.tasks.create, {
+				title: "Actionable overdue",
+				date: twoDaysAgo,
+				status: "in-progress",
+				clientId,
+				type: "external",
+			});
+			// Cancelled, overdue -> must NOT count
+			await asUser.mutation(api.tasks.create, {
+				title: "Cancelled overdue",
+				date: twoDaysAgo,
+				status: "cancelled",
+				clientId,
+				type: "external",
+			});
+
+			const stats = await asUser.query(api.tasks.getStats, {});
+
+			expect(stats.todayTasks).toBe(1);
+			expect(stats.overdue).toBe(1);
+			// Sidebar badge = todayTasks + overdue
+			expect(stats.todayTasks + stats.overdue).toBe(2);
+		});
 	});
 
 	describe("remove", () => {

--- a/packages/backend/convex/tasks.test.ts
+++ b/packages/backend/convex/tasks.test.ts
@@ -1352,16 +1352,24 @@ describe("Tasks", () => {
 			});
 
 			const twoDaysAgo = Date.now() - 2 * 24 * 60 * 60 * 1000;
+			const threeDaysOut = Date.now() + 3 * 24 * 60 * 60 * 1000;
 
-			// Actionable, due today -> counts toward todayTasks
+			// Actionable, due today -> count toward todayTasks
 			await asUser.mutation(api.tasks.create, {
-				title: "Actionable today",
+				title: "Pending today",
 				date: Date.now(),
 				status: "pending",
 				clientId,
 				type: "external",
 			});
-			// Completed today -> must NOT count
+			await asUser.mutation(api.tasks.create, {
+				title: "In-progress today",
+				date: Date.now(),
+				status: "in-progress",
+				clientId,
+				type: "external",
+			});
+			// Terminal, due today -> must NOT count
 			await asUser.mutation(api.tasks.create, {
 				title: "Completed today",
 				date: Date.now(),
@@ -1369,7 +1377,6 @@ describe("Tasks", () => {
 				clientId,
 				type: "external",
 			});
-			// Cancelled today -> must NOT count
 			await asUser.mutation(api.tasks.create, {
 				title: "Cancelled today",
 				date: Date.now(),
@@ -1377,15 +1384,21 @@ describe("Tasks", () => {
 				clientId,
 				type: "external",
 			});
-			// Actionable, overdue -> counts toward overdue
+			// Overdue -> only actionable counts
 			await asUser.mutation(api.tasks.create, {
-				title: "Actionable overdue",
+				title: "In-progress overdue",
 				date: twoDaysAgo,
 				status: "in-progress",
 				clientId,
 				type: "external",
 			});
-			// Cancelled, overdue -> must NOT count
+			await asUser.mutation(api.tasks.create, {
+				title: "Completed overdue",
+				date: twoDaysAgo,
+				status: "completed",
+				clientId,
+				type: "external",
+			});
 			await asUser.mutation(api.tasks.create, {
 				title: "Cancelled overdue",
 				date: twoDaysAgo,
@@ -1393,13 +1406,32 @@ describe("Tasks", () => {
 				clientId,
 				type: "external",
 			});
+			// This week -> only actionable counts toward thisWeek
+			await asUser.mutation(api.tasks.create, {
+				title: "Pending this week",
+				date: threeDaysOut,
+				status: "pending",
+				clientId,
+				type: "external",
+			});
+			await asUser.mutation(api.tasks.create, {
+				title: "Cancelled this week",
+				date: threeDaysOut,
+				status: "cancelled",
+				clientId,
+				type: "external",
+			});
 
 			const stats = await asUser.query(api.tasks.getStats, {});
 
-			expect(stats.todayTasks).toBe(1);
+			// Only pending/in-progress due today
+			expect(stats.todayTasks).toBe(2);
+			// Only pending/in-progress overdue
 			expect(stats.overdue).toBe(1);
+			// today (2 actionable) + this-week pending; terminal excluded
+			expect(stats.thisWeek).toBe(3);
 			// Sidebar badge = todayTasks + overdue
-			expect(stats.todayTasks + stats.overdue).toBe(2);
+			expect(stats.todayTasks + stats.overdue).toBe(3);
 		});
 	});
 

--- a/packages/backend/convex/tasks.ts
+++ b/packages/backend/convex/tasks.ts
@@ -788,8 +788,12 @@ export const getStats = optionalUserQuery({
 				stats.byStatus.cancelled++;
 			}
 
-			// Count today's tasks
-			if (task.date >= today && task.date < tomorrow) {
+			// Count today's tasks (actionable only)
+			if (
+				task.date >= today &&
+				task.date < tomorrow &&
+				(task.status === "pending" || task.status === "in-progress")
+			) {
 				stats.todayTasks++;
 			}
 


### PR DESCRIPTION
Cancelled tasks were falling through grouping/strikethrough logic gated only on status === "completed", so they showed as active (Overdue/Today/...) with no line-through on both the main Tasks page and the client/project record tabs.

- Add isTerminalStatus() (completed || cancelled) helper
- New "Cancelled" group (after Completed) on both surfaces
- Strikethrough + row dim + isOverdue + header "overdue" count now cover cancelled
- Cancelled rows show muted XCircle; toggle button disabled + handler guarded so terminal tasks can't be re-completed
- getStats.todayTasks now counts only pending/in-progress, so the sidebar badge (todayTasks + overdue) no longer renders for completed/cancelled tasks due today
- Add regression test: getStats excludes completed/cancelled from badge counts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Cancelled** task group with distinct **X** icon styling.
  * Terminal tasks (including cancelled) now render with dimmed, strikethrough presentation.

* **Bug Fixes**
  * Cancelled and completed tasks are excluded from overdue lists and task-count badges.
  * Task statistics now count only actionable tasks (pending/in-progress) for today and overdue.

* **Tests**
  * Added coverage ensuring completed and cancelled tasks are excluded from sidebar badge counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes cancelled tasks being treated as active by introducing an `isTerminalStatus()` helper (`completed || cancelled`) and applying it consistently across grouping, strikethrough, row dimming, overdue detection, and the toggle button/handler. It also patches the sidebar badge phantom count by narrowing `getStats.todayTasks` to only `pending` and `in-progress` tasks.

- `groupTasks` in both `page.tsx` and `record-tasks-tab.tsx` now routes cancelled tasks into a dedicated "Cancelled" group before the date-bucket checks, preventing them from appearing as Overdue/Today/This Week.
- The `getStats` backend query now applies the same `pending | in-progress` guard to `todayTasks` that `overdue` and `thisWeek` already had, eliminating the phantom badge.
- A regression test verifies that completed and cancelled tasks due today no longer inflate `todayTasks` or `overdue` badge counts.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the cancelled-task fixes are applied consistently across both UI surfaces and the backend badge counter, and a targeted regression test is included.

The core logic is correct and well-guarded. The isTerminalStatus helper being copy-pasted into two files is a future-proofing concern, and the page subtitle counting completed separately from cancelled while rolling both into total creates a display inconsistency for users with cancelled tasks. Neither blocks the fix from working correctly today.

Both page.tsx and record-tasks-tab.tsx contain identical copies of isTerminalStatus that will need to stay in sync. The completedTasks stat in page.tsx (line 597) is the one place that still does not account for cancelled tasks.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/(workspace)/tasks/page.tsx | Adds cancelled task grouping, XCircle icon, isTerminalStatus helper, and guards; minor: completedTasks subtitle stat still excludes cancelled, and helper is duplicated across files |
| apps/web/src/components/shared/record-tasks-tab.tsx | Mirrors the same cancelled-task fixes as page.tsx; isTerminalStatus helper is duplicated identically from page.tsx |
| packages/backend/convex/tasks.ts | Narrows todayTasks counter in getStats to pending/in-progress only; the overdue and thisWeek counters already had the same filter; change is minimal and correct |
| packages/backend/convex/tasks.test.ts | Adds regression test verifying todayTasks and overdue badge counts exclude completed/cancelled; thisWeek exclusion not covered by the new test |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/app/(workspace)/tasks/page.tsx`, line 597-602 ([link](https://github.com/xcarter93/onetool/blob/014f05befb8cd2309027cf8c53400c6f985588ec/apps/web/src/app/(workspace)/tasks/page.tsx#L597-L602)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Cancelled tasks invisible in page subtitle counts**

   `totalTasks` includes every task (cancelled included), but `completedTasks` only counts `status === "completed"`. The subtitle reads `"${totalTasks} total • ${completedTasks} completed • ${overdueTasks} overdue"`, so a user with 2 cancelled tasks will see "10 total • 3 completed • 2 overdue" — the remaining 5 are unaccounted for in the display. Cancelled tasks are now a first-class state; it may be worth either surfacing them in the subtitle or renaming the counter to reflect "done" tasks (completed + cancelled).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/app/(workspace)/tasks/page.tsx
   Line: 597-602

   Comment:
   **Cancelled tasks invisible in page subtitle counts**

   `totalTasks` includes every task (cancelled included), but `completedTasks` only counts `status === "completed"`. The subtitle reads `"${totalTasks} total • ${completedTasks} completed • ${overdueTasks} overdue"`, so a user with 2 cancelled tasks will see "10 total • 3 completed • 2 overdue" — the remaining 5 are unaccounted for in the display. Cancelled tasks are now a first-class state; it may be worth either surfacing them in the subtitle or renaming the counter to reflect "done" tasks (completed + cancelled).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/web/src/app/(workspace)/tasks/page.tsx:53-55
**Duplicated helper should live in a shared module**

`isTerminalStatus` is defined identically in both `page.tsx` and `record-tasks-tab.tsx`. If a new terminal state is added later (e.g. `"archived"`), both copies must be updated in sync — a missed update would reintroduce the exact class of bug this PR fixes. Extracting it to a shared utility (e.g. `src/lib/tasks.ts`) would be the safer long-term approach.

### Issue 2 of 3
apps/web/src/app/(workspace)/tasks/page.tsx:597-602
**Cancelled tasks invisible in page subtitle counts**

`totalTasks` includes every task (cancelled included), but `completedTasks` only counts `status === "completed"`. The subtitle reads `"${totalTasks} total • ${completedTasks} completed • ${overdueTasks} overdue"`, so a user with 2 cancelled tasks will see "10 total • 3 completed • 2 overdue" — the remaining 5 are unaccounted for in the display. Cancelled tasks are now a first-class state; it may be worth either surfacing them in the subtitle or renaming the counter to reflect "done" tasks (completed + cancelled).

### Issue 3 of 3
packages/backend/convex/tasks.test.ts:1315-1406
**New test doesn't cover `thisWeek` exclusion for terminal tasks**

The test asserts `todayTasks` and `overdue` correctly ignore completed/cancelled tasks, but `getStats` also has a `thisWeek` counter. Although that counter already filtered by `pending/in-progress` before this PR, adding a case (e.g. a cancelled task due this week) would make the regression coverage complete and make the invariant explicit for future readers.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tasks): treat cancelled tasks as ter..."](https://github.com/xcarter93/onetool/commit/014f05befb8cd2309027cf8c53400c6f985588ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43500557)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->