### PR TITLE
feat(data-grid): activity column header help tooltip explaining spark…

### DIFF
--- a/apps/web/src/app/(workspace)/clients/page.tsx
+++ b/apps/web/src/app/(workspace)/clients/page.tsx
@@ -79,6 +79,7 @@ import {
 } from "../projects/components/kanban";
 import { ClientDetailDrawer } from "./components/client-detail-drawer";
 import { ActivitySparkline } from "@/components/shared/activity-sparkline";
+import { ActivityColumnHeader } from "@/components/shared/activity-column-header";
 import { cn } from "@/lib/utils";
 
 type Client = {
@@ -269,7 +270,7 @@ const createColumns = (
 	},
 	{
 		id: "activity",
-		header: () => <div className="text-center">Activity</div>,
+		header: () => <ActivityColumnHeader />,
 		enableSorting: false,
 		cell: ({ row }) => (
 			<div className="flex justify-center">

--- a/apps/web/src/app/(workspace)/invoices/page.tsx
+++ b/apps/web/src/app/(workspace)/invoices/page.tsx
@@ -73,6 +73,7 @@ import {
 } from "../projects/components/kanban";
 import { InvoiceDetailDrawer } from "./components/invoice-detail-drawer";
 import { ActivitySparkline } from "@/components/shared/activity-sparkline";
+import { ActivityColumnHeader } from "@/components/shared/activity-column-header";
 import { cn } from "@/lib/utils";
 
 type InvoiceStatus = Doc<"invoices">["status"];
@@ -247,7 +248,7 @@ const createColumns = (
 	},
 	{
 		id: "activity",
-		header: () => <div className="text-center">Activity</div>,
+		header: () => <ActivityColumnHeader />,
 		enableSorting: false,
 		cell: ({ row }) => (
 			<div className="flex justify-center">

--- a/apps/web/src/app/(workspace)/projects/page.tsx
+++ b/apps/web/src/app/(workspace)/projects/page.tsx
@@ -75,6 +75,7 @@ import {
 } from "./components/kanban";
 import { ProjectDetailDrawer } from "./components/project-detail-drawer";
 import { ActivitySparkline } from "@/components/shared/activity-sparkline";
+import { ActivityColumnHeader } from "@/components/shared/activity-column-header";
 import { cn } from "@/lib/utils";
 
 // Enhanced project type that includes client information for display
@@ -227,7 +228,7 @@ const createColumns = (
 	},
 	{
 		id: "activity",
-		header: () => <div className="text-center">Activity</div>,
+		header: () => <ActivityColumnHeader />,
 		enableSorting: false,
 		cell: ({ row }) => (
 			<div className="flex justify-center">

--- a/apps/web/src/app/(workspace)/quotes/page.tsx
+++ b/apps/web/src/app/(workspace)/quotes/page.tsx
@@ -74,6 +74,7 @@ import {
 } from "../projects/components/kanban";
 import { QuoteDetailDrawer } from "./components/quote-detail-drawer";
 import { ActivitySparkline } from "@/components/shared/activity-sparkline";
+import { ActivityColumnHeader } from "@/components/shared/activity-column-header";
 import { cn } from "@/lib/utils";
 
 type QuoteWithClient = Doc<"quotes"> & {
@@ -227,7 +228,7 @@ const createColumns = (
 	},
 	{
 		id: "activity",
-		header: () => <div className="text-center">Activity</div>,
+		header: () => <ActivityColumnHeader />,
 		enableSorting: false,
 		cell: ({ row }) => (
 			<div className="flex justify-center">

--- a/apps/web/src/components/shared/activity-column-header.tsx
+++ b/apps/web/src/components/shared/activity-column-header.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { CircleHelp } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+// Shades are inverted vs the sparkline stroke: the tooltip surface is
+// `bg-foreground`, so the lighter shade contrasts in light mode and the
+// darker one in dark mode.
+const LEGEND = [
+	{
+		swatch: "bg-emerald-400 dark:bg-emerald-600",
+		label: "Trending up — more active recently",
+	},
+	{
+		swatch: "bg-red-400 dark:bg-red-600",
+		label: "Trending down — quieter recently",
+	},
+	{ swatch: "bg-muted-foreground", label: "Steady — no change" },
+] as const;
+
+/**
+ * Centered "Activity" column header with a help tooltip explaining what the
+ * sparkline stroke colors mean. Shared across the clients/projects/quotes/
+ * invoices grids so the legend stays in one place.
+ */
+export function ActivityColumnHeader() {
+	return (
+		<div className="flex items-center justify-center gap-1">
+			<span>Activity</span>
+			<Tooltip>
+				<TooltipTrigger
+					render={
+						<button
+							type="button"
+							aria-label="What do the activity colors mean?"
+							className="text-muted-foreground/70 hover:text-foreground focus-visible:text-foreground inline-flex cursor-help outline-none transition-colors"
+						/>
+					}
+				>
+					<CircleHelp className="size-3.5" />
+				</TooltipTrigger>
+				<TooltipContent side="top" className="max-w-xs">
+					<div className="space-y-1.5">
+						<p className="font-semibold">Last 30 days of activity</p>
+						<ul className="space-y-1">
+							{LEGEND.map((item) => (
+								<li key={item.label} className="flex items-center gap-2">
+									<span
+										className={cn(
+											"h-0.5 w-4 shrink-0 rounded-full",
+											item.swatch
+										)}
+									/>
+									<span>{item.label}</span>
+								</li>
+							))}
+						</ul>
+						<p className="text-background/70">
+							A dash (—) means no activity in this period.
+						</p>
+					</div>
+				</TooltipContent>
+			</Tooltip>
+		</div>
+	);
+}


### PR DESCRIPTION
…line colors

Add a shared ActivityColumnHeader with a CircleHelp icon + Base UI tooltip legend (green=trending up, red=down, gray=steady, dash=no activity) and wire it into the clients/projects/quotes/invoices grids. Focusable button trigger so the legend opens on hover and keyboard focus; swatch shades inverted vs the sparkline stroke to read against the tooltip's bg-foreground surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Activity column help tooltip to Clients, Invoices, Projects, and Quotes tables.
  * The tooltip explains sparkline colors for rising, falling, and steady trends over the last 30 days.
  * Clarified that a dash indicates no activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a shared `ActivityColumnHeader` component that adds a `CircleHelp` icon with a Base UI tooltip legend (green = trending up, red = down, gray = steady, dash = no activity) to the "Activity" column, then wires it into the clients, projects, quotes, and invoices data grids in place of the previous plain centered div.

- **New component** (`activity-column-header.tsx`): renders a focusable help-icon button using Base UI's `render` slot prop and a `TooltipContent` popup with a color-coded legend; swatch shades are intentionally inverted vs. the sparkline stroke to contrast against the `bg-foreground` tooltip surface.
- **Four grid pages updated**: each swaps the one-liner inline header for `<ActivityColumnHeader />` \u2014 purely mechanical, no logic changes.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the four grid pages each receive an identical one-line swap, and the new component is self-contained with no data or state dependencies.

The shared component works correctly and the wiring across the four grids is mechanical. The button removes its browser focus ring via `outline-none` without adding a visible ring replacement, which undercuts the keyboard-focus story called out in the PR description. The extra `max-w-xs` on `TooltipContent` is redundant but harmless.

apps/web/src/components/shared/activity-column-header.tsx — focus-indicator and redundant class worth a second look before shipping.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/shared/activity-column-header.tsx | New shared component: renders a centred "Activity" header with a Base UI tooltip legend for sparkline colors. Two minor style issues: `outline-none` removes the focus ring without a visible replacement, and `max-w-xs` is redundant on TooltipContent. |
| apps/web/src/app/(workspace)/clients/page.tsx | Replaces the inline `<div className="text-center">Activity</div>` header with the new shared `ActivityColumnHeader` component. Change is mechanical and correct. |
| apps/web/src/app/(workspace)/projects/page.tsx | Same header swap as clients/page.tsx — straightforward, no issues. |
| apps/web/src/app/(workspace)/invoices/page.tsx | Same header swap as clients/page.tsx — straightforward, no issues. |
| apps/web/src/app/(workspace)/quotes/page.tsx | Same header swap as clients/page.tsx — straightforward, no issues. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Data Grid Column: Activity] --> B[ActivityColumnHeader]
    B --> C[span: Activity label]
    B --> D[Tooltip]
    D --> E[TooltipTrigger\nbutton + CircleHelp icon]
    D --> F[TooltipContent\nLegend popup]
    F --> G[Emerald swatch\nTrending up]
    F --> H[Red swatch\nTrending down]
    F --> I[Muted swatch\nSteady]
    F --> J[Dash text\nNo activity]

    subgraph Pages using ActivityColumnHeader
        P1[clients/page.tsx]
        P2[projects/page.tsx]
        P3[quotes/page.tsx]
        P4[invoices/page.tsx]
    end

    P1 & P2 & P3 & P4 --> B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Data Grid Column: Activity] --> B[ActivityColumnHeader]
    B --> C[span: Activity label]
    B --> D[Tooltip]
    D --> E[TooltipTrigger\nbutton + CircleHelp icon]
    D --> F[TooltipContent\nLegend popup]
    F --> G[Emerald swatch\nTrending up]
    F --> H[Red swatch\nTrending down]
    F --> I[Muted swatch\nSteady]
    F --> J[Dash text\nNo activity]

    subgraph Pages using ActivityColumnHeader
        P1[clients/page.tsx]
        P2[projects/page.tsx]
        P3[quotes/page.tsx]
        P4[invoices/page.tsx]
    end

    P1 & P2 & P3 & P4 --> B
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/src/components/shared/activity-column-header.tsx:42
**Focus ring removed without accessible replacement**

`outline-none` suppresses the browser's default focus indicator, and the only substitute is `focus-visible:text-foreground` — a subtle icon-color shift. The PR description specifically calls out keyboard-focus support, but a color change alone may not meet WCAG 2.1 SC 2.4.11 (Focus Appearance). Consider adding `focus-visible:ring-2 focus-visible:ring-ring focus-visible:rounded-sm` (or similar) to make the focus state clearly visible to keyboard users.

### Issue 2 of 2
apps/web/src/components/shared/activity-column-header.tsx:48
**Redundant `max-w-xs` on `TooltipContent`**

`TooltipContent` already includes `max-w-xs` in its internal default classNames (see `tooltip.tsx` line 53). Passing it again via `className` is harmless — tw-merge deduplicates it — but it's unnecessary noise that can be removed.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(data-grid): activity column header ..."](https://github.com/xcarter93/onetool/commit/0e4799fa1ccf31fc805255432ce2282d8223010a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43671955)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->