### PR TITLE
feat(notifications): mark-all-read + route-safety in header bell

### DIFF
--- a/apps/web/src/components/layout/notification-bell.tsx
+++ b/apps/web/src/components/layout/notification-bell.tsx
@@ -4,7 +4,7 @@ import { useQuery, useMutation } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Bell } from "lucide-react";
+import { Bell, ChevronRight } from "lucide-react";
 import { Badge } from "@/components/reui/badge";
 import {
 	Popover,
@@ -18,6 +18,7 @@ import {
 	formatRelativeTime,
 	truncateText,
 	stripAuthorIdFromMessage,
+	resolveNotificationHref,
 } from "@/lib/notification-utils";
 import { useIsOrgSwitching } from "@/hooks/use-is-org-switching";
 import type { Id } from "@onetool/backend/convex/_generated/dataModel";
@@ -34,6 +35,8 @@ export function NotificationBell() {
 	});
 
 	const markAsRead = useMutation(api.notifications.markRead);
+	const markAllRead = useMutation(api.notifications.markAllRead);
+	const [markingAll, setMarkingAll] = useState(false);
 
 	// Treat the switch grace window as loading so the previous org's unread
 	// count and notification list don't flash.
@@ -41,10 +44,11 @@ export function NotificationBell() {
 	const notifications = isLoading ? [] : notificationData.notifications;
 	const unreadCount = isLoading ? 0 : notificationData.unreadCount;
 
-	// Handle notification click
+	// Handle notification click. `href` is a pre-resolved, known-good route
+	// (or null when the notification isn't navigable).
 	const handleNotificationClick = async (
 		notificationId: Id<"notifications">,
-		actionUrl?: string,
+		href: string | null,
 		isRead?: boolean
 	) => {
 		// Mark as read if not already
@@ -56,10 +60,22 @@ export function NotificationBell() {
 			}
 		}
 
-		// Navigate to the entity
-		if (actionUrl) {
-			router.push(actionUrl);
+		// Navigate only when the notification points at a real page.
+		if (href) {
+			router.push(href);
 			setOpen(false);
+		}
+	};
+
+	const handleMarkAllRead = async () => {
+		if (markingAll || unreadCount === 0) return;
+		setMarkingAll(true);
+		try {
+			await markAllRead({});
+		} catch (error) {
+			console.error("Failed to mark all notifications as read:", error);
+		} finally {
+			setMarkingAll(false);
 		}
 	};
 
@@ -103,9 +119,19 @@ export function NotificationBell() {
 						</h3>
 					</div>
 					{unreadCount > 0 && (
-						<span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
-							{unreadCount} new
-						</span>
+						<div className="flex items-center gap-1.5">
+							<span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
+								{unreadCount} new
+							</span>
+							<button
+								type="button"
+								onClick={handleMarkAllRead}
+								disabled={markingAll}
+								className="cursor-pointer rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:pointer-events-none disabled:opacity-50"
+							>
+								Mark all read
+							</button>
+						</div>
 					)}
 				</div>
 
@@ -137,43 +163,51 @@ export function NotificationBell() {
 						/>
 					) : (
 						<div className="p-1.5">
-							{notifications.map((notification) => (
-								<button
-									key={notification._id}
-									onClick={() =>
-										handleNotificationClick(
-											notification._id,
-											notification.actionUrl,
-											notification.isRead
-										)
-									}
-									className={cn(
-										"flex w-full cursor-pointer gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-muted/60",
-										!notification.isRead && "bg-primary/5"
-									)}
-								>
-									<span
+							{notifications.map((notification) => {
+								const href = resolveNotificationHref(notification);
+								return (
+									<button
+										key={notification._id}
+										onClick={() =>
+											handleNotificationClick(
+												notification._id,
+												href,
+												notification.isRead
+											)
+										}
 										className={cn(
-											"mt-1.5 size-2 shrink-0 rounded-full",
-											notification.isRead ? "bg-transparent" : "bg-primary"
+											"flex w-full cursor-pointer items-start gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-muted/60",
+											!notification.isRead && "bg-primary/5"
 										)}
-									/>
-									<div className="min-w-0 flex-1">
-										<p className="text-sm font-medium text-foreground">
-											{notification.title}
-										</p>
-										<p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
-											{truncateText(
-												stripAuthorIdFromMessage(notification.message),
-												100
+									>
+										<span
+											className={cn(
+												"mt-1.5 size-2 shrink-0 rounded-full",
+												notification.isRead ? "bg-transparent" : "bg-primary"
 											)}
-										</p>
-										<p className="mt-1 text-[11px] text-muted-foreground/80">
-											{formatRelativeTime(notification._creationTime)}
-										</p>
-									</div>
-								</button>
-							))}
+										/>
+										<div className="min-w-0 flex-1">
+											<p className="text-sm font-medium text-foreground">
+												{notification.title}
+											</p>
+											<p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+												{truncateText(
+													stripAuthorIdFromMessage(notification.message),
+													100
+												)}
+											</p>
+											<p className="mt-1 text-[11px] text-muted-foreground/80">
+												{formatRelativeTime(notification._creationTime)}
+											</p>
+										</div>
+										{/* Chevron marks a notification that navigates somewhere;
+										    its absence signals a non-routable, info-only item. */}
+										{href && (
+											<ChevronRight className="mt-1.5 size-4 shrink-0 self-start text-muted-foreground/50" />
+										)}
+									</button>
+								);
+							})}
 						</div>
 					)}
 				</ScrollArea>

--- a/apps/web/src/lib/notification-utils.ts
+++ b/apps/web/src/lib/notification-utils.ts
@@ -12,6 +12,51 @@ export function buildEntityUrl(
 	return `/${entityType}s/${entityId}`;
 }
 
+/** Entity types that have a real record/detail page in the workspace. */
+const ENTITY_DETAIL_PATHS: Record<string, (id: string) => string> = {
+	client: (id) => `/clients/${id}`,
+	project: (id) => `/projects/${id}`,
+	quote: (id) => `/quotes/${id}`,
+	invoice: (id) => `/invoices/${id}`,
+	// `task` intentionally omitted — no task detail page exists yet.
+};
+
+/** Non-record routes an actionUrl may legitimately point to. */
+const SAFE_ACTION_PATHS = new Set(["/home", "/tasks", "/automations"]);
+
+/**
+ * Resolve a safe navigation target for a notification, or `null` when it should
+ * not be clickable. Prefers the entity type/id (authoritative) and only falls
+ * back to a stored actionUrl when it points at a route we know exists — so we
+ * never route to a dead page (e.g. task records, which have no detail page).
+ */
+export function resolveNotificationHref(notification: {
+	entityType?: "client" | "project" | "quote" | "invoice" | "task" | null;
+	entityId?: string | null;
+	actionUrl?: string | null;
+}): string | null {
+	const { entityType, entityId, actionUrl } = notification;
+
+	// Tasks have no detail page — send to the task list instead of a dead record URL.
+	if (entityType === "task") return "/tasks";
+
+	if (entityType && entityId && ENTITY_DETAIL_PATHS[entityType]) {
+		return ENTITY_DETAIL_PATHS[entityType](entityId);
+	}
+
+	if (actionUrl) {
+		const path = actionUrl.split(/[?#]/)[0];
+		// Downgrade dead task-record links to the list page.
+		if (/^\/tasks\/.+/.test(path)) return "/tasks";
+		if (SAFE_ACTION_PATHS.has(path)) return actionUrl;
+		if (/^\/(clients|projects|quotes|invoices)\/[^/]+/.test(path)) {
+			return actionUrl;
+		}
+	}
+
+	return null;
+}
+
 /**
  * Format timestamp as relative time (e.g., "2 hours ago")
  */

--- a/packages/backend/convex/notifications.ts
+++ b/packages/backend/convex/notifications.ts
@@ -728,6 +728,32 @@ export const markMultipleRead = userMutation({
 });
 
 /**
+ * Mark every unread notification for the current user (in the active org) as read
+ */
+export const markAllRead = userMutation({
+	args: {},
+	handler: async (ctx): Promise<{ updated: number }> => {
+		const now = Date.now();
+		const unread = await ctx.db
+			.query("notifications")
+			.withIndex("by_user_read", (q) =>
+				q.eq("userId", ctx.user._id).eq("isRead", false)
+			)
+			.collect();
+
+		let updated = 0;
+		for (const notification of unread) {
+			// by_user_read isn't org-scoped; skip notifications from other orgs.
+			if (notification.orgId !== ctx.orgId) continue;
+			await ctx.db.patch(notification._id, { isRead: true, readAt: now });
+			updated++;
+		}
+
+		return { updated };
+	},
+});
+
+/**
  * Mark a notification as sent
  */
 // TODO: Candidate for deletion if confirmed unused.


### PR DESCRIPTION
- add markAllRead mutation (marks current-user unread in active org)
- add "Mark all read" button to notification popover header
- resolveNotificationHref: derive safe route from entityType/entityId; tasks -> /tasks list (no detail page), unknown -> null (non-routable)
- delineate clickable rows with a ChevronRight affordance; non-routable rows omit it (still click-to-mark-read); never route to nonexistent pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Mark all read” option for notifications.
  * Notifications now navigate directly to relevant detail pages when available.
  * Added navigation indicators for clickable notifications.

* **Bug Fixes**
  * Improved notification link handling to prevent invalid or unsafe destinations.
  * Task notifications now route to the main tasks page when appropriate.
  * Prevented duplicate “Mark all read” submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a "Mark all read" bulk action to the notification popover and introduces `resolveNotificationHref` to derive safe, known-good navigation targets from notification metadata — replacing the old raw `actionUrl` passthrough and explicitly routing tasks to the list page rather than a non-existent detail page.

- **`markAllRead` mutation** queries all unread notifications for the current user via `by_user_read` (not org-scoped), then filters to the active org in-memory before patching each row to `isRead: true`.
- **`resolveNotificationHref`** prioritises structured `entityType`/`entityId` data, falls back to `actionUrl` only when it matches a known-safe path pattern, and returns `null` for anything unrecognised — preventing navigation to dead pages.
- **Bell UI** wires the new mutation and utility into the popover header and renders a `ChevronRight` affordance only on rows that have a real navigation target.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the core routing logic is correct and the mutation is properly auth-gated. The two non-blocking concerns (silent error handling in the UI and the unanchored regex) don't affect correctness for current data.

The "Mark all read" bulk mutation works correctly for the common case; the cross-org scan is a latent efficiency concern rather than a bug. The entity-path regex passes through any actionUrl whose prefix matches an entity route, which is harmless today because all producers write simple two-segment paths, but could silently route to a 404 if a future producer appends a sub-path. The UI provides no feedback when the mutation throws, which leaves users without confirmation that the action failed.

The `markAllRead` handler in `packages/backend/convex/notifications.ts` and the entity-path regex in `apps/web/src/lib/notification-utils.ts` are worth a second look before the next significant notification feature lands.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/notifications.ts | Adds markAllRead mutation; uses by_user_read index (not org-scoped) and filters org in-memory — correct but does an unbounded collect() across all orgs before patching. |
| apps/web/src/lib/notification-utils.ts | Adds resolveNotificationHref with entity-type routing; entity path regex is unanchored at the end (allows sub-paths through); otherwise clean logic with clear intent. |
| apps/web/src/components/layout/notification-bell.tsx | Integrates markAllRead and resolveNotificationHref cleanly; handleMarkAllRead swallows errors silently (console.error only, no user toast); ChevronRight affordance wiring is correct. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks notification row] --> B[handleNotificationClick]
    B --> C{isRead?}
    C -- No --> D[markRead mutation]
    C -- Yes --> E{href != null?}
    D --> E
    E -- Yes --> F[router.push href\nsetOpen false]
    E -- No --> G[close popover only\nno navigation]

    H[User clicks Mark all read] --> I[handleMarkAllRead]
    I --> J{markingAll or\nunreadCount == 0?}
    J -- Yes --> K[no-op]
    J -- No --> L[setMarkingAll true]
    L --> M[markAllRead mutation]
    M --> N[query by_user_read index\nall orgs]
    N --> O{orgId matches\nactive org?}
    O -- Yes --> P[patch isRead=true\nreadAt=now]
    O -- No --> Q[skip]
    P --> R[return updated count]
    Q --> R
    M --> S[finally: setMarkingAll false]

    subgraph resolveNotificationHref
        T[entityType == task?] -- Yes --> U[return /tasks]
        T -- No --> V{entityType + entityId\nin ENTITY_DETAIL_PATHS?}
        V -- Yes --> W[return /entityType/entityId]
        V -- No --> X{actionUrl set?}
        X -- tasks sub-path --> Y[return /tasks]
        X -- SAFE_ACTION_PATHS match --> Z[return actionUrl]
        X -- entity detail regex match --> AA[return actionUrl]
        X -- no match --> BB[return null]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User clicks notification row] --> B[handleNotificationClick]
    B --> C{isRead?}
    C -- No --> D[markRead mutation]
    C -- Yes --> E{href != null?}
    D --> E
    E -- Yes --> F[router.push href\nsetOpen false]
    E -- No --> G[close popover only\nno navigation]

    H[User clicks Mark all read] --> I[handleMarkAllRead]
    I --> J{markingAll or\nunreadCount == 0?}
    J -- Yes --> K[no-op]
    J -- No --> L[setMarkingAll true]
    L --> M[markAllRead mutation]
    M --> N[query by_user_read index\nall orgs]
    N --> O{orgId matches\nactive org?}
    O -- Yes --> P[patch isRead=true\nreadAt=now]
    O -- No --> Q[skip]
    P --> R[return updated count]
    Q --> R
    M --> S[finally: setMarkingAll false]

    subgraph resolveNotificationHref
        T[entityType == task?] -- Yes --> U[return /tasks]
        T -- No --> V{entityType + entityId\nin ENTITY_DETAIL_PATHS?}
        V -- Yes --> W[return /entityType/entityId]
        V -- No --> X{actionUrl set?}
        X -- tasks sub-path --> Y[return /tasks]
        X -- SAFE_ACTION_PATHS match --> Z[return actionUrl]
        X -- entity detail regex match --> AA[return actionUrl]
        X -- no match --> BB[return null]
    end
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/web/src/components/layout/notification-bell.tsx:72-80
**Silent failure on "Mark all read"**

`handleMarkAllRead` catches the mutation error with `console.error` but gives the user no feedback — the button re-enables and nothing appears to have gone wrong. If the mutation fails (network error, Convex write-limit exceeded for a user with many notifications, etc.) the user has no way to know the action didn't take effect. A toast or inline error message should be shown in the `catch` block.

### Issue 2 of 3
packages/backend/convex/notifications.ts:737-753
**Unbounded cross-org `collect()` before org filter**

`by_user_read` is not org-scoped, so `.collect()` fetches every unread notification for the user across all organizations before the `orgId !== ctx.orgId` guard discards the irrelevant ones. For a user who has accumulated many unread notifications across past orgs (e.g. after switching between several workspaces), this reads and discards a lot of data each call. Adding an org-scoped index (e.g. `["orgId", "userId", "isRead"]`) and querying with `q.eq("orgId", ctx.orgId).eq("userId", ctx.user._id).eq("isRead", false)` would make the query tight without the post-filter step.

### Issue 3 of 3
apps/web/src/lib/notification-utils.ts:52-54
**Entity path regex allows unintended sub-routes through**

The pattern `/^\/(clients|projects|quotes|invoices)\/[^/]+/` has no end anchor (`$`), so a stored `actionUrl` like `/clients/abc123/deleted-tab` or `/invoices/xyz/old-section` passes the check and the full URL is returned. All current producers write simple `/${type}/${id}` paths, so this is not a live bug, but a future producer that appends a sub-path could silently route to a 404. Anchoring the regex with `$` (i.e. `/^\/(clients|projects|quotes|invoices)\/[^/]+$/`) would restrict to the exact detail-page pattern.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(notifications): mark-all-read + rou..."](https://github.com/xcarter93/onetool/commit/2a3209568f3ea390eb1753da6cf76ec90f66c525) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43503621)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->