### PR TITLE
Enhance UI with checkbox affordance and read-only UX for RBAC

### DIFF
--- a/apps/web/src/app/(workspace)/automations/components/automations-table.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/automations-table.tsx
@@ -92,17 +92,11 @@ export function AutomationsTable() {
 
 	const confirmDelete = useCallback(async () => {
 		if (!pendingDelete) return;
-		try {
-			await removeAutomation({ id: pendingDelete.id });
-			toast.success(
-				"Automation deleted",
-				`"${pendingDelete.name}" has been deleted.`
-			);
-			setPendingDelete(null);
-		} catch {
-			toast.error("Error", "Failed to delete automation");
-		}
-	}, [pendingDelete, removeAutomation, toast]);
+		// Success/error toasts owned by DeleteConfirmationModal; let errors
+		// propagate so it shows a single error toast (was double-toasting).
+		await removeAutomation({ id: pendingDelete.id });
+		setPendingDelete(null);
+	}, [pendingDelete, removeAutomation]);
 
 	const columns = useMemo<ColumnDef<Automation>[]>(
 		() => [

--- a/apps/web/src/app/(workspace)/clients/[clientId]/page.tsx
+++ b/apps/web/src/app/(workspace)/clients/[clientId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { PermissionGate } from "@/components/domain/permission-gate";
+import { usePermissions } from "@/hooks/use-permissions";
 import { useParams, useRouter } from "next/navigation";
 import { useQuery } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
@@ -18,6 +19,7 @@ function ClientDetailPageContent() {
 	const params = useParams();
 	const router = useRouter();
 	const clientId = params.clientId as string;
+	const { can } = usePermissions();
 	const [isTaskSheetOpen, setIsTaskSheetOpen] = useState(false);
 	const [isEmailSheetOpen, setIsEmailSheetOpen] = useState(false);
 	const [emailSheetMode, setEmailSheetMode] = useState<"new" | "reply">("new");
@@ -41,24 +43,31 @@ function ClientDetailPageContent() {
 		clientId: clientId as Id<"clients">,
 	});
 
-	// Fetch related data
-	const quotes = useQuery(api.quotes.list, {
-		clientId: clientId as Id<"clients">,
-	});
-	const projects = useQuery(api.projects.list, {
-		clientId: clientId as Id<"clients">,
-	});
-	const invoices = useQuery(api.invoices.list, {
-		clientId: clientId as Id<"clients">,
-	});
-	const clientTasks = useQuery(api.tasks.list, {
-		clientId: clientId as Id<"clients">,
-	});
+	// Fetch related data. Each list endpoint is gated and throws FORBIDDEN
+	// without the object's view grant, so skip it when the user can't see it.
+	const quotes = useQuery(
+		api.quotes.list,
+		can("quotes") ? { clientId: clientId as Id<"clients"> } : "skip"
+	);
+	const projects = useQuery(
+		api.projects.list,
+		can("projects") ? { clientId: clientId as Id<"clients"> } : "skip"
+	);
+	const invoices = useQuery(
+		api.invoices.list,
+		can("invoices") ? { clientId: clientId as Id<"clients"> } : "skip"
+	);
+	const clientTasks = useQuery(
+		api.tasks.list,
+		can("tasks") ? { clientId: clientId as Id<"clients"> } : "skip"
+	);
 
-	// Fetch email threads (grouped conversations) for this client
-	const clientThreads = useQuery(api.emailMessages.listThreadsByClient, {
-		clientId: clientId as Id<"clients">,
-	}) as EmailThreadSummary[] | undefined;
+	// Fetch email threads (grouped conversations) for this client. Gated on
+	// the inbox grant — skip without it to avoid a FORBIDDEN crash.
+	const clientThreads = useQuery(
+		api.emailMessages.listThreadsByClient,
+		can("inbox") ? { clientId: clientId as Id<"clients"> } : "skip"
+	) as EmailThreadSummary[] | undefined;
 
 	// Fetch activities for this client
 	const activities = useQuery(api.activities.getByEntity, {

--- a/apps/web/src/app/(workspace)/clients/[clientId]/page.tsx
+++ b/apps/web/src/app/(workspace)/clients/[clientId]/page.tsx
@@ -86,11 +86,11 @@ function ClientDetailPageContent() {
 		clientContacts === undefined ||
 		clientProperties === undefined ||
 		primaryContact === undefined ||
-		quotes === undefined ||
-		projects === undefined ||
-		invoices === undefined ||
-		clientTasks === undefined ||
-		clientThreads === undefined
+		(can("quotes") && quotes === undefined) ||
+		(can("projects") && projects === undefined) ||
+		(can("invoices") && invoices === undefined) ||
+		(can("tasks") && clientTasks === undefined) ||
+		(can("inbox") && clientThreads === undefined)
 	) {
 		return (
 			<div className="relative pl-6 pt-8 pb-20">

--- a/apps/web/src/app/(workspace)/clients/components/client-detail-drawer.tsx
+++ b/apps/web/src/app/(workspace)/clients/components/client-detail-drawer.tsx
@@ -12,6 +12,7 @@ import {
 	FileText,
 	FolderKanban,
 	Loader2,
+	Lock,
 	Mail,
 	Plus,
 	Receipt,
@@ -19,6 +20,8 @@ import {
 } from "lucide-react";
 
 import { StatusBadge } from "@/components/domain/status-badge";
+import { Badge } from "@/components/ui/badge";
+import { usePermissions } from "@/hooks/use-permissions";
 import {
 	Timeline,
 	TimelineContent,
@@ -88,6 +91,9 @@ export function ClientDetailDrawer({
 	onOpenChange,
 }: ClientDetailDrawerProps) {
 	const router = useRouter();
+	const { can, isLoading: permissionsLoading } = usePermissions();
+	const canModify = can("clients", "modify");
+	const showReadOnly = !permissionsLoading && !canModify;
 	const toast = useToast();
 	const preview = useQuery(
 		api.clients.getPreview,
@@ -163,11 +169,19 @@ export function ClientDetailDrawer({
 			}
 			title={title}
 			badge={
-				client ? (
-					<StatusBadge status={client.status} size="lg">
-						{STATUS_LABEL[client.status]}
-					</StatusBadge>
-				) : null
+				<>
+					{client ? (
+						<StatusBadge status={client.status} size="lg">
+							{STATUS_LABEL[client.status]}
+						</StatusBadge>
+					) : null}
+					{showReadOnly ? (
+						<Badge variant="secondary" className="gap-1">
+							<Lock className="h-3 w-3" />
+							Read Only
+						</Badge>
+					) : null}
+				</>
 			}
 			description={
 				data
@@ -184,7 +198,11 @@ export function ClientDetailDrawer({
 						mode="create"
 						initialValues={{ clientId: clientId ?? undefined }}
 						trigger={
-							<Button variant="outline" size="sm">
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={!can("tasks", "modify")}
+							>
 								<Plus className="size-3.5" />
 								Add Task
 							</Button>
@@ -202,19 +220,33 @@ export function ClientDetailDrawer({
 								email: contactEmail,
 							}}
 						>
-							<Button variant="outline" size="sm">
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={!can("inbox", "modify")}
+							>
 								<Mail className="size-3.5" />
 								Email
 							</Button>
 						</SendClientEmailPopover>
 					) : null}
 					{client && client.status === "archived" ? (
-						<Button variant="outline" size="sm" onClick={handleRestore}>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={handleRestore}
+							disabled={!can("clients", "modify")}
+						>
 							<RotateCcw className="size-3.5" />
 							Restore
 						</Button>
 					) : client ? (
-						<Button variant="outline" size="sm" onClick={handleArchive}>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={handleArchive}
+							disabled={!can("clients", "delete")}
+						>
 							<Archive className="size-3.5" />
 							Archive
 						</Button>
@@ -258,6 +290,7 @@ export function ClientDetailDrawer({
 								key={client.status}
 								clientId={client._id}
 								currentStatus={client.status}
+								canModify={canModify}
 							/>
 						</DrawerSection>
 					) : null}
@@ -377,9 +410,11 @@ export function ClientDetailDrawer({
 function StatusControl({
 	clientId,
 	currentStatus,
+	canModify,
 }: {
 	clientId: Id<"clients">;
 	currentStatus: ClientStatus;
+	canModify: boolean;
 }) {
 	const updateClient = useMutation(api.clients.update);
 	const toast = useToast();
@@ -406,6 +441,7 @@ function StatusControl({
 				<Select
 					value={status}
 					onValueChange={(v) => setStatus(v as ClientStatus)}
+					disabled={!canModify}
 				>
 					<SelectTrigger className="h-9 flex-1">
 						<SelectValue />

--- a/apps/web/src/app/(workspace)/clients/components/client-detail-header.tsx
+++ b/apps/web/src/app/(workspace)/clients/components/client-detail-header.tsx
@@ -9,6 +9,7 @@ import { StickyDetailHeader } from "@/components/shared/sticky-detail-header";
 import { Heart, ListTodo, FolderPlus, FileText } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
+import { usePermissions } from "@/hooks/use-permissions";
 import { cn } from "@/lib/utils";
 
 interface ClientDetailHeaderProps {
@@ -31,6 +32,7 @@ export function ClientDetailHeader({
 	hasPrimaryContactEmail,
 }: ClientDetailHeaderProps) {
 	const toast = useToast();
+	const { can } = usePermissions();
 
 	// Favorite functionality
 	const isFavorited = useQuery(api.favorites.isFavorited, {
@@ -96,20 +98,40 @@ export function ClientDetailHeader({
 
 					{/* Right side - Quick action buttons */}
 					<div className="flex items-center gap-2 shrink-0">
-						<Button variant="outline" size="sm" onClick={onAddTask}>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={onAddTask}
+							disabled={!can("tasks", "modify")}
+						>
 							<ListTodo className="h-4 w-4" />
 							Create Task
 						</Button>
-						<Button variant="outline" size="sm" onClick={onCreateProject}>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={onCreateProject}
+							disabled={!can("projects", "modify")}
+						>
 							<FolderPlus className="h-4 w-4" />
 							Create Project
 						</Button>
-						<Button variant="outline" size="sm" onClick={onCreateQuote}>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={onCreateQuote}
+							disabled={!can("quotes", "modify")}
+						>
 							<FileText className="h-4 w-4" />
 							Create Quote
 						</Button>
 						{hasPrimaryContactEmail && (
-							<Button variant="outline" size="sm" onClick={onComposeEmail}>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={onComposeEmail}
+								disabled={!can("inbox", "modify")}
+							>
 								<EnvelopeIcon className="h-4 w-4" />
 								Compose Email
 							</Button>

--- a/apps/web/src/app/(workspace)/clients/components/client-detail-sidebar.tsx
+++ b/apps/web/src/app/(workspace)/clients/components/client-detail-sidebar.tsx
@@ -32,9 +32,12 @@ import {
 	DollarSign,
 	AlertCircle,
 	Pencil,
+	Lock,
 	Check,
 	X,
 } from "lucide-react";
+import { usePermissions } from "@/hooks/use-permissions";
+import { Badge } from "@/components/ui/badge";
 import { ClientDocumentsSection } from "./client-documents-section";
 
 function formatLeadSource(leadSource?: string): string {
@@ -112,6 +115,14 @@ export function ClientDetailSidebar({
 	const toast = useToast();
 	const updateClient = useMutation(api.clients.update);
 
+	const { can, isLoading: permissionsLoading } = usePermissions();
+	const canModify = can("clients", "modify");
+	const showReadOnly = !permissionsLoading && !canModify;
+	// Editable rows get the interactive affordance; read-only rows sit flat.
+	const rowClass = `flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors${
+		canModify ? " group hover:bg-muted/50 cursor-pointer" : ""
+	}`;
+
 	const [editingField, setEditingField] = useState<EditingField>(null);
 	const [editValue, setEditValue] = useState("");
 	const [localTags, setLocalTags] = useState<string[]>(client.tags || []);
@@ -142,6 +153,7 @@ export function ClientDetailSidebar({
 	}, [editingField]);
 
 	const startEditing = (field: EditingField, currentValue: string) => {
+		if (!canModify) return;
 		setEditingField(field);
 		setEditValue(currentValue);
 	};
@@ -174,6 +186,7 @@ export function ClientDetailSidebar({
 	};
 
 	const handleTagsChange: React.Dispatch<React.SetStateAction<string[]>> = (action) => {
+		if (!canModify) return;
 		const newTags = typeof action === "function" ? action(localTags) : action;
 		setLocalTags(newTags);
 		// Auto-save tags
@@ -234,21 +247,30 @@ export function ClientDetailSidebar({
 		</div>
 	);
 
-	// Shared pencil icon for non-editing rows
-	const renderPencil = () => (
-		<Pencil className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0 ml-auto mt-0.5" />
-	);
+	// Shared pencil icon for non-editing rows (hidden entirely when read-only)
+	const renderPencil = () =>
+		canModify ? (
+			<Pencil className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0 ml-auto mt-0.5" />
+		) : null;
 
 	return (
 		<div className="px-5 py-4">
 			{/* Record Details Section */}
-			<h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-3">
-				Record Details
-			</h3>
+			<div className="mb-3 flex items-center justify-between gap-2">
+				<h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+					Record Details
+				</h3>
+				{showReadOnly && (
+					<Badge variant="secondary" className="gap-1">
+						<Lock className="h-3 w-3" />
+						Read Only
+					</Badge>
+				)}
+			</div>
 			<div className="space-y-0">
 				{/* Client Name */}
 				<div
-					className="flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors group hover:bg-muted/50 cursor-pointer"
+					className={rowClass}
 					onClick={() => editingField !== "companyName" && startEditing("companyName", client.companyName)}
 				>
 					<Building2 className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
@@ -278,7 +300,7 @@ export function ClientDetailSidebar({
 
 				{/* Status */}
 				<div
-					className="flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors group hover:bg-muted/50 cursor-pointer"
+					className={rowClass}
 					onClick={() => editingField !== "status" && startEditing("status", client.status)}
 				>
 					<CircleDot className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
@@ -317,7 +339,7 @@ export function ClientDetailSidebar({
 
 				{/* Lead Source */}
 				<div
-					className="flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors group hover:bg-muted/50 cursor-pointer"
+					className={rowClass}
 					onClick={() => editingField !== "leadSource" && startEditing("leadSource", client.leadSource || "")}
 				>
 					<Target className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
@@ -353,7 +375,7 @@ export function ClientDetailSidebar({
 
 				{/* Description */}
 				<div
-					className="flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors group hover:bg-muted/50 cursor-pointer"
+					className={rowClass}
 					onClick={() => editingField !== "description" && startEditing("description", client.companyDescription || "")}
 				>
 					<FileText className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
@@ -392,7 +414,7 @@ export function ClientDetailSidebar({
 
 				{/* Communication Preference */}
 				<div
-					className="flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors group hover:bg-muted/50 cursor-pointer"
+					className={rowClass}
 					onClick={() => editingField !== "communicationPreference" && startEditing("communicationPreference", client.communicationPreference || "")}
 				>
 					<MessageSquare className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
@@ -436,6 +458,7 @@ export function ClientDetailSidebar({
 							setTags={handleTagsChange}
 							placeholder="Add a tag..."
 							size="sm"
+							disabled={!canModify}
 						/>
 					</div>
 				</div>

--- a/apps/web/src/app/(workspace)/clients/page.tsx
+++ b/apps/web/src/app/(workspace)/clients/page.tsx
@@ -192,7 +192,8 @@ const createColumns = (
 	onDelete: (id: string, name: string) => void,
 	onRestore: (id: string, name: string) => void,
 	isArchivedTab: boolean,
-	canModify: boolean
+	canModify: boolean,
+	canDelete: boolean
 ): ColumnDef<Client>[] => [
 	{
 		accessorKey: "name",
@@ -306,6 +307,7 @@ const createColumns = (
 							variant="outline"
 							size="icon-sm"
 							onClick={() => onDelete(row.original.id, row.original.name)}
+							disabled={!canDelete}
 							className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950"
 							aria-label={`Archive client ${row.original.name}`}
 						>
@@ -401,6 +403,7 @@ function ClientsPageContent() {
 	const { hasPremiumAccess } = useFeatureAccess();
 	const { can } = usePermissions();
 	const canModifyClients = can("clients", "modify");
+	const canDeleteClients = can("clients", "delete");
 
 	const archiveClient = useMutation(api.clients.archive);
 	const restoreClient = useMutation(api.clients.restore);
@@ -497,21 +500,10 @@ function ClientsPageContent() {
 
 	const confirmDelete = async () => {
 		if (!clientToDelete) return;
-		try {
-			await archiveClient({ id: clientToDelete.id as Id<"clients"> });
-			setDeleteModalOpen(false);
-			setClientToDelete(null);
-			toast.success(
-				"Client Archived",
-				`${clientToDelete.name} has been archived. It will be permanently deleted in 7 days.`
-			);
-		} catch (error) {
-			console.error("Failed to archive client:", error);
-			toast.error(
-				"Archive Failed",
-				"Failed to archive the client. Please try again."
-			);
-		}
+		// Success/error toasts + closing are owned by DeleteConfirmationModal;
+		// let errors propagate so the modal shows a single error toast.
+		await archiveClient({ id: clientToDelete.id as Id<"clients"> });
+		setClientToDelete(null);
 	};
 
 	// Switching dataset resets the dataset-scoped filters (their status options
@@ -588,7 +580,8 @@ function ClientsPageContent() {
 				handleDelete,
 				handleRestore,
 				isArchivedTab,
-				canModifyClients
+				canModifyClients,
+				canDeleteClients
 			),
 		[
 			router,
@@ -597,6 +590,7 @@ function ClientsPageContent() {
 			handleRestore,
 			isArchivedTab,
 			canModifyClients,
+			canDeleteClients,
 		]
 	);
 

--- a/apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-header.tsx
+++ b/apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-header.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { AnimatePresence, motion } from "motion/react";
+import { usePermissions } from "@/hooks/use-permissions";
 import { cn } from "@/lib/utils";
 
 type InvoiceStatus = "draft" | "sent" | "paid" | "overdue" | "cancelled";
@@ -44,17 +45,23 @@ export function InvoiceDetailHeader({
 	onGeneratePdf,
 	onCancel,
 }: InvoiceDetailHeaderProps) {
+	const { can } = usePermissions();
+	const canModify = can("invoices", "modify");
 	const renderStatusActions = () => {
 		switch (currentStatus) {
 			case "draft":
 				return (
 					<>
-						<Button size="sm" onClick={() => onStatusChange("sent")}>
+						<Button
+							size="sm"
+							onClick={() => onStatusChange("sent")}
+							disabled={!canModify}
+						>
 							<Send className="h-4 w-4" />
 							Mark as Sent
 						</Button>
 						{/* TODO(reui-rebuild): success button intent mapped to default */}
-						<Button size="sm" onClick={onMarkPaid}>
+						<Button size="sm" onClick={onMarkPaid} disabled={!canModify}>
 							<CheckCircle className="h-4 w-4" />
 							Mark as Paid
 						</Button>
@@ -65,7 +72,7 @@ export function InvoiceDetailHeader({
 				return (
 					<>
 						{/* TODO(reui-rebuild): success button intent mapped to default */}
-						<Button size="sm" onClick={onMarkPaid}>
+						<Button size="sm" onClick={onMarkPaid} disabled={!canModify}>
 							<CheckCircle className="h-4 w-4" />
 							Mark as Paid
 						</Button>
@@ -73,6 +80,7 @@ export function InvoiceDetailHeader({
 							variant="outline"
 							size="sm"
 							onClick={() => onStatusChange("draft")}
+							disabled={!canModify}
 						>
 							<RotateCcw className="h-4 w-4" />
 							Revert to Draft
@@ -85,6 +93,7 @@ export function InvoiceDetailHeader({
 						variant="outline"
 						size="sm"
 						onClick={() => onStatusChange("sent")}
+						disabled={!canModify}
 					>
 						<RotateCcw className="h-4 w-4" />
 						Reopen
@@ -96,6 +105,7 @@ export function InvoiceDetailHeader({
 						variant="outline"
 						size="sm"
 						onClick={() => onStatusChange("draft")}
+						disabled={!canModify}
 					>
 						<RotateCcw className="h-4 w-4" />
 						Reopen (Draft)
@@ -180,16 +190,31 @@ export function InvoiceDetailHeader({
 					</AnimatePresence>
 					<div className="flex items-center gap-2 shrink-0">
 						{renderStatusActions()}
-						<Button variant="outline" size="sm" onClick={onSendToClient}>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={onSendToClient}
+							disabled={!canModify}
+						>
 							<Mail className="h-4 w-4" />
 							Send to Client
 						</Button>
-						<Button variant="outline" size="sm" onClick={onGeneratePdf}>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={onGeneratePdf}
+							disabled={!canModify}
+						>
 							<FileText className="h-4 w-4" />
 							Generate PDF
 						</Button>
 						{currentStatus !== "cancelled" && (
-							<Button variant="destructive" size="sm" onClick={onCancel}>
+							<Button
+								variant="destructive"
+								size="sm"
+								onClick={onCancel}
+								disabled={!canModify}
+							>
 								<XCircle className="h-4 w-4" />
 								Cancel
 							</Button>

--- a/apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-sidebar.tsx
+++ b/apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-sidebar.tsx
@@ -32,6 +32,7 @@ import {
 	Percent,
 	Receipt,
 	Pencil,
+	Lock,
 	Check,
 	X,
 	FileText,
@@ -41,6 +42,7 @@ import {
 	Clock,
 } from "lucide-react";
 import Link from "next/link";
+import { usePermissions } from "@/hooks/use-permissions";
 
 type InvoiceStatus = "draft" | "sent" | "paid" | "overdue" | "cancelled";
 
@@ -113,6 +115,14 @@ export function InvoiceDetailSidebar({
 	const toast = useToast();
 	const updateInvoice = useMutation(api.invoices.update);
 
+	const { can, isLoading: permissionsLoading } = usePermissions();
+	const canModify = can("invoices", "modify");
+	const showReadOnly = !permissionsLoading && !canModify;
+	// Editable rows get the interactive affordance; read-only rows sit flat.
+	const rowClass = `flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors${
+		canModify ? " group hover:bg-muted/50 cursor-pointer" : ""
+	}`;
+
 	const [editingField, setEditingField] = useState<EditingField>(null);
 	const [editValue, setEditValue] = useState("");
 	const [editDateValue, setEditDateValue] = useState<Date | undefined>(
@@ -129,6 +139,7 @@ export function InvoiceDetailSidebar({
 			: (invoice.status as InvoiceStatus);
 
 	const startEditing = (field: EditingField, currentValue: string) => {
+		if (!canModify) return;
 		setEditingField(field);
 		setEditValue(currentValue);
 	};
@@ -137,6 +148,7 @@ export function InvoiceDetailSidebar({
 		field: "dueDate",
 		currentTimestamp?: number
 	) => {
+		if (!canModify) return;
 		setEditingField(field);
 		setEditDateValue(
 			currentTimestamp ? new Date(currentTimestamp) : undefined
@@ -197,20 +209,30 @@ export function InvoiceDetailSidebar({
 		</div>
 	);
 
-	const renderPencil = () => (
-		<Pencil className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0 ml-auto mt-0.5" />
-	);
+	// Shared pencil icon for non-editing rows (hidden entirely when read-only)
+	const renderPencil = () =>
+		canModify ? (
+			<Pencil className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0 ml-auto mt-0.5" />
+		) : null;
 
 	return (
 		<div className="px-5 py-4">
 			{/* Record Details Section */}
-			<h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-3">
-				Record Details
-			</h3>
+			<div className="mb-3 flex items-center justify-between gap-2">
+				<h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+					Record Details
+				</h3>
+				{showReadOnly && (
+					<Badge variant="secondary" className="gap-1">
+						<Lock className="h-3 w-3" />
+						Read Only
+					</Badge>
+				)}
+			</div>
 			<div className="space-y-0">
 				{/* Status (editable) */}
 				<div
-					className="flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors group hover:bg-muted/50 cursor-pointer"
+					className={rowClass}
 					onClick={() =>
 						editingField !== "status" &&
 						startEditing("status", invoice.status)
@@ -266,7 +288,7 @@ export function InvoiceDetailSidebar({
 
 				{/* Due Date (editable) */}
 				<div
-					className="flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors group hover:bg-muted/50 cursor-pointer"
+					className={rowClass}
 					onClick={() =>
 						editingField !== "dueDate" &&
 						startEditingDate("dueDate", invoice.dueDate)

--- a/apps/web/src/app/(workspace)/invoices/[invoiceId]/page.tsx
+++ b/apps/web/src/app/(workspace)/invoices/[invoiceId]/page.tsx
@@ -354,7 +354,7 @@ function InvoiceDetailPageContent() {
 					`Invoice #${invoice._id.slice(-6)}`
 				}
 				itemType="Invoice"
-				isArchive={true}
+				mode="cancel"
 			/>
 
 			{invoice && (

--- a/apps/web/src/app/(workspace)/invoices/[invoiceId]/page.tsx
+++ b/apps/web/src/app/(workspace)/invoices/[invoiceId]/page.tsx
@@ -150,21 +150,9 @@ function InvoiceDetailPageContent() {
 	};
 
 	const confirmCancelInvoice = async () => {
-		try {
-			await updateInvoice({ id: invoiceId, status: "cancelled" });
-			toast.success(
-				"Invoice Cancelled",
-				"Invoice has been cancelled"
-			);
-			setIsCancelModalOpen(false);
-		} catch (err) {
-			const message =
-				err instanceof Error
-					? err.message
-					: "Failed to cancel invoice";
-			toast.error("Error", message);
-			setIsCancelModalOpen(false);
-		}
+		// Success toast + modal close are owned by DeleteConfirmationModal;
+		// let errors propagate so the modal shows a single error toast.
+		await updateInvoice({ id: invoiceId, status: "cancelled" });
 	};
 
 	const handleGeneratePdf = async () => {

--- a/apps/web/src/app/(workspace)/invoices/components/invoice-detail-drawer.tsx
+++ b/apps/web/src/app/(workspace)/invoices/components/invoice-detail-drawer.tsx
@@ -9,12 +9,15 @@ import {
 	CheckCircle2,
 	ExternalLink,
 	Loader2,
+	Lock,
 	Plus,
 	Receipt,
 	Send,
 } from "lucide-react";
 
 import { StatusBadge } from "@/components/domain/status-badge";
+import { Badge } from "@/components/ui/badge";
+import { usePermissions } from "@/hooks/use-permissions";
 import {
 	Timeline,
 	TimelineContent,
@@ -95,6 +98,9 @@ export function InvoiceDetailDrawer({
 	onOpenChange,
 }: InvoiceDetailDrawerProps) {
 	const router = useRouter();
+	const { can, isLoading: permissionsLoading } = usePermissions();
+	const canModify = can("invoices", "modify");
+	const showReadOnly = !permissionsLoading && !canModify;
 	const toast = useToast();
 	const preview = useQuery(
 		api.invoices.getPreview,
@@ -172,17 +178,29 @@ export function InvoiceDetailDrawer({
 			}
 			title={title}
 			badge={
-				invoice && effectiveStatus ? (
-					<StatusBadge status={effectiveStatus} size="lg">
-						{STATUS_LABEL[effectiveStatus]}
-					</StatusBadge>
-				) : null
+				<>
+					{invoice && effectiveStatus ? (
+						<StatusBadge status={effectiveStatus} size="lg">
+							{STATUS_LABEL[effectiveStatus]}
+						</StatusBadge>
+					) : null}
+					{showReadOnly ? (
+						<Badge variant="secondary" className="gap-1">
+							<Lock className="h-3 w-3" />
+							Read Only
+						</Badge>
+					) : null}
+				</>
 			}
 			description={data ? (client?.companyName ?? "No client") : undefined}
 			actions={
 				<>
 					{canMarkPaid ? (
-						<Button size="sm" disabled={pending} onClick={handleMarkPaid}>
+						<Button
+							size="sm"
+							disabled={pending || !can("invoices", "modify")}
+							onClick={handleMarkPaid}
+						>
 							<CheckCircle2 className="size-3.5" />
 							Mark paid
 						</Button>
@@ -191,7 +209,7 @@ export function InvoiceDetailDrawer({
 						<Button
 							variant="outline"
 							size="sm"
-							disabled={pending}
+							disabled={pending || !can("invoices", "modify")}
 							onClick={handleSend}
 						>
 							<Send className="size-3.5" />
@@ -205,7 +223,11 @@ export function InvoiceDetailDrawer({
 							clientId: client?._id,
 						}}
 						trigger={
-							<Button variant="outline" size="sm">
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={!can("tasks", "modify")}
+							>
 								<Plus className="size-3.5" />
 								Add Task
 							</Button>
@@ -265,6 +287,7 @@ export function InvoiceDetailDrawer({
 							key={effectiveStatus}
 							invoiceId={invoice._id}
 							currentStatus={effectiveStatus}
+							canModify={canModify}
 						/>
 					</DrawerSection>
 
@@ -368,9 +391,11 @@ export function InvoiceDetailDrawer({
 function StatusControl({
 	invoiceId,
 	currentStatus,
+	canModify,
 }: {
 	invoiceId: Id<"invoices">;
 	currentStatus: InvoiceStatus;
+	canModify: boolean;
 }) {
 	const updateInvoice = useMutation(api.invoices.update);
 	const toast = useToast();
@@ -403,6 +428,7 @@ function StatusControl({
 				<Select
 					value={status}
 					onValueChange={(v) => setStatus(v as InvoiceStatus)}
+					disabled={!canModify}
 				>
 					<SelectTrigger className="h-9 flex-1">
 						<SelectValue />

--- a/apps/web/src/app/(workspace)/invoices/page.tsx
+++ b/apps/web/src/app/(workspace)/invoices/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { PermissionGate } from "@/components/domain/permission-gate";
+import { usePermissions } from "@/hooks/use-permissions";
 import React from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -162,7 +163,8 @@ const formatInvoiceDate = (timestamp?: number) => {
 const createColumns = (
 	router: ReturnType<typeof useRouter>,
 	onDelete: (id: string, name: string) => void,
-	onPreview: (id: string) => void
+	onPreview: (id: string) => void,
+	canDelete: boolean
 ): ColumnDef<InvoiceWithClient>[] => [
 	{
 		accessorKey: "invoiceNumber",
@@ -265,6 +267,7 @@ const createColumns = (
 					variant="outline"
 					size="icon-sm"
 					onClick={() => onDelete(row.original._id, row.original.invoiceNumber)}
+					disabled={!canDelete}
 					className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950"
 					aria-label={`Delete invoice ${row.original.invoiceNumber}`}
 				>
@@ -296,18 +299,21 @@ function InvoicesPageContent() {
 	const updateInvoiceStatus = useMutation(api.invoices.update);
 	const [kanbanData, setKanbanData] = useState<InvoiceKanbanItem[]>([]);
 	const isOrgSwitching = useIsOrgSwitching();
+	const { can } = usePermissions();
+	const canDeleteInvoices = can("invoices", "delete");
 
-	// Fetch invoices, clients, and projects from Convex
+	// Fetch invoices, clients, and projects from Convex. The clients/projects
+	// reads are gated — skip them without the grant so the page doesn't crash.
 	const invoices = useQuery(api.invoices.list, {});
-	const clients = useQuery(api.clients.list, {});
-	const projects = useQuery(api.projects.list, {});
+	const clients = useQuery(api.clients.list, can("clients") ? {} : "skip");
+	const projects = useQuery(api.projects.list, can("projects") ? {} : "skip");
 
 	// Combine invoices with resolved client and project names
 	const data = React.useMemo((): InvoiceWithClient[] => {
-		if (!invoices || !clients || !projects) return [];
+		if (!invoices) return [];
 		return invoices.map((invoice) => {
-			const client = clients.find((c) => c._id === invoice.clientId);
-			const project = projects.find((p) => p._id === invoice.projectId);
+			const client = clients?.find((c) => c._id === invoice.clientId);
+			const project = projects?.find((p) => p._id === invoice.projectId);
 			return {
 				...invoice,
 				clientName: client?.companyName || "Unknown Client",
@@ -446,20 +452,16 @@ function InvoicesPageContent() {
 	}, []);
 
 	const confirmDelete = async () => {
-		if (invoiceToDelete) {
-			try {
-				await deleteInvoice({ id: invoiceToDelete.id as Id<"invoices"> });
-				setDeleteModalOpen(false);
-				setInvoiceToDelete(null);
-			} catch (error) {
-				console.error("Failed to delete invoice:", error);
-			}
-		}
+		if (!invoiceToDelete) return;
+		// Success/error toasts + closing are owned by DeleteConfirmationModal;
+		// let errors propagate so the modal shows a single error toast.
+		await deleteInvoice({ id: invoiceToDelete.id as Id<"invoices"> });
+		setInvoiceToDelete(null);
 	};
 
 	const columns = React.useMemo(
-		() => createColumns(router, handleDelete, openPreview),
-		[router, handleDelete, openPreview]
+		() => createColumns(router, handleDelete, openPreview, canDeleteInvoices),
+		[router, handleDelete, openPreview, canDeleteInvoices]
 	);
 
 	const table = useReactTable({

--- a/apps/web/src/app/(workspace)/invoices/page.tsx
+++ b/apps/web/src/app/(workspace)/invoices/page.tsx
@@ -431,12 +431,10 @@ function InvoicesPageContent() {
 		);
 	}, [searchedData]);
 
-	// Loading state
-	const isLoading =
-		isOrgSwitching ||
-		invoices === undefined ||
-		clients === undefined ||
-		projects === undefined;
+	// Loading state — gate only on the primary invoices query. The clients and
+	// projects reads are permission-skipped and stay undefined without the grant,
+	// which would otherwise pin the page on the skeleton forever.
+	const isLoading = isOrgSwitching || invoices === undefined;
 
 	// Empty state
 	const isEmpty = !isLoading && data.length === 0;

--- a/apps/web/src/app/(workspace)/projects/[projectId]/page.tsx
+++ b/apps/web/src/app/(workspace)/projects/[projectId]/page.tsx
@@ -5,7 +5,6 @@ import { usePermissions } from "@/hooks/use-permissions";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
 import { useParams, useRouter } from "next/navigation";
-import { useToast } from "@/hooks/use-toast";
 import { TaskSheet } from "@/components/shared/task-sheet";
 import DeleteConfirmationModal from "@/components/ui/delete-confirmation-modal";
 import { InvoiceGenerationModal } from "@/app/(workspace)/projects/components/invoice-generation-modal";
@@ -19,7 +18,6 @@ import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 function ProjectDetailPageContent() {
 	const params = useParams();
 	const router = useRouter();
-	const toast = useToast();
 	const [isTaskSheetOpen, setIsTaskSheetOpen] = useState(false);
 	const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 	const [isDeleting, setIsDeleting] = useState(false);
@@ -35,7 +33,7 @@ function ProjectDetailPageContent() {
 	// Skip related queries if project is null or deletion is in progress
 	const projectTasks = useQuery(
 		api.tasks.list,
-		project === null || isDeleting ? "skip" : { projectId }
+		project === null || isDeleting || !can("tasks") ? "skip" : { projectId }
 	);
 	const projectQuotes = useQuery(
 		api.quotes.list,
@@ -79,15 +77,12 @@ function ProjectDetailPageContent() {
 		setIsDeleting(true);
 		try {
 			await deleteProject({ id: projectId });
-			toast.success("Project Deleted", "Project has been successfully deleted");
-			setIsDeleteModalOpen(false);
+			// Success toast + modal close are owned by DeleteConfirmationModal.
 			router.push("/projects");
 		} catch (err) {
-			const message =
-				err instanceof Error ? err.message : "Failed to delete project";
-			toast.error("Error", message);
-			setIsDeleteModalOpen(false);
+			// Re-throw so the modal shows a single error toast and stays open.
 			setIsDeleting(false);
+			throw err;
 		}
 	};
 

--- a/apps/web/src/app/(workspace)/projects/components/project-detail-drawer.tsx
+++ b/apps/web/src/app/(workspace)/projects/components/project-detail-drawer.tsx
@@ -12,12 +12,15 @@ import {
 	FolderKanban,
 	ListChecks,
 	Loader2,
+	Lock,
 	Plus,
 	Receipt,
 	Users,
 } from "lucide-react";
 
 import { StatusBadge } from "@/components/domain/status-badge";
+import { Badge } from "@/components/ui/badge";
+import { usePermissions } from "@/hooks/use-permissions";
 import {
 	Timeline,
 	TimelineContent,
@@ -110,6 +113,9 @@ export function ProjectDetailDrawer({
 	onOpenChange,
 }: ProjectDetailDrawerProps) {
 	const router = useRouter();
+	const { can, isLoading: permissionsLoading } = usePermissions();
+	const canModify = can("projects", "modify");
+	const showReadOnly = !permissionsLoading && !canModify;
 	const preview = useQuery(
 		api.projects.getPreview,
 		projectId ? { id: projectId } : "skip"
@@ -148,11 +154,19 @@ export function ProjectDetailDrawer({
 			}
 			title={title}
 			badge={
-				project ? (
-					<StatusBadge status={project.status} size="lg">
-						{STATUS_LABEL[project.status]}
-					</StatusBadge>
-				) : null
+				<>
+					{project ? (
+						<StatusBadge status={project.status} size="lg">
+							{STATUS_LABEL[project.status]}
+						</StatusBadge>
+					) : null}
+					{showReadOnly ? (
+						<Badge variant="secondary" className="gap-1">
+							<Lock className="h-3 w-3" />
+							Read Only
+						</Badge>
+					) : null}
+				</>
 			}
 			description={
 				data
@@ -174,7 +188,11 @@ export function ProjectDetailDrawer({
 							clientId: data?.client?._id,
 						}}
 						trigger={
-							<Button variant="outline" size="sm">
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={!can("tasks", "modify")}
+							>
 								<Plus className="size-3.5" />
 								Add Task
 							</Button>
@@ -229,6 +247,7 @@ export function ProjectDetailDrawer({
 							key={project.status}
 							projectId={project._id}
 							currentStatus={project.status}
+							canModify={canModify}
 						/>
 					</DrawerSection>
 
@@ -364,9 +383,11 @@ export function ProjectDetailDrawer({
 function StatusControl({
 	projectId,
 	currentStatus,
+	canModify,
 }: {
 	projectId: Id<"projects">;
 	currentStatus: ProjectStatus;
+	canModify: boolean;
 }) {
 	const updateProject = useMutation(api.projects.update);
 	const toast = useToast();
@@ -393,6 +414,7 @@ function StatusControl({
 				<Select
 					value={status}
 					onValueChange={(v) => setStatus(v as ProjectStatus)}
+					disabled={!canModify}
 				>
 					<SelectTrigger className="h-9 flex-1">
 						<SelectValue />

--- a/apps/web/src/app/(workspace)/projects/components/project-detail-header.tsx
+++ b/apps/web/src/app/(workspace)/projects/components/project-detail-header.tsx
@@ -6,6 +6,7 @@ import { StickyDetailHeader } from "@/components/shared/sticky-detail-header";
 import { ListTodo, FileText, Receipt, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { AnimatePresence, motion } from "motion/react";
+import { usePermissions } from "@/hooks/use-permissions";
 import { cn } from "@/lib/utils";
 
 interface ProjectDetailHeaderProps {
@@ -25,6 +26,7 @@ export function ProjectDetailHeader({
 	onGenerateInvoice,
 	onDelete,
 }: ProjectDetailHeaderProps) {
+	const { can } = usePermissions();
 	return (
 		<StickyDetailHeader>
 			{(isSticky) => (
@@ -70,11 +72,21 @@ export function ProjectDetailHeader({
 						)}
 					</AnimatePresence>
 					<div className="flex items-center gap-2 shrink-0">
-						<Button variant="outline" size="sm" onClick={onAddTask}>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={onAddTask}
+							disabled={!can("tasks", "modify")}
+						>
 							<ListTodo className="h-4 w-4" />
 							Add Task
 						</Button>
-						<Button variant="outline" size="sm" onClick={onAddQuote}>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={onAddQuote}
+							disabled={!can("quotes", "modify")}
+						>
 							<FileText className="h-4 w-4" />
 							Add Quote
 						</Button>
@@ -82,12 +94,17 @@ export function ProjectDetailHeader({
 							variant="outline"
 							size="sm"
 							onClick={onGenerateInvoice}
-							disabled={!hasApprovedQuotes}
+							disabled={!hasApprovedQuotes || !can("invoices", "modify")}
 						>
 							<Receipt className="h-4 w-4" />
 							Generate Invoice
 						</Button>
-						<Button variant="destructive" size="sm" onClick={onDelete}>
+						<Button
+							variant="destructive"
+							size="sm"
+							onClick={onDelete}
+							disabled={!can("projects", "delete")}
+						>
 							<Trash2 className="h-4 w-4" />
 							Delete
 						</Button>

--- a/apps/web/src/app/(workspace)/projects/components/project-detail-sidebar.tsx
+++ b/apps/web/src/app/(workspace)/projects/components/project-detail-sidebar.tsx
@@ -33,10 +33,13 @@ import {
 	AlertCircle,
 	Type,
 	Pencil,
+	Lock,
 	Check,
 	X,
 } from "lucide-react";
 import Link from "next/link";
+import { usePermissions } from "@/hooks/use-permissions";
+import { Badge } from "@/components/ui/badge";
 import { ProjectDocumentsSection } from "./project-documents-section";
 
 function formatDate(timestamp?: number) {
@@ -92,21 +95,32 @@ export function ProjectDetailSidebar({
 	const updateProject = useMutation(api.projects.update);
 	const users = useQuery(api.users.listByOrg);
 
+	const { can, isLoading: permissionsLoading } = usePermissions();
+	const canModify = can("projects", "modify");
+	const showReadOnly = !permissionsLoading && !canModify;
+	// Editable rows get the interactive affordance; read-only rows sit flat.
+	const rowClass = `flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors${
+		canModify ? " group hover:bg-muted/50 cursor-pointer" : ""
+	}`;
+
 	const [editingField, setEditingField] = useState<EditingField>(null);
 	const [editValue, setEditValue] = useState("");
 	const [editDateValue, setEditDateValue] = useState<Date | undefined>(undefined);
 	const [editAssignedUsers, setEditAssignedUsers] = useState<string[]>([]);
 	const startEditing = (field: EditingField, currentValue: string) => {
+		if (!canModify) return;
 		setEditingField(field);
 		setEditValue(currentValue);
 	};
 
 	const startEditingDate = (field: "startDate" | "endDate", currentTimestamp?: number) => {
+		if (!canModify) return;
 		setEditingField(field);
 		setEditDateValue(currentTimestamp ? new Date(currentTimestamp) : undefined);
 	};
 
 	const startEditingAssignedUsers = () => {
+		if (!canModify) return;
 		setEditingField("assignedUserIds");
 		setEditAssignedUsers((project.assignedUserIds || []) as string[]);
 	};
@@ -178,21 +192,30 @@ export function ProjectDetailSidebar({
 		</div>
 	);
 
-	// Shared pencil icon for non-editing rows
-	const renderPencil = () => (
-		<Pencil className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0 ml-auto mt-0.5" />
-	);
+	// Shared pencil icon for non-editing rows (hidden entirely when read-only)
+	const renderPencil = () =>
+		canModify ? (
+			<Pencil className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0 ml-auto mt-0.5" />
+		) : null;
 
 	return (
 		<div className="px-5 py-4">
 			{/* Record Details Section */}
-			<h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-3">
-				Record Details
-			</h3>
+			<div className="mb-3 flex items-center justify-between gap-2">
+				<h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+					Record Details
+				</h3>
+				{showReadOnly && (
+					<Badge variant="secondary" className="gap-1">
+						<Lock className="h-3 w-3" />
+						Read Only
+					</Badge>
+				)}
+			</div>
 			<div className="space-y-0">
 				{/* Title */}
 				<div
-					className="flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors group hover:bg-muted/50 cursor-pointer"
+					className={rowClass}
 					onClick={() => editingField !== "title" && startEditing("title", project.title)}
 				>
 					<Type className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
@@ -224,7 +247,7 @@ export function ProjectDetailSidebar({
 
 				{/* Status */}
 				<div
-					className="flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors group hover:bg-muted/50 cursor-pointer"
+					className={rowClass}
 					onClick={() => editingField !== "status" && startEditing("status", project.status)}
 				>
 					<CircleDot className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
@@ -260,7 +283,7 @@ export function ProjectDetailSidebar({
 
 				{/* Project Type */}
 				<div
-					className="flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors group hover:bg-muted/50 cursor-pointer"
+					className={rowClass}
 					onClick={() => editingField !== "projectType" && startEditing("projectType", project.projectType)}
 				>
 					<Layers className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
@@ -293,7 +316,7 @@ export function ProjectDetailSidebar({
 
 				{/* Start Date */}
 				<div
-					className="flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors group hover:bg-muted/50 cursor-pointer"
+					className={rowClass}
 					onClick={() => editingField !== "startDate" && startEditingDate("startDate", project.startDate)}
 				>
 					<CalendarIcon className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
@@ -324,7 +347,7 @@ export function ProjectDetailSidebar({
 
 				{/* End Date */}
 				<div
-					className="flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors group hover:bg-muted/50 cursor-pointer"
+					className={rowClass}
 					onClick={() => editingField !== "endDate" && startEditingDate("endDate", project.endDate)}
 				>
 					<CalendarCheck className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
@@ -363,7 +386,7 @@ export function ProjectDetailSidebar({
 
 				{/* Assigned Users */}
 				<div
-					className="flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors group hover:bg-muted/50 cursor-pointer"
+					className={rowClass}
 					onClick={() => editingField !== "assignedUserIds" && startEditingAssignedUsers()}
 				>
 					<Users className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />

--- a/apps/web/src/app/(workspace)/projects/page.tsx
+++ b/apps/web/src/app/(workspace)/projects/page.tsx
@@ -159,7 +159,8 @@ const formatProjectDate = (timestamp?: number) => {
 const createColumns = (
 	router: ReturnType<typeof useRouter>,
 	onDelete: (id: string, name: string) => void,
-	onPreview: (id: string) => void
+	onPreview: (id: string) => void,
+	canDelete: boolean
 ): ColumnDef<ProjectWithClient>[] => [
 	{
 		accessorKey: "title",
@@ -246,6 +247,7 @@ const createColumns = (
 					variant="outline"
 					size="icon-sm"
 					onClick={() => onDelete(row.original._id, row.original.title)}
+					disabled={!canDelete}
 					className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950"
 					aria-label={`Delete project ${row.original.title}`}
 				>
@@ -278,6 +280,8 @@ function ProjectsPageContent() {
 	const [kanbanData, setKanbanData] = useState<ProjectKanbanItem[]>([]);
 	const isOrgSwitching = useIsOrgSwitching();
 	const { can } = usePermissions();
+	const canModifyProjects = can("projects", "modify");
+	const canDeleteProjects = can("projects", "delete");
 
 	// Fetch projects and clients from Convex
 	const projects = useQuery(api.projects.list, {});
@@ -394,20 +398,16 @@ function ProjectsPageContent() {
 	}, []);
 
 	const confirmDelete = async () => {
-		if (projectToDelete) {
-			try {
-				await deleteProject({ id: projectToDelete.id as Id<"projects"> });
-				setDeleteModalOpen(false);
-				setProjectToDelete(null);
-			} catch (error) {
-				console.error("Failed to delete project:", error);
-			}
-		}
+		if (!projectToDelete) return;
+		// Success/error toasts + closing are owned by DeleteConfirmationModal;
+		// let errors propagate so the modal shows a single error toast.
+		await deleteProject({ id: projectToDelete.id as Id<"projects"> });
+		setProjectToDelete(null);
 	};
 
 	const columns = React.useMemo(
-		() => createColumns(router, handleDelete, openPreview),
-		[router, handleDelete, openPreview]
+		() => createColumns(router, handleDelete, openPreview, canDeleteProjects),
+		[router, handleDelete, openPreview, canDeleteProjects]
 	);
 
 	const table = useReactTable({
@@ -519,7 +519,7 @@ function ProjectsPageContent() {
 						</p>
 					</div>
 				</div>
-				<Button onClick={() => router.push("/projects/new")}>
+				<Button onClick={() => router.push("/projects/new")} disabled={!canModifyProjects}>
 					<Plus className="h-4 w-4" />
 					Create Project
 				</Button>
@@ -655,7 +655,7 @@ function ProjectsPageContent() {
 								title="No projects yet"
 								description="Get started by creating your first project. Projects help you organize work and track progress."
 								action={
-									<Button onClick={() => router.push("/projects/new")}>
+									<Button onClick={() => router.push("/projects/new")} disabled={!canModifyProjects}>
 										<Plus className="h-4 w-4" />
 										Create Your First Project
 									</Button>

--- a/apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-header.tsx
+++ b/apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-header.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { AnimatePresence, motion } from "motion/react";
+import { usePermissions } from "@/hooks/use-permissions";
 import { cn } from "@/lib/utils";
 
 type QuoteStatus = "draft" | "sent" | "approved" | "declined" | "expired";
@@ -42,11 +43,16 @@ export function QuoteDetailHeader({
 	onDelete,
 	onConvertToInvoice,
 }: QuoteDetailHeaderProps) {
+	const { can } = usePermissions();
 	const renderStatusActions = () => {
 		switch (currentStatus) {
 			case "draft":
 				return (
-					<Button size="sm" onClick={() => onStatusChange("sent")}>
+					<Button
+						size="sm"
+						onClick={() => onStatusChange("sent")}
+						disabled={!can("quotes", "modify")}
+					>
 						<Send className="h-4 w-4" />
 						Mark as Sent
 					</Button>
@@ -54,7 +60,11 @@ export function QuoteDetailHeader({
 			case "sent":
 				return (
 					// TODO(reui-rebuild): success button intent mapped to default
-					<Button size="sm" onClick={() => onStatusChange("approved")}>
+					<Button
+						size="sm"
+						onClick={() => onStatusChange("approved")}
+						disabled={!can("quotes", "modify")}
+					>
 						<Check className="h-4 w-4" />
 						Mark Approved
 					</Button>
@@ -62,7 +72,11 @@ export function QuoteDetailHeader({
 			case "approved":
 				return (
 					<>
-						<Button size="sm" onClick={onConvertToInvoice}>
+						<Button
+							size="sm"
+							onClick={onConvertToInvoice}
+							disabled={!can("invoices", "modify")}
+						>
 							<Receipt className="h-4 w-4" />
 							Convert to Invoice
 						</Button>
@@ -70,6 +84,7 @@ export function QuoteDetailHeader({
 							variant="outline"
 							size="sm"
 							onClick={() => onStatusChange("draft")}
+							disabled={!can("quotes", "modify")}
 						>
 							<RotateCcw className="h-4 w-4" />
 							Reopen
@@ -83,6 +98,7 @@ export function QuoteDetailHeader({
 						variant="outline"
 						size="sm"
 						onClick={() => onStatusChange("draft")}
+						disabled={!can("quotes", "modify")}
 					>
 						<RotateCcw className="h-4 w-4" />
 						Reopen
@@ -161,17 +177,27 @@ export function QuoteDetailHeader({
 								variant="outline"
 								size="sm"
 								onClick={onSendToClient}
-								disabled={sendDisabled}
+								disabled={sendDisabled || !can("quotes", "modify")}
 							>
 								<PenLine className="h-4 w-4" />
 								Send for e-signature
 							</Button>
 						</span>
-						<Button variant="outline" size="sm" onClick={onGeneratePdf}>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={onGeneratePdf}
+							disabled={!can("quotes", "modify")}
+						>
 							<FileText className="h-4 w-4" />
 							Generate PDF
 						</Button>
-						<Button variant="destructive" size="sm" onClick={onDelete}>
+						<Button
+							variant="destructive"
+							size="sm"
+							onClick={onDelete}
+							disabled={!can("quotes", "delete")}
+						>
 							<Trash2 className="h-4 w-4" />
 							Delete
 						</Button>

--- a/apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-sidebar.tsx
+++ b/apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-sidebar.tsx
@@ -770,6 +770,7 @@ export function QuoteDetailSidebar({
 							variant="outline"
 							size="sm"
 							onClick={onGeneratePdf}
+							disabled={!canModify}
 						>
 							<FileText className="h-4 w-4 mr-2" />
 							Generate PDF

--- a/apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-sidebar.tsx
+++ b/apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-sidebar.tsx
@@ -33,6 +33,7 @@ import {
 	Receipt,
 	Type,
 	Pencil,
+	Lock,
 	Check,
 	X,
 	FileText,
@@ -42,6 +43,7 @@ import {
 	Clock,
 } from "lucide-react";
 import Link from "next/link";
+import { usePermissions } from "@/hooks/use-permissions";
 
 type QuoteStatus = "draft" | "sent" | "approved" | "declined" | "expired";
 
@@ -114,6 +116,14 @@ export function QuoteDetailSidebar({
 	const toast = useToast();
 	const updateQuote = useMutation(api.quotes.update);
 
+	const { can, isLoading: permissionsLoading } = usePermissions();
+	const canModify = can("quotes", "modify");
+	const showReadOnly = !permissionsLoading && !canModify;
+	// Editable rows get the interactive affordance; read-only rows sit flat.
+	const rowClass = `flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors${
+		canModify ? " group hover:bg-muted/50 cursor-pointer" : ""
+	}`;
+
 	const [editingField, setEditingField] = useState<EditingField>(null);
 	const [editValue, setEditValue] = useState("");
 	const [editDateValue, setEditDateValue] = useState<Date | undefined>(
@@ -121,6 +131,7 @@ export function QuoteDetailSidebar({
 	);
 
 	const startEditing = (field: EditingField, currentValue: string) => {
+		if (!canModify) return;
 		setEditingField(field);
 		setEditValue(currentValue);
 	};
@@ -129,6 +140,7 @@ export function QuoteDetailSidebar({
 		field: "validUntil",
 		currentTimestamp?: number
 	) => {
+		if (!canModify) return;
 		setEditingField(field);
 		setEditDateValue(
 			currentTimestamp ? new Date(currentTimestamp) : undefined
@@ -202,20 +214,29 @@ export function QuoteDetailSidebar({
 		</div>
 	);
 
-	const renderPencil = () => (
-		<Pencil className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0 ml-auto mt-0.5" />
-	);
+	const renderPencil = () =>
+		canModify ? (
+			<Pencil className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0 ml-auto mt-0.5" />
+		) : null;
 
 	return (
 		<div className="px-5 py-4">
 			{/* Record Details Section */}
-			<h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-3">
-				Record Details
-			</h3>
+			<div className="mb-3 flex items-center justify-between gap-2">
+				<h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+					Record Details
+				</h3>
+				{showReadOnly && (
+					<Badge variant="secondary" className="gap-1">
+						<Lock className="h-3 w-3" />
+						Read Only
+					</Badge>
+				)}
+			</div>
 			<div className="space-y-0">
 				{/* Title */}
 				<div
-					className="flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors group hover:bg-muted/50 cursor-pointer"
+					className={rowClass}
 					onClick={() =>
 						editingField !== "title" &&
 						startEditing("title", quote.title || "")
@@ -257,7 +278,7 @@ export function QuoteDetailSidebar({
 
 				{/* Status */}
 				<div
-					className="flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors group hover:bg-muted/50 cursor-pointer"
+					className={rowClass}
 					onClick={() =>
 						editingField !== "status" &&
 						startEditing("status", quote.status)
@@ -310,7 +331,7 @@ export function QuoteDetailSidebar({
 
 				{/* Valid Until */}
 				<div
-					className="flex items-start gap-3 py-2.5 -mx-2 px-2 rounded-md transition-colors group hover:bg-muted/50 cursor-pointer"
+					className={rowClass}
 					onClick={() =>
 						editingField !== "validUntil" &&
 						startEditingDate("validUntil", quote.validUntil)

--- a/apps/web/src/app/(workspace)/quotes/[quoteId]/page.tsx
+++ b/apps/web/src/app/(workspace)/quotes/[quoteId]/page.tsx
@@ -174,18 +174,12 @@ function QuoteDetailPageContent() {
 		setIsDeleting(true);
 		try {
 			await deleteQuote({ id: quoteId });
-			toast.success(
-				"Quote Deleted",
-				"Quote has been successfully deleted"
-			);
-			setIsDeleteModalOpen(false);
+			// Success toast + modal close are owned by DeleteConfirmationModal.
 			router.push("/quotes");
 		} catch (err) {
-			const message =
-				err instanceof Error ? err.message : "Failed to delete quote";
-			toast.error("Error", message);
-			setIsDeleteModalOpen(false);
+			// Re-throw so the modal shows a single error toast and stays open.
 			setIsDeleting(false);
+			throw err;
 		}
 	};
 

--- a/apps/web/src/app/(workspace)/quotes/components/quote-detail-drawer.tsx
+++ b/apps/web/src/app/(workspace)/quotes/components/quote-detail-drawer.tsx
@@ -10,12 +10,15 @@ import {
 	ExternalLink,
 	FileText,
 	Loader2,
+	Lock,
 	PenLine,
 	Receipt,
 	XCircle,
 } from "lucide-react";
 
 import { StatusBadge } from "@/components/domain/status-badge";
+import { Badge } from "@/components/ui/badge";
+import { usePermissions } from "@/hooks/use-permissions";
 import {
 	Timeline,
 	TimelineContent,
@@ -82,6 +85,9 @@ export function QuoteDetailDrawer({
 	onOpenChange,
 }: QuoteDetailDrawerProps) {
 	const router = useRouter();
+	const { can, isLoading: permissionsLoading } = usePermissions();
+	const canModify = can("quotes", "modify");
+	const showReadOnly = !permissionsLoading && !canModify;
 	const toast = useToast();
 	const updateQuote = useMutation(api.quotes.update);
 	const createInvoice = useMutation(api.invoices.createFromQuote);
@@ -166,11 +172,19 @@ export function QuoteDetailDrawer({
 			}
 			title={title}
 			badge={
-				quote ? (
-					<StatusBadge status={quote.status} size="lg">
-						{STATUS_LABEL[quote.status]}
-					</StatusBadge>
-				) : null
+				<>
+					{quote ? (
+						<StatusBadge status={quote.status} size="lg">
+							{STATUS_LABEL[quote.status]}
+						</StatusBadge>
+					) : null}
+					{showReadOnly ? (
+						<Badge variant="secondary" className="gap-1">
+							<Lock className="h-3 w-3" />
+							Read Only
+						</Badge>
+					) : null}
+				</>
 			}
 			description={
 				data
@@ -183,7 +197,11 @@ export function QuoteDetailDrawer({
 				quote ? (
 					<>
 						{canSend ? (
-							<Button size="sm" onClick={sendForSignature}>
+							<Button
+								size="sm"
+								disabled={!can("quotes", "modify")}
+								onClick={sendForSignature}
+							>
 								<PenLine className="size-3.5" />
 								Send for e-signature
 							</Button>
@@ -191,13 +209,18 @@ export function QuoteDetailDrawer({
 						{canDecide ? (
 							<>
 								{/* TODO(reui-rebuild): success button intent mapped to default */}
-								<Button size="sm" onClick={() => void setStatus("approved")}>
+								<Button
+									size="sm"
+									disabled={!can("quotes", "modify")}
+									onClick={() => void setStatus("approved")}
+								>
 									<CheckCircle2 className="size-3.5" />
 									Approve
 								</Button>
 								<Button
 									variant="destructive"
 									size="sm"
+									disabled={!can("quotes", "modify")}
 									onClick={() => void setStatus("declined")}
 								>
 									<XCircle className="size-3.5" />
@@ -208,7 +231,7 @@ export function QuoteDetailDrawer({
 						{canConvert ? (
 							<Button
 								size="sm"
-								disabled={converting}
+								disabled={converting || !can("invoices", "modify")}
 								onClick={convertToInvoice}
 							>
 								{converting ? (
@@ -266,6 +289,7 @@ export function QuoteDetailDrawer({
 							key={quote.status}
 							quoteId={quote._id}
 							currentStatus={quote.status}
+							canModify={canModify}
 						/>
 					</DrawerSection>
 
@@ -369,9 +393,11 @@ export function QuoteDetailDrawer({
 function StatusControl({
 	quoteId,
 	currentStatus,
+	canModify,
 }: {
 	quoteId: Id<"quotes">;
 	currentStatus: QuoteStatus;
+	canModify: boolean;
 }) {
 	const updateQuote = useMutation(api.quotes.update);
 	const toast = useToast();
@@ -398,6 +424,7 @@ function StatusControl({
 				<Select
 					value={status}
 					onValueChange={(v) => setStatus(v as QuoteStatus)}
+					disabled={!canModify}
 				>
 					<SelectTrigger className="h-9 flex-1">
 						<SelectValue />

--- a/apps/web/src/app/(workspace)/quotes/new/page.tsx
+++ b/apps/web/src/app/(workspace)/quotes/new/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { PermissionGate } from "@/components/domain/permission-gate";
+import { usePermissions } from "@/hooks/use-permissions";
 import { useState, useMemo } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useQuery, useMutation } from "convex/react";
@@ -55,18 +56,25 @@ function NewQuotePageContent() {
 	);
 
 	// Fetch data from Convex
-	const clientsResult = useQuery(api.clients.list, {});
+	const { can } = usePermissions();
+	// Gated read — skip without the clients grant to avoid a FORBIDDEN crash.
+	const clientsResult = useQuery(
+		api.clients.list,
+		can("clients") ? {} : "skip"
+	);
 	const clients = useMemo(() => clientsResult || [], [clientsResult]);
 	const projectsResult = useQuery(
 		api.projects.list,
-		selectedClient ? { clientId: selectedClient._id } : "skip"
+		selectedClient && can("projects")
+			? { clientId: selectedClient._id }
+			: "skip"
 	);
 	const projects = useMemo(() => projectsResult || [], [projectsResult]);
 
 	// Get project from URL param
 	const projectFromParam = useQuery(
 		api.projects.get,
-		projectIdParam ? { id: projectIdParam } : "skip"
+		projectIdParam && can("projects") ? { id: projectIdParam } : "skip"
 	);
 
 	// Mutations

--- a/apps/web/src/app/(workspace)/quotes/page.tsx
+++ b/apps/web/src/app/(workspace)/quotes/page.tsx
@@ -407,9 +407,10 @@ function QuotesPageContent() {
 		);
 	}, [searchedData]);
 
-	// Loading state
-	const isLoading =
-		quotes === undefined || clients === undefined || projects === undefined;
+	// Loading state — gate only on the primary quotes query. The clients and
+	// projects reads are permission-skipped and stay undefined without the grant,
+	// which would otherwise pin the page on the skeleton forever.
+	const isLoading = quotes === undefined;
 
 	// Empty state
 	const isEmpty = !isLoading && data.length === 0;

--- a/apps/web/src/app/(workspace)/quotes/page.tsx
+++ b/apps/web/src/app/(workspace)/quotes/page.tsx
@@ -288,18 +288,19 @@ function QuotesPageContent() {
 	const updateQuoteStatus = useMutation(api.quotes.update);
 	const [kanbanData, setKanbanData] = useState<QuoteKanbanItem[]>([]);
 
-	// Fetch data from Convex
+	// Fetch data from Convex. The clients/projects reads are gated — skip them
+	// without the grant so the page doesn't crash for quotes-only viewers.
 	const quotes = useQuery(api.quotes.list, {});
-	const clients = useQuery(api.clients.list, {});
-	const projects = useQuery(api.projects.list, {});
+	const clients = useQuery(api.clients.list, can("clients") ? {} : "skip");
+	const projects = useQuery(api.projects.list, can("projects") ? {} : "skip");
 
 	// Combine quotes with client and project data
 	const data = React.useMemo((): QuoteWithClient[] => {
-		if (!quotes || !clients || !projects) return [];
+		if (!quotes) return [];
 
 		return quotes.map((quote) => {
-			const client = clients.find((c) => c._id === quote.clientId);
-			const project = projects.find((p) => p._id === quote.projectId);
+			const client = clients?.find((c) => c._id === quote.clientId);
+			const project = projects?.find((p) => p._id === quote.projectId);
 
 			return {
 				...quote,
@@ -424,17 +425,11 @@ function QuotesPageContent() {
 	}, []);
 
 	const confirmDelete = async () => {
-		if (quoteToDelete) {
-			try {
-				await deleteQuote({ id: quoteToDelete.id as Id<"quotes"> });
-				setDeleteModalOpen(false);
-				setQuoteToDelete(null);
-				toast.success("Quote Deleted", `${quoteToDelete.name} has been deleted.`);
-			} catch (error) {
-				console.error("Failed to delete quote:", error);
-				toast.error("Delete Failed", "Failed to delete the quote. Please try again.");
-			}
-		}
+		if (!quoteToDelete) return;
+		// Success/error toasts + closing are owned by DeleteConfirmationModal;
+		// let errors propagate so the modal shows a single error toast.
+		await deleteQuote({ id: quoteToDelete.id as Id<"quotes"> });
+		setQuoteToDelete(null);
 	};
 
 	const columns = React.useMemo(

--- a/apps/web/src/app/(workspace)/reports/page.tsx
+++ b/apps/web/src/app/(workspace)/reports/page.tsx
@@ -132,10 +132,9 @@ function ReportsPageContent() {
 
 	const confirmDelete = async () => {
 		if (!reportToDelete) return;
-		// Success/error toasts owned by DeleteConfirmationModal; let errors propagate.
+		// Success toast + modal close are owned by DeleteConfirmationModal
+		// (onClose); let errors propagate so it shows a single error toast.
 		await deleteReport({ id: reportToDelete.id as Id<"reports"> });
-		setDeleteModalOpen(false);
-		setReportToDelete(null);
 	};
 
 	const [duplicatingId, setDuplicatingId] = useState<string | null>(null);
@@ -244,7 +243,10 @@ function ReportsPageContent() {
 			{reportToDelete && (
 				<DeleteConfirmationModal
 					isOpen={deleteModalOpen}
-					onClose={() => setDeleteModalOpen(false)}
+					onClose={() => {
+						setDeleteModalOpen(false);
+						setReportToDelete(null);
+					}}
 					onConfirm={confirmDelete}
 					title="Delete Report"
 					itemName={reportToDelete.name}

--- a/apps/web/src/app/(workspace)/reports/page.tsx
+++ b/apps/web/src/app/(workspace)/reports/page.tsx
@@ -132,13 +132,10 @@ function ReportsPageContent() {
 
 	const confirmDelete = async () => {
 		if (!reportToDelete) return;
-		try {
-			await deleteReport({ id: reportToDelete.id as Id<"reports"> });
-			setDeleteModalOpen(false);
-			setReportToDelete(null);
-		} catch (error) {
-			console.error("Failed to delete report:", error);
-		}
+		// Success/error toasts owned by DeleteConfirmationModal; let errors propagate.
+		await deleteReport({ id: reportToDelete.id as Id<"reports"> });
+		setDeleteModalOpen(false);
+		setReportToDelete(null);
 	};
 
 	const [duplicatingId, setDuplicatingId] = useState<string | null>(null);

--- a/apps/web/src/app/(workspace)/tasks/page.tsx
+++ b/apps/web/src/app/(workspace)/tasks/page.tsx
@@ -137,7 +137,9 @@ function createColumns(
 	onToggleComplete: (task: Task) => void,
 	onEdit: (task: Task) => void,
 	onDelete: (task: Task) => void,
-	updatingTasks: Set<Id<"tasks">>
+	updatingTasks: Set<Id<"tasks">>,
+	canModify: boolean,
+	canDelete: boolean
 ): ColumnDef<Task>[] {
 	return [
 		{
@@ -150,7 +152,9 @@ function createColumns(
 				return (
 					<button
 						onClick={() => onToggleComplete(task)}
-						disabled={isUpdating || task.status === "cancelled"}
+						disabled={
+							isUpdating || task.status === "cancelled" || !canModify
+						}
 						className={cn(
 							"p-0.5 rounded-full transition-colors",
 							"hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
@@ -293,7 +297,7 @@ function createColumns(
 					<div className="flex items-center gap-1">
 						<button
 							onClick={() => onEdit(task)}
-							disabled={isUpdating}
+							disabled={isUpdating || !canModify}
 							className="p-1.5 rounded-md hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
 							title="Edit task"
 						>
@@ -301,7 +305,7 @@ function createColumns(
 						</button>
 						<button
 							onClick={() => onDelete(task)}
-							disabled={isUpdating}
+							disabled={isUpdating || !canDelete}
 							className="p-1.5 rounded-md hover:bg-red-100 dark:hover:bg-red-900/20 text-muted-foreground hover:text-red-600 transition-colors"
 							title="Delete task"
 						>
@@ -375,6 +379,8 @@ function TasksPageContent() {
 	const [deleteModalOpen, setDeleteModalOpen] = useState(false);
 	const [taskToDelete, setTaskToDelete] = useState<Task | null>(null);
 	const { can } = usePermissions();
+	const canModifyTasks = can("tasks", "modify");
+	const canDeleteTasks = can("tasks", "delete");
 
 	// Queries
 	const allTasks = useQuery(api.tasks.list, {});
@@ -576,7 +582,8 @@ function TasksPageContent() {
 			setDeleteModalOpen(false);
 			setTaskToDelete(null);
 		} catch (error) {
-			console.error("Error deleting task:", error);
+			// Re-throw so the modal shows a single error toast, not a false success.
+			throw error;
 		} finally {
 			if (taskToDelete) {
 				setUpdatingTasks((prev) => {
@@ -617,10 +624,12 @@ function TasksPageContent() {
 				handleToggleComplete,
 				handleEdit,
 				handleDeleteRequest,
-				updatingTasks
+				updatingTasks,
+				canModifyTasks,
+				canDeleteTasks
 			),
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[clients, projects, users, updatingTasks]
+		[clients, projects, users, updatingTasks, canModifyTasks, canDeleteTasks]
 	);
 
 	return (
@@ -648,7 +657,7 @@ function TasksPageContent() {
 				<TaskSheet
 					mode="create"
 					trigger={
-						<Button>
+						<Button disabled={!canModifyTasks}>
 							<Plus className="h-4 w-4" />
 							New Task
 						</Button>
@@ -731,7 +740,7 @@ function TasksPageContent() {
 								<TaskSheet
 									mode="create"
 									trigger={
-										<Button>
+										<Button disabled={!canModifyTasks}>
 											<Plus className="h-4 w-4" />
 											Create Your First Task
 										</Button>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -47,7 +47,7 @@
 	--color-muted: var(--muted);
 	--color-secondary-foreground: var(--secondary-foreground);
 	--color-secondary: var(--secondary);
-	--color-primary-foreground: var(--primary-foreground);
+	--color-primary-foreground: var(--primary-fg);
 	--color-primary: var(--primary);
 	--color-popover-foreground: var(--popover-foreground);
 	--color-popover: var(--popover);

--- a/apps/web/src/app/reui-nova.css
+++ b/apps/web/src/app/reui-nova.css
@@ -65,6 +65,13 @@
   }
 }
 
+@custom-variant data-indeterminate {
+  &:where([data-state="indeterminate"]),
+  &:where([data-indeterminate]:not([data-indeterminate="false"])) {
+    @slot;
+  }
+}
+
 @custom-variant data-selected {
   &:where([data-selected="true"]) {
     @slot;
@@ -390,7 +397,7 @@
 
   /* MARK: Checkbox */
   .cn-checkbox {
-    @apply border-input dark:bg-input/30 data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary data-checked:border-primary aria-invalid:aria-checked:border-primary aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 flex size-4 items-center justify-center rounded-[4px] border transition-colors group-has-disabled/field:opacity-50 focus-visible:ring-3 aria-invalid:ring-3;
+    @apply border-input dark:bg-input/30 data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary data-checked:border-primary data-indeterminate:bg-primary data-indeterminate:text-primary-foreground dark:data-indeterminate:bg-primary data-indeterminate:border-primary aria-invalid:aria-checked:border-primary aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 flex size-4 items-center justify-center rounded-[4px] border transition-colors group-has-disabled/field:opacity-50 focus-visible:ring-3 aria-invalid:ring-3;
   }
 
   .cn-checkbox-indicator {

--- a/apps/web/src/components/shared/record-tasks-tab.tsx
+++ b/apps/web/src/components/shared/record-tasks-tab.tsx
@@ -123,6 +123,8 @@ function isOverdue(task: Task): boolean {
 
 function createColumns(
 	entityType: "client" | "project",
+	canModify: boolean,
+	canDelete: boolean,
 	clients: { _id: Id<"clients">; companyName: string }[] | undefined,
 	projects: { _id: Id<"projects">; title: string }[] | undefined,
 	users:
@@ -144,9 +146,9 @@ function createColumns(
 				return (
 					<button
 						onClick={() => onToggleComplete(task)}
-						disabled={isUpdating || task.status === "cancelled"}
+						disabled={isUpdating || task.status === "cancelled" || !canModify}
 						className={cn(
-							"p-0.5 rounded-full transition-colors",
+							"p-0.5 rounded-full transition-colors disabled:opacity-40 disabled:cursor-not-allowed",
 							"hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
 							isUpdating && "opacity-50 cursor-not-allowed"
 						)}
@@ -300,16 +302,16 @@ function createColumns(
 				<div className="flex items-center gap-1">
 					<button
 						onClick={() => onEdit(task)}
-						disabled={isUpdating}
-						className="p-1.5 rounded-md hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+						disabled={isUpdating || !canModify}
+						className="p-1.5 rounded-md hover:bg-muted text-muted-foreground hover:text-foreground transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
 						title="Edit task"
 					>
 						<Edit className="h-3.5 w-3.5" />
 					</button>
 					<button
 						onClick={() => onDelete(task)}
-						disabled={isUpdating}
-						className="p-1.5 rounded-md hover:bg-red-100 dark:hover:bg-red-900/20 text-muted-foreground hover:text-red-600 transition-colors"
+						disabled={isUpdating || !canDelete}
+						className="p-1.5 rounded-md hover:bg-red-100 dark:hover:bg-red-900/20 text-muted-foreground hover:text-red-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
 						title="Delete task"
 					>
 						<Trash2 className="h-3.5 w-3.5" />
@@ -385,6 +387,8 @@ export function RecordTasksTab({
 	const [deleteModalOpen, setDeleteModalOpen] = useState(false);
 	const [taskToDelete, setTaskToDelete] = useState<Task | null>(null);
 	const { can } = usePermissions();
+	const canModifyTasks = can("tasks", "modify");
+	const canDeleteTasks = can("tasks", "delete");
 
 	// Queries for related data — skip without the view grant, gated endpoints
 	// throw FORBIDDEN otherwise. This component is shared across record types.
@@ -474,6 +478,8 @@ export function RecordTasksTab({
 		() =>
 			createColumns(
 				entityType,
+				canModifyTasks,
+				canDeleteTasks,
 				clients as
 					| { _id: Id<"clients">; companyName: string }[]
 					| undefined,
@@ -489,7 +495,7 @@ export function RecordTasksTab({
 				updatingTasks
 			),
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[clients, projects, users, updatingTasks, entityType]
+		[clients, projects, users, updatingTasks, entityType, canModifyTasks, canDeleteTasks]
 	);
 
 	const totalTasks = tasks?.length ?? 0;
@@ -501,7 +507,7 @@ export function RecordTasksTab({
 				<h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
 					Tasks ({totalTasks})
 				</h3>
-				<Button variant="outline" size="sm" onClick={onAddTask}>
+				<Button variant="outline" size="sm" onClick={onAddTask} disabled={!canModifyTasks}>
 					<Plus className="h-4 w-4" />
 					Add Task
 				</Button>

--- a/apps/web/src/components/shared/record-tasks-tab.tsx
+++ b/apps/web/src/components/shared/record-tasks-tab.tsx
@@ -456,7 +456,8 @@ export function RecordTasksTab({
 			setDeleteModalOpen(false);
 			setTaskToDelete(null);
 		} catch (error) {
-			console.error("Error deleting task:", error);
+			// Re-throw so the modal shows a single error toast, not a false success.
+			throw error;
 		} finally {
 			if (taskToDelete) {
 				setUpdatingTasks((prev) => {

--- a/apps/web/src/components/shared/sku-selector.tsx
+++ b/apps/web/src/components/shared/sku-selector.tsx
@@ -102,7 +102,7 @@ export function SKUSelector({ onSelect, disabled = false }: SKUSelectorProps) {
 
 					{/* SKU List */}
 					<div className="max-h-[300px] overflow-y-auto bg-white dark:bg-gray-900">
-						{skus === undefined ? (
+						{can("skus") && skus === undefined ? (
 							<div className="p-4 text-center text-sm text-muted-foreground bg-white dark:bg-gray-900">
 								Loading SKUs...
 							</div>

--- a/apps/web/src/components/shared/sku-selector.tsx
+++ b/apps/web/src/components/shared/sku-selector.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import { useQuery } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
+import { usePermissions } from "@/hooks/use-permissions";
 import { Button } from "@/components/ui/button";
 import {
 	Popover,
@@ -43,7 +44,9 @@ const formatCurrency = (amount: number) => {
 export function SKUSelector({ onSelect, disabled = false }: SKUSelectorProps) {
 	const [open, setOpen] = useState(false);
 	const [searchQuery, setSearchQuery] = useState("");
-	const skus = useQuery(api.skus.list);
+	const { can } = usePermissions();
+	// Gated read — skip without the SKU catalog grant to avoid a FORBIDDEN crash.
+	const skus = useQuery(api.skus.list, can("skus") ? {} : "skip");
 
 	const filteredSKUs = React.useMemo(() => {
 		if (!skus) return [];

--- a/apps/web/src/components/shared/task-sheet.tsx
+++ b/apps/web/src/components/shared/task-sheet.tsx
@@ -554,6 +554,7 @@ export function TaskSheet({
 						onClick={() => handleSubmit()}
 						disabled={
 							isSubmitting ||
+							!can("tasks", "modify") ||
 							!formData.title.trim() ||
 							(formData.type === "external" && !formData.clientId) ||
 							(formData.repeat !== "none" && !formData.repeatUntil)

--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { CheckIcon } from "lucide-react"
+import { CheckIcon, MinusIcon } from "lucide-react"
 import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox"
 
 import { cn } from "@/lib/utils"
@@ -10,7 +10,7 @@ function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "cn-checkbox peer relative shrink-0 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "cn-checkbox group/checkbox peer relative shrink-0 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}
@@ -19,8 +19,10 @@ function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
         data-slot="checkbox-indicator"
         className="cn-checkbox-indicator grid place-content-center text-current transition-none"
       >
-        <CheckIcon
-        />
+        {/* Base UI renders the indicator for both checked and indeterminate;
+            swap to a dash for indeterminate so "some" reads apart from "all". */}
+        <CheckIcon className="col-start-1 row-start-1 group-data-[indeterminate]/checkbox:hidden" />
+        <MinusIcon className="col-start-1 row-start-1 hidden group-data-[indeterminate]/checkbox:block" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   )

--- a/apps/web/src/components/ui/delete-confirmation-modal.tsx
+++ b/apps/web/src/components/ui/delete-confirmation-modal.tsx
@@ -10,14 +10,19 @@ import {
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 
+type ConfirmMode = "delete" | "archive" | "cancel";
+
 interface DeleteConfirmationModalProps {
 	isOpen: boolean;
 	onClose: () => void;
-	onConfirm: () => void;
+	onConfirm: () => void | Promise<void>;
 	title: string;
 	itemName: string;
 	itemType: string;
-	isArchive?: boolean; // New prop to indicate if this is archiving vs deleting
+	/** Preferred: which flavor of confirmation this is. */
+	mode?: ConfirmMode;
+	/** Shorthand alias for `mode="archive"`; ignored when `mode` is set. */
+	isArchive?: boolean;
 }
 
 const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = ({
@@ -27,20 +32,26 @@ const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = ({
 	title,
 	itemName,
 	itemType,
-	isArchive = false,
+	mode: modeProp,
+	isArchive,
 }) => {
 	const toast = useToast();
+	const mode: ConfirmMode = modeProp ?? (isArchive ? "archive" : "delete");
+	const lowerType = itemType.toLowerCase();
 
 	const handleConfirm = async () => {
 		try {
-			// Execute the confirm action
 			await onConfirm();
 
-			// Show success toast
-			if (isArchive) {
+			if (mode === "archive") {
 				toast.success(
 					`${itemType} Archived`,
 					`"${itemName}" has been archived successfully. You can restore it within 7 days.`
+				);
+			} else if (mode === "cancel") {
+				toast.success(
+					`${itemType} Cancelled`,
+					`"${itemName}" has been cancelled.`
 				);
 			} else {
 				toast.success(
@@ -49,18 +60,23 @@ const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = ({
 				);
 			}
 
-			// Close the modal
 			onClose();
 		} catch (error) {
-			// Show error toast if something goes wrong
+			const verb =
+				mode === "archive"
+					? "archive"
+					: mode === "cancel"
+						? "cancel"
+						: "delete";
 			toast.error(
-				`Failed to ${
-					isArchive ? "archive" : "delete"
-				} ${itemType.toLowerCase()}`,
+				`Failed to ${verb} ${lowerType}`,
 				error instanceof Error ? error.message : "An unexpected error occurred"
 			);
 		}
 	};
+
+	// Red destructive framing only for permanent deletes; archive/cancel are amber.
+	const iconColor = mode === "delete" ? "text-red-500" : "text-yellow-500";
 
 	return (
 		<AlertDialog
@@ -74,109 +90,145 @@ const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = ({
 					<AlertDialogTitle>{title}</AlertDialogTitle>
 				</AlertDialogHeader>
 				<div className="space-y-4">
-				<div className="flex items-center space-x-3">
-					<div className="shrink-0">
-						<svg
-							className="h-10 w-10 text-red-500"
-							fill="none"
-							viewBox="0 0 24 24"
-							strokeWidth="1.5"
-							stroke="currentColor"
+					<div className="flex items-center space-x-3">
+						<div className="shrink-0">
+							<svg
+								className={`h-10 w-10 ${iconColor}`}
+								fill="none"
+								viewBox="0 0 24 24"
+								strokeWidth="1.5"
+								stroke="currentColor"
+							>
+								<path
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+								/>
+							</svg>
+						</div>
+						<div>
+							<h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
+								Are you sure?
+							</h3>
+							<p className="text-sm text-gray-600 dark:text-gray-400">
+								{mode === "archive" ? (
+									<>
+										This will archive the <strong>{itemType}</strong> &quot;
+										{itemName}&quot;. Archived {lowerType}s will have all
+										associated details deleted in 7 days, but you can restore
+										them before then.
+									</>
+								) : mode === "cancel" ? (
+									<>
+										This will cancel the <strong>{itemType}</strong> &quot;
+										{itemName}&quot;. No further activity will be recorded
+										against it.
+									</>
+								) : (
+									<>
+										This action cannot be undone. This will permanently delete the{" "}
+										<strong>{itemType}</strong> &quot;{itemName}&quot; and remove
+										all associated data.
+									</>
+								)}
+							</p>
+						</div>
+					</div>
+
+					{mode === "delete" && (
+						<div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md p-3">
+							<div className="flex">
+								<div className="shrink-0">
+									<svg
+										className="h-5 w-5 text-red-400"
+										viewBox="0 0 20 20"
+										fill="currentColor"
+									>
+										<path
+											fillRule="evenodd"
+											d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z"
+											clipRule="evenodd"
+										/>
+									</svg>
+								</div>
+								<div className="ml-3">
+									<p className="text-sm text-red-700 dark:text-red-300">
+										<strong>Warning:</strong> This is a destructive action that
+										cannot be reversed.
+									</p>
+								</div>
+							</div>
+						</div>
+					)}
+
+					{mode === "archive" && (
+						<div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-md p-3">
+							<div className="flex">
+								<div className="shrink-0">
+									<svg
+										className="h-5 w-5 text-yellow-400"
+										viewBox="0 0 20 20"
+										fill="currentColor"
+									>
+										<path
+											fillRule="evenodd"
+											d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
+											clipRule="evenodd"
+										/>
+									</svg>
+								</div>
+								<div className="ml-3">
+									<p className="text-sm text-yellow-700 dark:text-yellow-300">
+										<strong>Archive Notice:</strong> Archived items can be
+										restored within 7 days. After 7 days, they will be permanently
+										deleted.
+									</p>
+								</div>
+							</div>
+						</div>
+					)}
+
+					{mode === "cancel" && (
+						<div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-md p-3">
+							<div className="flex">
+								<div className="shrink-0">
+									<svg
+										className="h-5 w-5 text-yellow-400"
+										viewBox="0 0 20 20"
+										fill="currentColor"
+									>
+										<path
+											fillRule="evenodd"
+											d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z"
+											clipRule="evenodd"
+										/>
+									</svg>
+								</div>
+								<div className="ml-3">
+									<p className="text-sm text-yellow-700 dark:text-yellow-300">
+										<strong>Note:</strong> The {lowerType} won&apos;t be deleted —
+										it will be marked cancelled and kept for your records.
+									</p>
+								</div>
+							</div>
+						</div>
+					)}
+
+					<div className="flex justify-end space-x-3">
+						<Button onClick={onClose} variant="secondary">
+							{mode === "cancel" ? `Keep ${itemType}` : "Cancel"}
+						</Button>
+						<Button
+							onClick={handleConfirm}
+							variant={mode === "archive" ? "outline" : "destructive"}
 						>
-							<path
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
-							/>
-						</svg>
+							{mode === "archive"
+								? `Archive ${itemType}`
+								: mode === "cancel"
+									? `Cancel ${itemType}`
+									: `Delete ${itemType}`}
+						</Button>
 					</div>
-					<div>
-						<h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
-							Are you sure?
-						</h3>
-						<p className="text-sm text-gray-600 dark:text-gray-400">
-							{isArchive ? (
-								<>
-									This will archive the <strong>{itemType}</strong> &quot;
-									{itemName}&quot;. Archived {itemType.toLowerCase()}s will have
-									all associated details deleted in 7 days, but you can restore
-									them before then.
-								</>
-							) : (
-								<>
-									This action cannot be undone. This will permanently delete the{" "}
-									<strong>{itemType}</strong> &quot;{itemName}&quot; and remove
-									all associated data.
-								</>
-							)}
-						</p>
-					</div>
-				</div>
-
-				{!isArchive && (
-					<div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md p-3">
-						<div className="flex">
-							<div className="shrink-0">
-								<svg
-									className="h-5 w-5 text-red-400"
-									viewBox="0 0 20 20"
-									fill="currentColor"
-								>
-									<path
-										fillRule="evenodd"
-										d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z"
-										clipRule="evenodd"
-									/>
-								</svg>
-							</div>
-							<div className="ml-3">
-								<p className="text-sm text-red-700 dark:text-red-300">
-									<strong>Warning:</strong> This is a destructive action that
-									cannot be reversed.
-								</p>
-							</div>
-						</div>
-					</div>
-				)}
-
-				{isArchive && (
-					<div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-md p-3">
-						<div className="flex">
-							<div className="shrink-0">
-								<svg
-									className="h-5 w-5 text-yellow-400"
-									viewBox="0 0 20 20"
-									fill="currentColor"
-								>
-									<path
-										fillRule="evenodd"
-										d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
-										clipRule="evenodd"
-									/>
-								</svg>
-							</div>
-							<div className="ml-3">
-								<p className="text-sm text-yellow-700 dark:text-yellow-300">
-									<strong>Archive Notice:</strong> Archived items can be
-									restored within 7 days. After 7 days, they will be permanently
-									deleted.
-								</p>
-							</div>
-						</div>
-					</div>
-				)}
-
-				<div className="flex justify-end space-x-3">
-					<Button onClick={onClose} variant="secondary">
-						Cancel
-					</Button>
-					<Button
-						onClick={handleConfirm}
-						variant={isArchive ? "outline" : "destructive"}
-					>
-						{isArchive ? `Archive ${itemType}` : `Delete ${itemType}`}
-					</Button>
-				</div>
 				</div>
 			</AlertDialogContent>
 		</AlertDialog>


### PR DESCRIPTION
This pull request implements comprehensive permission-based access control for client-related UI components. It ensures that users only see or interact with actions they are allowed to perform, disables or hides UI elements when permissions are lacking, and adds clear "Read Only" indicators when appropriate. The changes touch all major client views, including detail drawers, sidebars, headers, and tables, and refactor data fetching to avoid permission errors.

**Permission-based UI controls and indicators:**

* All client action buttons (e.g., add/edit task, project, quote, email, archive, restore) are now disabled if the user lacks the relevant permission, using the `usePermissions` hook and the `can` function. [[1]](diffhunk://#diff-37689e8f685c26ad342db5eedd13d6a7857ef47b663f56afb56a061bb730dbeeL187-R205) [[2]](diffhunk://#diff-37689e8f685c26ad342db5eedd13d6a7857ef47b663f56afb56a061bb730dbeeL205-R249) [[3]](diffhunk://#diff-3db6ca6f3b975ba8b4c9aad77523351bd948f58bea4e0a40a7729a15059f360bL99-R134) [[4]](diffhunk://#diff-3db6ca6f3b975ba8b4c9aad77523351bd948f58bea4e0a40a7729a15059f360bR35) [[5]](diffhunk://#diff-37689e8f685c26ad342db5eedd13d6a7857ef47b663f56afb56a061bb730dbeeR94-R96)
* "Read Only" badges are displayed in the client detail drawer and sidebar when the user does not have modification rights, and edit affordances (like the pencil icon and row hover/click) are hidden or disabled. [[1]](diffhunk://#diff-37689e8f685c26ad342db5eedd13d6a7857ef47b663f56afb56a061bb730dbeeL166-R184) [[2]](diffhunk://#diff-50f4ee8feccf2892fe772117c4fad5c40f02f638dc8417a0a9d39a9205e49f4dL237-R273) [[3]](diffhunk://#diff-50f4ee8feccf2892fe772117c4fad5c40f02f638dc8417a0a9d39a9205e49f4dR118-R125)

**Permission-gated data fetching:**

* All `useQuery` calls for client-related data (quotes, projects, invoices, tasks, email threads) are now conditionally executed only if the user has the relevant "view" permission, preventing forbidden errors and unnecessary requests. ([apps/web/src/app/(workspace)/clients/[clientId]/page.tsxL44-R70](diffhunk://#diff-52fab02d5ab974663f9a97215b28ce8d432a03c895ff6fc585f50c4a9160c8acL44-R70), [apps/web/src/app/(workspace)/clients/[clientId]/page.tsxR22](diffhunk://#diff-52fab02d5ab974663f9a97215b28ce8d432a03c895ff6fc585f50c4a9160c8acR22), [apps/web/src/app/(workspace)/clients/[clientId]/page.tsxR4](diffhunk://#diff-52fab02d5ab974663f9a97215b28ce8d432a03c895ff6fc585f50c4a9160c8acR4))

**Granular field-level editing and controls:**

* Editing client fields (name, status, lead source, description, tags, communication preference) in the sidebar is now only possible if the user has modification rights; otherwise, the UI is read-only and interactive elements are disabled. [[1]](diffhunk://#diff-50f4ee8feccf2892fe772117c4fad5c40f02f638dc8417a0a9d39a9205e49f4dR156) [[2]](diffhunk://#diff-50f4ee8feccf2892fe772117c4fad5c40f02f638dc8417a0a9d39a9205e49f4dR189) [[3]](diffhunk://#diff-50f4ee8feccf2892fe772117c4fad5c40f02f638dc8417a0a9d39a9205e49f4dR461) [[4]](diffhunk://#diff-50f4ee8feccf2892fe772117c4fad5c40f02f638dc8417a0a9d39a9205e49f4dL320-R342) [[5]](diffhunk://#diff-50f4ee8feccf2892fe772117c4fad5c40f02f638dc8417a0a9d39a9205e49f4dL356-R378) [[6]](diffhunk://#diff-50f4ee8feccf2892fe772117c4fad5c40f02f638dc8417a0a9d39a9205e49f4dL395-R417) [[7]](diffhunk://#diff-50f4ee8feccf2892fe772117c4fad5c40f02f638dc8417a0a9d39a9205e49f4dL281-R303)

**Table and bulk actions:**

* The clients table disables the archive/delete action for users without delete permissions, and the column configuration now distinguishes between modify and delete permissions. [[1]](diffhunk://#diff-bfa6a51d283906f06ade4220834d0476b2b1804f71298c7b7b9c3ba46ad85a65L195-R196) [[2]](diffhunk://#diff-bfa6a51d283906f06ade4220834d0476b2b1804f71298c7b7b9c3ba46ad85a65R310) [[3]](diffhunk://#diff-bfa6a51d283906f06ade4220834d0476b2b1804f71298c7b7b9c3ba46ad85a65R406)

**Error handling improvements:**

* In the automations table, error toasts are now handled only by the modal, preventing duplicate notifications on deletion errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added permission-aware controls across clients, projects, quotes, invoices, tasks, automations, and SKU selection, including read-only lock badges and disabled editing/status actions.
  * Restricted data loads when access is unavailable to avoid permission errors and improve loading states.
  * Enhanced delete/confirm dialogs with distinct flows for delete, archive, and cancel.
  * Checkbox indeterminate state now shows a minus icon.

* **Bug Fixes**
  * Standardized confirmation success/error handling so modal-level feedback is shown consistently.
  * Corrected primary foreground theme color and improved indeterminate checkbox styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies a consistent RBAC permission layer across all major workspace views (clients, projects, quotes, invoices, tasks, automations). It gates both data-fetching queries and UI action controls via `usePermissions().can()`, and refactors confirmation-dialog handlers so `DeleteConfirmationModal` owns all success/error toasts rather than duplicating them in page-level callbacks.

- **Permission-gated queries**: `useQuery` calls for related records (quotes, projects, invoices, tasks, email threads, SKUs) are now conditionally skipped with `"skip"` when the user lacks the relevant grant, preventing FORBIDDEN errors for restricted roles.
- **UI controls and Read Only indicators**: Action buttons (create, edit, status transitions, archive/delete) are disabled via `disabled={!can(...)}`, inline-edit affordances (hover highlight, cursor, pencil icon) are removed when `canModify` is false, and "Read Only" badges appear in drawers and sidebars once permissions finish loading.
- **Checkbox indeterminate affordance + CSS fixes**: The `Checkbox` component gains a `MinusIcon` indicator for indeterminate state, backed by a new `@custom-variant data-indeterminate` in `reui-nova.css`; `globals.css` also corrects `--color-primary-foreground` to reference the defined `--primary-fg` variable instead of the previously-undefined `--primary-foreground`.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the permission enforcement is consistent and well-structured, existing DeleteConfirmationModal behaviour is correctly relied upon, and the CSS variable fix resolves a previously-broken reference.

The pattern is applied correctly and comprehensively across 30 files. Two non-blocking issues are worth addressing: the Generate PDF buttons gate a client-side export on the modify permission, blocking view-only users from downloading documents; and reports/page.tsx confirmDelete still manually closes the modal on success while every other refactored page delegates that to DeleteConfirmationModal.

apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-header.tsx and apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-header.tsx (Generate PDF permission gate); apps/web/src/app/(workspace)/reports/page.tsx (modal-close inconsistency).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/(workspace)/clients/[clientId]/page.tsx | Adds permission-gated useQuery calls for quotes, projects, invoices, tasks, and email threads, preventing FORBIDDEN errors for users without the corresponding view grants. |
| apps/web/src/app/(workspace)/clients/components/client-detail-drawer.tsx | Adds 'Read Only' badge when user lacks clients.modify, disables Add Task / Email / Restore / Archive buttons per permission, and passes canModify to StatusControl to disable the status Select. |
| apps/web/src/app/(workspace)/clients/components/client-detail-sidebar.tsx | Gates inline field editing (name, status, lead source, description, communication preference, tags) on clients.modify; shows 'Read Only' badge and removes hover/cursor affordances when read-only. |
| apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-header.tsx | All status-change, Send to Client, Generate PDF, and Cancel buttons are gated on invoices.modify; Generate PDF blocks read-only users unnecessarily since it is a client-side export with no server mutation. |
| apps/web/src/app/(workspace)/reports/page.tsx | Removes try/catch from confirmDelete and lets errors propagate, but still manually calls setDeleteModalOpen(false) on success — inconsistent with the pattern applied in every other refactored page. |
| apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-header.tsx | Status-change, Send for e-signature, Generate PDF, and Delete buttons are permission-gated; Generate PDF is gated on quotes.modify rather than the read-only grant, restricting view-only users from exporting. |
| apps/web/src/components/ui/checkbox.tsx | Adds indeterminate-state support: renders both CheckIcon and MinusIcon with CSS toggling via group-data-[indeterminate]/checkbox Tailwind variants, matching the new @custom-variant declaration in reui-nova.css. |
| apps/web/src/app/globals.css | Fixes --color-primary-foreground to reference the correct --primary-fg variable (defined in globals.css) rather than the previously-undefined --primary-foreground. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Component mounts] --> B[usePermissions hook]
    B --> C{isLoading?}
    C -->|yes| D[can returns false\nbuttons disabled\nRead Only badge hidden]
    C -->|no| E{can resource, action ?}
    E -->|true| F[Button enabled\nInline editing active\nQuery runs normally]
    E -->|false| G[Button disabled\nRead Only badge shown\nInline editing blocked]
    G --> H{Data query needs\nview grant?}
    F --> H
    H -->|can resource| I[useQuery runs]
    H -->|no grant| J[useQuery skipped]
    I --> K[Data rendered]
    J --> L[Graceful fallback\ne.g. clientName = Unknown Client]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Component mounts] --> B[usePermissions hook]
    B --> C{isLoading?}
    C -->|yes| D[can returns false\nbuttons disabled\nRead Only badge hidden]
    C -->|no| E{can resource, action ?}
    E -->|true| F[Button enabled\nInline editing active\nQuery runs normally]
    E -->|false| G[Button disabled\nRead Only badge shown\nInline editing blocked]
    G --> H{Data query needs\nview grant?}
    F --> H
    H -->|can resource| I[useQuery runs]
    H -->|no grant| J[useQuery skipped]
    I --> K[Data rendered]
    J --> L[Graceful fallback\ne.g. clientName = Unknown Client]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/src/app/(workspace)/reports/page.tsx:133-139
**Inconsistent modal-close pattern with the rest of the PR**

Every other refactored `confirmDelete` in this PR (clients, quotes, invoices, projects) removes the explicit `setDeleteModalOpen(false)` / `setXxxToDelete(null)` calls on success and relies on `DeleteConfirmationModal.handleConfirm → onClose()` to close. Here both `setDeleteModalOpen(false)` and `setReportToDelete(null)` are still called after the `await`, causing a double invocation of `onClose()` (since the modal's `handleConfirm` calls it too). It works because setting state to the same value is idempotent, but it contradicts the comment above and will confuse future maintainers.

### Issue 2 of 2
apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-header.tsx:190-200
**"Generate PDF" gated on modify permission unnecessarily restricts read-only users**

`handleGeneratePdf` in `invoices/[invoiceId]/page.tsx` uses `@react-pdf/renderer` entirely client-side — it reads the already-fetched invoice data, builds a blob, and triggers a browser download with no server mutation. Requiring `invoices.modify` to generate a PDF means a user who can view an invoice but not edit it cannot export it. The same concern applies to "Generate PDF" in `quote-detail-header.tsx` (`can("quotes", "modify")`). Consider moving these to a read-only permission check (`can("invoices")` / `can("quotes")`) so view-only users can still export documents.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(rbac): read-only gating for records..."](https://github.com/xcarter93/onetool/commit/54a1303000e9f1d8814672a544a7251328248421) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43629832)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->