### PR TITLE
feat(org): dedicated Team tab for member roster + RBAC access management

### DIFF
--- a/apps/web/src/app/(workspace)/organization/profile/_components/overview-tab.tsx
+++ b/apps/web/src/app/(workspace)/organization/profile/_components/overview-tab.tsx
@@ -1,42 +1,13 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
-import {
-	useOrganization,
-	useClerk,
-	useReverification,
-} from "@clerk/nextjs";
-import {
-	isClerkAPIResponseError,
-	isReverificationCancelledError,
-} from "@clerk/nextjs/errors";
-import { useMutation, useQuery } from "convex/react";
+import { useCallback, useRef, useState } from "react";
+import { useOrganization, useClerk, useReverification } from "@clerk/nextjs";
+import { isReverificationCancelledError } from "@clerk/nextjs/errors";
+import { useMutation } from "convex/react";
 import { useRouter } from "next/navigation";
-import {
-	ColumnDef,
-	getCoreRowModel,
-	getSortedRowModel,
-	SortingState,
-	useReactTable,
-} from "@tanstack/react-table";
-import {
-	Lock,
-	Mail,
-	ShieldCheck,
-	Upload,
-	UserPlus,
-	Trash2,
-	LogOut,
-	Loader2,
-} from "lucide-react";
+import { Lock, Upload, Trash2, LogOut, Loader2 } from "lucide-react";
 
