### PR TITLE
style(canvas): make workspace dot-grid more visible in both themes

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -68,6 +68,8 @@
 	--fg: oklch(0.141 0.005 285.823);
 	--background: var(--bg);
 	--foreground: var(--fg);
+	/* Tint of the workspace dot-grid; per-theme so each can be tuned alone. */
+	--canvas-dot: color-mix(in oklch, var(--foreground) 12%, transparent);
 	/* Ensure muted-foreground is defined for Tailwind text-muted-foreground */
 	--muted-foreground: var(--muted-fg);
 
@@ -158,6 +160,7 @@
 	--fg: oklch(0.985 0 0);
 	--background: var(--bg);
 	--foreground: var(--fg);
+	--canvas-dot: color-mix(in oklch, var(--foreground) 12%, transparent);
 	/* Dark mode mapping for muted-foreground */
 	--muted-foreground: var(--muted-fg);
 
@@ -618,15 +621,11 @@
 	/* ========================================================================
 	   Workspace canvas texture
 	   Reusable fine dot-grid for the main content area across every workspace
-	   page. The dot color is derived from --foreground via color-mix, so it
-	   adapts to light/dark automatically and stays subtle (6% tint). The base
-	   stays transparent so the underlying --background shows through.
+	   page. The dot color comes from --canvas-dot. The base stays transparent
+	   so the underlying --background shows through.
 	   ======================================================================== */
 	.workspace-canvas {
-		background-image: radial-gradient(
-			color-mix(in oklch, var(--foreground) 6%, transparent) 1px,
-			transparent 1px
-		);
+		background-image: radial-gradient(var(--canvas-dot) 1px, transparent 1px);
 		background-size: 22px 22px;
 		background-position: -1px -1px;
 		/* Canvas scrolls inside the picture-frame card — keep its scrollbar


### PR DESCRIPTION
Extract the dot color into a --canvas-dot token defined per theme and raise it from 6% to 12%, so the grid reads on the light canvas instead of washing out to near-invisible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved workspace canvas dot-grid styling across light and dark themes.
  * Ensured dot colors adapt consistently to the active theme for a more polished appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the dot-grid color from an inline `color-mix()` call into a dedicated `--canvas-dot` CSS custom property defined per-theme (`:root` and `.dark`), and doubles the tint from 6% to 12% to make the grid legible on the light canvas.

- The `--canvas-dot` token is defined in both `:root` and `.dark` with the same formula at 12%, providing explicit per-theme hooks for future independent tuning.
- `.workspace-canvas` is simplified from a four-line `radial-gradient` to a single `var(--canvas-dot)` reference, improving readability.
- Note: since CSS custom properties containing `var()` resolve lazily at use-time, the `:root` definition alone would already pick up the correct dark-mode `--foreground`; the `.dark` redefinition is technically redundant today, but having both explicit makes the per-theme intent clear and future tuning trivial.

<h3>Confidence Score: 5/5</h3>

A focused, cosmetic CSS change — introducing a new token and raising an opacity value — with no logic, layout, or behavioral side-effects.

The change touches only a single CSS file, affects a visual-only property (dot-grid opacity), and introduces no new dependencies or computed values beyond what was already inline. Both themes receive explicit token definitions, making the intent clear and the diff easy to revert.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/globals.css | Extracts inline dot-color formula into a --canvas-dot CSS custom property in both :root and .dark, and raises the tint from 6% to 12% for improved grid visibility on the light canvas. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[":root (light theme)"] -- "--foreground: oklch(0.141...)" --> C
    B[".dark (dark theme)"] -- "--foreground: oklch(0.985...)" --> D

    C["--canvas-dot: color-mix(in oklch,\n var(--foreground) 12%, transparent)"]
    D["--canvas-dot: color-mix(in oklch,\n var(--foreground) 12%, transparent)"]

    C --> E[".workspace-canvas\nradial-gradient(var(--canvas-dot) 1px, transparent 1px)"]
    D --> E

    E --> F[Rendered dot-grid on canvas]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[":root (light theme)"] -- "--foreground: oklch(0.141...)" --> C
    B[".dark (dark theme)"] -- "--foreground: oklch(0.985...)" --> D

    C["--canvas-dot: color-mix(in oklch,\n var(--foreground) 12%, transparent)"]
    D["--canvas-dot: color-mix(in oklch,\n var(--foreground) 12%, transparent)"]

    C --> E[".workspace-canvas\nradial-gradient(var(--canvas-dot) 1px, transparent 1px)"]
    D --> E

    E --> F[Rendered dot-grid on canvas]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["style(canvas): make workspace dot-grid m..."](https://github.com/xcarter93/onetool/commit/95d389ae0f4ad3140fb82964e82307a33cdaeffc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43710952)</sub>

<!-- /greptile_comment -->