-import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
-import {
-	InputGroup,
-	InputGroupAddon,
-	InputGroupInput,
-} from "@/components/ui/input-group";
 import { Field, FieldLabel, FieldError } from "@/components/ui/field";
 import { Button } from "@/components/ui/button";
 import {
@@ -44,7 +15,6 @@ import {
 	AvatarImage,
 	AvatarFallback,
 } from "@/components/ui/avatar";
-import { Badge } from "@/components/reui/badge";
 import {
 	Frame,
 	FrameHeader,
@@ -53,26 +23,6 @@ import {
 	FramePanel,
 	FrameFooter,
 } from "@/components/reui/frame";
-import {
-	DataGrid,
-	DataGridContainer,
-} from "@/components/reui/data-grid/data-grid";
-import { DataGridTable } from "@/components/reui/data-grid/data-grid-table";
-import {
-	Select,
-	SelectTrigger,
-	SelectValue,
-	SelectContent,
-	SelectItem,
-} from "@/components/ui/select";
-import {
-	Item,
-	ItemMedia,
-	ItemContent,
-	ItemTitle,
-	ItemDescription,
-	ItemActions,
-} from "@/components/ui/item";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/hooks/use-toast";
 import { useConfirmDialog } from "@/hooks/use-confirm-dialog";
@@ -80,54 +30,9 @@ import { api } from "@onetool/backend/convex/_generated/api";
 import { useOrgOwner } from "../_hooks/use-org-owner";
 import { useSaveValidation } from "../_hooks/use-save-validation";
 import { useRegisterSettingsSave } from "../_hooks/use-settings-save";
-import { Eyebrow, SectionHeading } from "./settings-card";
-
-// Clerk role keys round-trip verbatim through the org webhook. The instance uses
-// only the two Clerk defaults; gate on Clerk's live membership.role (NOT the
-// Convex `role` column, which is written inconsistently).
-const ADMIN_ROLE = "org:admin";
-const MEMBER_ROLE = "org:member";
-const ROLE_OPTIONS = [
-	{ value: ADMIN_ROLE, label: "Admin" },
-	{ value: MEMBER_ROLE, label: "Member" },
-];
-
-// Opt-in fetch params, hoisted so the object identity is stable across renders.
-const ORGANIZATION_PARAMS = {
-	memberships: { pageSize: 20 },
-	invitations: { pageSize: 20 },
-};
-
-function roleLabel(role: string | undefined | null) {
-	if (role === ADMIN_ROLE) return "Admin";
-	if (role === MEMBER_ROLE) return "Member";
-	return role ?? "Member";
-}
-
-function getInitials(name: string, email?: string) {
-	const src = name.trim() || (email ?? "").trim();
-	const parts = src.split(/\s+/).filter(Boolean);
-	if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
-	if (src.length >= 2) return src.slice(0, 2).toUpperCase();
-	return src.slice(0, 1).toUpperCase() || "?";
-}
-
-function memberDisplayName(member: {
-	publicUserData?:
-		| { firstName?: string | null; lastName?: string | null; identifier?: string | null }
-		| null;
-}) {
-	const info = member.publicUserData;
-	const name = `${info?.firstName ?? ""} ${info?.lastName ?? ""}`.trim();
-	return name || info?.identifier || "";
-}
-
-function clerkErr(err: unknown, fallback = "Something went wrong.") {
-	if (isClerkAPIResponseError(err)) {
-		return err.errors[0]?.longMessage ?? err.errors[0]?.message ?? fallback;
-	}
-	return err instanceof Error ? err.message : fallback;
-}
+import { SectionHeading } from "./settings-card";
+import { TeamMembersTable } from "./team-members-table";
+import { ADMIN_ROLE, getInitials, clerkErr } from "../_lib/org-members";
 
 export function OverviewTab() {
 	const router = useRouter();
@@ -137,15 +42,9 @@ export function OverviewTab() {
 	const { isOwner } = useOrgOwner();
 	const updateOrganization = useMutation(api.organizations.update);
 
-	const { organization, membership, memberships, invitations, isLoaded } =
-		useOrganization(ORGANIZATION_PARAMS);
+	const { organization, membership, isLoaded } = useOrganization();
 
 	const isAdmin = membership?.role === ADMIN_ROLE;
-
-	type MemberRow = NonNullable<NonNullable<typeof memberships>["data"]>[number];
-	type InviteRow = NonNullable<
-		NonNullable<typeof invitations>["data"]
-	>[number];
 
 	// Reverification-guarded destroy (Clerk renders its own step-up modal).
 	const deleteOrganization = useReverification(() => organization!.destroy());
@@ -172,31 +71,14 @@ export function OverviewTab() {
 		}
 	}
 
-	// Invitations form.
-	const {
-		showErrors: inviteShowErrors,
-		markSaveAttempt: markInviteAttempt,
-		clearErrors: clearInviteErrors,
-	} = useSaveValidation();
-	const [inviteEmail, setInviteEmail] = useState("");
-	const [inviteRole, setInviteRole] = useState(MEMBER_ROLE);
-	const [inviting, setInviting] = useState(false);
-
-	// Per-row in-flight ids.
-	const [pendingMemberId, setPendingMemberId] = useState<string | null>(null);
-	const [pendingInviteId, setPendingInviteId] = useState<string | null>(null);
 	const [leaving, setLeaving] = useState(false);
 	const [deleting, setDeleting] = useState(false);
 
 	const nameInvalid = nameShowErrors && !orgName.trim();
-	const inviteInvalid = inviteShowErrors && !inviteEmail.trim();
 
 	// Org-name save/discard, registered with the container's unified footer.
 	// Both callbacks — and the registration hook itself — must run on every
 	// render (before the loading early-return below) to satisfy Rules of Hooks.
-	// `organization` isn't narrowed non-null yet at this point, so each guards
-	// on it directly; that's a no-op in practice since `dirty` can't be true
-	// until the form is seeded from a loaded organization.
 	const handleSaveName = useCallback(async () => {
 		if (!organization || !isAdmin) return;
 		markNameAttempt();
@@ -234,240 +116,6 @@ export function OverviewTab() {
 		save: handleSaveName,
 		discard: handleDiscardName,
 		saveLabel: "Save changes",
-	});
-
-	// Per-member access summary for the Access chip + "Manage access" link,
-	// joined to Clerk rows by externalId (Clerk user id). Admin-only surface.
-	const accessRows = useQuery(
-		api.permissions.orgMemberAccess,
-		isAdmin ? {} : "skip",
-	);
-	type AccessRow = NonNullable<typeof accessRows>[number];
-	const accessByExternalId = useMemo(() => {
-		const map = new Map<string, AccessRow>();
-		accessRows?.forEach((row) => map.set(row.externalId, row));
-		return map;
-	}, [accessRows]);
-
-	const handleRoleChange = async (
-		member: MemberRow,
-		role: string,
-	) => {
-		if (member.role === role) return;
-		setPendingMemberId(member.id);
-		try {
-			await member.update({ role });
-			await memberships?.revalidate?.();
-			toast.success("Role updated", "The member's role has been changed.");
-		} catch (error) {
-			toast.error("Couldn't update role", clerkErr(error));
-		} finally {
-			setPendingMemberId(null);
-		}
-	};
-
-	const handleRemoveMember = async (member: MemberRow) => {
-		const confirmed = await confirmDialog({
-			title: "Remove member",
-			message: `Remove ${memberDisplayName(member) || "this member"} from the organization? They'll lose access immediately.`,
-			confirmLabel: "Remove member",
-			cancelLabel: "Cancel",
-			variant: "destructive",
-		});
-		if (!confirmed) return;
-		setPendingMemberId(member.id);
-		try {
-			await member.destroy();
-			await memberships?.revalidate?.();
-			toast.success("Member removed", "They no longer have access.");
-		} catch (error) {
-			toast.error("Couldn't remove member", clerkErr(error));
-		} finally {
-			setPendingMemberId(null);
-		}
-	};
-
-	const members = memberships?.data ?? [];
-
-	const memberColumns = useMemo<ColumnDef<MemberRow>[]>(() => {
-		const base: ColumnDef<MemberRow>[] = [
-			{
-				id: "member",
-				accessorFn: (member) => memberDisplayName(member),
-				header: "Member",
-				cell: ({ row }) => {
-					const member = row.original;
-					const info = member.publicUserData;
-					const name = memberDisplayName(member);
-					const email = info?.identifier ?? "";
-					const isSelf = member.id === membership?.id;
-					return (
-						<div className="flex items-center gap-3">
-							<Avatar className="size-8">
-								{info?.imageUrl ? (
-									<AvatarImage src={info.imageUrl} alt="" />
-								) : null}
-								<AvatarFallback className="text-xs font-medium">
-									{getInitials(name, email)}
-								</AvatarFallback>
-							</Avatar>
-							<div className="flex flex-col">
-								<span className="text-sm font-medium text-foreground">
-									{name}
-									{isSelf && (
-										<span className="font-normal text-muted-foreground">
-											{" "}
-											(you)
-										</span>
-									)}
-								</span>
-								{email && name !== email && (
-									<span className="text-xs text-muted-foreground">{email}</span>
-								)}
-							</div>
-						</div>
-					);
-				},
-			},
-			{
-				id: "role",
-				header: "Role",
-				cell: ({ row }) => {
-					const member = row.original;
-					const isSelf = member.id === membership?.id;
-					const access = accessByExternalId.get(member.publicUserData?.userId ?? "");
-					const isOwnerRow = access?.isOwner ?? false;
-					const rowBusy = pendingMemberId === member.id;
-					if (isAdmin && !isSelf && !isOwnerRow) {
-						return (
-							<Select
-								value={member.role}
-								onValueChange={(value) => {
-									if (value) handleRoleChange(member, value);
-								}}
-								disabled={rowBusy}
-							>
-								<SelectTrigger size="sm" className="w-28">
-									<SelectValue />
-								</SelectTrigger>
-								<SelectContent>
-									{ROLE_OPTIONS.map((option) => (
-										<SelectItem key={option.value} value={option.value}>
-											{option.label}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
-						);
-					}
-					if (isOwnerRow) {
-						return (
-							<Badge variant="primary-light" radius="full" size="lg">
-								<Lock className="h-3 w-3" aria-hidden="true" /> Owner
-							</Badge>
-						);
-					}
-					return (
-						<Badge
-							variant={member.role === ADMIN_ROLE ? "primary-light" : "secondary"}
-							radius="full"
-							size="lg"
-						>
-							{roleLabel(member.role)}
-						</Badge>
-					);
-				},
-			},
-		];
-
-		if (!isAdmin) return base;
-
-		return [
-			...base,
-			{
-				id: "access",
-				header: "Access",
-				cell: ({ row }) => {
-					const member = row.original;
-					const access = accessByExternalId.get(member.publicUserData?.userId ?? "");
-					if (accessRows === undefined) {
-						return <div className="h-5 w-16 animate-pulse rounded-full bg-muted" />;
-					}
-					if (!access) {
-						return <span className="text-xs text-muted-foreground">—</span>;
-					}
-					const label =
-						access.isOwner || access.isAdmin
-							? "Full access"
-							: access.hasCustomPermissions
-								? "Custom"
-								: "Default";
-					return (
-						<Badge variant="outline" radius="full" size="lg">
-							{label}
-						</Badge>
-					);
-				},
-			},
-			{
-				id: "actions",
-				header: "",
-				cell: ({ row }) => {
-					const member = row.original;
-					const isSelf = member.id === membership?.id;
-					if (isSelf) return null;
-					const rowBusy = pendingMemberId === member.id;
-					const access = accessByExternalId.get(member.publicUserData?.userId ?? "");
-					const isOwnerRow = access?.isOwner ?? false;
-					const convexUserId = access?.userId;
-					const name = memberDisplayName(member) || "this member";
-					return (
-						<div
-							className="flex items-center justify-end gap-2"
-							onClick={(e) => e.stopPropagation()}
-						>
-							{!isOwnerRow && convexUserId && (
-								<Button
-									variant="outline"
-									size="icon-sm"
-									aria-label={`Manage access for ${name}`}
-									onClick={() =>
-										router.push(`/organization/profile/members/${convexUserId}`)
-									}
-								>
-									<ShieldCheck className="h-4 w-4" />
-								</Button>
-							)}
-							<Button
-								variant="outline"
-								size="icon-sm"
-								aria-label="Remove member"
-								disabled={rowBusy}
-								onClick={() => handleRemoveMember(member)}
-								className="hover:border-destructive/40 hover:bg-destructive/10 hover:text-destructive"
-							>
-								{rowBusy ? (
-									<Loader2 className="h-4 w-4 animate-spin" />
-								) : (
-									<Trash2 className="h-4 w-4" />
-								)}
-							</Button>
-						</div>
-					);
-				},
-			},
-		];
-	}, [isAdmin, membership?.id, accessByExternalId, accessRows, pendingMemberId, router]);
-
-	const [memberSorting, setMemberSorting] = useState<SortingState>([]);
-	const memberTable = useReactTable({
-		data: members,
-		columns: memberColumns,
-		state: { sorting: memberSorting },
-		onSortingChange: setMemberSorting,
-		getRowId: (member) => member.id,
-		getCoreRowModel: getCoreRowModel(),
-		getSortedRowModel: getSortedRowModel(),
 	});
 
 	if (!isLoaded || !organization) {
@@ -513,45 +161,6 @@ export function OverviewTab() {
 		} finally {
 			setUploadingLogo(false);
 			if (logoInputRef.current) logoInputRef.current.value = "";
-		}
-	};
-
-	const handleInvite = async () => {
-		markInviteAttempt();
-		const email = inviteEmail.trim();
-		if (!email) return;
-		setInviting(true);
-		try {
-			await organization.inviteMember({ emailAddress: email, role: inviteRole });
-			await invitations?.revalidate?.();
-			setInviteEmail("");
-			clearInviteErrors();
-			toast.success("Invitation sent", `Invited ${email}.`);
-		} catch (error) {
-			toast.error("Couldn't send invitation", clerkErr(error));
-		} finally {
-			setInviting(false);
-		}
-	};
-
-	const handleRevoke = async (invitation: InviteRow) => {
-		const confirmed = await confirmDialog({
-			title: "Revoke invitation",
-			message: `Revoke the invitation for ${invitation.emailAddress}?`,
-			confirmLabel: "Revoke",
-			cancelLabel: "Cancel",
-			variant: "destructive",
-		});
-		if (!confirmed) return;
-		setPendingInviteId(invitation.id);
-		try {
-			await invitation.revoke();
-			await invitations?.revalidate?.();
-			toast.success("Invitation revoked", "The invite is no longer valid.");
-		} catch (error) {
-			toast.error("Couldn't revoke invitation", clerkErr(error));
-		} finally {
-			setPendingInviteId(null);
 		}
 	};
 
@@ -602,9 +211,6 @@ export function OverviewTab() {
 		}
 	};
 
-	const pendingInvites = (invitations?.data ?? []).filter(
-		(invitation) => invitation.status === "pending",
-	);
 	const orgImageUrl = organization.imageUrl;
 	const viewOnlyBadge = !isAdmin ? (
 		<span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/60 px-2.5 py-1 text-xs font-medium text-muted-foreground">
@@ -616,7 +222,7 @@ export function OverviewTab() {
 		<div className="space-y-8">
 			<SectionHeading
 				title="Organization"
-				description="Manage your organization's profile, team, and invitations."
+				description="Manage your organization's profile and branding."
 				aside={viewOnlyBadge}
 			/>
 
@@ -706,193 +312,8 @@ export function OverviewTab() {
 				</FrameFooter>
 			</Frame>
 
-			{/* Members + invitations */}
-			<div
-				className={cn(
-					"grid items-start gap-6",
-					isAdmin && "lg:grid-cols-2",
-				)}
-			>
-				<Frame>
-					<FrameHeader className="flex-row items-center justify-between gap-3">
-						<div className="flex flex-col gap-0.5">
-							<FrameTitle>Team members</FrameTitle>
-							<FrameDescription>
-								People with access to this organization.
-							</FrameDescription>
-						</div>
-						<Badge
-							variant="secondary"
-							radius="full"
-							size="lg"
-							className="shrink-0"
-						>
-							{memberships?.count ?? members.length}
-						</Badge>
-					</FrameHeader>
-
-					<DataGrid
-						table={memberTable}
-						recordCount={members.length}
-						emptyMessage="No members yet."
-						tableLayout={{ width: "auto", headerBackground: true }}
-					>
-						<FramePanel className="p-0">
-							<div className="overflow-x-auto">
-								<DataGridContainer className="rounded-lg border">
-									<DataGridTable />
-								</DataGridContainer>
-							</div>
-						</FramePanel>
-
-						{memberships?.hasNextPage && (
-							<FrameFooter className="items-center">
-								<Button
-									variant="ghost"
-									size="sm"
-									onClick={() => memberships.fetchNext?.()}
-									disabled={memberships.isFetching}
-								>
-									{memberships.isFetching && (
-										<Loader2 className="h-4 w-4 animate-spin" />
-									)}
-									Load more
-								</Button>
-							</FrameFooter>
-						)}
-					</DataGrid>
-				</Frame>
-
-				{/* Invitations (admins only) */}
-				{isAdmin && (
-					<Frame>
-						<FrameHeader>
-							<FrameTitle>Invitations</FrameTitle>
-							<FrameDescription>
-								Invite teammates by email. They&apos;ll get a link to join this
-								organization.
-							</FrameDescription>
-						</FrameHeader>
-
-						<FramePanel className="p-0">
-							<div className="flex flex-col gap-3 p-4 sm:flex-row sm:items-start sm:p-5">
-								<Field
-									className="flex-1"
-									data-invalid={inviteInvalid || undefined}
-								>
-									<FieldLabel htmlFor="invite-email" className="sr-only">
-										Email address
-									</FieldLabel>
-									<InputGroup className={cn(inviting && "opacity-70")}>
-										<InputGroupAddon>
-											<Mail />
-										</InputGroupAddon>
-										<InputGroupInput
-											id="invite-email"
-											type="email"
-											inputMode="email"
-											placeholder="teammate@business.com"
-											value={inviteEmail}
-											disabled={inviting}
-											aria-invalid={inviteInvalid || undefined}
-											onChange={(event) => setInviteEmail(event.target.value)}
-										/>
-									</InputGroup>
-									{inviteInvalid && (
-										<FieldError>Enter an email address to invite.</FieldError>
-									)}
-								</Field>
-								<Select
-									value={inviteRole}
-									onValueChange={(value) => {
-										if (value) setInviteRole(value);
-									}}
-									disabled={inviting}
-								>
-									<SelectTrigger className="sm:w-32">
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										{ROLE_OPTIONS.map((option) => (
-											<SelectItem key={option.value} value={option.value}>
-												{option.label}
-											</SelectItem>
-										))}
-									</SelectContent>
-								</Select>
-								<Button onClick={handleInvite} disabled={inviting}>
-									{inviting ? (
-										<Loader2 className="h-4 w-4 animate-spin" />
-									) : (
-										<UserPlus className="h-4 w-4" />
-									)}
-									Send invite
-								</Button>
-							</div>
-
-							{pendingInvites.length > 0 ? (
-								<div className="border-t border-border">
-									<div className="px-4 pt-3.5">
-										<Eyebrow>Pending</Eyebrow>
-									</div>
-									<div className="divide-y divide-border">
-										{pendingInvites.map((invitation) => {
-											const rowBusy = pendingInviteId === invitation.id;
-											return (
-												<Item
-													key={invitation.id}
-													size="sm"
-													className="px-4 py-3.5"
-												>
-													<ItemMedia variant="icon">
-														<Mail className="h-4 w-4" />
-													</ItemMedia>
-													<ItemContent>
-														<ItemTitle>{invitation.emailAddress}</ItemTitle>
-													</ItemContent>
-													<ItemActions>
-														<Badge
-															variant={
-																invitation.role === ADMIN_ROLE
-																	? "primary-light"
-																	: "secondary"
-															}
-															radius="full"
-															size="lg"
-														>
-															{roleLabel(invitation.role)}
-														</Badge>
-														<Button
-															variant="outline"
-															size="icon-sm"
-															aria-label="Revoke invitation"
-															disabled={rowBusy}
-															onClick={() => handleRevoke(invitation)}
-															className="hover:border-destructive/40 hover:bg-destructive/10 hover:text-destructive"
-														>
-															{rowBusy ? (
-																<Loader2 className="h-4 w-4 animate-spin" />
-															) : (
-																<Trash2 className="h-4 w-4" />
-															)}
-														</Button>
-													</ItemActions>
-												</Item>
-											);
-										})}
-									</div>
-								</div>
-							) : (
-								<div className="border-t border-border px-4 py-3.5">
-									<p className="text-sm text-muted-foreground">
-										No pending invitations.
-									</p>
-								</div>
-							)}
-						</FramePanel>
-					</Frame>
-				)}
-			</div>
+			{/* Team roster (read-only summary; full management lives on the Team tab) */}
+			<TeamMembersTable readOnly />
 
 			{/* Danger zone */}
 			<Frame className="border-destructive/30">

--- a/apps/web/src/app/(workspace)/organization/profile/_components/team-members-table.tsx
+++ b/apps/web/src/app/(workspace)/organization/profile/_components/team-members-table.tsx
@@ -1,0 +1,391 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useOrganization } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+import { useQuery } from "convex/react";
+import {
+	ColumnDef,
+	getCoreRowModel,
+	getSortedRowModel,
+	SortingState,
+	useReactTable,
+} from "@tanstack/react-table";
+import { Lock, ShieldCheck, Trash2, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+	Avatar,
+	AvatarImage,
+	AvatarFallback,
+} from "@/components/ui/avatar";
+import { Badge } from "@/components/reui/badge";
+import {
+	Frame,
+	FrameHeader,
+	FrameTitle,
+	FrameDescription,
+	FramePanel,
+	FrameFooter,
+} from "@/components/reui/frame";
+import {
+	DataGrid,
+	DataGridContainer,
+} from "@/components/reui/data-grid/data-grid";
+import { DataGridTable } from "@/components/reui/data-grid/data-grid-table";
+import {
+	Select,
+	SelectTrigger,
+	SelectValue,
+	SelectContent,
+	SelectItem,
+} from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+import { useConfirmDialog } from "@/hooks/use-confirm-dialog";
+import { api } from "@onetool/backend/convex/_generated/api";
+import {
+	ADMIN_ROLE,
+	ROLE_OPTIONS,
+	ORGANIZATION_PARAMS,
+	roleLabel,
+	getInitials,
+	memberDisplayName,
+	clerkErr,
+} from "../_lib/org-members";
+
+/**
+ * Roster of org members. In `readOnly` mode (the Overview summary) roles render
+ * as static badges with no remove/manage-access controls; the full Team tab
+ * variant lets admins edit roles, remove members, and open the RBAC editor.
+ */
+export function TeamMembersTable({ readOnly = false }: { readOnly?: boolean }) {
+	const router = useRouter();
+	const toast = useToast();
+	const { confirm: confirmDialog } = useConfirmDialog();
+	const { membership, memberships } = useOrganization(ORGANIZATION_PARAMS);
+
+	const isAdmin = membership?.role === ADMIN_ROLE;
+	// Admins get management controls, but the summary variant stays read-only.
+	const canManage = isAdmin && !readOnly;
+
+	type MemberRow = NonNullable<NonNullable<typeof memberships>["data"]>[number];
+
+	const [pendingMemberId, setPendingMemberId] = useState<string | null>(null);
+
+	// Per-member access summary for the Access chip + "Manage access" link,
+	// joined to Clerk rows by externalId (Clerk user id). Admin-only surface.
+	const accessRows = useQuery(
+		api.permissions.orgMemberAccess,
+		isAdmin ? {} : "skip",
+	);
+	type AccessRow = NonNullable<typeof accessRows>[number];
+	const accessByExternalId = useMemo(() => {
+		const map = new Map<string, AccessRow>();
+		accessRows?.forEach((row) => map.set(row.externalId, row));
+		return map;
+	}, [accessRows]);
+
+	const handleRoleChange = async (member: MemberRow, role: string) => {
+		if (member.role === role) return;
+		setPendingMemberId(member.id);
+		try {
+			await member.update({ role });
+			await memberships?.revalidate?.();
+			toast.success("Role updated", "The member's role has been changed.");
+		} catch (error) {
+			toast.error("Couldn't update role", clerkErr(error));
+		} finally {
+			setPendingMemberId(null);
+		}
+	};
+
+	const handleRemoveMember = async (member: MemberRow) => {
+		const confirmed = await confirmDialog({
+			title: "Remove member",
+			message: `Remove ${memberDisplayName(member) || "this member"} from the organization? They'll lose access immediately.`,
+			confirmLabel: "Remove member",
+			cancelLabel: "Cancel",
+			variant: "destructive",
+		});
+		if (!confirmed) return;
+		setPendingMemberId(member.id);
+		try {
+			await member.destroy();
+			await memberships?.revalidate?.();
+			toast.success("Member removed", "They no longer have access.");
+		} catch (error) {
+			toast.error("Couldn't remove member", clerkErr(error));
+		} finally {
+			setPendingMemberId(null);
+		}
+	};
+
+	const members = memberships?.data ?? [];
+
+	const memberColumns = useMemo<ColumnDef<MemberRow>[]>(() => {
+		const base: ColumnDef<MemberRow>[] = [
+			{
+				id: "member",
+				accessorFn: (member) => memberDisplayName(member),
+				header: "Member",
+				cell: ({ row }) => {
+					const member = row.original;
+					const info = member.publicUserData;
+					const name = memberDisplayName(member);
+					const email = info?.identifier ?? "";
+					const isSelf = member.id === membership?.id;
+					return (
+						<div className="flex items-center gap-3">
+							<Avatar className="size-8">
+								{info?.imageUrl ? (
+									<AvatarImage src={info.imageUrl} alt="" />
+								) : null}
+								<AvatarFallback className="text-xs font-medium">
+									{getInitials(name, email)}
+								</AvatarFallback>
+							</Avatar>
+							<div className="flex flex-col">
+								<span className="text-sm font-medium text-foreground">
+									{name}
+									{isSelf && (
+										<span className="font-normal text-muted-foreground">
+											{" "}
+											(you)
+										</span>
+									)}
+								</span>
+								{email && name !== email && (
+									<span className="text-xs text-muted-foreground">{email}</span>
+								)}
+							</div>
+						</div>
+					);
+				},
+			},
+			{
+				id: "role",
+				header: "Role",
+				cell: ({ row }) => {
+					const member = row.original;
+					const isSelf = member.id === membership?.id;
+					const access = accessByExternalId.get(
+						member.publicUserData?.userId ?? "",
+					);
+					const isOwnerRow = access?.isOwner ?? false;
+					const rowBusy = pendingMemberId === member.id;
+					if (canManage && !isSelf && !isOwnerRow) {
+						return (
+							<Select
+								value={member.role}
+								onValueChange={(value) => {
+									if (value) handleRoleChange(member, value);
+								}}
+								disabled={rowBusy}
+							>
+								<SelectTrigger size="sm" className="w-28">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{ROLE_OPTIONS.map((option) => (
+										<SelectItem key={option.value} value={option.value}>
+											{option.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						);
+					}
+					if (isOwnerRow) {
+						return (
+							<Badge variant="primary-light" radius="full" size="lg">
+								<Lock className="h-3 w-3" aria-hidden="true" /> Owner
+							</Badge>
+						);
+					}
+					return (
+						<Badge
+							variant={member.role === ADMIN_ROLE ? "primary-light" : "secondary"}
+							radius="full"
+							size="lg"
+						>
+							{roleLabel(member.role)}
+						</Badge>
+					);
+				},
+			},
+		];
+
+		if (!isAdmin) return base;
+
+		const withAccess: ColumnDef<MemberRow>[] = [
+			...base,
+			{
+				id: "access",
+				header: "Access",
+				cell: ({ row }) => {
+					const member = row.original;
+					const access = accessByExternalId.get(
+						member.publicUserData?.userId ?? "",
+					);
+					if (accessRows === undefined) {
+						return (
+							<div className="h-5 w-16 animate-pulse rounded-full bg-muted" />
+						);
+					}
+					if (!access) {
+						return <span className="text-xs text-muted-foreground">—</span>;
+					}
+					const label =
+						access.isOwner || access.isAdmin
+							? "Full access"
+							: access.hasCustomPermissions
+								? "Custom"
+								: "Default";
+					return (
+						<Badge variant="outline" radius="full" size="lg">
+							{label}
+						</Badge>
+					);
+				},
+			},
+		];
+
+		// The summary (read-only) roster stops here — no remove / manage-access.
+		if (!canManage) return withAccess;
+
+		return [
+			...withAccess,
+			{
+				id: "actions",
+				header: "",
+				cell: ({ row }) => {
+					const member = row.original;
+					const isSelf = member.id === membership?.id;
+					if (isSelf) return null;
+					const rowBusy = pendingMemberId === member.id;
+					const access = accessByExternalId.get(
+						member.publicUserData?.userId ?? "",
+					);
+					const isOwnerRow = access?.isOwner ?? false;
+					const convexUserId = access?.userId;
+					const name = memberDisplayName(member) || "this member";
+					return (
+						<div
+							className="flex items-center justify-end gap-2"
+							onClick={(e) => e.stopPropagation()}
+						>
+							{!isOwnerRow && convexUserId && (
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={() =>
+										router.push(
+											`/organization/profile/members/${convexUserId}`,
+										)
+									}
+								>
+									<ShieldCheck className="h-4 w-4" />
+									Manage access
+								</Button>
+							)}
+							<Button
+								variant="outline"
+								size="icon-sm"
+								aria-label={`Remove ${name}`}
+								disabled={rowBusy}
+								onClick={() => handleRemoveMember(member)}
+								className="hover:border-destructive/40 hover:bg-destructive/10 hover:text-destructive"
+							>
+								{rowBusy ? (
+									<Loader2 className="h-4 w-4 animate-spin" />
+								) : (
+									<Trash2 className="h-4 w-4" />
+								)}
+							</Button>
+						</div>
+					);
+				},
+			},
+		];
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [
+		isAdmin,
+		canManage,
+		membership?.id,
+		accessByExternalId,
+		accessRows,
+		pendingMemberId,
+		router,
+	]);
+
+	const [memberSorting, setMemberSorting] = useState<SortingState>([]);
+	const memberTable = useReactTable({
+		data: members,
+		columns: memberColumns,
+		state: { sorting: memberSorting },
+		onSortingChange: setMemberSorting,
+		getRowId: (member) => member.id,
+		getCoreRowModel: getCoreRowModel(),
+		getSortedRowModel: getSortedRowModel(),
+	});
+
+	return (
+		<Frame>
+			<FrameHeader className="flex-row items-center justify-between gap-3">
+				<div className="flex flex-col gap-0.5">
+					<FrameTitle>Team members</FrameTitle>
+					<FrameDescription>
+						People with access to this organization.
+					</FrameDescription>
+				</div>
+				<div className="flex shrink-0 items-center gap-2">
+					<Badge variant="secondary" radius="full" size="lg">
+						{memberships?.count ?? members.length}
+					</Badge>
+					{readOnly && isAdmin && (
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() =>
+								router.push("/organization/profile?tab=team")
+							}
+						>
+							Manage team
+						</Button>
+					)}
+				</div>
+			</FrameHeader>
+
+			<DataGrid
+				table={memberTable}
+				recordCount={members.length}
+				emptyMessage="No members yet."
+				tableLayout={{ width: "auto", headerBackground: true }}
+			>
+				<FramePanel className="p-0">
+					<div className="overflow-x-auto">
+						<DataGridContainer className="rounded-lg border">
+							<DataGridTable />
+						</DataGridContainer>
+					</div>
+				</FramePanel>
+
+				{memberships?.hasNextPage && (
+					<FrameFooter className="items-center">
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => memberships.fetchNext?.()}
+							disabled={memberships.isFetching}
+						>
+							{memberships.isFetching && (
+								<Loader2 className="h-4 w-4 animate-spin" />
+							)}
+							Load more
+						</Button>
+					</FrameFooter>
+				)}
+			</DataGrid>
+		</Frame>
+	);
+}

--- a/apps/web/src/app/(workspace)/organization/profile/_components/team-members-table.tsx
+++ b/apps/web/src/app/(workspace)/organization/profile/_components/team-members-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useOrganization } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import { useQuery } from "convex/react";
@@ -46,7 +46,7 @@ import { api } from "@onetool/backend/convex/_generated/api";
 import {
 	ADMIN_ROLE,
 	ROLE_OPTIONS,
-	ORGANIZATION_PARAMS,
+	MEMBERSHIPS_PARAMS,
 	roleLabel,
 	getInitials,
 	memberDisplayName,
@@ -62,7 +62,7 @@ export function TeamMembersTable({ readOnly = false }: { readOnly?: boolean }) {
 	const router = useRouter();
 	const toast = useToast();
 	const { confirm: confirmDialog } = useConfirmDialog();
-	const { membership, memberships } = useOrganization(ORGANIZATION_PARAMS);
+	const { membership, memberships } = useOrganization(MEMBERSHIPS_PARAMS);
 
 	const isAdmin = membership?.role === ADMIN_ROLE;
 	// Admins get management controls, but the summary variant stays read-only.
@@ -85,40 +85,49 @@ export function TeamMembersTable({ readOnly = false }: { readOnly?: boolean }) {
 		return map;
 	}, [accessRows]);
 
-	const handleRoleChange = async (member: MemberRow, role: string) => {
-		if (member.role === role) return;
-		setPendingMemberId(member.id);
-		try {
-			await member.update({ role });
-			await memberships?.revalidate?.();
-			toast.success("Role updated", "The member's role has been changed.");
-		} catch (error) {
-			toast.error("Couldn't update role", clerkErr(error));
-		} finally {
-			setPendingMemberId(null);
-		}
-	};
+	// Wrapped in useCallback (with `memberships` as a dep) so the columns memo
+	// below can list them explicitly — this keeps the closed-over `revalidate`
+	// current instead of relying on a suppressed exhaustive-deps rule.
+	const handleRoleChange = useCallback(
+		async (member: MemberRow, role: string) => {
+			if (member.role === role) return;
+			setPendingMemberId(member.id);
+			try {
+				await member.update({ role });
+				await memberships?.revalidate?.();
+				toast.success("Role updated", "The member's role has been changed.");
+			} catch (error) {
+				toast.error("Couldn't update role", clerkErr(error));
+			} finally {
+				setPendingMemberId(null);
+			}
+		},
+		[memberships, toast],
+	);
 
-	const handleRemoveMember = async (member: MemberRow) => {
-		const confirmed = await confirmDialog({
-			title: "Remove member",
-			message: `Remove ${memberDisplayName(member) || "this member"} from the organization? They'll lose access immediately.`,
-			confirmLabel: "Remove member",
-			cancelLabel: "Cancel",
-			variant: "destructive",
-		});
-		if (!confirmed) return;
-		setPendingMemberId(member.id);
-		try {
-			await member.destroy();
-			await memberships?.revalidate?.();
-			toast.success("Member removed", "They no longer have access.");
-		} catch (error) {
-			toast.error("Couldn't remove member", clerkErr(error));
-		} finally {
-			setPendingMemberId(null);
-		}
-	};
+	const handleRemoveMember = useCallback(
+		async (member: MemberRow) => {
+			const confirmed = await confirmDialog({
+				title: "Remove member",
+				message: `Remove ${memberDisplayName(member) || "this member"} from the organization? They'll lose access immediately.`,
+				confirmLabel: "Remove member",
+				cancelLabel: "Cancel",
+				variant: "destructive",
+			});
+			if (!confirmed) return;
+			setPendingMemberId(member.id);
+			try {
+				await member.destroy();
+				await memberships?.revalidate?.();
+				toast.success("Member removed", "They no longer have access.");
+			} catch (error) {
+				toast.error("Couldn't remove member", clerkErr(error));
+			} finally {
+				setPendingMemberId(null);
+			}
+		},
+		[memberships, confirmDialog, toast],
+	);
 
 	const members = memberships?.data ?? [];
 
@@ -182,7 +191,13 @@ export function TeamMembersTable({ readOnly = false }: { readOnly?: boolean }) {
 								}}
 								disabled={rowBusy}
 							>
-								<SelectTrigger size="sm" className="w-28">
+								<SelectTrigger
+									size="sm"
+									className="w-28"
+									aria-label={`Change role for ${
+										memberDisplayName(member) || "this member"
+									}`}
+								>
 									<SelectValue />
 								</SelectTrigger>
 								<SelectContent>
@@ -307,7 +322,6 @@ export function TeamMembersTable({ readOnly = false }: { readOnly?: boolean }) {
 				},
 			},
 		];
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
 		isAdmin,
 		canManage,
@@ -316,6 +330,8 @@ export function TeamMembersTable({ readOnly = false }: { readOnly?: boolean }) {
 		accessRows,
 		pendingMemberId,
 		router,
+		handleRoleChange,
+		handleRemoveMember,
 	]);
 
 	const [memberSorting, setMemberSorting] = useState<SortingState>([]);

--- a/apps/web/src/app/(workspace)/organization/profile/_components/team-tab.tsx
+++ b/apps/web/src/app/(workspace)/organization/profile/_components/team-tab.tsx
@@ -43,7 +43,7 @@ import {
 	ADMIN_ROLE,
 	MEMBER_ROLE,
 	ROLE_OPTIONS,
-	ORGANIZATION_PARAMS,
+	INVITATIONS_PARAMS,
 	roleLabel,
 	clerkErr,
 } from "../_lib/org-members";
@@ -52,7 +52,7 @@ export function TeamTab() {
 	const toast = useToast();
 	const { confirm: confirmDialog } = useConfirmDialog();
 	const { organization, membership, invitations, isLoaded } =
-		useOrganization(ORGANIZATION_PARAMS);
+		useOrganization(INVITATIONS_PARAMS);
 
 	const isAdmin = membership?.role === ADMIN_ROLE;
 

--- a/apps/web/src/app/(workspace)/organization/profile/_components/team-tab.tsx
+++ b/apps/web/src/app/(workspace)/organization/profile/_components/team-tab.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useState } from "react";
+import { useOrganization } from "@clerk/nextjs";
+import { Lock, Mail, UserPlus, Trash2, Loader2 } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/reui/badge";
+import {
+	Frame,
+	FrameHeader,
+	FrameTitle,
+	FrameDescription,
+	FramePanel,
+} from "@/components/reui/frame";
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupInput,
+} from "@/components/ui/input-group";
+import { Field, FieldLabel, FieldError } from "@/components/ui/field";
+import {
+	Select,
+	SelectTrigger,
+	SelectValue,
+	SelectContent,
+	SelectItem,
+} from "@/components/ui/select";
+import {
+	Item,
+	ItemMedia,
+	ItemContent,
+	ItemTitle,
+	ItemActions,
+} from "@/components/ui/item";
+import { useToast } from "@/hooks/use-toast";
+import { useConfirmDialog } from "@/hooks/use-confirm-dialog";
+import { useSaveValidation } from "../_hooks/use-save-validation";
+import { Eyebrow, SectionHeading } from "./settings-card";
+import { TeamMembersTable } from "./team-members-table";
+import {
+	ADMIN_ROLE,
+	MEMBER_ROLE,
+	ROLE_OPTIONS,
+	ORGANIZATION_PARAMS,
+	roleLabel,
+	clerkErr,
+} from "../_lib/org-members";
+
+export function TeamTab() {
+	const toast = useToast();
+	const { confirm: confirmDialog } = useConfirmDialog();
+	const { organization, membership, invitations, isLoaded } =
+		useOrganization(ORGANIZATION_PARAMS);
+
+	const isAdmin = membership?.role === ADMIN_ROLE;
+
+	type InviteRow = NonNullable<
+		NonNullable<typeof invitations>["data"]
+	>[number];
+
+	const {
+		showErrors: inviteShowErrors,
+		markSaveAttempt: markInviteAttempt,
+		clearErrors: clearInviteErrors,
+	} = useSaveValidation();
+	const [inviteEmail, setInviteEmail] = useState("");
+	const [inviteRole, setInviteRole] = useState(MEMBER_ROLE);
+	const [inviting, setInviting] = useState(false);
+	const [pendingInviteId, setPendingInviteId] = useState<string | null>(null);
+	const inviteInvalid = inviteShowErrors && !inviteEmail.trim();
+
+	const handleInvite = async () => {
+		if (!organization) return;
+		markInviteAttempt();
+		const email = inviteEmail.trim();
+		if (!email) return;
+		setInviting(true);
+		try {
+			await organization.inviteMember({ emailAddress: email, role: inviteRole });
+			await invitations?.revalidate?.();
+			setInviteEmail("");
+			clearInviteErrors();
+			toast.success("Invitation sent", `Invited ${email}.`);
+		} catch (error) {
+			toast.error("Couldn't send invitation", clerkErr(error));
+		} finally {
+			setInviting(false);
+		}
+	};
+
+	const handleRevoke = async (invitation: InviteRow) => {
+		const confirmed = await confirmDialog({
+			title: "Revoke invitation",
+			message: `Revoke the invitation for ${invitation.emailAddress}?`,
+			confirmLabel: "Revoke",
+			cancelLabel: "Cancel",
+			variant: "destructive",
+		});
+		if (!confirmed) return;
+		setPendingInviteId(invitation.id);
+		try {
+			await invitation.revoke();
+			await invitations?.revalidate?.();
+			toast.success("Invitation revoked", "The invite is no longer valid.");
+		} catch (error) {
+			toast.error("Couldn't revoke invitation", clerkErr(error));
+		} finally {
+			setPendingInviteId(null);
+		}
+	};
+
+	if (!isLoaded) {
+		return (
+			<div className="flex items-center justify-center py-16">
+				<Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+			</div>
+		);
+	}
+
+	const pendingInvites = (invitations?.data ?? []).filter(
+		(invitation) => invitation.status === "pending",
+	);
+	const viewOnlyBadge = !isAdmin ? (
+		<span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/60 px-2.5 py-1 text-xs font-medium text-muted-foreground">
+			<Lock className="h-3 w-3" aria-hidden="true" /> View only
+		</span>
+	) : undefined;
+
+	return (
+		<div className="space-y-8">
+			<SectionHeading
+				title="Team"
+				description="Manage who's on your team, their roles, and what they can access."
+				aside={viewOnlyBadge}
+			/>
+
+			<TeamMembersTable />
+
+			{isAdmin && (
+				<Frame>
+					<FrameHeader>
+						<FrameTitle>Invitations</FrameTitle>
+						<FrameDescription>
+							Invite teammates by email. They&apos;ll get a link to join this
+							organization.
+						</FrameDescription>
+					</FrameHeader>
+
+					<FramePanel className="p-0">
+						<div className="flex flex-col gap-3 p-4 sm:flex-row sm:items-start sm:p-5">
+							<Field
+								className="flex-1"
+								data-invalid={inviteInvalid || undefined}
+							>
+								<FieldLabel htmlFor="invite-email" className="sr-only">
+									Email address
+								</FieldLabel>
+								<InputGroup className={cn(inviting && "opacity-70")}>
+									<InputGroupAddon>
+										<Mail />
+									</InputGroupAddon>
+									<InputGroupInput
+										id="invite-email"
+										type="email"
+										inputMode="email"
+										placeholder="teammate@business.com"
+										value={inviteEmail}
+										disabled={inviting}
+										aria-invalid={inviteInvalid || undefined}
+										onChange={(event) => setInviteEmail(event.target.value)}
+									/>
+								</InputGroup>
+								{inviteInvalid && (
+									<FieldError>Enter an email address to invite.</FieldError>
+								)}
+							</Field>
+							<Select
+								value={inviteRole}
+								onValueChange={(value) => {
+									if (value) setInviteRole(value);
+								}}
+								disabled={inviting}
+							>
+								<SelectTrigger className="sm:w-32">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{ROLE_OPTIONS.map((option) => (
+										<SelectItem key={option.value} value={option.value}>
+											{option.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+							<Button onClick={handleInvite} disabled={inviting}>
+								{inviting ? (
+									<Loader2 className="h-4 w-4 animate-spin" />
+								) : (
+									<UserPlus className="h-4 w-4" />
+								)}
+								Send invite
+							</Button>
+						</div>
+
+						{pendingInvites.length > 0 ? (
+							<div className="border-t border-border">
+								<div className="px-4 pt-3.5">
+									<Eyebrow>Pending</Eyebrow>
+								</div>
+								<div className="divide-y divide-border">
+									{pendingInvites.map((invitation) => {
+										const rowBusy = pendingInviteId === invitation.id;
+										return (
+											<Item
+												key={invitation.id}
+												size="sm"
+												className="px-4 py-3.5"
+											>
+												<ItemMedia variant="icon">
+													<Mail className="h-4 w-4" />
+												</ItemMedia>
+												<ItemContent>
+													<ItemTitle>{invitation.emailAddress}</ItemTitle>
+												</ItemContent>
+												<ItemActions>
+													<Badge
+														variant={
+															invitation.role === ADMIN_ROLE
+																? "primary-light"
+																: "secondary"
+														}
+														radius="full"
+														size="lg"
+													>
+														{roleLabel(invitation.role)}
+													</Badge>
+													<Button
+														variant="outline"
+														size="icon-sm"
+														aria-label="Revoke invitation"
+														disabled={rowBusy}
+														onClick={() => handleRevoke(invitation)}
+														className="hover:border-destructive/40 hover:bg-destructive/10 hover:text-destructive"
+													>
+														{rowBusy ? (
+															<Loader2 className="h-4 w-4 animate-spin" />
+														) : (
+															<Trash2 className="h-4 w-4" />
+														)}
+													</Button>
+												</ItemActions>
+											</Item>
+										);
+									})}
+								</div>
+							</div>
+						) : (
+							<div className="border-t border-border px-4 py-3.5">
+								<p className="text-sm text-muted-foreground">
+									No pending invitations.
+								</p>
+							</div>
+						)}
+					</FramePanel>
+				</Frame>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/app/(workspace)/organization/profile/_lib/org-members.ts
+++ b/apps/web/src/app/(workspace)/organization/profile/_lib/org-members.ts
@@ -10,9 +10,13 @@ export const ROLE_OPTIONS = [
 	{ value: MEMBER_ROLE, label: "Member" },
 ];
 
-// Opt-in fetch params, hoisted so the object identity is stable across renders.
-export const ORGANIZATION_PARAMS = {
+// Opt-in fetch params, hoisted so object identity stays stable across renders.
+// Split per resource so a component only fetches the collection it renders — the
+// read-only roster shouldn't pull invitations.
+export const MEMBERSHIPS_PARAMS = {
 	memberships: { pageSize: 20 },
+};
+export const INVITATIONS_PARAMS = {
 	invitations: { pageSize: 20 },
 };
 

--- a/apps/web/src/app/(workspace)/organization/profile/_lib/org-members.ts
+++ b/apps/web/src/app/(workspace)/organization/profile/_lib/org-members.ts
@@ -1,0 +1,52 @@
+import { isClerkAPIResponseError } from "@clerk/nextjs/errors";
+
+// Clerk role keys round-trip verbatim through the org webhook. The instance uses
+// only the two Clerk defaults; gate on Clerk's live membership.role (NOT the
+// Convex `role` column, which is written inconsistently).
+export const ADMIN_ROLE = "org:admin";
+export const MEMBER_ROLE = "org:member";
+export const ROLE_OPTIONS = [
+	{ value: ADMIN_ROLE, label: "Admin" },
+	{ value: MEMBER_ROLE, label: "Member" },
+];
+
+// Opt-in fetch params, hoisted so the object identity is stable across renders.
+export const ORGANIZATION_PARAMS = {
+	memberships: { pageSize: 20 },
+	invitations: { pageSize: 20 },
+};
+
+export function roleLabel(role: string | undefined | null) {
+	if (role === ADMIN_ROLE) return "Admin";
+	if (role === MEMBER_ROLE) return "Member";
+	return role ?? "Member";
+}
+
+export function getInitials(name: string, email?: string) {
+	const src = name.trim() || (email ?? "").trim();
+	const parts = src.split(/\s+/).filter(Boolean);
+	if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+	if (src.length >= 2) return src.slice(0, 2).toUpperCase();
+	return src.slice(0, 1).toUpperCase() || "?";
+}
+
+export function memberDisplayName(member: {
+	publicUserData?:
+		| {
+				firstName?: string | null;
+				lastName?: string | null;
+				identifier?: string | null;
+		  }
+		| null;
+}) {
+	const info = member.publicUserData;
+	const name = `${info?.firstName ?? ""} ${info?.lastName ?? ""}`.trim();
+	return name || info?.identifier || "";
+}
+
+export function clerkErr(err: unknown, fallback = "Something went wrong.") {
+	if (isClerkAPIResponseError(err)) {
+		return err.errors[0]?.longMessage ?? err.errors[0]?.message ?? fallback;
+	}
+	return err instanceof Error ? err.message : fallback;
+}

--- a/apps/web/src/app/(workspace)/organization/profile/members/[userId]/page.tsx
+++ b/apps/web/src/app/(workspace)/organization/profile/members/[userId]/page.tsx
@@ -415,10 +415,10 @@ export default function MemberAccessPage() {
 						<Button
 							variant="outline"
 							onClick={() =>
-								router.push("/organization/profile?tab=overview")
+								router.push("/organization/profile?tab=team")
 							}
 						>
-							Back to organization
+							Back to team
 						</Button>
 					}
 				/>
@@ -623,10 +623,10 @@ export default function MemberAccessPage() {
 					variant="ghost"
 					size="sm"
 					className="-ml-2 text-muted-foreground"
-					onClick={() => router.push("/organization/profile?tab=overview")}
+					onClick={() => router.push("/organization/profile?tab=team")}
 				>
 					<ArrowLeft className="h-4 w-4" aria-hidden="true" />
-					Organization settings
+					Back to team
 				</Button>
 			</div>
 

--- a/apps/web/src/app/(workspace)/organization/profile/page.tsx
+++ b/apps/web/src/app/(workspace)/organization/profile/page.tsx
@@ -11,6 +11,7 @@ import {
 	Lock,
 	ShieldCheck,
 	Tags,
+	Users,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -31,6 +32,7 @@ import {
 	type SettingsNavItem,
 } from "./_components/settings-nav";
 import { OverviewTab } from "./_components/overview-tab";
+import { TeamTab } from "./_components/team-tab";
 import { BusinessInfoTab } from "./_components/business-info-tab";
 import { PaymentsTab } from "./_components/payments-tab";
 import { DocumentsTab } from "./_components/documents-tab";
@@ -38,6 +40,7 @@ import { SKUsTab } from "./_components/skus-tab";
 
 const TAB_VALUES = [
 	"overview",
+	"team",
 	"business",
 	"payments",
 	"documents",
@@ -53,9 +56,10 @@ const TAB_PERMISSIONS: Partial<Record<TabValue, PermissionObject>> = {
 	skus: "skus",
 };
 
-// Stripe payouts stay role-gated (no matrix object in v1); Overview and
-// Business Info remain viewable read-only for members.
-const ADMIN_TABS: readonly TabValue[] = ["payments"];
+// Team management and Stripe payouts are admin/owner-only (no grantable "manage
+// team" object in v1). Overview and Business Info stay viewable read-only for
+// members — the Overview tab still shows a read-only team roster.
+const ADMIN_TABS: readonly TabValue[] = ["team", "payments"];
 
 const isTabValue = (value: string): value is TabValue =>
 	TAB_VALUES.includes(value as TabValue);
@@ -192,8 +196,15 @@ export default function OrganizationProfilePage() {
 			{
 				value: "overview",
 				label: "Overview",
-				sublabel: "Profile & team",
+				sublabel: "Profile & branding",
 				icon: LayoutGrid,
+			},
+			{
+				value: "team",
+				label: "Team",
+				sublabel: "Members & access",
+				icon: Users,
+				locked: !permsLoading && !hasFullAccess,
 			},
 			{
 				value: "business",
@@ -304,15 +315,18 @@ export default function OrganizationProfilePage() {
 											icon={<Lock className="h-6 w-6" aria-hidden="true" />}
 											title="You don't have access to this area"
 											description={
-												ADMIN_TABS.includes(activeTab)
-													? "Only organization admins can access payment settings."
-													: "Ask an organization admin to grant you access from the team settings."
+												activeTab === "team"
+													? "Only organization admins can manage team members and access."
+													: ADMIN_TABS.includes(activeTab)
+														? "Only organization admins can access payment settings."
+														: "Ask an organization admin to grant you access from the team settings."
 											}
 										/>
 									</div>
 								) : (
 									<>
 										{renderTab === "overview" && <OverviewTab />}
+										{renderTab === "team" && <TeamTab />}
 										{renderTab === "business" && <BusinessInfoTab />}
 										{renderTab === "payments" && <PaymentsTab />}
 										{renderTab === "documents" && <DocumentsTab />}

--- a/apps/web/src/components/layout/app-sidebar.tsx
+++ b/apps/web/src/components/layout/app-sidebar.tsx
@@ -151,6 +151,10 @@ const data = {
 							url: "/organization/profile",
 						},
 						{
+							title: "Team",
+							url: "/organization/profile?tab=team",
+						},
+						{
 							title: "Business Info",
 							url: "/organization/profile?tab=business",
 						},


### PR DESCRIPTION
Promotes team/access management out of the buried shield-icon-on-Overview entry point into its own admin/owner-gated surface.

- New "Team" tab in Organization Settings (Overview · Team · Business · …), reachable from the sidebar (Settings → Team), the settings nav rail, and a "Manage team" button on the Overview roster.
- Overview keeps a read-only team roster (role badges + access chip, admin summary only) — no role editing, remove, or RBAC-editor entry there.
- Team tab holds the full management surface: editable roles, remove member, invitations, and an explicit "Manage access" button (replacing the mystery shield icon) that opens the existing full-page per-member RBAC editor.
- Shared TeamMembersTable(readOnly) drives both tabs so they never drift.
- Team tab + sidebar item are admin/owner-only (hasFullAccess); members get a read-only roster on Overview and a no-access panel if they deep-link to it.
- Member editor "Back" returns to the Team tab.

Extracts shared Clerk role/member helpers to _lib/org-members.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Team tab to organization settings and a Team link in the Settings sidebar.
  * Introduced a team members roster with roles and access details, including “Load more”.
  * For admins, enabled member role/access management plus invitation sending and revoking.

* **Improvements**
  * Member access pages now route back directly to the Team tab.
  * Non-admins see a view-only team experience, with confirmation prompts and notifications for sensitive actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR promotes team and RBAC management out of the Overview tab into a dedicated \"Team\" tab, gated to admins/owners. A new shared `TeamMembersTable` component drives both surfaces (read-only roster on Overview, full management on Team), and Clerk/member utility helpers are extracted to `_lib/org-members.ts`.

- **New Team tab** added to Organization Settings with full member management (role editing, remove, invitations, \"Manage access\" RBAC button); access-gated via `ADMIN_TABS` and `hasFullAccess` in both the page controller and sidebar `canViewSettingsSubItem`.
- **Overview tab** reduced to profile/branding only, showing a read-only `TeamMembersTable` with a \"Manage team\" shortcut for admins.
- **Member RBAC editor** \"Back\" navigation updated from `?tab=overview` to `?tab=team` to reflect the new entry point.

<h3>Confidence Score: 4/5</h3>

The change is well-structured and access-gating is consistent across the page controller, nav rail, and sidebar. The two issues in TeamMembersTable are non-blocking quality concerns.

The refactor correctly moves management functionality into a new gated tab and shares the table component cleanly. Two concerns in TeamMembersTable: the shared ORGANIZATION_PARAMS causes an unnecessary invitations fetch on every Overview load, and the eslint-disable on the useMemo dependency array conceals a stale-closure risk on the role-change and remove-member handlers if Clerk's memberships reference updates between renders.

apps/web/src/app/(workspace)/organization/profile/_components/team-members-table.tsx — the ORGANIZATION_PARAMS overreach and suppressed useMemo deps are worth addressing before merge.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/(workspace)/organization/profile/_components/team-members-table.tsx | New shared table component for both Overview (read-only) and Team tab (full management); two issues: ORGANIZATION_PARAMS unnecessarily fetches invitations, and the useMemo eslint-disable suppresses a real stale-closure risk on handleRoleChange/handleRemoveMember. |
| apps/web/src/app/(workspace)/organization/profile/_components/team-tab.tsx | New Team tab component; moves invitations management and full member management out of OverviewTab; access-gating logic is correct, loading state handled properly. |
| apps/web/src/app/(workspace)/organization/profile/_components/overview-tab.tsx | Correctly trimmed down to profile/branding only; delegates team roster to the shared TeamMembersTable component in readOnly mode. |
| apps/web/src/app/(workspace)/organization/profile/_lib/org-members.ts | Clean extraction of shared Clerk role/member helpers; constants, labels, and utility functions are well-organized with no logic changes. |
| apps/web/src/app/(workspace)/organization/profile/page.tsx | Team tab added to TAB_VALUES and ADMIN_TABS; access-gating logic (hasFullAccess check, no-access panel message) is correct; nav rail item with locked state wired properly. |
| apps/web/src/components/layout/app-sidebar.tsx | Team sub-item added to Settings nav; correctly falls through to the hasFullAccess gate in canViewSettingsSubItem since Team is not in SETTINGS_SUBITEM_PERMISSIONS. |
| apps/web/src/app/(workspace)/organization/profile/members/[userId]/page.tsx | Back-navigation updated from overview to team tab in both the page header and breadcrumb button; straightforward and correct. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User visits organization profile] --> B{hasFullAccess?}
    B -- No --> C[Overview tab only\nRead-only team roster\nNo Team tab in nav]
    B -- Yes --> D[Full nav: Overview - Team - Business]

    D --> E[Overview tab]
    E --> F[TeamMembersTable readOnly=true]
    F -- Admin clicks Manage team --> G[Team tab]

    D --> G
    G --> H[TeamMembersTable readOnly=false]
    G --> J[Invitations panel]

    H -- Admin clicks Manage access --> K[Member RBAC editor page]
    K -- Back to team --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User visits organization profile] --> B{hasFullAccess?}
    B -- No --> C[Overview tab only\nRead-only team roster\nNo Team tab in nav]
    B -- Yes --> D[Full nav: Overview - Team - Business]

    D --> E[Overview tab]
    E --> F[TeamMembersTable readOnly=true]
    F -- Admin clicks Manage team --> G[Team tab]

    D --> G
    G --> H[TeamMembersTable readOnly=false]
    G --> J[Invitations panel]

    H -- Admin clicks Manage access --> K[Member RBAC editor page]
    K -- Back to team --> G
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/web/src/app/(workspace)/organization/profile/_components/team-members-table.tsx`, line 768 ([link](https://github.com/xcarter93/onetool/blob/c7587e82a5a8ebdfb61745d0c796d02b8df6770a/apps/web/src/app/(workspace)/organization/profile/_components/team-members-table.tsx#L768)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Unnecessary invitations fetch in read-only mode**

   `TeamMembersTable` calls `useOrganization(ORGANIZATION_PARAMS)` where `ORGANIZATION_PARAMS` includes `invitations: { pageSize: 20 }`, but this component never destructures or uses `invitations`. On the Overview tab (where `TeamMembersTable readOnly` is always rendered, even for non-admins), this causes an extra Clerk pagination request to fetch invitation data on every page load. Consider splitting the constant — e.g. a `MEMBERSHIPS_PARAMS` that omits `invitations` — and passing only `{ memberships: { pageSize: 20 } }` here.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/app/(workspace)/organization/profile/_components/team-members-table.tsx
   Line: 768

   Comment:
   **Unnecessary invitations fetch in read-only mode**

   `TeamMembersTable` calls `useOrganization(ORGANIZATION_PARAMS)` where `ORGANIZATION_PARAMS` includes `invitations: { pageSize: 20 }`, but this component never destructures or uses `invitations`. On the Overview tab (where `TeamMembersTable readOnly` is always rendered, even for non-admins), this causes an extra Clerk pagination request to fetch invitation data on every page load. Consider splitting the constant — e.g. a `MEMBERSHIPS_PARAMS` that omits `invitations` — and passing only `{ memberships: { pageSize: 20 } }` here.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


2. `apps/web/src/app/(workspace)/organization/profile/_components/team-members-table.tsx`, line 1013-1022 ([link](https://github.com/xcarter93/onetool/blob/c7587e82a5a8ebdfb61745d0c796d02b8df6770a/apps/web/src/app/(workspace)/organization/profile/_components/team-members-table.tsx#L1013-L1022)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale closure risk from suppressed exhaustive-deps**

   `handleRoleChange` and `handleRemoveMember` are regular (non-`useCallback`) functions defined in the component body, so each render produces a new function reference. Both close over `memberships?.revalidate`, but neither function is in the `useMemo` deps array. If `memberships` is updated (e.g. after `fetchNext`) without any of the listed deps changing, the memo won't recompute and the action handlers will silently call the stale `revalidate` from the previous render, potentially leaving the table stale after a role change or removal. Wrapping the handlers in `useCallback` (with `memberships` as a dep) and adding them to the `useMemo` dependency list would make the relationship explicit and safe to lint.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/app/(workspace)/organization/profile/_components/team-members-table.tsx
   Line: 1013-1022

   Comment:
   **Stale closure risk from suppressed exhaustive-deps**

   `handleRoleChange` and `handleRemoveMember` are regular (non-`useCallback`) functions defined in the component body, so each render produces a new function reference. Both close over `memberships?.revalidate`, but neither function is in the `useMemo` deps array. If `memberships` is updated (e.g. after `fetchNext`) without any of the listed deps changing, the memo won't recompute and the action handlers will silently call the stale `revalidate` from the previous render, potentially leaving the table stale after a role change or removal. Wrapping the handlers in `useCallback` (with `memberships` as a dep) and adding them to the `useMemo` dependency list would make the relationship explicit and safe to lint.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/src/app/(workspace)/organization/profile/_components/team-members-table.tsx:768
**Unnecessary invitations fetch in read-only mode**

`TeamMembersTable` calls `useOrganization(ORGANIZATION_PARAMS)` where `ORGANIZATION_PARAMS` includes `invitations: { pageSize: 20 }`, but this component never destructures or uses `invitations`. On the Overview tab (where `TeamMembersTable readOnly` is always rendered, even for non-admins), this causes an extra Clerk pagination request to fetch invitation data on every page load. Consider splitting the constant — e.g. a `MEMBERSHIPS_PARAMS` that omits `invitations` — and passing only `{ memberships: { pageSize: 20 } }` here.

### Issue 2 of 2
apps/web/src/app/(workspace)/organization/profile/_components/team-members-table.tsx:1013-1022
**Stale closure risk from suppressed exhaustive-deps**

`handleRoleChange` and `handleRemoveMember` are regular (non-`useCallback`) functions defined in the component body, so each render produces a new function reference. Both close over `memberships?.revalidate`, but neither function is in the `useMemo` deps array. If `memberships` is updated (e.g. after `fetchNext`) without any of the listed deps changing, the memo won't recompute and the action handlers will silently call the stale `revalidate` from the previous render, potentially leaving the table stale after a role change or removal. Wrapping the handlers in `useCallback` (with `memberships` as a dep) and adding them to the `useMemo` dependency list would make the relationship explicit and safe to lint.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(org): dedicated Team tab for member..."](https://github.com/xcarter93/onetool/commit/c7587e82a5a8ebdfb61745d0c796d02b8df6770a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43635325)</sub>

<!-- /greptile_comment -->