### PR TITLE
Fix automation event emissions, date comparisons, and error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ skills-lock.json
 
 # App Store pre-submission runbook (contains config/credential locations — never commit)
 apps/mobile/APP-STORE-SUBMISSION.md
+
+graphify-out/

--- a/apps/web/src/app/(workspace)/automations/components/editor/debug-panel.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/editor/debug-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import {
 	Loader2,
 	CheckCircle2,
@@ -26,6 +26,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { RunRecordRef } from "../../hooks/use-automation-editor";
 import { DebugTimeline } from "./debug-timeline";
+import { summarizeLoopFailures, type RunStatus } from "../../lib/run-format";
 
 type SampleRecord = {
 	entityType: "client" | "project" | "quote" | "invoice" | "task";
@@ -73,7 +74,25 @@ function StatusLine({ execution }: { execution: ExecutionDoc }) {
 				? `Failed: ${execution.error}`
 				: "Test failed";
 
-	const map = {
+	const { total: loopTotal, failed: loopFailed } = summarizeLoopFailures(
+		execution.loopSummary
+	);
+	// A test run is a dry run over a sample: nothing failed, it *would* fail.
+	const isDry = execution.dryRun === true;
+	const withErrorsText =
+		loopTotal > 0
+			? isDry
+				? `Test completed — ${loopFailed} of ${loopTotal} previewed item${
+						loopTotal === 1 ? "" : "s"
+					} would fail`
+				: `Completed — ${loopFailed} of ${loopTotal} item${
+						loopTotal === 1 ? "" : "s"
+					} failed`
+			: "Completed with errors";
+
+	// Typed against RunStatus so a future added status fails to compile here
+	// instead of silently falling through the `if (!s) return null` guard.
+	const map: Record<RunStatus, { icon: ReactNode; text: string; cls: string }> = {
 		running: {
 			icon: (
 				<Loader2 className="size-4 animate-spin text-blue-600 dark:text-blue-400" />
@@ -87,6 +106,13 @@ function StatusLine({ execution }: { execution: ExecutionDoc }) {
 			),
 			text: "Test completed",
 			cls: "text-emerald-700 dark:text-emerald-300",
+		},
+		completed_with_errors: {
+			icon: (
+				<AlertTriangle className="size-4 text-amber-600 dark:text-amber-400" />
+			),
+			text: withErrorsText,
+			cls: "text-amber-700 dark:text-amber-300",
 		},
 		failed: {
 			icon: <XCircle className="size-4 text-red-600 dark:text-red-400" />,
@@ -103,7 +129,7 @@ function StatusLine({ execution }: { execution: ExecutionDoc }) {
 			text: "Test cancelled",
 			cls: "text-muted-foreground",
 		},
-	} as const;
+	};
 
 	const s = map[execution.status];
 	if (!s) return null; // guard an out-of-enum status rather than crash the panel
@@ -118,6 +144,85 @@ function StatusLine({ execution }: { execution: ExecutionDoc }) {
 		>
 			<span className="mt-px shrink-0">{s.icon}</span>
 			<span className="min-w-0 break-words">{s.text}</span>
+		</div>
+	);
+}
+
+/**
+ * One block per loop node that had at least one item fail — headline count,
+ * the first few failing items by label/error, and a partial-write caveat
+ * when the backend flagged any of them `partial: true`.
+ */
+function PartialProgressBanner({ execution }: { execution: ExecutionDoc }) {
+	// Test runs are dry: nothing was written, and the loop only walks a sample.
+	// Saying "updated 2 of 50 records" there would be false twice over.
+	const dry = execution?.dryRun === true;
+	const loopsWithFailures = (execution?.loopSummary ?? []).filter(
+		(s) => s.failed > 0
+	);
+	if (loopsWithFailures.length === 0) return null;
+
+	const MAX_SHOWN = 3;
+
+	return (
+		<div className="space-y-2">
+			{loopsWithFailures.map((summary) => {
+				const shown = summary.errors.slice(0, MAX_SHOWN);
+				const hiddenCount = summary.errors.length - shown.length;
+				const anyPartial = shown.some((e) => e.partial);
+				return (
+					<div
+						key={summary.nodeId}
+						className="space-y-1.5 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 dark:border-amber-900/50 dark:bg-amber-950/20"
+					>
+						<div className="flex items-start justify-between gap-2">
+							<span className="text-xs font-medium text-amber-900 dark:text-amber-200">
+								{dry
+									? `${summary.succeeded} of ${summary.total} previewed item${
+											summary.total === 1 ? "" : "s"
+										} would run`
+									: `Updated ${summary.succeeded} of ${summary.total} record${
+											summary.total === 1 ? "" : "s"
+										}`}
+								{!dry && summary.skipped > 0
+									? ` — ${summary.skipped} skipped`
+									: ""}
+							</span>
+							<Badge variant="warning" className="shrink-0">
+								{summary.failed} {dry ? "would fail" : "failed"}
+							</Badge>
+						</div>
+						{shown.length > 0 && (
+							<ul className="space-y-1">
+								{shown.map((err) => (
+									<li
+										key={err.index}
+										className="text-[11px] leading-relaxed text-amber-900/90 dark:text-amber-200/90"
+									>
+										<span className="font-medium">
+											{err.label ?? `Item ${err.index + 1}`}:
+										</span>{" "}
+										<span className="text-amber-800/80 dark:text-amber-300/70">
+											{err.error}
+										</span>
+									</li>
+								))}
+							</ul>
+						)}
+						{hiddenCount > 0 && (
+							<p className="text-[11px] text-amber-800/70 dark:text-amber-300/60">
+								+{hiddenCount} more
+							</p>
+						)}
+						{anyPartial && !dry && (
+							<p className="text-[11px] text-amber-800/80 dark:text-amber-300/70">
+								Some failed items may have been partially updated — check the
+								timeline for which steps ran.
+							</p>
+						)}
+					</div>
+				);
+			})}
 		</div>
 	);
 }
@@ -232,6 +337,10 @@ export function DebugPanel({
 			</div>
 
 			{hasActiveRun && <StatusLine execution={execution} />}
+
+			{hasActiveRun && execution && execution.status !== "running" && (
+				<PartialProgressBanner execution={execution} />
+			)}
 
 			{hasActiveRun && execution?.dataTruncated && (
 				<Tooltip>

--- a/apps/web/src/app/(workspace)/automations/components/editor/debug-panel.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/editor/debug-panel.tsx
@@ -169,7 +169,7 @@ function PartialProgressBanner({ execution }: { execution: ExecutionDoc }) {
 			{loopsWithFailures.map((summary) => {
 				const shown = summary.errors.slice(0, MAX_SHOWN);
 				const hiddenCount = summary.errors.length - shown.length;
-				const anyPartial = shown.some((e) => e.partial);
+				const anyPartial = summary.errors.some((e) => e.partial);
 				return (
 					<div
 						key={summary.nodeId}

--- a/apps/web/src/app/(workspace)/automations/components/editor/debug-timeline.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/editor/debug-timeline.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import {
 	CheckCircle2,
 	XCircle,
@@ -60,6 +60,72 @@ const RESULT_ICON: Record<ExecutedNode["result"], ReactNode> = {
 	),
 };
 
+// Worst-outcome ranking for a loop iteration's group icon — mirrors the
+// failure-wins merge in lib/run-status.ts, over the raw executed-entry result.
+const RESULT_RANK: Record<ExecutedNode["result"], number> = {
+	failed: 3,
+	running: 2,
+	success: 1,
+	skipped: 0,
+};
+
+function worstResult(results: ExecutedNode["result"][]): ExecutedNode["result"] {
+	return results.reduce((worst, r) =>
+		RESULT_RANK[r] > RESULT_RANK[worst] ? r : worst
+	);
+}
+
+/** One rendered row: a plain step, or a run of consecutive entries from the
+ * same loop iteration collapsed into a group. */
+type TimelineRow =
+	| { kind: "entry"; index: number }
+	| {
+			kind: "group";
+			key: string;
+			label: string;
+			worst: ExecutedNode["result"];
+			indexes: number[];
+	  };
+
+/**
+ * Consecutive entries sharing loopNodeId+loopIndex collapse into one
+ * iteration group so a mid-loop failure can be traced to its record.
+ * Everything else (trigger, fetch, the loop node's own summary entry,
+ * post-loop steps) has no loopNodeId and stays a flat top-level row.
+ */
+function groupEntries(entries: ExecutedNode[]): TimelineRow[] {
+	const rows: TimelineRow[] = [];
+	let i = 0;
+	while (i < entries.length) {
+		const entry = entries[i];
+		if (entry.loopNodeId != null && entry.loopIndex != null) {
+			const { loopNodeId, loopIndex } = entry;
+			const indexes: number[] = [];
+			let j = i;
+			while (
+				j < entries.length &&
+				entries[j].loopNodeId === loopNodeId &&
+				entries[j].loopIndex === loopIndex
+			) {
+				indexes.push(j);
+				j++;
+			}
+			rows.push({
+				kind: "group",
+				key: `${loopNodeId}:${loopIndex}`,
+				label: entry.loopItemLabel || `Item ${loopIndex + 1}`,
+				worst: worstResult(indexes.map((idx) => entries[idx].result)),
+				indexes,
+			});
+			i = j;
+		} else {
+			rows.push({ kind: "entry", index: i });
+			i++;
+		}
+	}
+	return rows;
+}
+
 /** The backend caps snapshots at ~4KB, replacing oversized payloads with a
  * { _truncated, preview } marker whose `preview` is a raw JSON prefix. */
 function isTruncated(v: unknown): v is { _truncated: true; preview?: string } {
@@ -112,114 +178,166 @@ export function DebugTimeline({
 	rfNodes,
 	onNavigateToNode,
 }: DebugTimelineProps) {
-	// One row open at a time keeps the 280px panel legible.
+	// One entry's detail pane open at a time keeps the 280px panel legible.
 	const [expanded, setExpanded] = useState<number | null>(null);
+	// Group open/closed overrides, keyed by "loopNodeId:loopIndex". A key
+	// absent here falls back to the failed-wins default, so a group that
+	// picks up a failure as a streaming test run continues auto-opens.
+	const [groupOverrides, setGroupOverrides] = useState<Record<string, boolean>>(
+		{}
+	);
+
+	const rows = useMemo(() => groupEntries(entries), [entries]);
+
 	if (entries.length === 0) return null;
 
-	return (
-		<ol className="space-y-0.5">
-			{entries.map((entry, i) => {
-				const isOpen = expanded === i;
-				const label = resolveLabel(entry.nodeId, rfNodes);
-				const duration =
-					entry.completedAt != null && entry.startedAt != null
-						? formatDuration(entry.completedAt - entry.startedAt)
-						: null;
-				const hasDetail =
-					entry.input !== undefined ||
-					entry.output !== undefined ||
-					entry.error != null ||
-					entry.recordsProcessed != null;
+	const renderEntry = (i: number) => {
+		const entry = entries[i];
+		const isOpen = expanded === i;
+		const label = resolveLabel(entry.nodeId, rfNodes);
+		const duration =
+			entry.completedAt != null && entry.startedAt != null
+				? formatDuration(entry.completedAt - entry.startedAt)
+				: null;
+		const hasDetail =
+			entry.input !== undefined ||
+			entry.output !== undefined ||
+			entry.error != null ||
+			entry.recordsProcessed != null;
 
-				return (
-					<li key={i}>
-						<div className={cn("rounded-md", isOpen && "bg-accent/40")}>
-							<div className="flex items-center gap-1">
-								<button
-									type="button"
-									aria-expanded={isOpen}
-									onClick={() => setExpanded(isOpen ? null : i)}
-									className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-								>
-									<ChevronRight
-										className={cn(
-											"size-3 shrink-0 text-muted-foreground motion-safe:transition-transform motion-safe:duration-150",
-											isOpen && "rotate-90"
-										)}
-									/>
-									<span className="shrink-0">
-										{RESULT_ICON[entry.result] ?? RESULT_ICON.skipped}
-									</span>
-									<span className="min-w-0 flex-1 truncate text-sm">
-										<span className="tabular-nums text-muted-foreground">
-											{i + 1}.
-										</span>{" "}
-										{label}
-									</span>
-									{entry.truncated && (
-										<Tooltip>
-											<TooltipTrigger
-												render={
-													<Badge
-														variant="warning"
-														className="shrink-0 gap-1 px-1.5 py-0 text-[10px]"
-													/>
-												}
-											>
-												<AlertTriangle className="size-2.5" aria-hidden />
-												Truncated
-											</TooltipTrigger>
-											<TooltipContent side="top" className="max-w-xs">
-												This step stopped scanning at the{" "}
-												{FETCH_SCAN_CEILING.toLocaleString()} most recent
-												records; older records were not considered.
-											</TooltipContent>
-										</Tooltip>
-									)}
-									{duration && (
-										<span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
-											{duration}
-										</span>
-									)}
-								</button>
-								<Button
-									variant="ghost"
-									size="icon-sm"
-									onClick={() => onNavigateToNode(entry.nodeId)}
-									aria-label={`Focus ${label} on canvas`}
-									className="shrink-0 text-muted-foreground"
-								>
-									<Crosshair className="size-3.5" />
-								</Button>
-							</div>
+		return (
+			<li key={i}>
+				<div className={cn("rounded-md", isOpen && "bg-accent/40")}>
+					<div className="flex items-center gap-1">
+						<button
+							type="button"
+							aria-expanded={isOpen}
+							onClick={() => setExpanded(isOpen ? null : i)}
+							className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+						>
+							<ChevronRight
+								className={cn(
+									"size-3 shrink-0 text-muted-foreground motion-safe:transition-transform motion-safe:duration-150",
+									isOpen && "rotate-90"
+								)}
+							/>
+							<span className="shrink-0">
+								{RESULT_ICON[entry.result] ?? RESULT_ICON.skipped}
+							</span>
+							<span className="min-w-0 flex-1 truncate text-sm">
+								<span className="tabular-nums text-muted-foreground">
+									{i + 1}.
+								</span>{" "}
+								{label}
+							</span>
+							{entry.truncated && (
+								<Tooltip>
+									<TooltipTrigger
+										render={
+											<Badge
+												variant="warning"
+												className="shrink-0 gap-1 px-1.5 py-0 text-[10px]"
+											/>
+										}
+									>
+										<AlertTriangle className="size-2.5" aria-hidden />
+										Truncated
+									</TooltipTrigger>
+									<TooltipContent side="top" className="max-w-xs">
+										This step stopped scanning at the{" "}
+										{FETCH_SCAN_CEILING.toLocaleString()} most recent
+										records; older records were not considered.
+									</TooltipContent>
+								</Tooltip>
+							)}
+							{duration && (
+								<span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+									{duration}
+								</span>
+							)}
+						</button>
+						<Button
+							variant="ghost"
+							size="icon-sm"
+							onClick={() => onNavigateToNode(entry.nodeId)}
+							aria-label={`Focus ${label} on canvas`}
+							className="shrink-0 text-muted-foreground"
+						>
+							<Crosshair className="size-3.5" />
+						</Button>
+					</div>
 
-							{isOpen && (
-								<div className="space-y-2 pb-2 pl-7 pr-2">
-									{entry.error != null && (
-										<div className="rounded-md bg-red-50 px-2 py-1.5 text-[11px] text-red-700 dark:bg-red-950/30 dark:text-red-300">
-											{entry.error}
-										</div>
-									)}
-									{entry.recordsProcessed != null && (
-										<div className="text-[11px] text-muted-foreground">
-											{entry.recordsProcessed} record
-											{entry.recordsProcessed === 1 ? "" : "s"} processed
-										</div>
-									)}
-									{entry.input !== undefined && (
-										<JsonBlock label="Input" value={entry.input} />
-									)}
-									{entry.output !== undefined && (
-										<JsonBlock label="Output" value={entry.output} />
-									)}
-									{!hasDetail && (
-										<div className="text-[11px] text-muted-foreground">
-											No data captured for this step.
-										</div>
-									)}
+					{isOpen && (
+						<div className="space-y-2 pb-2 pl-7 pr-2">
+							{entry.error != null && (
+								<div className="rounded-md bg-red-50 px-2 py-1.5 text-[11px] text-red-700 dark:bg-red-950/30 dark:text-red-300">
+									{entry.error}
+								</div>
+							)}
+							{entry.recordsProcessed != null && (
+								<div className="text-[11px] text-muted-foreground">
+									{entry.recordsProcessed} record
+									{entry.recordsProcessed === 1 ? "" : "s"} processed
+								</div>
+							)}
+							{entry.input !== undefined && (
+								<JsonBlock label="Input" value={entry.input} />
+							)}
+							{entry.output !== undefined && (
+								<JsonBlock label="Output" value={entry.output} />
+							)}
+							{!hasDetail && (
+								<div className="text-[11px] text-muted-foreground">
+									No data captured for this step.
 								</div>
 							)}
 						</div>
+					)}
+				</div>
+			</li>
+		);
+	};
+
+	return (
+		<ol className="space-y-0.5">
+			{rows.map((row) => {
+				if (row.kind === "entry") return renderEntry(row.index);
+
+				const isGroupOpen = groupOverrides[row.key] ?? row.worst === "failed";
+				return (
+					<li key={row.key}>
+						<button
+							type="button"
+							aria-expanded={isGroupOpen}
+							onClick={() =>
+								setGroupOverrides((prev) => ({
+									...prev,
+									[row.key]: !isGroupOpen,
+								}))
+							}
+							className="flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+						>
+							<ChevronRight
+								className={cn(
+									"size-3 shrink-0 text-muted-foreground motion-safe:transition-transform motion-safe:duration-150",
+									isGroupOpen && "rotate-90"
+								)}
+							/>
+							<span className="shrink-0">
+								{RESULT_ICON[row.worst] ?? RESULT_ICON.skipped}
+							</span>
+							<span className="min-w-0 flex-1 truncate text-sm font-medium">
+								{row.label}
+							</span>
+							<span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+								{row.indexes.length} step{row.indexes.length === 1 ? "" : "s"}
+							</span>
+						</button>
+						{isGroupOpen && (
+							<ol className="ml-3.5 space-y-0.5 border-l border-border/60 pl-2">
+								{row.indexes.map((i) => renderEntry(i))}
+							</ol>
+						)}
 					</li>
 				);
 			})}

--- a/apps/web/src/app/(workspace)/automations/components/editor/formula-editor-modal.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/editor/formula-editor-modal.tsx
@@ -97,6 +97,20 @@ function formatPreviewValue(value: Val): string {
 	return String(value);
 }
 
+/**
+ * The IANA tz this automation's formulas evaluate in at run time. Must stay in
+ * lockstep with automationFormulaTz() in automationExecutor.ts: scheduled
+ * automations use their schedule's tz, everything else runs in UTC.
+ */
+function runtimeTimezone(trigger: TriggerConfig | AutomationTrigger | null): string {
+	if (!trigger || trigger.type !== "scheduled") return "UTC";
+	// A stale `schedule` can linger on the draft config after a type switch, so
+	// read it only once the trigger is actually scheduled.
+	return "schedule" in trigger && trigger.schedule?.timezone
+		? trigger.schedule.timezone
+		: "UTC";
+}
+
 /** Order-preserving group-by, shared by the Variables and Functions reference lists. */
 function groupBy<T>(items: T[], keyOf: (item: T) => string): [string, T[]][] {
 	const groups: [string, T[]][] = [];
@@ -189,7 +203,10 @@ export function FormulaEditorModal({
 		| null
 		| undefined;
 
-	const tz = useMemo(() => Intl.DateTimeFormat().resolvedOptions().timeZone, []);
+	// The tz the automation will ACTUALLY run in — mirrors automationFormulaTz on
+	// the backend. Previewing in the browser's tz made authoring-time results
+	// differ from production for every non-local user.
+	const tz = useMemo(() => runtimeTimezone(trigger), [trigger]);
 
 	// Formulas this one may reference — excludes itself (no self-reference).
 	const referenceFormulas = useMemo(
@@ -368,7 +385,12 @@ export function FormulaEditorModal({
 
 						<div className="space-y-1.5 rounded-md border border-border bg-muted/30 p-3">
 							<div className="flex items-center justify-between gap-2">
-								<span className="text-xs font-medium text-muted-foreground">Preview</span>
+								<span className="text-xs font-medium text-muted-foreground">
+									Preview{" "}
+									<span className="font-normal">
+										· dates in {tz} (this automation&rsquo;s run timezone)
+									</span>
+								</span>
 								{sampleRecords.length > 1 && (
 									<Select
 										value={selectedSample?.entityId}

--- a/apps/web/src/app/(workspace)/automations/components/editor/formula-editor-modal.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/editor/formula-editor-modal.tsx
@@ -10,6 +10,7 @@ import {
 	parseFormula,
 	runFormula,
 	FORMULA_FUNCTIONS,
+	isCalendarDateEpoch,
 	type FormulaFnDoc,
 	type Val,
 } from "@onetool/backend/convex/lib/formula";
@@ -90,9 +91,16 @@ function toFormulaVal(value: unknown): Val {
 	return null;
 }
 
-function formatPreviewValue(value: Val): string {
+function formatPreviewValue(value: Val, tz: string): string {
 	if (value === null) return "(empty)";
-	if (value instanceof Date) return value.toLocaleString();
+	if (value instanceof Date) {
+		// Match runtime display semantics: a calendar date reads in UTC
+		// (date-only), an instant in the tz the automation will run in —
+		// the browser's tz can be a day off for non-local users.
+		return isCalendarDateEpoch(value.getTime())
+			? value.toLocaleDateString(undefined, { timeZone: "UTC" })
+			: value.toLocaleString(undefined, { timeZone: tz });
+	}
 	if (typeof value === "boolean") return value ? "true" : "false";
 	return String(value);
 }
@@ -264,7 +272,7 @@ export function FormulaEditorModal({
 			}
 			try {
 				const value = runFormula(expression, { resolve, now: Date.now(), tz });
-				setPreview({ ok: true, text: formatPreviewValue(value) });
+				setPreview({ ok: true, text: formatPreviewValue(value, tz) });
 			} catch (err) {
 				setPreview({
 					ok: false,

--- a/apps/web/src/app/(workspace)/automations/components/editor/workflow-drawer.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/editor/workflow-drawer.tsx
@@ -27,6 +27,7 @@ import { TRIGGER_NODE_ID, type EditorNode } from "../../lib/flow-adapter";
 import { getAvailableVariables, type VariableOption } from "../../lib/variables";
 import {
 	MAX_FORMULAS,
+	triggerScopeObjectType,
 	type FormulaResource,
 	type WorkflowNode,
 	type WorkflowNodeType,
@@ -487,7 +488,7 @@ export function WorkflowDrawer({
 					className="mt-0 min-h-0 flex-1 overflow-y-auto"
 				>
 					<DebugPanel
-						objectType={trigger?.objectType}
+						objectType={triggerScopeObjectType(trigger) ?? undefined}
 						triggerType={trigger?.type}
 						sampleRecords={sampleRecords}
 						execution={execution}

--- a/apps/web/src/app/(workspace)/automations/components/flow/condition-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/condition-node-rf.tsx
@@ -12,7 +12,7 @@ import {
 	type AutomationObjectType,
 	type ConditionNodeConfig,
 } from "../../lib/node-types";
-import { conditionSentence } from "../../lib/condition-sentence";
+import { conditionSentence, describeVarPath } from "../../lib/condition-sentence";
 
 function getSummary(
 	config: ConditionNodeConfig | undefined,
@@ -27,10 +27,12 @@ function getSummary(
 		return { title: "Set a condition", description: "Configure condition...", isConfigured: false };
 	}
 
-	const firstField = allRules[0].field;
-	const title =
-		(objectType ? getFieldDefinition(objectType, firstField)?.label : undefined) ??
-		firstField;
+	const firstRule = allRules[0];
+	const title = firstRule.left?.kind === "var"
+		? describeVarPath(firstRule.left.path, objectType)
+		: ((objectType
+				? getFieldDefinition(objectType, firstRule.field)?.label
+				: undefined) ?? firstRule.field);
 	// Full plain-English readback (A5-1); the card truncates to one line.
 	const description =
 		conditionSentence(config.logic, config.groups, objectType) ||

--- a/apps/web/src/app/(workspace)/automations/components/flow/trigger-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/trigger-node-rf.tsx
@@ -9,6 +9,7 @@ import { BaseHandle } from "@/components/base-handle";
 import {
 	OBJECT_TYPE_LABELS,
 	describeSchedule,
+	triggerScopeObjectType,
 	getStatusOptions,
 	validateSchedule,
 	type TriggerConfig,
@@ -21,7 +22,7 @@ function entryCriteriaSuffix(trigger: TriggerConfig): string {
 	const sentence = conditionSentence(
 		trigger.entryCriteria.logic,
 		trigger.entryCriteria.groups,
-		trigger.objectType ?? null
+		triggerScopeObjectType(trigger)
 	);
 	return sentence ? ` · when ${sentence}` : "";
 }
@@ -32,14 +33,15 @@ function getSummary(trigger: TriggerConfig | undefined): {
 } {
 	if (!trigger) return { title: "Configure trigger", description: "Select a trigger type..." };
 
-	const objectLabel = trigger.objectType ? OBJECT_TYPE_LABELS[trigger.objectType] : "";
+	const scopeObjectType = triggerScopeObjectType(trigger);
+	const objectLabel = scopeObjectType ? OBJECT_TYPE_LABELS[scopeObjectType] : "";
 	const triggerType = trigger.type || "status_changed";
 	const whenSuffix = entryCriteriaSuffix(trigger);
 
 	switch (triggerType) {
 		case "status_changed": {
 			const title = "Status Changed";
-			const statusOptions = trigger.objectType ? getStatusOptions(trigger.objectType) : [];
+			const statusOptions = scopeObjectType ? getStatusOptions(scopeObjectType) : [];
 			const toLabel =
 				statusOptions.find((s) => s.value === trigger.toStatus)?.label || trigger.toStatus;
 			if (trigger.fromStatus && toLabel) {

--- a/apps/web/src/app/(workspace)/automations/components/recent-failures-timeline.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/recent-failures-timeline.tsx
@@ -34,7 +34,7 @@ export function RecentFailuresTimeline({ className }: { className?: string }) {
 			<FrameHeader>
 				<FrameTitle>Recent failures</FrameTitle>
 				<FrameDescription className="text-xs">
-					Production runs that failed, or finished with items skipped
+					Production runs that failed, or completed with item errors
 				</FrameDescription>
 			</FrameHeader>
 
@@ -120,7 +120,10 @@ export function RecentFailuresTimeline({ className }: { className?: string }) {
 										</span>
 									</div>
 									<p className="text-muted-foreground mt-1.5 line-clamp-3 text-xs leading-relaxed">
-										{failure.error ?? "Run failed."}
+										{failure.error ??
+											(failure.status === "completed_with_errors"
+												? "One or more items failed; the rest completed."
+												: "Run failed.")}
 									</p>
 								</TimelineContent>
 							</TimelineItem>

--- a/apps/web/src/app/(workspace)/automations/components/recent-failures-timeline.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/recent-failures-timeline.tsx
@@ -20,7 +20,7 @@ import {
 	TimelineTitle,
 } from "@/components/reui/timeline";
 import { Badge } from "@/components/ui/badge";
-import { XCircle, CheckCircle2, Clock } from "lucide-react";
+import { XCircle, CheckCircle2, Clock, AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatRelativeTime } from "@/lib/notification-utils";
 
@@ -34,7 +34,7 @@ export function RecentFailuresTimeline({ className }: { className?: string }) {
 			<FrameHeader>
 				<FrameTitle>Recent failures</FrameTitle>
 				<FrameDescription className="text-xs">
-					Production runs that ended in an error
+					Production runs that failed, or finished with items skipped
 				</FrameDescription>
 			</FrameHeader>
 
@@ -87,14 +87,30 @@ export function RecentFailuresTimeline({ className }: { className?: string }) {
 												{failure.automationName}
 											</button>
 										</TimelineTitle>
-										<Badge variant="destructive" className="gap-1.5">
-											<XCircle className="size-3" aria-hidden />
-											Failed
-										</Badge>
+										{failure.status === "completed_with_errors" ? (
+											<Badge
+												variant="outline"
+												className="gap-1.5 border-warning/30 bg-warning/10 text-warning"
+											>
+												<AlertTriangle className="size-3" aria-hidden />
+												Completed with errors
+											</Badge>
+										) : (
+											<Badge variant="destructive" className="gap-1.5">
+												<XCircle className="size-3" aria-hidden />
+												Failed
+											</Badge>
+										)}
 									</div>
-									<TimelineIndicator className="flex size-6 items-center justify-center border-none bg-destructive/10 text-destructive group-data-[orientation=vertical]/timeline:-left-6">
-										<XCircle className="size-3.5" />
-									</TimelineIndicator>
+									{failure.status === "completed_with_errors" ? (
+										<TimelineIndicator className="flex size-6 items-center justify-center border-none bg-warning/10 text-warning group-data-[orientation=vertical]/timeline:-left-6">
+											<AlertTriangle className="size-3.5" />
+										</TimelineIndicator>
+									) : (
+										<TimelineIndicator className="flex size-6 items-center justify-center border-none bg-destructive/10 text-destructive group-data-[orientation=vertical]/timeline:-left-6">
+											<XCircle className="size-3.5" />
+										</TimelineIndicator>
+									)}
 								</TimelineHeader>
 								<TimelineContent className="mt-1.5">
 									<div className="text-muted-foreground flex items-center gap-1.5 text-xs">

--- a/apps/web/src/app/(workspace)/automations/components/run-metrics-tiles.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/run-metrics-tiles.tsx
@@ -90,8 +90,14 @@ export function RunMetricsTiles() {
 					value={formatPercent(metrics?.successRate)}
 					sub={
 						metrics
-							? `${metrics.failedCount.toLocaleString()} failed of ${(
-									metrics.successCount + metrics.failedCount
+							? `${metrics.failedCount.toLocaleString()} failed${
+									metrics.withErrorsCount > 0
+										? ` · ${metrics.withErrorsCount.toLocaleString()} partial`
+										: ""
+								} of ${(
+									metrics.successCount +
+									metrics.failedCount +
+									metrics.withErrorsCount
 								).toLocaleString()}`
 							: undefined
 					}

--- a/apps/web/src/app/(workspace)/automations/components/run-status-badge.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/run-status-badge.tsx
@@ -1,11 +1,19 @@
 import type { ElementType } from "react";
 import { Badge } from "@/components/reui/badge";
-import { CheckCircle2, XCircle, Loader2, MinusCircle, Ban } from "lucide-react";
+import {
+	CheckCircle2,
+	XCircle,
+	Loader2,
+	MinusCircle,
+	Ban,
+	AlertTriangle,
+} from "lucide-react";
 import { RUN_STATUS_META, type RunStatus } from "../lib/run-format";
 
 const STATUS_ICON: Record<RunStatus, ElementType> = {
 	running: Loader2,
 	completed: CheckCircle2,
+	completed_with_errors: AlertTriangle,
 	failed: XCircle,
 	skipped: MinusCircle,
 	cancelled: Ban,

--- a/apps/web/src/app/(workspace)/automations/components/run-throughput-chart.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/run-throughput-chart.tsx
@@ -24,6 +24,7 @@ const WINDOW_DAYS = 30;
 const SERIES = [
 	{ key: "success", label: "Successful", color: "var(--primary)" },
 	{ key: "failed", label: "Failed", color: "var(--destructive)" },
+	{ key: "withErrors", label: "Completed with errors", color: "var(--warning)" },
 ] as const;
 
 const chartConfig: ChartConfig = Object.fromEntries(
@@ -41,7 +42,9 @@ function ThroughputTooltip({
 	payload,
 }: {
 	active?: boolean;
-	payload?: { payload: { day: number; success: number; failed: number } }[];
+	payload?: {
+		payload: { day: number; success: number; failed: number; withErrors: number };
+	}[];
 }) {
 	if (!active || !payload?.length) return null;
 	const point = payload[0].payload;
@@ -76,6 +79,7 @@ export function RunThroughputChart({ className }: { className?: string }) {
 	const patternPrefix = useId();
 	const SUCCESS_STRIPE_ID = stripeId(patternPrefix, 0);
 	const FAILED_STRIPE_ID = stripeId(patternPrefix, 1);
+	const WITH_ERRORS_STRIPE_ID = stripeId(patternPrefix, 2);
 	const raw = useQuery(api.automations.getRunThroughput, {
 		windowDays: WINDOW_DAYS,
 	});
@@ -83,11 +87,13 @@ export function RunThroughputChart({ className }: { className?: string }) {
 
 	const { data, total, delta, positive } = useMemo(() => {
 		// Skipped runs are excluded everywhere: bands, headline, and delta.
+		// completed_with_errors runs DID execute, so they count toward `runs`.
 		const points = (raw ?? []).map((d) => ({
 			day: d.day,
 			success: d.success,
 			failed: d.failed,
-			runs: d.success + d.failed,
+			withErrors: d.withErrors,
+			runs: d.success + d.failed + d.withErrors,
 		}));
 		const sum = points.reduce((s, p) => s + p.runs, 0);
 		const mid = Math.floor(points.length / 2);
@@ -166,7 +172,7 @@ export function RunThroughputChart({ className }: { className?: string }) {
 							>
 								<ChartStripeDefs
 									idPrefix={patternPrefix}
-									colors={["var(--primary)", "var(--destructive)"]}
+									colors={["var(--primary)", "var(--destructive)", "var(--warning)"]}
 								/>
 								<CartesianGrid
 									vertical={false}
@@ -190,6 +196,14 @@ export function RunThroughputChart({ className }: { className?: string }) {
 									dataKey="failed"
 									stackId="runs"
 									fill={`url(#${FAILED_STRIPE_ID})`}
+									stroke="transparent"
+									activeDot={false}
+								/>
+								<Area
+									type="monotone"
+									dataKey="withErrors"
+									stackId="runs"
+									fill={`url(#${WITH_ERRORS_STRIPE_ID})`}
 									stroke="transparent"
 									activeDot={false}
 								/>

--- a/apps/web/src/app/(workspace)/automations/components/runs-table.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/runs-table.tsx
@@ -40,6 +40,7 @@ import {
 	RUN_STATUS_META,
 	formatDuration,
 	formatTriggerSource,
+	summarizeLoopFailures,
 	type RunRow,
 	type RunStatus,
 } from "../lib/run-format";
@@ -86,23 +87,42 @@ export function RunsTable() {
 				id: "status",
 				header: "Status",
 				size: 170,
-				cell: ({ row }) => (
-					<div className="flex items-center gap-1.5">
-						<RunStatusBadge status={row.original.status as RunStatus} />
-						{row.original.dataTruncated && (
-							<Tooltip>
-								<TooltipTrigger render={<Badge variant="warning" className="gap-1" />}>
-									<AlertTriangle className="size-3" aria-hidden />
-									Truncated
-								</TooltipTrigger>
-								<TooltipContent side="top" className="max-w-xs">
-									At least one step stopped scanning at the 5,000 most recent
-									records; older records were not considered.
-								</TooltipContent>
-							</Tooltip>
-						)}
-					</div>
-				),
+				cell: ({ row }) => {
+					const status = row.original.status as RunStatus;
+					const loopFailed =
+						status === "completed_with_errors"
+							? summarizeLoopFailures(row.original.loopSummary).failed
+							: 0;
+					return (
+						<div className="flex flex-wrap items-center gap-1.5">
+							<RunStatusBadge status={status} />
+							{row.original.dataTruncated && (
+								<Tooltip>
+									<TooltipTrigger render={<Badge variant="warning" className="gap-1" />}>
+										<AlertTriangle className="size-3" aria-hidden />
+										Truncated
+									</TooltipTrigger>
+									<TooltipContent side="top" className="max-w-xs">
+										At least one step stopped scanning at the 5,000 most recent
+										records; older records were not considered.
+									</TooltipContent>
+								</Tooltip>
+							)}
+							{loopFailed > 0 && (
+								<Tooltip>
+									<TooltipTrigger render={<Badge variant="warning" className="gap-1" />}>
+										<AlertTriangle className="size-3" aria-hidden />
+										{loopFailed} failed
+									</TooltipTrigger>
+									<TooltipContent side="top" className="max-w-xs">
+										{loopFailed} item{loopFailed === 1 ? "" : "s"} failed during this
+										run — open the automation to see which.
+									</TooltipContent>
+								</Tooltip>
+							)}
+						</div>
+					);
+				},
 			},
 			{
 				id: "started",

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/automation-sidebar.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/automation-sidebar.tsx
@@ -220,6 +220,7 @@ export function AutomationSidebar({
 				return (
 					<StepPicker
 						inLoop={inLoop}
+						triggerType={trigger?.type}
 						onSelect={(type, actionType) =>
 							onStepTypeSelect(type, mode.placeholderNodeId, actionType)
 						}

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/action-config.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/action-config.tsx
@@ -31,6 +31,7 @@ import {
 	type TriggerConfig,
 	type UpdateFieldAction,
 	type WorkflowNode,
+	triggerScopeObjectType,
 } from "../../../lib/node-types";
 import { getScopeObjectType } from "../../../lib/variables";
 import type { ConfigPanelProps } from "../automation-sidebar";
@@ -99,11 +100,28 @@ function UpdateFieldFields({
 	nodeId,
 	formulas,
 	commit,
-}: ActionFieldsProps<UpdateFieldAction> & { triggerObjectType: AutomationObjectType }) {
+}: ActionFieldsProps<UpdateFieldAction> & {
+	triggerObjectType: AutomationObjectType | null;
+}) {
 	// Inside a loop body, `target: "self"` (and its related FKs) resolve against
 	// the loop's fetched item, not the trigger record — mirror the engine.
 	const scope = getScopeObjectType(nodes, nodeId, triggerObjectType);
-	const scopeObjectType = scope.objectType ?? triggerObjectType;
+	const scopeObjectType = scope.objectType;
+
+	// Both targets — self and related — resolve off the record in scope, so with
+	// no record there is nothing this action can update. The engine hard-fails on
+	// it, and save-time validation now rejects it.
+	if (!scopeObjectType) {
+		return (
+			<PanelSection title="Inputs">
+				<p className="text-xs text-muted-foreground">
+					This automation runs on a schedule, so there is no record to update.
+					Add a Find records step and move this action inside a Loop.
+				</p>
+			</PanelSection>
+		);
+	}
+
 	const targetOptions = getTargetOptions(scopeObjectType);
 	const targetValue = typeof action.target === "string" ? action.target : action.target.related;
 	const targetObjectType =
@@ -153,7 +171,7 @@ function UpdateFieldFields({
 							: undefined
 						: scope.inLoop
 							? `Updates the ${targetObjectType} linked to the current loop item.`
-							: `Updates the ${targetObjectType} linked to the triggering ${triggerObjectType}.`
+							: `Updates the ${targetObjectType} linked to the triggering ${scopeObjectType}.`
 				}
 			>
 				<Select
@@ -515,10 +533,16 @@ export function ActionConfigPanel({
 		);
 	}
 
-	const triggerObjectType: AutomationObjectType = trigger?.objectType || "quote";
-	const config =
-		(node.config as ActionNodeConfig | undefined) ?? defaultConfig(triggerObjectType);
+	const triggerObjectType = triggerScopeObjectType(trigger);
 	const workflowNodes = nodes.filter((n): n is WorkflowNode => n.type !== "placeholder");
+	// null on a scheduled automation outside a loop. Seeding the default config
+	// off an arbitrary object type would render a "This Quote" target on an
+	// automation that has no quote — and no record at all.
+	const seedObjectType =
+		getScopeObjectType(workflowNodes, nodeId, triggerObjectType).objectType ??
+		"client";
+	const config =
+		(node.config as ActionNodeConfig | undefined) ?? defaultConfig(seedObjectType);
 	const meta = ACTION_META[config.action.type];
 
 	const commit = (next: ActionNodeConfig) => {

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/condition-config.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/condition-config.tsx
@@ -4,11 +4,11 @@ import React from "react";
 import { GitBranch } from "lucide-react";
 import { NextStepTree } from "../next-step-tree";
 import type {
-	AutomationObjectType,
 	ConditionNodeConfig,
 	WorkflowNode,
 } from "../../../lib/node-types";
-import { getScopeObjectType } from "../../../lib/variables";
+import { triggerScopeObjectType } from "../../../lib/node-types";
+import { getAvailableVariables, getScopeObjectType } from "../../../lib/variables";
 import type { ConfigPanelProps } from "../automation-sidebar";
 import { ConfigPanelHeader } from "./config-panel-header";
 import { DeleteStepButton, PanelSection } from "./panel-primitives";
@@ -40,14 +40,22 @@ export function ConditionConfigPanel({
 		);
 	}
 
-	const triggerObjectType: AutomationObjectType = trigger?.objectType || "quote";
+	const triggerObjectType = triggerScopeObjectType(trigger);
 	const config = (node.config as ConditionNodeConfig | undefined) ?? defaultConfig();
 	const workflowNodes = nodes.filter((n): n is WorkflowNode => n.type !== "placeholder");
 
 	// Inside a loop body, conditions read the loop's fetched item, not the
 	// trigger record — mirror the engine (automationExecutor.ts executeNodeV2).
+	// null on a scheduled automation outside a loop: nothing puts a record in
+	// scope, so the only thing left to test is a step result.
 	const scope = getScopeObjectType(workflowNodes, nodeId, triggerObjectType);
-	const objectType: AutomationObjectType = scope.objectType ?? triggerObjectType;
+	const objectType = scope.objectType;
+
+	// Step results and formulas can be tested without a record at all.
+	const variableLeftOptions = (
+		trigger ? getAvailableVariables(workflowNodes, trigger, nodeId, formulas) : []
+	).filter((o) => o.path.startsWith("node.") || o.path.startsWith("formula."));
+	const hasNothingToTest = !objectType && variableLeftOptions.length === 0;
 
 	const commit = (next: ConditionNodeConfig) => {
 		const source: ConditionNodeConfig["source"] =
@@ -67,8 +75,16 @@ export function ConditionConfigPanel({
 
 			<div className="flex-1">
 				<PanelSection title="Conditions">
+					{!objectType && (
+						<p className="text-xs text-muted-foreground">
+							{hasNothingToTest
+								? "This automation runs on a schedule, so there is no record to test. Add a Find records step, then test its result here — or move this condition inside a Loop to test each record."
+								: "This automation runs on a schedule, so there is no record to test. Compare a step result instead, or move this condition inside a Loop to test each record."}
+						</p>
+					)}
 					<FilterGroupsEditor
 						objectType={objectType}
+						variableLeftOptions={variableLeftOptions}
 						groups={config.groups}
 						onChange={(groups) => commit({ ...config, groups })}
 						topLevelLogic={{

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/condition-config.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/condition-config.tsx
@@ -52,9 +52,13 @@ export function ConditionConfigPanel({
 	const objectType = scope.objectType;
 
 	// Step results and formulas can be tested without a record at all.
-	const variableLeftOptions = (
-		trigger ? getAvailableVariables(workflowNodes, trigger, nodeId, formulas) : []
-	).filter((o) => o.path.startsWith("node.") || o.path.startsWith("formula."));
+	const availableVariables = trigger
+		? getAvailableVariables(workflowNodes, trigger, nodeId, formulas)
+		: [];
+	const variableLeftOptions = availableVariables.filter(
+		(o) => o.path.startsWith("node.") || o.path.startsWith("formula.")
+	);
+	const varLabels = new Map(availableVariables.map((o) => [o.path, o.label]));
 	const hasNothingToTest = !objectType && variableLeftOptions.length === 0;
 
 	const commit = (next: ConditionNodeConfig) => {
@@ -101,6 +105,7 @@ export function ConditionConfigPanel({
 						logic={config.logic}
 						groups={config.groups}
 						objectType={objectType}
+						varLabels={varLabels}
 					/>
 				</PanelSection>
 			</div>

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/condition-sentence-summary.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/condition-sentence-summary.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import {
 	conditionSentenceParts,
+	type VarLabelMap,
 } from "../../../lib/condition-sentence";
 import type {
 	AutomationObjectType,
@@ -19,13 +20,15 @@ export function ConditionSentenceSummary({
 	logic,
 	groups,
 	objectType,
+	varLabels,
 }: {
 	prefix: string;
 	logic: "and" | "or";
 	groups: ConditionGroup[];
 	objectType: AutomationObjectType | null;
+	varLabels?: VarLabelMap;
 }) {
-	const parts = conditionSentenceParts(logic, groups, objectType);
+	const parts = conditionSentenceParts(logic, groups, objectType, varLabels);
 	if (parts.length === 0) return null;
 
 	return (

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/fetch-config.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/fetch-config.tsx
@@ -15,6 +15,7 @@ import {
 	DEFAULT_FETCH_LIMIT,
 	MAX_FETCH_LIMIT,
 	OBJECT_TYPE_OPTIONS,
+	triggerScopeObjectType,
 	type AutomationObjectType,
 	type FetchNodeConfig,
 	type WorkflowNode,
@@ -51,7 +52,7 @@ export function FetchConfigPanel({
 
 	const currentConfig: FetchNodeConfig = (node.config as FetchNodeConfig | undefined) ?? {
 		kind: "fetch_records",
-		objectType: trigger?.objectType || "client",
+		objectType: triggerScopeObjectType(trigger) ?? "client",
 		filters: [],
 	};
 	const workflowNodes = nodes.filter((n): n is WorkflowNode => n.type !== "placeholder");

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/filter-groups-editor.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/filter-groups-editor.tsx
@@ -14,6 +14,7 @@ import {
 	MAX_CONDITION_GROUPS,
 	MAX_RULES_PER_GROUP,
 	VALUELESS_OPERATORS,
+	VARIABLE_LEFT_OPERATORS,
 	getFieldDefinition,
 	getFilterableFields,
 	operatorsForField,
@@ -27,6 +28,10 @@ import {
 } from "../../../lib/node-types";
 import { ValueInput } from "./value-input";
 import { OPERATOR_LABELS } from "../../../lib/condition-sentence";
+import type { VariableOption } from "../../../lib/variables";
+
+/** Left-side select values are namespaced so a variable can't collide with a field key. */
+const VAR_PREFIX = "var:";
 
 /**
  * Shared group/rule builder for condition-config.tsx (with a top-level
@@ -49,8 +54,24 @@ export function emptyFilterRule(
 		: { field, operator, value: { kind: "static", value: "" } };
 }
 
+/** A rule that tests a scope value (a step result) instead of a record field. */
+function emptyVariableRule(path: string): ConditionRule {
+	return {
+		field: "",
+		left: { kind: "var", path },
+		operator: "greater_than",
+		value: { kind: "static", value: "" },
+	};
+}
+
 export interface FilterGroupsEditorProps {
-	objectType: AutomationObjectType;
+	/** null when nothing puts a record in scope (a scheduled trigger outside a loop). */
+	objectType: AutomationObjectType | null;
+	/**
+	 * Step results / formulas a rule may test on its left side. Condition panels
+	 * only — a fetch filter or entry criteria must name a real field.
+	 */
+	variableLeftOptions?: VariableOption[];
 	groups: ConditionGroup[];
 	onChange: (groups: ConditionGroup[]) => void;
 	/** Present for condition-config: lets the user choose "all"/"any" across groups. Omit when groups are always ANDed (fetch-config). */
@@ -68,6 +89,7 @@ export interface FilterGroupsEditorProps {
 
 export function FilterGroupsEditor({
 	objectType,
+	variableLeftOptions,
 	groups,
 	onChange,
 	topLevelLogic,
@@ -77,7 +99,15 @@ export function FilterGroupsEditor({
 	targetNodeId,
 	formulas,
 }: FilterGroupsEditorProps) {
-	const fields = getFilterableFields(objectType);
+	const fields = objectType ? getFilterableFields(objectType) : [];
+	const variableOptions = variableLeftOptions ?? [];
+	const canAddRule = fields.length > 0 || variableOptions.length > 0;
+
+	const newRule = (): ConditionRule | null => {
+		if (objectType && fields[0]) return emptyFilterRule(objectType, fields[0].key);
+		if (variableOptions[0]) return emptyVariableRule(variableOptions[0].path);
+		return null;
+	};
 
 	const updateGroup = (groupIndex: number, group: ConditionGroup) => {
 		onChange(groups.map((g, i) => (i === groupIndex ? group : g)));
@@ -92,11 +122,9 @@ export function FilterGroupsEditor({
 	const addRule = (groupIndex: number) => {
 		const group = groups[groupIndex];
 		if (group.rules.length >= MAX_RULES_PER_GROUP) return;
-		const firstField = fields[0]?.key ?? "";
-		updateGroup(groupIndex, {
-			...group,
-			rules: [...group.rules, emptyFilterRule(objectType, firstField)],
-		});
+		const rule = newRule();
+		if (!rule) return;
+		updateGroup(groupIndex, { ...group, rules: [...group.rules, rule] });
 	};
 
 	const removeRule = (groupIndex: number, ruleIndex: number) => {
@@ -192,20 +220,47 @@ export function FilterGroupsEditor({
 					)}
 
 					{group.rules.map((rule, ruleIndex) => {
-						const fieldDef = getFieldDefinition(objectType, rule.field);
-						const operators = fieldDef ? operatorsForField(objectType, rule.field) : [];
+						const variableLeft = rule.left?.kind === "var" ? rule.left : undefined;
+						const leftOption = variableLeft
+							? variableOptions.find((o) => o.path === variableLeft.path)
+							: undefined;
+						const fieldDef =
+							!variableLeft && objectType
+								? getFieldDefinition(objectType, rule.field)
+								: undefined;
+						const operators = variableLeft
+							? [...VARIABLE_LEFT_OPERATORS]
+							: fieldDef && objectType
+								? operatorsForField(objectType, rule.field)
+								: [];
 						const needsValue = !isValueless(rule.operator);
+						// A step result has no registry entry; drive the value control off
+						// the variable's own type, defaulting to a number.
+						const valueSpec = variableLeft
+							? { type: leftOption?.fieldType ?? ("number" as const) }
+							: fieldDef;
 
 						return (
 							<div key={ruleIndex} className="flex items-start gap-2">
 								<div className="flex-1 space-y-2">
 									<Select
-										value={rule.field}
-										onValueChange={(field) => {
-											if (!field) return;
-											const nextOperators = operatorsForField(objectType, field);
+										value={
+											variableLeft ? `${VAR_PREFIX}${variableLeft.path}` : rule.field
+										}
+										onValueChange={(next) => {
+											if (!next) return;
+											if (next.startsWith(VAR_PREFIX)) {
+												updateRule(
+													groupIndex,
+													ruleIndex,
+													emptyVariableRule(next.slice(VAR_PREFIX.length))
+												);
+												return;
+											}
+											if (!objectType) return;
+											const nextOperators = operatorsForField(objectType, next);
 											updateRule(groupIndex, ruleIndex, {
-												field,
+												field: next,
 												operator: nextOperators[0] ?? "equals",
 												value: isValueless(nextOperators[0] ?? "equals")
 													? undefined
@@ -220,6 +275,14 @@ export function FilterGroupsEditor({
 											{fields.map((f) => (
 												<SelectItem key={f.key} value={f.key}>
 													{f.label}
+												</SelectItem>
+											))}
+											{variableOptions.map((o) => (
+												<SelectItem
+													key={o.path}
+													value={`${VAR_PREFIX}${o.path}`}
+												>
+													{o.label}
 												</SelectItem>
 											))}
 										</SelectContent>
@@ -248,9 +311,9 @@ export function FilterGroupsEditor({
 										</SelectContent>
 									</Select>
 
-									{needsValue && fieldDef && (
+									{needsValue && valueSpec && (
 										<ValueInput
-											field={fieldDef}
+											field={valueSpec}
 											value={rule.value}
 											onChange={(value) => updateRule(groupIndex, ruleIndex, { ...rule, value })}
 											nodes={nodes}
@@ -272,7 +335,7 @@ export function FilterGroupsEditor({
 						);
 					})}
 
-					{group.rules.length < MAX_RULES_PER_GROUP && (
+					{group.rules.length < MAX_RULES_PER_GROUP && canAddRule && (
 						<Button
 							type="button"
 							variant="outline"

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/loop-config.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/loop-config.tsx
@@ -124,6 +124,38 @@ export function LoopConfigPanel({
 									}
 								/>
 							</PanelField>
+
+							<PanelField
+								label="If an item fails"
+								helper={
+									// Absent field = "abort", the behavior of every automation
+									// published before this control existed — don't imply that
+									// changed until the user picks something explicitly.
+									config.onItemError == null
+										? "This loop stops the whole run at the first item that fails."
+										: undefined
+								}
+							>
+								<Select
+									value={config.onItemError ?? "abort"}
+									onValueChange={(onItemError) =>
+										commit({
+											...config,
+											onItemError: onItemError as LoopNodeConfig["onItemError"],
+										})
+									}
+								>
+									<SelectTrigger>
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="continue">
+											Skip it and continue with the remaining items
+										</SelectItem>
+										<SelectItem value="abort">Stop the whole run</SelectItem>
+									</SelectContent>
+								</Select>
+							</PanelField>
 						</>
 					)}
 				</PanelSection>

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/trigger-config.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/trigger-config.tsx
@@ -21,6 +21,7 @@ import {
 	describeSchedule,
 	getFilterableFields,
 	getStatusOptions,
+	triggerScopeObjectType,
 	validateSchedule,
 	type AutomationObjectType,
 	type AutomationSchedule,
@@ -95,7 +96,9 @@ export function TriggerConfigPanel({
 		toStatus: "",
 	};
 	const triggerType = currentTrigger.type || "status_changed";
-	const objectType = currentTrigger.objectType || "quote";
+	// A scheduled trigger has no record, so it has no object type. The fallback
+	// only seeds the pickers for the record trigger types below.
+	const objectType = triggerScopeObjectType(currentTrigger) ?? "quote";
 	const statusOptions = getStatusOptions(objectType);
 	const filterableFields = getFilterableFields(objectType);
 
@@ -106,7 +109,6 @@ export function TriggerConfigPanel({
 		} else if (newType === "scheduled") {
 			onTriggerChange({
 				type: "scheduled",
-				objectType,
 				schedule: currentTrigger.schedule ?? defaultSchedule(),
 			});
 		} else {
@@ -147,6 +149,7 @@ export function TriggerConfigPanel({
 	const handleObjectTypeChange = (value: string) => {
 		const newObjType = value as AutomationObjectType;
 		const newStatusOptions = getStatusOptions(newObjType);
+		if (currentTrigger.type === "scheduled") return;
 		onTriggerChange({
 			...currentTrigger,
 			objectType: newObjType,
@@ -211,30 +214,25 @@ export function TriggerConfigPanel({
 						</Select>
 					</PanelField>
 
-					<PanelField
-						label="Object type"
-						helper={
-							triggerType === "scheduled"
-								? "Sets the record context for later steps."
-								: undefined
-						}
-					>
-						<Select
-							value={objectType}
-							onValueChange={(value) => value && handleObjectTypeChange(value)}
-						>
-							<SelectTrigger>
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								{OBJECT_TYPE_OPTIONS.map((type) => (
-									<SelectItem key={type.value} value={type.value}>
-										{type.label}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-					</PanelField>
+					{triggerType !== "scheduled" && (
+						<PanelField label="Object type">
+							<Select
+								value={objectType}
+								onValueChange={(value) => value && handleObjectTypeChange(value)}
+							>
+								<SelectTrigger>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{OBJECT_TYPE_OPTIONS.map((type) => (
+										<SelectItem key={type.value} value={type.value}>
+											{type.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</PanelField>
+					)}
 
 					{triggerType === "status_changed" && (
 						<>

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/step-picker.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/step-picker.tsx
@@ -30,6 +30,8 @@ export type StepGroupItem = {
 	/** Selects the action variant when type is "action". */
 	actionType?: string;
 	comingSoon?: boolean;
+	/** Set when the step can't work in this position; shown instead of enabling it. */
+	disabledReason?: string;
 };
 
 type StepGroup = {
@@ -151,19 +153,41 @@ interface StepPickerProps {
 	onClose?: () => void;
 	/** True when inserting inside a loop body — offers "Next item" and hides "End" (invalid there). */
 	inLoop?: boolean;
+	/** The trigger's type. A scheduled run has no record, which rules some steps out. */
+	triggerType?: string;
 }
 
-export function StepPicker({ onSelect, onClose, inLoop = false }: StepPickerProps) {
+export function StepPicker({
+	onSelect,
+	onClose,
+	inLoop = false,
+	triggerType,
+}: StepPickerProps) {
 	const [search, setSearch] = useState("");
 	const lowerSearch = search.toLowerCase();
 
+	// A scheduled run has no triggering record, so outside a loop there is
+	// nothing for "Update Record" to act on. Offering it anyway would let a user
+	// build a step they cannot save and cannot fix in place — the panel has no
+	// control for pointing it at another record.
+	const noRecordInScope = triggerType === "scheduled" && !inLoop;
+
 	const filteredGroups = STEP_GROUPS.map((group) => ({
 		...group,
-		items: group.items.filter((item) => {
-			if (item.type === "next_item" && !inLoop) return false;
-			if (item.type === "end" && inLoop) return false;
-			return item.label.toLowerCase().includes(lowerSearch);
-		}),
+		items: group.items
+			.filter((item) => {
+				if (item.type === "next_item" && !inLoop) return false;
+				if (item.type === "end" && inLoop) return false;
+				return item.label.toLowerCase().includes(lowerSearch);
+			})
+			.map((item) =>
+				noRecordInScope && item.type === "action" && !item.actionType
+					? {
+							...item,
+							disabledReason: "Needs a record — add Find Records, then a Loop",
+						}
+					: item
+			),
 	})).filter((group) => group.items.length > 0);
 
 	return (
@@ -209,15 +233,18 @@ export function StepPicker({ onSelect, onClose, inLoop = false }: StepPickerProp
 						<div className="space-y-0.5">
 							{group.items.map((item) => {
 								const Icon = item.icon;
+								const disabled =
+									item.comingSoon || Boolean(item.disabledReason);
 								return (
 									<button
 										key={`${item.type}-${item.actionType ?? ""}-${item.label}`}
 										type="button"
-										disabled={item.comingSoon}
-										onClick={() => !item.comingSoon && onSelect(item.type, item.actionType)}
+										disabled={disabled}
+										title={item.disabledReason}
+										onClick={() => !disabled && onSelect(item.type, item.actionType)}
 										className={cn(
 											"w-full flex items-center gap-3 px-3 py-2 rounded-md transition-colors text-left",
-											item.comingSoon
+											disabled
 												? "opacity-50 cursor-not-allowed"
 												: "hover:bg-accent"
 										)}
@@ -232,6 +259,11 @@ export function StepPicker({ onSelect, onClose, inLoop = false }: StepPickerProp
 										</div>
 										<span className="text-sm flex-1">
 											{item.label}
+											{item.disabledReason && (
+												<span className="block text-xs text-muted-foreground">
+													{item.disabledReason}
+												</span>
+											)}
 										</span>
 										{item.comingSoon && (
 											<span className="text-[10px] font-medium text-muted-foreground bg-muted px-1.5 py-0.5 rounded-full shrink-0">

--- a/apps/web/src/app/(workspace)/automations/hooks/use-automation-editor.ts
+++ b/apps/web/src/app/(workspace)/automations/hooks/use-automation-editor.ts
@@ -165,9 +165,18 @@ function buildFetchNode(
 	};
 }
 
-/** Config (sourceNodeId) is set once the user picks a fetch_records step in the panel. */
+/**
+ * sourceNodeId is set once the user picks a fetch_records step in the panel.
+ * New loops are born with onItemError: "continue" (the builder's default);
+ * a loop published before this field existed has it absent, which means
+ * "abort" — see loopNodeConfigValidator in workflowTypes.ts.
+ */
 function buildLoopNode(id: string): WorkflowNode {
-	return { id, type: "loop" };
+	return {
+		id,
+		type: "loop",
+		config: { kind: "loop", sourceNodeId: "", onItemError: "continue" },
+	};
 }
 
 /** sourceNodeId/field are chosen once the user picks a Find records step in the panel. */

--- a/apps/web/src/app/(workspace)/automations/hooks/use-automation-editor.ts
+++ b/apps/web/src/app/(workspace)/automations/hooks/use-automation-editor.ts
@@ -8,6 +8,7 @@ import type { Id } from "@onetool/backend/convex/_generated/dataModel";
 import { useToast } from "@/hooks/use-toast";
 import {
 	getStatusOptions,
+	triggerScopeObjectType,
 	type AutomationAction,
 	type AutomationTrigger,
 	type ConditionNodeConfig,
@@ -72,7 +73,7 @@ function buildTriggerFromType(
 	triggerType: string,
 	currentTrigger: TriggerConfig | null
 ): TriggerConfig {
-	const objectType = currentTrigger?.objectType ?? "quote";
+	const objectType = triggerScopeObjectType(currentTrigger) ?? "quote";
 	const nextType = triggerType as TriggerType;
 
 	if (nextType === "record_created" || nextType === "record_updated") {
@@ -80,9 +81,9 @@ function buildTriggerFromType(
 	}
 
 	if (nextType === "scheduled") {
+		// No objectType: a scheduled run has no triggering record.
 		return {
 			type: nextType,
-			objectType,
 			schedule: {
 				frequency: "daily",
 				timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -158,7 +159,7 @@ function buildFetchNode(
 		type: "fetch_records",
 		config: {
 			kind: "fetch_records",
-			objectType: trigger.objectType ?? "client",
+			objectType: triggerScopeObjectType(trigger) ?? "client",
 			filters: [],
 		},
 		nextNodeId: downstreamId,
@@ -234,7 +235,7 @@ function buildNextItemNode(id: string): WorkflowNode {
 
 /** Build the v2 trigger arg accepted by automations.create/update. */
 function buildTriggerForSave(trigger: TriggerConfig) {
-	const objectType = trigger.objectType ?? "client";
+	const objectType = triggerScopeObjectType(trigger) ?? "client";
 	// Empty criteria are dropped so unused editors don't dirty the doc.
 	const entryCriteria =
 		trigger.entryCriteria && trigger.entryCriteria.groups.length > 0
@@ -256,7 +257,6 @@ function buildTriggerForSave(trigger: TriggerConfig) {
 		case "scheduled":
 			return {
 				type: "scheduled" as const,
-				objectType,
 				schedule: trigger.schedule ?? {
 					frequency: "daily" as const,
 					timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -863,9 +863,10 @@ export function useAutomationEditor(automationId: string | null) {
 		[execution]
 	);
 	const isRunning = execution?.status === "running";
+	const sampleScopeObjectType = triggerScopeObjectType(trigger);
 	const sampleRecords = useQuery(
 		api.automationExecutor.getSampleRecords,
-		trigger?.objectType ? { objectType: trigger.objectType } : "skip"
+		sampleScopeObjectType ? { objectType: sampleScopeObjectType } : "skip"
 	);
 
 	/**
@@ -873,7 +874,7 @@ export function useAutomationEditor(automationId: string | null) {
 	 * or null if validation blocked the save. Shared by Save / Publish / Test.
 	 */
 	const persistWorkingCopy = useCallback(async (): Promise<string | null> => {
-		const validation = validateWorkflowForSave(trigger, nodes);
+		const validation = validateWorkflowForSave(trigger, nodes, formulas);
 		if (!validation.valid) {
 			toast.error(
 				"Validation Error",

--- a/apps/web/src/app/(workspace)/automations/lib/condition-sentence.test.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/condition-sentence.test.ts
@@ -121,4 +121,56 @@ describe("conditionSentence", () => {
 		expect(parts.map((p) => p.kind)).toEqual(["rule", "text", "rule"]);
 		expect(parts[1].text).toBe(" and ");
 	});
+
+	it("renders a variable-left rule with the exact label when provided", () => {
+		const groups: ConditionGroup[] = [
+			{
+				logic: "and",
+				rules: [
+					{
+						field: "",
+						left: { kind: "var", path: "node.agg1.result" },
+						operator: "greater_than",
+						value: { kind: "static", value: 10000 },
+					},
+				],
+			},
+		];
+		const varLabels = new Map([["node.agg1.result", "Aggregate result"]]);
+		expect(conditionSentence("and", groups, null, varLabels)).toBe(
+			"Aggregate result is greater than 10000"
+		);
+	});
+
+	it("never leaks a raw internal path for known variable shapes", () => {
+		const groups: ConditionGroup[] = [
+			{
+				logic: "and",
+				rules: [
+					{
+						field: "",
+						left: { kind: "var", path: "node.agg1.result" },
+						operator: "greater_than",
+						value: { kind: "static", value: 10000 },
+					},
+					{
+						field: "",
+						left: { kind: "var", path: "formula.f1" },
+						operator: "equals",
+						value: { kind: "var", path: "workflow.now" },
+					},
+					{
+						field: "",
+						left: { kind: "var", path: "node.fetch1.count" },
+						operator: "gte",
+						value: { kind: "static", value: 3 },
+					},
+				],
+			},
+		];
+		// No varLabels map (the canvas card path) — generic descriptions, no {path}.
+		expect(conditionSentence("and", groups, null)).toBe(
+			"Computed result is greater than 10000 and Formula result equals Current time and Found records count is at least 3"
+		);
+	});
 });

--- a/apps/web/src/app/(workspace)/automations/lib/condition-sentence.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/condition-sentence.ts
@@ -49,11 +49,34 @@ function isRuleComplete(rule: ConditionRule): boolean {
 	return true;
 }
 
-/** trigger.record.<field> paths render as the field label; anything else as a raw {path}. */
-function describeVarPath(
+/** Path → friendly label for callers that computed variable options (exact labels). */
+export type VarLabelMap = ReadonlyMap<string, string>;
+
+const GLOBAL_PATH_LABELS: Record<string, string> = {
+	"workflow.now": "Current time",
+	"workflow.tz": "Timezone",
+	"org.id": "Organization ID",
+	"org.name": "Organization name",
+	"user.id": "Your user ID",
+	"user.name": "Your name",
+	"user.email": "Your email",
+	"trigger.event.oldValue": "Previous value",
+	"trigger.event.newValue": "New value",
+};
+
+/**
+ * trigger.record.<field> paths render as the field label; other known path
+ * shapes get a generic description. Exact labels come from `varLabels` when the
+ * caller has them (the config panel does; the canvas card doesn't).
+ */
+export function describeVarPath(
 	path: string,
-	objectType: AutomationObjectType | null
+	objectType: AutomationObjectType | null,
+	varLabels?: VarLabelMap
 ): string {
+	const exact = varLabels?.get(path);
+	if (exact) return exact;
+
 	const prefix = "trigger.record.";
 	if (path.startsWith(prefix)) {
 		const field = path.slice(prefix.length);
@@ -64,15 +87,27 @@ function describeVarPath(
 		if (!label) return objectType ? field : "the triggering record";
 		return label;
 	}
+
+	const global = GLOBAL_PATH_LABELS[path];
+	if (global) return global;
+	if (/^node\.[^.]+\.count$/.test(path)) return "Found records count";
+	if (/^node\.[^.]+\.result$/.test(path)) return "Computed result";
+	if (/^loop\.[^.]+\.index$/.test(path)) return "Loop item index";
+	const loopItem = path.match(/^loop\.[^.]+\.item\.(.+)$/);
+	if (loopItem) {
+		return loopItem[1] === "_id" ? "Loop item ID" : `Loop item ${loopItem[1]}`;
+	}
+	if (/^formula\.[^.]+$/.test(path)) return "Formula result";
 	return `{${path}}`;
 }
 
 function describeValue(
 	objectType: AutomationObjectType | null,
 	field: string,
-	value: ValueRef
+	value: ValueRef,
+	varLabels?: VarLabelMap
 ): string {
-	if (value.kind === "var") return describeVarPath(value.path, objectType);
+	if (value.kind === "var") return describeVarPath(value.path, objectType, varLabels);
 
 	const fieldDef = objectType ? getFieldDefinition(objectType, field) : undefined;
 	if (fieldDef?.type === "select") {
@@ -83,12 +118,17 @@ function describeValue(
 	return String(value.value);
 }
 
-function ruleText(rule: ConditionRule, objectType: AutomationObjectType | null): string {
+function ruleText(
+	rule: ConditionRule,
+	objectType: AutomationObjectType | null,
+	varLabels?: VarLabelMap
+): string {
 	const fieldDef = objectType ? getFieldDefinition(objectType, rule.field) : undefined;
 	const fieldLabel = rule.left
 		? describeVarPath(
 				rule.left.kind === "var" ? rule.left.path : String(rule.left.value),
-				objectType
+				objectType,
+				varLabels
 			)
 		: (fieldDef?.label ?? rule.field);
 	const opLabel = OPERATOR_LABELS[rule.operator] ?? rule.operator;
@@ -96,14 +136,15 @@ function ruleText(rule: ConditionRule, objectType: AutomationObjectType | null):
 	if (isValueless(rule.operator) || rule.value === undefined) {
 		return `${fieldLabel} ${opLabel}`;
 	}
-	return `${fieldLabel} ${opLabel} ${describeValue(objectType, rule.field, rule.value)}`;
+	return `${fieldLabel} ${opLabel} ${describeValue(objectType, rule.field, rule.value, varLabels)}`;
 }
 
 type RenderedGroup = { parts: SentencePart[]; multi: boolean };
 
 function renderGroup(
 	group: ConditionGroup,
-	objectType: AutomationObjectType | null
+	objectType: AutomationObjectType | null,
+	varLabels?: VarLabelMap
 ): RenderedGroup | null {
 	const completeRules = group.rules.filter(isRuleComplete);
 	if (completeRules.length === 0) return null;
@@ -111,7 +152,7 @@ function renderGroup(
 	const parts: SentencePart[] = [];
 	completeRules.forEach((rule, index) => {
 		if (index > 0) parts.push({ kind: "text", text: ` ${group.logic} ` });
-		parts.push({ kind: "rule", text: ruleText(rule, objectType) });
+		parts.push({ kind: "rule", text: ruleText(rule, objectType, varLabels) });
 	});
 	return { parts, multi: completeRules.length > 1 };
 }
@@ -125,10 +166,11 @@ function renderGroup(
 export function conditionSentenceParts(
 	logic: "and" | "or",
 	groups: ConditionGroup[],
-	objectType: AutomationObjectType | null
+	objectType: AutomationObjectType | null,
+	varLabels?: VarLabelMap
 ): SentencePart[] {
 	const rendered = groups
-		.map((group) => renderGroup(group, objectType))
+		.map((group) => renderGroup(group, objectType, varLabels))
 		.filter((g): g is RenderedGroup => g !== null);
 
 	if (rendered.length === 0) return [];
@@ -151,9 +193,10 @@ export function conditionSentenceParts(
 export function conditionSentence(
 	logic: "and" | "or",
 	groups: ConditionGroup[],
-	objectType: AutomationObjectType | null
+	objectType: AutomationObjectType | null,
+	varLabels?: VarLabelMap
 ): string {
-	return conditionSentenceParts(logic, groups, objectType)
+	return conditionSentenceParts(logic, groups, objectType, varLabels)
 		.map((part) => part.text)
 		.join("");
 }

--- a/apps/web/src/app/(workspace)/automations/lib/condition-sentence.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/condition-sentence.ts
@@ -37,7 +37,7 @@ function isValueless(operator: ConditionOperator): boolean {
 }
 
 function isRuleComplete(rule: ConditionRule): boolean {
-	if (!rule.field.trim()) return false;
+	if (!rule.left && !rule.field.trim()) return false;
 	if (isValueless(rule.operator)) return true;
 	if (rule.value === undefined) return false;
 	if (
@@ -59,7 +59,10 @@ function describeVarPath(
 		const field = path.slice(prefix.length);
 		if (field === "_id") return "Trigger record ID"; // not in the field registry
 		const label = objectType ? getFieldDefinition(objectType, field)?.label : undefined;
-		return label ?? field;
+		// With no record in scope there is no field to name it after. Say so
+		// rather than leaking a raw path that reads like it resolves.
+		if (!label) return objectType ? field : "the triggering record";
+		return label;
 	}
 	return `{${path}}`;
 }
@@ -82,7 +85,12 @@ function describeValue(
 
 function ruleText(rule: ConditionRule, objectType: AutomationObjectType | null): string {
 	const fieldDef = objectType ? getFieldDefinition(objectType, rule.field) : undefined;
-	const fieldLabel = fieldDef?.label ?? rule.field;
+	const fieldLabel = rule.left
+		? describeVarPath(
+				rule.left.kind === "var" ? rule.left.path : String(rule.left.value),
+				objectType
+			)
+		: (fieldDef?.label ?? rule.field);
 	const opLabel = OPERATOR_LABELS[rule.operator] ?? rule.operator;
 
 	if (isValueless(rule.operator) || rule.value === undefined) {

--- a/apps/web/src/app/(workspace)/automations/lib/editor-signature.test.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/editor-signature.test.ts
@@ -4,7 +4,9 @@ import {
 	automationToReactFlow,
 	reactFlowToFlatArray,
 } from "./flow-adapter";
+import { legacyTriggerToDraft } from "./legacy-load";
 import type {
+	AutomationTrigger,
 	ConditionNodeConfig,
 	FetchNodeConfig,
 	TriggerConfig,
@@ -227,5 +229,39 @@ describe("definitionSignature — load round-trip stability", () => {
 
 		// Stable => isDirty would be false immediately after load.
 		expect(workingSig).toBe(loadedSig);
+	});
+});
+
+describe("stored scheduled triggers with a legacy objectType (A1)", () => {
+	it("signs identically with and without the stored objectType", () => {
+		// Old rows carry objectType on scheduled triggers; the save path strips
+		// it. If load kept it, the published signature could never equal the
+		// draft signature and every stored scheduled automation would wear a
+		// "Publish changes" badge forever.
+		const schedule = {
+			frequency: "daily",
+			timezone: "UTC",
+			time: "09:00",
+		} as const;
+		const legacyStored = {
+			type: "scheduled",
+			objectType: "quote",
+			schedule,
+		} as unknown as AutomationTrigger;
+		const cleanStored = {
+			type: "scheduled",
+			schedule,
+		} as unknown as AutomationTrigger;
+
+		const nodes: WorkflowNode[] = [node("n1")];
+		const legacySig = definitionSignature(
+			legacyTriggerToDraft(legacyStored),
+			nodes
+		);
+		const cleanSig = definitionSignature(
+			legacyTriggerToDraft(cleanStored),
+			nodes
+		);
+		expect(legacySig).toBe(cleanSig);
 	});
 });

--- a/apps/web/src/app/(workspace)/automations/lib/flow-adapter.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/flow-adapter.ts
@@ -14,6 +14,7 @@ import type {
 	WorkflowNode,
 	WorkflowNodeConfig,
 } from "./node-types";
+import { triggerScopeObjectType } from "./node-types";
 import { legacyNodeToV2 } from "./legacy-load";
 import { collectLoopBody } from "./graph-utils";
 import {
@@ -186,7 +187,7 @@ function resolveLoopBackSourceId(
 }
 
 function buildNodeData(node: EditorNode, trigger: TriggerConfig) {
-	const triggerObjectType = trigger.objectType ?? null;
+	const triggerObjectType = triggerScopeObjectType(trigger);
 
 	if (isPlaceholderEntry(node)) {
 		return { nodeType: "placeholder" as const };
@@ -278,7 +279,7 @@ export function automationToReactFlow(
 			data: {
 				nodeType: "trigger",
 				trigger,
-				triggerObjectType: trigger.objectType ?? null,
+				triggerObjectType: triggerScopeObjectType(trigger),
 			},
 			position: { x: 0, y: 0 },
 		} as AppNode);

--- a/apps/web/src/app/(workspace)/automations/lib/legacy-load.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/legacy-load.ts
@@ -64,9 +64,11 @@ export function legacyTriggerToDraft(trigger: AutomationTrigger): TriggerConfig 
 				entryCriteria: trigger.entryCriteria,
 			};
 		case "scheduled":
+			// objectType is deliberately dropped: a scheduled run has no record.
+			// Rehydrating it would keep offering dead trigger.record.* tokens, and
+			// would make every stored scheduled automation read as unpublished.
 			return {
 				type: "scheduled",
-				objectType: trigger.objectType,
 				schedule: trigger.schedule,
 			};
 	}

--- a/apps/web/src/app/(workspace)/automations/lib/node-types.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/node-types.ts
@@ -208,9 +208,8 @@ export const TRIGGER_TYPE_OPTIONS: {
 	},
 ];
 
-export type TriggerConfig = {
-	type?: TriggerType;
-	objectType?: AutomationObjectType;
+/** Fields shared by every trigger draft, regardless of type. */
+type TriggerConfigBase = {
 	/** status_changed */
 	fromStatus?: string;
 	toStatus?: string;
@@ -227,6 +226,44 @@ export type TriggerConfig = {
 		dayOfMonth?: number;
 	};
 };
+
+/**
+ * The scheduled variant OMITS objectType — a scheduled run has no triggering
+ * record, so there is no object for it to name. Omission (not `objectType?:
+ * never`) is deliberate: `never` still typechecks on reads, so it would let
+ * every stale `trigger.objectType` site keep compiling. Absent means the
+ * compiler names them all.
+ */
+export type TriggerConfig =
+	| (TriggerConfigBase & {
+			type?: "status_changed" | "record_created" | "record_updated";
+			objectType?: AutomationObjectType;
+	  })
+	| (TriggerConfigBase & { type: "scheduled" });
+
+/**
+ * Operators offered when a condition rule's left side is a variable (a step
+ * result or a formula) rather than a record field. No registry entry exists to
+ * derive them from, so the set is fixed and deliberately conservative.
+ */
+export const VARIABLE_LEFT_OPERATORS = [
+	"equals",
+	"not_equals",
+	"greater_than",
+	"less_than",
+	"gte",
+	"lte",
+	"is_empty",
+	"is_not_empty",
+] as const;
+
+/** The object type bound to `trigger.record`, or null when there is none. */
+export function triggerScopeObjectType(
+	trigger: TriggerConfig | null | undefined
+): AutomationObjectType | null {
+	if (!trigger || trigger.type === "scheduled") return null;
+	return trigger.objectType ?? null;
+}
 
 // ---------------------------------------------------------------------------
 // 6. Action target UI options (derived from the registry relations map)

--- a/apps/web/src/app/(workspace)/automations/lib/run-format.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/run-format.ts
@@ -4,6 +4,7 @@ import type { Doc } from "@onetool/backend/convex/_generated/dataModel";
 export type RunStatus =
 	| "running"
 	| "completed"
+	| "completed_with_errors"
 	| "failed"
 	| "skipped"
 	| "cancelled";
@@ -22,6 +23,7 @@ export const RUN_STATUS_META: Record<
 > = {
 	running: { label: "Running", badge: "default" },
 	completed: { label: "Completed", badge: "success" },
+	completed_with_errors: { label: "Completed with errors", badge: "warning" },
 	failed: { label: "Failed", badge: "destructive" },
 	skipped: { label: "Skipped", badge: "outline" },
 	cancelled: { label: "Cancelled", badge: "warning" },
@@ -31,24 +33,11 @@ export const RUN_STATUS_META: Record<
 export const RUN_STATUS_FILTER_ORDER: RunStatus[] = [
 	"completed",
 	"failed",
+	"completed_with_errors",
 	"running",
 	"skipped",
 	"cancelled",
 ];
-
-/**
- * Status palette for the throughput chart. Validated with the dataviz
- * validate_palette.js six-checks (light + dark): success/failed carry ΔE 23
- * CVD separation; skipped is an intentional neutral gray with legend+icon relief.
- * These are reserved status colors — never reuse them for a categorical series.
- */
-export const RUN_CHART_SERIES = [
-	{ key: "success", label: "Completed", light: "#059669", dark: "#34d399" },
-	{ key: "failed", label: "Failed", light: "#dc2626", dark: "#f87171" },
-	{ key: "skipped", label: "Skipped", light: "#64748b", dark: "#94a3b8" },
-] as const;
-
-export type RunThroughputKey = (typeof RUN_CHART_SERIES)[number]["key"];
 
 /**
  * Human-readable duration. `ms` is an elapsed span (e.g. active execution time).
@@ -113,6 +102,20 @@ export function formatTriggerSource(triggeredBy: string | undefined): string {
 		default:
 			return triggeredBy.replace(/_/g, " ").replace(/^\w/, (c) => c.toUpperCase());
 	}
+}
+
+/**
+ * Sum item totals/failures across every loop node in a run's `loopSummary`
+ * (a run can contain more than one loop). Zeroed out when there's no summary.
+ */
+export function summarizeLoopFailures(
+	loopSummary: Doc<"workflowExecutions">["loopSummary"]
+): { total: number; failed: number } {
+	if (!loopSummary || loopSummary.length === 0) return { total: 0, failed: 0 };
+	return loopSummary.reduce(
+		(acc, s) => ({ total: acc.total + s.total, failed: acc.failed + s.failed }),
+		{ total: 0, failed: 0 }
+	);
 }
 
 /**

--- a/apps/web/src/app/(workspace)/automations/lib/run-status.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/run-status.ts
@@ -17,7 +17,13 @@ type ExecutedEntry = {
 };
 
 type ExecutionLike = {
-	status: "running" | "completed" | "failed" | "skipped" | "cancelled";
+	status:
+		| "running"
+		| "completed"
+		| "completed_with_errors"
+		| "failed"
+		| "skipped"
+		| "cancelled";
 	currentNodeId?: string;
 	nodesExecuted: ExecutedEntry[];
 };

--- a/apps/web/src/app/(workspace)/automations/lib/validation.test.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/validation.test.ts
@@ -507,3 +507,134 @@ describe("validateWorkflowForSave — trigger entry criteria", () => {
 		).toBe(true);
 	});
 });
+
+describe("validateWorkflowForSave — scheduled triggers have no record (A1)", () => {
+	const scheduled: TriggerConfig = {
+		type: "scheduled",
+		schedule: { frequency: "daily", timezone: "UTC", time: "09:00" },
+	};
+
+	const updateSelf: WorkflowNode = {
+		id: "act1",
+		type: "action",
+		config: {
+			kind: "action",
+			action: {
+				type: "update_field",
+				target: "self",
+				field: "status",
+				value: { kind: "static", value: "active" },
+			},
+		},
+	};
+
+	function conditionNode(id: string, config: ConditionNodeConfig): WorkflowNode {
+		return { id, type: "condition", config };
+	}
+
+	it("rejects a top-level update_field, and says why", () => {
+		const result = validateWorkflowForSave(scheduled, [updateSelf]);
+		const error = result.errors.find((e) => e.nodeId === "act1");
+		expect(error?.type).toBe("no_trigger_record");
+		expect(error?.message).toMatch(/no record to update/i);
+	});
+
+	it("rejects a top-level condition that reads a record field", () => {
+		const nodes = [conditionNode("cond1", conditionRule("status", "equals"))];
+		const result = validateWorkflowForSave(scheduled, nodes);
+		expect(
+			result.errors.some(
+				(e) => e.nodeId === "cond1" && e.type === "no_trigger_record"
+			)
+		).toBe(true);
+	});
+
+	it("accepts a top-level condition whose left side is a step result", () => {
+		const nodes = [
+			fetchNode("fetch1", "invoice"),
+			aggregateNode("agg1", {
+				kind: "aggregate",
+				sourceNodeId: "fetch1",
+				field: "total",
+				op: "sum",
+			}),
+			conditionNode("cond1", {
+				kind: "condition",
+				logic: "and",
+				groups: [
+					{
+						logic: "and",
+						rules: [
+							{
+								field: "",
+								left: { kind: "var", path: "node.agg1.result" },
+								operator: "greater_than",
+								value: { kind: "static", value: 10000 },
+							},
+						],
+					},
+				],
+			}),
+		];
+		const result = validateWorkflowForSave(scheduled, nodes);
+		expect(result.errors.filter((e) => e.nodeId === "cond1")).toHaveLength(0);
+	});
+
+	it("rejects a {{trigger.record.*}} token inside a message template", () => {
+		const notify: WorkflowNode = {
+			id: "notify1",
+			type: "action",
+			config: {
+				kind: "action",
+				action: {
+					type: "send_notification",
+					recipient: "org_admins",
+					message: "Total is {{trigger.record.total}}",
+				},
+			},
+		};
+		const result = validateWorkflowForSave(scheduled, [notify]);
+		const error = result.errors.find((e) => e.nodeId === "notify1");
+		expect(error?.type).toBe("no_trigger_record");
+		expect(error?.message).toMatch(/always empty/i);
+	});
+
+	it("rejects a formula that reads the trigger record", () => {
+		const notify: WorkflowNode = {
+			id: "notify1",
+			type: "action",
+			config: {
+				kind: "action",
+				action: {
+					type: "send_notification",
+					recipient: "org_admins",
+					message: "hi",
+				},
+			},
+		};
+		const result = validateWorkflowForSave(scheduled, [notify], [
+			{
+				id: "f1",
+				name: "Doubled",
+				returnType: "number",
+				expression: "{trigger.record.budget} * 2",
+			},
+		]);
+		expect(result.errors.some((e) => e.type === "no_trigger_record")).toBe(true);
+	});
+
+	it("leaves a correctly-built fetch -> loop -> update alone", () => {
+		const nodes: WorkflowNode[] = [
+			fetchNode("fetch1", "project"),
+			{
+				id: "loop1",
+				type: "loop",
+				config: { kind: "loop", sourceNodeId: "fetch1" } satisfies LoopNodeConfig,
+				bodyStartNodeId: "act1",
+			},
+			updateSelf,
+		];
+		const result = validateWorkflowForSave(scheduled, nodes);
+		expect(result.errors.some((e) => e.type === "no_trigger_record")).toBe(false);
+	});
+});

--- a/apps/web/src/app/(workspace)/automations/lib/validation.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/validation.ts
@@ -35,8 +35,10 @@ import {
 	type DelayUntilNodeConfig,
 	type FetchNodeConfig,
 	type LoopNodeConfig,
+	type FormulaResource,
 	type TriggerConfig,
 	type WorkflowNode,
+	triggerScopeObjectType,
 } from "./node-types";
 import { getScopeObjectType } from "./variables";
 
@@ -47,6 +49,7 @@ export type ValidationResult = {
 			| "placeholder_present"
 			| "missing_required_config"
 			| "no_trigger"
+			| "no_trigger_record"
 			| "end_inside_loop"
 			| "next_item_outside_loop";
 		message: string;
@@ -64,11 +67,17 @@ function isRuleComplete(
 	objectType: AutomationObjectType | null,
 	rule: ConditionRule
 ): boolean {
-	if (!rule.field.trim()) return false;
-	if (objectType) {
-		const operators = operatorsForField(objectType, rule.field);
-		if (operators.length > 0 && !operators.includes(rule.operator)) {
-			return false;
+	if (rule.left) {
+		// Tests a scope value, not a record field — there is no field to check
+		// and no registry entry to validate the operator against.
+		if (rule.left.kind !== "var" || !rule.left.path.trim()) return false;
+	} else {
+		if (!rule.field.trim()) return false;
+		if (objectType) {
+			const operators = operatorsForField(objectType, rule.field);
+			if (operators.length > 0 && !operators.includes(rule.operator)) {
+				return false;
+			}
 		}
 	}
 	const valueless = (VALUELESS_OPERATORS as readonly string[]).includes(
@@ -95,9 +104,11 @@ function validateTrigger(
 		return;
 	}
 
+	const triggerObjectType = triggerScopeObjectType(trigger);
+
 	switch (trigger.type ?? "status_changed") {
 		case "status_changed":
-			if (!trigger.objectType || !trigger.toStatus?.trim()) {
+			if (!triggerObjectType || !trigger.toStatus?.trim()) {
 				errors.push({
 					type: "missing_required_config",
 					message: "Trigger status is required",
@@ -106,7 +117,7 @@ function validateTrigger(
 			break;
 		case "record_created":
 		case "record_updated":
-			if (!trigger.objectType) {
+			if (!triggerObjectType) {
 				errors.push({
 					type: "missing_required_config",
 					message: "Trigger object type is required",
@@ -136,7 +147,18 @@ function validateTrigger(
 	// Entry criteria (A5-2): absent/empty is fine; started-but-incomplete
 	// rules block save, mirroring condition-node completeness.
 	if (trigger.entryCriteria) {
-		const objectType = trigger.objectType ?? null;
+		const objectType = triggerObjectType;
+		// Entry criteria run against records being matched, so a rule must name a
+		// real field — the backend rejects a variable left side here too.
+		const hasVariableLeft = trigger.entryCriteria.groups.some((group) =>
+			group.rules.some((rule) => rule.left !== undefined)
+		);
+		if (hasVariableLeft) {
+			errors.push({
+				type: "missing_required_config",
+				message: "Entry criteria must compare a field on the record",
+			});
+		}
 		const incomplete = trigger.entryCriteria.groups.some((group) =>
 			group.rules.some((rule) => !isRuleComplete(objectType, rule))
 		);
@@ -214,9 +236,12 @@ function validateActionNode(
 	switch (action.type) {
 		case "update_field": {
 			if (!scopeObjectType) {
+				// Reached on a scheduled automation outside a loop — the trigger is
+				// fine, there is simply no record for the action to touch.
 				errors.push({
-					type: "missing_required_config",
-					message: "Set a trigger before configuring actions",
+					type: "no_trigger_record",
+					message:
+						"This automation runs on a schedule, so there is no record to update. Add a Find records step and move this action inside a Loop.",
 					nodeId,
 				});
 				return;
@@ -611,15 +636,98 @@ function validateDelayUntilNode(
 	// var kind: resolved at run time — nothing further to check here.
 }
 
+const TEMPLATE_TOKEN = /\{\{\s*([^}]+?)\s*\}\}/g;
+
+/** Scope paths a config reads: var refs plus {{tokens}} inside static strings. */
+function collectConfigPaths(value: unknown, out: string[] = []): string[] {
+	if (typeof value === "string") {
+		for (const match of value.matchAll(TEMPLATE_TOKEN)) out.push(match[1].trim());
+		return out;
+	}
+	if (Array.isArray(value)) {
+		for (const item of value) collectConfigPaths(item, out);
+		return out;
+	}
+	if (value !== null && typeof value === "object") {
+		const obj = value as Record<string, unknown>;
+		if (obj.kind === "var" && typeof obj.path === "string") out.push(obj.path);
+		for (const key of Object.keys(obj)) collectConfigPaths(obj[key], out);
+	}
+	return out;
+}
+
+function readsTriggerRecord(path: string): boolean {
+	return /^trigger\.(record|event)\b/.test(path);
+}
+
+/**
+ * Mirrors the backend (automations.ts validateScheduledRecordScope) so a broken
+ * scheduled automation fails inline at save rather than throwing from the
+ * server. A scheduled run walks with trigger.record = {}, so anything reading or
+ * acting on the trigger record is dead.
+ *
+ * Keyed on loop-body membership, never on the stored condition `source`: inside
+ * a loop the record in scope IS the loop item, and legacy in-loop conditions
+ * carry source "trigger" but run correctly.
+ */
+function validateScheduledRecordScope(
+	nodes: EditorNode[],
+	workflowNodes: WorkflowNode[],
+	errors: ValidationResult["errors"]
+): void {
+	for (const node of nodes) {
+		const config = (node as WorkflowNode).config;
+		if (!config) continue;
+
+		const deadPath = collectConfigPaths(config).find(readsTriggerRecord);
+		if (deadPath) {
+			errors.push({
+				type: "no_trigger_record",
+				message: `"${deadPath}" is always empty — a scheduled automation has no triggering record. Add a Find records step and read the loop item instead.`,
+				nodeId: node.id,
+			});
+			continue;
+		}
+
+		const inLoop = getScopeObjectType(workflowNodes, node.id, null).inLoop;
+		if (inLoop) continue;
+
+		if (
+			config.kind === "condition" &&
+			config.groups.some((group) => group.rules.some((rule) => !rule.left))
+		) {
+			errors.push({
+				type: "no_trigger_record",
+				message:
+					"This condition has nothing to test — a scheduled automation has no triggering record. Compare a step result instead, or move it inside a Loop.",
+				nodeId: node.id,
+			});
+		}
+		if (config.kind === "action" && config.action.type === "create_task") {
+			if (config.action.linkToRecord) {
+				errors.push({
+					type: "no_trigger_record",
+					message:
+						"There is no record to link this task to — a scheduled automation has no triggering record. Put it inside a Loop, or turn off \"Link to record\".",
+					nodeId: node.id,
+				});
+			}
+		}
+		// A top-level update_field is caught by validateActionNode, which already
+		// sees a null scope object type.
+	}
+}
+
 export function validateWorkflowForSave(
 	trigger: TriggerConfig | null,
-	nodes: EditorNode[]
+	nodes: EditorNode[],
+	formulas?: FormulaResource[]
 ): ValidationResult {
 	const errors: ValidationResult["errors"] = [];
 	const warnings: ValidationResult["warnings"] = [];
 
 	validateTrigger(trigger, errors);
-	const objectType = trigger?.objectType ?? null;
+	const objectType = triggerScopeObjectType(trigger);
 
 	// Check for empty workflow (no real steps)
 	if (nodes.length === 0) {
@@ -635,6 +743,24 @@ export function validateWorkflowForSave(
 	const workflowNodes: WorkflowNode[] = nodes.filter(
 		(n): n is WorkflowNode => n.type !== "placeholder"
 	);
+
+	if (trigger?.type === "scheduled") {
+		validateScheduledRecordScope(nodes, workflowNodes, errors);
+		// Formulas are automation-level: a node-only scan never sees them, so one
+		// reading the trigger record is dead at every use site.
+		for (const formula of formulas ?? []) {
+			const tokens = formula.expression.match(/\{([^}]+)\}/g) ?? [];
+			const dead = tokens
+				.map((t) => t.slice(1, -1).trim())
+				.find(readsTriggerRecord);
+			if (dead) {
+				errors.push({
+					type: "no_trigger_record",
+					message: `Formula "${formula.name}" reads "${dead}", which is always empty — a scheduled automation has no triggering record.`,
+				});
+			}
+		}
+	}
 
 	for (const node of nodes) {
 		const config = (node as WorkflowNode).config;

--- a/apps/web/src/app/(workspace)/automations/lib/variables.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/variables.ts
@@ -170,7 +170,14 @@ function triggerVariableOptions(
 	trigger: TriggerConfig | AutomationTrigger
 ): VariableOption[] {
 	const options: VariableOption[] = [];
-	const triggerObjectType = trigger.objectType as AutomationObjectType | undefined;
+	// A scheduled trigger has no record, so it offers no trigger.record.* tokens.
+	// This is the root site: every picker, the drawer's Variables pane, and the
+	// formula reference pane all read from here.
+	const triggerObjectType =
+		effectiveTriggerType(trigger) === "scheduled"
+			? undefined
+			: ((trigger as { objectType?: AutomationObjectType }).objectType ??
+				undefined);
 
 	if (triggerObjectType) {
 		// Runtime resolves _id by raw property lookup on the record; offer it explicitly.

--- a/packages/backend/convex/assistantTools.ts
+++ b/packages/backend/convex/assistantTools.ts
@@ -1,4 +1,8 @@
 import { createTool } from "@convex-dev/agent";
+import {
+	triggerRecordObjectType,
+	type AutomationTrigger,
+} from "./lib/workflowTypes";
 import { ConvexError } from "convex/values";
 import { z } from "zod";
 import { api } from "./_generated/api";
@@ -1126,7 +1130,7 @@ export const getAutomations = createTool({
 				name: a.name,
 				description: truncate(a.description, TEXT_CAP),
 				isActive: a.status === "active",
-				trigger: `${a.trigger.type}${"objectType" in a.trigger ? ` (${a.trigger.objectType})` : ""}`,
+				trigger: `${a.trigger.type}${triggerRecordObjectType(a.trigger as AutomationTrigger) ? ` (${triggerRecordObjectType(a.trigger as AutomationTrigger)})` : ""}`,
 				lastTriggeredAt: isoInstant(a.lastTriggeredAt),
 				triggerCount: a.triggerCount,
 			})),

--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -1058,6 +1058,45 @@ describe("automationExecutor (v2 engine)", () => {
 		});
 	});
 
+	describe("date writes are normalized to the calendar-date encoding", () => {
+		it("stores an instant written into a date field as UTC midnight", async () => {
+			const { asUser } = await setupUser();
+
+			const clientId = await asUser.mutation(api.clients.create, {
+				portalAccessId: crypto.randomUUID(),
+				companyName: "Acme Co",
+				status: "lead",
+			});
+
+			// A mid-afternoon instant, not a calendar date. A formula like
+			// ADDDAYS(NOW(), 3) produces exactly this shape.
+			const instant = Date.UTC(2026, 6, 4, 15, 30, 0);
+
+			await asUser.mutation(api.automations.create, {
+				name: "Stamp a start date",
+				trigger: { type: "record_created", objectType: "project" },
+				nodes: [updateFieldActionNode("act-1", "startDate", instant)],
+				isActive: true,
+			});
+
+			const projectId = await asUser.mutation(api.projects.create, {
+				clientId,
+				title: "Kitchen remodel",
+				status: "planned",
+				projectType: "one-off",
+			});
+
+			await drainEvents();
+
+			const project = await t.run(async (ctx) => ctx.db.get(projectId));
+			// Written through unchanged, the stored value would be an instant, which
+			// the formula layer then reads as an instant forever after — and
+			// `startDate == TODAY()` would go quietly false for this record.
+			expect(project?.startDate).toBe(Date.UTC(2026, 6, 4));
+			expect((project?.startDate as number) % 86_400_000).toBe(0);
+		});
+	});
+
 	describe("org isolation", () => {
 		it("does not fire an org A automation for an org B record", async () => {
 			const orgA = await setupUser({

--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { setupConvexTest } from "./test.setup";
 import { createTestOrg, createTestIdentity, addMemberToOrg } from "./test.helpers";
 import { api, internal } from "./_generated/api";
-import { scanOrgRows } from "./automationExecutor";
+import { isFatalExecutionError, scanOrgRows } from "./automationExecutor";
 import { projectCountsAggregate } from "./aggregates";
 import type { Id } from "./_generated/dataModel";
 
@@ -2395,6 +2395,33 @@ describe("automationExecutor (v2 engine)", () => {
 				expect(executions[0].status).toBe("completed");
 				expect(executions[0].triggerRecord).toBeUndefined();
 			});
+
+			it("startTestRun rejects a sample record on a scheduled automation", async () => {
+				const { asUser } = await setupUser();
+
+				const clientId = await asUser.mutation(api.clients.create, {
+					portalAccessId: crypto.randomUUID(),
+					companyName: "Acme Co",
+					status: "active",
+				});
+				const automationId = await asUser.mutation(api.automations.create, {
+					name: "Scheduled test-run guard",
+					trigger: {
+						type: "scheduled",
+						schedule: { frequency: "daily", timezone: "UTC", time: "09:00" },
+					},
+					nodes: [notifyNode("notify-1")],
+				});
+
+				// Binding a record would make the dry run lie: production scheduled
+				// dispatch never has one.
+				await expect(
+					asUser.mutation(api.automationExecutor.startTestRun, {
+						automationId,
+						record: { entityType: "client", entityId: clientId },
+					})
+				).rejects.toThrow(/without a triggering record/);
+			});
 		});
 
 		it("adjust_time: shifts a base timestamp by a fixed offset (add and subtract)", async () => {
@@ -3358,6 +3385,25 @@ describe("automationExecutor (v2 engine)", () => {
 		});
 
 		describe("per-item error isolation (Phase A3)", () => {
+			it("isFatalExecutionError matches Convex's verbatim limit errors", () => {
+				// Wording from get-convex/convex-backend. These doom the whole
+				// transaction and must rethrow, not count as one item's failure.
+				const fatal = [
+					"Too many documents read in a single function execution (limit: 32000)",
+					"Too many bytes read in a single function execution",
+					"Too many bytes written in a single function execution",
+					"Too many writes in a single function execution",
+					"Too many functions scheduled by this mutation",
+					"Function execution timed out (maximum duration: 1s)",
+				];
+				for (const message of fatal) {
+					expect(isFatalExecutionError(new Error(message)), message).toBe(true);
+				}
+				expect(
+					isFatalExecutionError(new Error("Status bogus is not valid for project"))
+				).toBe(false);
+			});
+
 			/**
 			 * Projects whose titles are valid project statuses, plus poisoned ones
 			 * titled "bogus". The loop body writes status = {loop item's title}, so a

--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -1480,13 +1480,48 @@ describe("automationExecutor (v2 engine)", () => {
 		function loopNode(
 			id: string,
 			sourceNodeId: string,
-			opts: { bodyStartNodeId?: string; nextNodeId?: string } = {}
+			opts: {
+				bodyStartNodeId?: string;
+				nextNodeId?: string;
+				onItemError?: "continue" | "abort";
+			} = {}
 		) {
 			return {
 				id,
 				type: "loop" as const,
-				config: { kind: "loop" as const, sourceNodeId },
+				config: {
+					kind: "loop" as const,
+					sourceNodeId,
+					onItemError: opts.onItemError,
+				},
 				bodyStartNodeId: opts.bodyStartNodeId,
+				nextNodeId: opts.nextNodeId,
+			};
+		}
+
+		/**
+		 * Writes a field from a variable path. Used to poison individual loop items:
+		 * driving project.status off the item's own title makes a project titled
+		 * "bogus" fail select coercion while its valid-status siblings succeed.
+		 */
+		function updateFieldFromVarNode(
+			id: string,
+			field: string,
+			path: string,
+			opts: { nextNodeId?: string } = {}
+		) {
+			return {
+				id,
+				type: "action" as const,
+				config: {
+					kind: "action" as const,
+					action: {
+						type: "update_field" as const,
+						target: "self" as const,
+						field,
+						value: { kind: "var" as const, path },
+					},
+				},
 				nextNodeId: opts.nextNodeId,
 			};
 		}
@@ -2988,6 +3023,287 @@ describe("automationExecutor (v2 engine)", () => {
 						isActive: false,
 					})
 				).rejects.toThrow(/only works inside a loop/);
+			});
+		});
+
+		describe("per-item error isolation (Phase A3)", () => {
+			/**
+			 * Projects whose titles are valid project statuses, plus poisoned ones
+			 * titled "bogus". The loop body writes status = {loop item's title}, so a
+			 * poisoned project fails select coercion and its siblings don't.
+			 *
+			 * `titles` is given in LOOP order. fetch_records returns newest-first, so
+			 * they're created back-to-front — otherwise every index assertion below
+			 * would be quietly testing the reverse of what it reads like.
+			 */
+			async function createProjects(
+				asUser: ReturnType<typeof t.withIdentity>,
+				titles: string[]
+			) {
+				const clientId = await asUser.mutation(api.clients.create, {
+					portalAccessId: crypto.randomUUID(),
+					companyName: "Acme Co",
+					status: "active",
+				});
+				for (const title of [...titles].reverse()) {
+					await asUser.mutation(api.projects.create, {
+						clientId,
+						title,
+						status: "planned",
+						projectType: "one-off",
+					});
+				}
+				return clientId;
+			}
+
+			function poisonedLoopNodes(onItemError?: "continue" | "abort") {
+				return [
+					fetchNode(
+						"fetch-1",
+						"project",
+						[filterGroup("status", "equals", "planned")],
+						{ nextNodeId: "loop-1", limit: 100 }
+					),
+					loopNode("loop-1", "fetch-1", {
+						bodyStartNodeId: "body-act",
+						nextNodeId: "end-1",
+						onItemError,
+					}),
+					updateFieldFromVarNode(
+						"body-act",
+						"status",
+						"loop.loop-1.item.title"
+					),
+					endNode("end-1"),
+				];
+			}
+
+			async function runPoisonedLoop(
+				titles: string[],
+				onItemError?: "continue" | "abort"
+			) {
+				const { asUser, orgId } = await setupUser();
+				await makeOrgPremium(orgId);
+				await createProjects(asUser, titles);
+
+				const automationId = await asUser.mutation(api.automations.create, {
+					name: "Advance every project",
+					trigger: {
+						type: "scheduled",
+						schedule: { frequency: "daily", timezone: "UTC", time: "09:00" },
+					},
+					nodes: poisonedLoopNodes(onItemError),
+					isActive: true,
+				});
+
+				await runScheduledOnce(automationId);
+
+				const execution = await t.run(async (ctx) => {
+					const rows = await ctx.db.query("workflowExecutions").collect();
+					return rows[0];
+				});
+				const projects = await t.run(async (ctx) =>
+					ctx.db.query("projects").collect()
+				);
+				return { execution, projects };
+			}
+
+			it("skips the failing item and finishes the rest — completed_with_errors names the record", async () => {
+				// 5 items: three advance, one is poisoned, one advances after it.
+				const { execution, projects } = await runPoisonedLoop(
+					["in-progress", "in-progress", "bogus", "in-progress", "completed"],
+					"continue"
+				);
+
+				expect(execution.status).toBe("completed_with_errors");
+				expect(execution.resumeState).toBeUndefined();
+
+				// The poisoned record is untouched; every other record was written.
+				const advanced = projects.filter((p) => p.status !== "planned");
+				expect(advanced).toHaveLength(4);
+				expect(
+					projects.find((p) => p.title === "bogus")?.status
+				).toBe("planned");
+
+				const summary = execution.loopSummary?.find(
+					(l) => l.nodeId === "loop-1"
+				);
+				expect(summary).toBeDefined();
+				expect(summary).toMatchObject({
+					total: 5,
+					succeeded: 4,
+					failed: 1,
+					skipped: 0,
+				});
+				expect(summary!.errors).toHaveLength(1);
+				expect(summary!.errors[0].label).toBe("bogus");
+				expect(summary!.errors[0].index).toBe(2);
+				expect(summary!.errors[0].error).toContain("not a valid value");
+			});
+
+			it("stamps loop identity on body entries so a failure traces to its record", async () => {
+				const { execution } = await runPoisonedLoop(
+					["in-progress", "bogus", "in-progress"],
+					"continue"
+				);
+
+				const bodyEntries = execution.nodesExecuted.filter(
+					(n) => n.nodeId === "body-act"
+				);
+				expect(bodyEntries).toHaveLength(3);
+				expect(bodyEntries.map((e) => e.loopIndex)).toEqual([0, 1, 2]);
+				expect(bodyEntries.every((e) => e.loopNodeId === "loop-1")).toBe(true);
+				expect(bodyEntries.every((e) => !!e.loopItemId)).toBe(true);
+
+				const failedEntry = bodyEntries.find((e) => e.result === "failed");
+				expect(failedEntry?.loopItemLabel).toBe("bogus");
+				expect(failedEntry?.loopIndex).toBe(1);
+
+				// The loop node's own entries carry no iteration identity.
+				const loopEntry = execution.nodesExecuted.find(
+					(n) => n.nodeId === "loop-1"
+				);
+				expect(loopEntry?.loopIndex).toBeUndefined();
+			});
+
+			it("a legacy loop (no onItemError) still aborts the whole run at the first failure", async () => {
+				// Field absent = "abort" — the semantics every snapshot published
+				// before onItemError existed actually had.
+				const { execution, projects } = await runPoisonedLoop([
+					"in-progress",
+					"bogus",
+					"in-progress",
+				]);
+
+				expect(execution.status).toBe("failed");
+				// Item 0 was written (its chunk committed); item 2 never ran.
+				expect(
+					projects.filter((p) => p.status === "in-progress")
+				).toHaveLength(1);
+				// Even a failed run reports what got through before it stopped, and
+				// names the record it died on.
+				const summary = execution.loopSummary?.find(
+					(l) => l.nodeId === "loop-1"
+				);
+				expect(summary).toMatchObject({ total: 3, succeeded: 1, failed: 1 });
+				expect(summary!.errors).toHaveLength(1);
+				expect(summary!.errors[0].label).toBe("bogus");
+			});
+
+			it('"abort" set explicitly behaves the same as the legacy absent field', async () => {
+				const { execution } = await runPoisonedLoop(
+					["in-progress", "bogus", "in-progress"],
+					"abort"
+				);
+				expect(execution.status).toBe("failed");
+			});
+
+			it("circuit breaker: the first 10 items all failing stops the run as a config problem", async () => {
+				// 12 poisoned records, none of which can ever succeed.
+				const { execution, projects } = await runPoisonedLoop(
+					Array.from({ length: 12 }, () => "bogus"),
+					"continue"
+				);
+
+				expect(execution.status).toBe("failed");
+				expect(execution.error).toContain("configuration problem");
+				// It stopped at 10 rather than grinding through all 12.
+				const summary = execution.loopSummary?.find(
+					(l) => l.nodeId === "loop-1"
+				);
+				expect(summary).toMatchObject({ total: 12, succeeded: 0, failed: 10 });
+				// Nothing was written.
+				expect(
+					projects.every((p) => p.status === "planned")
+				).toBe(true);
+			});
+
+			it("one success disarms the circuit breaker — later failures don't trip it", async () => {
+				// One good item first, then 12 poisoned ones: the breaker only fires
+				// when nothing at all has succeeded.
+				const titles = [
+					"in-progress",
+					...Array.from({ length: 12 }, () => "bogus"),
+				];
+				const { execution } = await runPoisonedLoop(titles, "continue");
+
+				expect(execution.status).toBe("completed_with_errors");
+				expect(
+					execution.loopSummary?.find((l) => l.nodeId === "loop-1")
+				).toMatchObject({ total: 13, succeeded: 1, failed: 12 });
+			});
+
+			it("compacts successful iterations past the log window but keeps every failure", async () => {
+				// 60 items (> the 50-iteration log window) with one poisoned item near
+				// the end. Without compaction the failure is exactly the kind of entry
+				// the 400-entry cap eats.
+				const titles = Array.from({ length: 60 }, (_, i) =>
+					i === 55 ? "bogus" : "in-progress"
+				);
+				const { execution } = await runPoisonedLoop(titles, "continue");
+
+				expect(execution.status).toBe("completed_with_errors");
+				expect(
+					execution.loopSummary?.find((l) => l.nodeId === "loop-1")
+				).toMatchObject({ total: 60, succeeded: 59, failed: 1 });
+
+				const bodyEntries = execution.nodesExecuted.filter(
+					(n) => n.nodeId === "body-act"
+				);
+				// The first 50 iterations are logged in full; later successes are
+				// dropped from the log (their outcome lives in loopSummary).
+				expect(bodyEntries.filter((e) => e.result === "success")).toHaveLength(
+					50
+				);
+				// The late failure survives regardless — that's the whole point.
+				const failures = bodyEntries.filter((e) => e.result === "failed");
+				expect(failures).toHaveLength(1);
+				expect(failures[0].loopIndex).toBe(55);
+				expect(failures[0].loopItemLabel).toBe("bogus");
+
+				// The log never hit the global truncation cap.
+				expect(
+					execution.nodesExecuted.some((e) =>
+						e.error?.includes("Execution log truncated")
+					)
+				).toBe(false);
+
+				// Exactly one note explains why the log stops short of the tally.
+				const notes = execution.nodesExecuted.filter((e) =>
+					String(
+						(e.output as { note?: string } | undefined)?.note ?? ""
+					).includes("Step-by-step log covers")
+				);
+				expect(notes).toHaveLength(1);
+			});
+
+			it("carries failures across a chunk boundary and still finishes", async () => {
+				// 30 items (> LOOP_CHUNK_SIZE of 25) with poison on both sides of the
+				// boundary — the tally has to survive the checkpoint/resume hop.
+				const titles = Array.from({ length: 30 }, (_, i) =>
+					i === 3 || i === 27 ? "bogus" : "in-progress"
+				);
+				const { execution, projects } = await runPoisonedLoop(
+					titles,
+					"continue"
+				);
+
+				expect(execution.status).toBe("completed_with_errors");
+				expect(execution.resumeState).toBeUndefined();
+				expect(
+					projects.filter((p) => p.status === "in-progress")
+				).toHaveLength(28);
+
+				const summary = execution.loopSummary?.find(
+					(l) => l.nodeId === "loop-1"
+				);
+				expect(summary).toMatchObject({
+					total: 30,
+					succeeded: 28,
+					failed: 2,
+					skipped: 0,
+				});
+				expect(summary!.errors.map((e) => e.index)).toEqual([3, 27]);
 			});
 		});
 

--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -42,6 +42,22 @@ function updateFieldActionNode(
 	};
 }
 
+/** A step a scheduled run can execute: no record scope needed. */
+function notifyNode(id: string, message = "Scheduled run fired") {
+	return {
+		id,
+		type: "action" as const,
+		config: {
+			kind: "action" as const,
+			action: {
+				type: "send_notification" as const,
+				recipient: "org_admins" as const,
+				message,
+			},
+		},
+	};
+}
+
 function conditionNode(
 	id: string,
 	field: string,
@@ -1151,7 +1167,8 @@ describe("automationExecutor (v2 engine)", () => {
 				};
 				nodes?:
 					| ReturnType<typeof conditionNode>[]
-					| ReturnType<typeof updateFieldActionNode>[];
+					| ReturnType<typeof updateFieldActionNode>[]
+					| ReturnType<typeof notifyNode>[];
 				isActive?: boolean;
 			} = {}
 		) {
@@ -1165,7 +1182,9 @@ describe("automationExecutor (v2 engine)", () => {
 						time: "09:00",
 					},
 				},
-				nodes: overrides.nodes ?? [conditionNode("cond-1", "status", "equals", "active")],
+				// A scheduled run has no trigger record, so the default step must not
+				// need one — a top-level condition or update_field is rejected at save.
+				nodes: overrides.nodes ?? [notifyNode("notify-1")],
 				isActive: overrides.isActive,
 			};
 		}
@@ -1252,14 +1271,15 @@ describe("automationExecutor (v2 engine)", () => {
 			const switchedAway = await t.run(async (ctx) => ctx.db.get(id));
 			expect(switchedAway?.nextRunAt).toBeUndefined();
 
-			// Publishing a scheduled trigger sets it again.
+			// Publishing a scheduled trigger sets it again. The condition has to go:
+			// switching back to a schedule takes the trigger record away with it.
 			await asUser.mutation(api.automations.update, {
 				id,
 				trigger: {
 					type: "scheduled",
 					schedule: { frequency: "daily" as const, timezone: "UTC", time: "09:00" },
 				},
-				nodes: [conditionNode("cond-1", "status", "equals", "active")],
+				nodes: [notifyNode("notify-1")],
 			});
 			await asUser.mutation(api.automations.publish, { id });
 			const switchedBack = await t.run(async (ctx) => ctx.db.get(id));
@@ -1354,19 +1374,57 @@ describe("automationExecutor (v2 engine)", () => {
 			expect(executions).toHaveLength(0);
 		});
 
-		it("a record-dependent action on a scheduled run fails with a clear error", async () => {
-			const { asUser, orgId } = await setupUser();
+		it("a record-dependent action on a scheduled trigger is rejected at save", async () => {
+			const { asUser } = await setupUser();
+
+			await expect(
+				asUser.mutation(
+					api.automations.create,
+					scheduledAutomation({
+						isActive: true,
+						nodes: [updateFieldActionNode("act-1", "notes", "Should not run")],
+					})
+				)
+			).rejects.toThrow(/no record to update/i);
+		});
+
+		it("a snapshot published before that rule still fails the run with a clear error", async () => {
+			// Rows published before the save-time rule landed can still carry a
+			// top-level update_field. The runtime guard is what protects them.
+			const { orgId } = await setupUser();
 			await makeOrgPremium(orgId);
 
-			const id = await asUser.mutation(
-				api.automations.create,
-				scheduledAutomation({
-					isActive: true,
-					nodes: [updateFieldActionNode("act-1", "notes", "Should not run")],
-				})
-			);
-			const past = Date.now() - 1000;
-			await t.run(async (ctx) => ctx.db.patch(id, { nextRunAt: past }));
+			const trigger = {
+				type: "scheduled" as const,
+				schedule: {
+					frequency: "daily" as const,
+					timezone: "UTC",
+					time: "09:00",
+				},
+			};
+			const nodes = [updateFieldActionNode("act-1", "notes", "Should not run")];
+
+			await t.run(async (ctx) => {
+				const user = await ctx.db.query("users").first();
+				const now = Date.now();
+				return ctx.db.insert("workflowAutomations", {
+					orgId,
+					name: "Legacy broken scheduled",
+					trigger,
+					nodes,
+					status: "active" as const,
+					publishedSnapshot: {
+						trigger,
+						nodes,
+						version: 1,
+						publishedAt: now,
+					},
+					nextRunAt: now - 1000,
+					createdBy: user!._id,
+					createdAt: now,
+					updatedAt: now,
+				});
+			});
 
 			await t.mutation(internal.automationExecutor.dispatchScheduledAutomations, {});
 			await drainScheduled();
@@ -2064,6 +2122,279 @@ describe("automationExecutor (v2 engine)", () => {
 			expect(result("avg")).toBeNull();
 			expect(result("min")).toBeNull();
 			expect(result("max")).toBeNull();
+		});
+
+		describe("scheduled triggers have no record (A1)", () => {
+			/** A condition whose left side is a scope value, not a record field. */
+			function varLeftConditionNode(
+				id: string,
+				path: string,
+				operator: string,
+				value: number,
+				opts: { nextNodeId?: string; elseNodeId?: string } = {}
+			) {
+				return {
+					id,
+					type: "condition" as const,
+					config: {
+						kind: "condition" as const,
+						logic: "and" as const,
+						groups: [
+							{
+								logic: "and" as const,
+								rules: [
+									{
+										field: "",
+										left: { kind: "var" as const, path },
+										// eslint-disable-next-line @typescript-eslint/no-explicit-any
+										operator: operator as any,
+										value: { kind: "static" as const, value },
+									},
+								],
+							},
+						],
+					},
+					nextNodeId: opts.nextNodeId,
+					elseNodeId: opts.elseNodeId,
+				};
+			}
+
+			async function seedInvoices(
+				orgId: Id<"organizations">,
+				clientId: Id<"clients">,
+				totals: number[]
+			) {
+				await t.run(async (ctx) => {
+					for (let i = 0; i < totals.length; i++) {
+						await ctx.db.insert("invoices", {
+							orgId,
+							clientId,
+							invoiceNumber: `INV-A1-${i}`,
+							status: "sent" as const,
+							subtotal: totals[i],
+							total: totals[i],
+							issuedDate: Date.now(),
+							dueDate: Date.now(),
+							publicToken: crypto.randomUUID(),
+						});
+					}
+				});
+			}
+
+			// The pattern A1 exists to unlock: a record-less run that branches on an
+			// aggregate. Before the var-left rule this was unbuildable — a condition
+			// could only read a record field, and a scheduled run has no record.
+			it("fetch -> aggregate -> condition on the aggregate -> notify", async () => {
+				const { asUser, orgId } = await setupUser();
+				await makeOrgPremium(orgId);
+
+				const clientId = await asUser.mutation(api.clients.create, {
+					portalAccessId: crypto.randomUUID(),
+					companyName: "Acme Co",
+					status: "active",
+				});
+				await seedInvoices(orgId, clientId, [6000, 5000]); // sum 11,000
+
+				const automationId = await asUser.mutation(api.automations.create, {
+					name: "Unpaid over 10k",
+					trigger: {
+						type: "scheduled",
+						schedule: { frequency: "daily", timezone: "UTC", time: "09:00" },
+					},
+					nodes: [
+						fetchNode("fetch-1", "invoice", [], { nextNodeId: "agg-1" }),
+						{
+							id: "agg-1",
+							type: "aggregate" as const,
+							config: {
+								kind: "aggregate" as const,
+								sourceNodeId: "fetch-1",
+								field: "total",
+								op: "sum" as const,
+							},
+							nextNodeId: "cond-1",
+						},
+						varLeftConditionNode(
+							"cond-1",
+							"node.agg-1.result",
+							"greater_than",
+							10000,
+							{ nextNodeId: "notify-1", elseNodeId: "end-1" }
+						),
+						sendNotificationActionNode(
+							"notify-1",
+							"org_admins",
+							"Unpaid invoices are over $10k",
+							{ nextNodeId: "end-1" }
+						),
+						endNode("end-1"),
+					],
+					isActive: true,
+				});
+
+				await runScheduledOnce(automationId);
+
+				const executions = await t.run(async (ctx) =>
+					ctx.db.query("workflowExecutions").collect()
+				);
+				expect(executions).toHaveLength(1);
+				expect(executions[0].status).toBe("completed");
+
+				const notifications = await t.run(async (ctx) =>
+					ctx.db.query("notifications").collect()
+				);
+				expect(notifications).toHaveLength(1);
+				expect(notifications[0].message).toMatch(/over \$10k/);
+			});
+
+			it("takes the else branch when the aggregate is under the threshold", async () => {
+				const { asUser, orgId } = await setupUser();
+				await makeOrgPremium(orgId);
+
+				const clientId = await asUser.mutation(api.clients.create, {
+					portalAccessId: crypto.randomUUID(),
+					companyName: "Acme Co",
+					status: "active",
+				});
+				await seedInvoices(orgId, clientId, [1000]); // sum 1,000
+
+				const automationId = await asUser.mutation(api.automations.create, {
+					name: "Unpaid over 10k",
+					trigger: {
+						type: "scheduled",
+						schedule: { frequency: "daily", timezone: "UTC", time: "09:00" },
+					},
+					nodes: [
+						fetchNode("fetch-1", "invoice", [], { nextNodeId: "agg-1" }),
+						{
+							id: "agg-1",
+							type: "aggregate" as const,
+							config: {
+								kind: "aggregate" as const,
+								sourceNodeId: "fetch-1",
+								field: "total",
+								op: "sum" as const,
+							},
+							nextNodeId: "cond-1",
+						},
+						varLeftConditionNode(
+							"cond-1",
+							"node.agg-1.result",
+							"greater_than",
+							10000,
+							{ nextNodeId: "notify-1", elseNodeId: "end-1" }
+						),
+						sendNotificationActionNode(
+							"notify-1",
+							"org_admins",
+							"Unpaid invoices are over $10k",
+							{ nextNodeId: "end-1" }
+						),
+						endNode("end-1"),
+					],
+					isActive: true,
+				});
+
+				await runScheduledOnce(automationId);
+
+				const executions = await t.run(async (ctx) =>
+					ctx.db.query("workflowExecutions").collect()
+				);
+				expect(executions[0].status).toBe("completed");
+				const notifications = await t.run(async (ctx) =>
+					ctx.db.query("notifications").collect()
+				);
+				expect(notifications).toHaveLength(0);
+			});
+
+			// Back-compat: the correctly-built scheduled shape (record scope comes
+			// from the loop, not the trigger) must keep validating AND running. The
+			// rejection rules key on loop-body membership; invert that and this
+			// breaks every working scheduled automation in production.
+			it("fetch -> loop -> update inside the loop still saves and runs", async () => {
+				const { asUser, orgId } = await setupUser();
+				await makeOrgPremium(orgId);
+
+				const clientId = await asUser.mutation(api.clients.create, {
+					portalAccessId: crypto.randomUUID(),
+					companyName: "Acme Co",
+					status: "active",
+				});
+				// Created through the API so aggregates initialise (see CLAUDE.md).
+				const projectIds = await Promise.all(
+					["Alpha", "Beta"].map((title) =>
+						asUser.mutation(api.projects.create, {
+							clientId,
+							title,
+							status: "planned",
+							projectType: "one-off",
+						})
+					)
+				);
+
+				const automationId = await asUser.mutation(api.automations.create, {
+					name: "Nightly project sweep",
+					trigger: {
+						type: "scheduled",
+						schedule: { frequency: "daily", timezone: "UTC", time: "09:00" },
+					},
+					nodes: [
+						fetchNode("fetch-1", "project", [], { nextNodeId: "loop-1" }),
+						loopNode("loop-1", "fetch-1", {
+							bodyStartNodeId: "act-1",
+							nextNodeId: "end-1",
+						}),
+						updateFieldActionNode("act-1", "status", "in-progress"),
+						endNode("end-1"),
+					],
+					isActive: true,
+				});
+
+				await runScheduledOnce(automationId);
+
+				const executions = await t.run(async (ctx) =>
+					ctx.db.query("workflowExecutions").collect()
+				);
+				expect(executions[0].status).toBe("completed");
+
+				const projects = await t.run(async (ctx) =>
+					Promise.all(projectIds.map((id) => ctx.db.get(id)))
+				);
+				for (const project of projects) {
+					expect(project?.status).toBe("in-progress");
+				}
+			});
+
+			// The dead field: stored rows carry it, so it must still parse — and the
+			// run must stay record-less regardless.
+			it("a stored objectType is stripped on save and the run stays record-less", async () => {
+				const { asUser, orgId } = await setupUser();
+				await makeOrgPremium(orgId);
+
+				const automationId = await asUser.mutation(api.automations.create, {
+					name: "Legacy scheduled with objectType",
+					trigger: {
+						type: "scheduled",
+						objectType: "quote",
+						schedule: { frequency: "daily", timezone: "UTC", time: "09:00" },
+					},
+					nodes: [notifyNode("notify-1")],
+					isActive: true,
+				});
+
+				const stored = await t.run(async (ctx) => ctx.db.get(automationId));
+				expect(stored?.trigger).not.toHaveProperty("objectType");
+				expect(stored?.publishedSnapshot?.trigger).not.toHaveProperty(
+					"objectType"
+				);
+
+				await runScheduledOnce(automationId);
+				const executions = await t.run(async (ctx) =>
+					ctx.db.query("workflowExecutions").collect()
+				);
+				expect(executions[0].status).toBe("completed");
+				expect(executions[0].triggerRecord).toBeUndefined();
+			});
 		});
 
 		it("adjust_time: shifts a base timestamp by a fixed offset (add and subtract)", async () => {

--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -941,6 +941,123 @@ describe("automationExecutor (v2 engine)", () => {
 		});
 	});
 
+	describe("update_field on a non-status field", () => {
+		it("non-status update_field emits record_updated so chained automations fire", async () => {
+			const { asUser } = await setupUser();
+
+			// A writes a non-status field. Only `status` writes went through
+			// applyStatusUpdate (which emits); this path used to patch silently.
+			await asUser.mutation(api.automations.create, {
+				name: "A \u2014 stamp notes on create",
+				trigger: { type: "record_created", objectType: "client" },
+				nodes: [updateFieldActionNode("act-1", "notes", "A wrote this")],
+				isActive: true,
+			});
+
+			// B chains on the field A writes. Without the emit it never fires.
+			await asUser.mutation(api.automations.create, {
+				name: "B \u2014 react to the notes change",
+				trigger: {
+					type: "record_updated",
+					objectType: "client",
+					fields: ["notes"],
+				},
+				nodes: [updateFieldActionNode("act-1", "companyDescription", "B ran")],
+				isActive: true,
+			});
+
+			const clientId = await asUser.mutation(api.clients.create, {
+				portalAccessId: crypto.randomUUID(),
+				companyName: "Acme Co",
+				status: "lead",
+			});
+
+			await drainEvents();
+
+			const client = await t.run(async (ctx) => ctx.db.get(clientId));
+			expect(client?.notes).toBe("A wrote this");
+			// The cascade's payoff: B's write only lands if A's write was announced.
+			expect(client?.companyDescription).toBe("B ran");
+
+			const executions = await t.run(async (ctx) =>
+				ctx.db.query("workflowExecutions").collect()
+			);
+			expect(executions).toHaveLength(2);
+			expect(executions.map((e) => e.status)).toEqual([
+				"completed",
+				"completed",
+			]);
+
+			const cascadeEvents = await t.run(async (ctx) =>
+				ctx.db
+					.query("domainEvents")
+					.filter((q) =>
+						q.and(
+							q.eq(q.field("eventType"), "entity.record_updated"),
+							q.eq(
+								q.field("eventSource"),
+								"automationExecutor.executeActionNodeV2"
+							)
+						)
+					)
+					.collect()
+			);
+			const notesCascade = cascadeEvents.find(
+				(e) => e.payload.field === "notes"
+			);
+			expect(notesCascade).toBeDefined();
+			expect(notesCascade?.payload.oldValue).toBeUndefined();
+			expect(notesCascade?.payload.newValue).toBe("A wrote this");
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const metadata = notesCascade?.payload.metadata as any;
+			expect(metadata?.changedFields).toEqual(["notes"]);
+			expect(metadata?.isCascade).toBe(true);
+		});
+
+		it("a no-op update_field (same value) emits no record_updated event", async () => {
+			const { asUser } = await setupUser();
+
+			await asUser.mutation(api.automations.create, {
+				name: "Rewrite notes with the value already on the record",
+				trigger: { type: "record_created", objectType: "client" },
+				nodes: [updateFieldActionNode("act-1", "notes", "Preset note")],
+				isActive: true,
+			});
+
+			await asUser.mutation(api.clients.create, {
+				portalAccessId: crypto.randomUUID(),
+				companyName: "Acme Co",
+				status: "lead",
+				notes: "Preset note",
+			});
+
+			await drainEvents();
+
+			// The action ran \u2014 it just had nothing to announce.
+			const executions = await t.run(async (ctx) =>
+				ctx.db.query("workflowExecutions").collect()
+			);
+			expect(executions).toHaveLength(1);
+			expect(executions[0].status).toBe("completed");
+
+			const cascadeEvents = await t.run(async (ctx) =>
+				ctx.db
+					.query("domainEvents")
+					.filter((q) =>
+						q.and(
+							q.eq(q.field("eventType"), "entity.record_updated"),
+							q.eq(
+								q.field("eventSource"),
+								"automationExecutor.executeActionNodeV2"
+							)
+						)
+					)
+					.collect()
+			);
+			expect(cascadeEvents).toHaveLength(0);
+		});
+	});
+
 	describe("org isolation", () => {
 		it("does not fire an org A automation for an org B record", async () => {
 			const orgA = await setupUser({

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -38,6 +38,7 @@ import {
 	MAX_LOOP_ITEM_ERRORS,
 	MAX_LOOP_ITERATIONS,
 	objectTypeValidator,
+	triggerRecordObjectType,
 	type ActionTarget,
 	type AutomationAction,
 	type AutomationObjectType,
@@ -4175,10 +4176,9 @@ export const startTestRun = userMutation({
 		}
 
 		const trigger = automation.trigger;
-		const triggerObjectType =
-			"objectType" in trigger && trigger.objectType
-				? (trigger.objectType as ObjectType)
-				: undefined;
+		const triggerObjectType = triggerRecordObjectType(
+			trigger as AutomationTrigger
+		) as ObjectType | undefined;
 
 		let triggerObject: Record<string, unknown> = {};
 		let scopeRecord: ScopeRecord | undefined;
@@ -4397,11 +4397,9 @@ export const startManualRun = userMutation({
 		}
 
 		const { trigger } = executableDefinition(automation);
-		const triggerType = "type" in trigger ? trigger.type : "status_changed";
-		const objectType =
-			"objectType" in trigger && trigger.objectType
-				? (trigger.objectType as ObjectType)
-				: undefined;
+		const objectType = triggerRecordObjectType(
+			trigger as AutomationTrigger
+		) as ObjectType | undefined;
 
 		let triggerRecord:
 			| { entityType: string; entityId: string; label?: string }
@@ -4430,7 +4428,7 @@ export const startManualRun = userMutation({
 				entityId: objectId,
 				label: sampleRecordLabel(objType, obj as Record<string, unknown>),
 			};
-		} else if (objectType && triggerType !== "scheduled") {
+		} else if (objectType) {
 			throw new Error("Pick a record to run this automation against");
 		}
 
@@ -4519,9 +4517,9 @@ export const getSampleRecords = userQuery({
 			// Manual runs execute the published snapshot, so derive the record
 			// type from it — an unpublished object-type edit must not leak here.
 			const { trigger } = executableDefinition(automation);
-			if ("objectType" in trigger && trigger.objectType) {
-				objectType = trigger.objectType as ObjectType;
-			}
+			objectType = triggerRecordObjectType(trigger as AutomationTrigger) as
+				| ObjectType
+				| undefined;
 		}
 		if (!objectType) return [];
 

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -883,10 +883,14 @@ const MAX_ITEM_ERROR_CHARS = 500;
  * validation throw, a plan-limit throw, a ConvexError from a handler) is a
  * genuine per-item failure and is caught.
  */
-function isFatalExecutionError(error: unknown): boolean {
+export function isFatalExecutionError(error: unknown): boolean {
 	const message = error instanceof Error ? error.message : String(error);
+	// Verbatim Convex limit errors (get-convex/convex-backend): "Too many
+	// documents read / bytes read / bytes written / writes in a single function
+	// execution", "Too many functions scheduled by this mutation", "Function
+	// execution timed out (maximum duration: …)".
 	return (
-		/too many (reads|writes|bytes|documents|function calls|scheduled functions)/i.test(
+		/too many (reads|writes|bytes|documents|function calls|functions(?: being)? scheduled|scheduled functions)/i.test(
 			message
 		) ||
 		/execution timed out/i.test(message) ||
@@ -4186,6 +4190,13 @@ export const startTestRun = userMutation({
 			| { entityType: string; entityId: string; label?: string }
 			| undefined;
 		if (args.record) {
+			// A scheduled run never has a triggering record; binding one here would
+			// make the dry run lie about production behavior.
+			if ("type" in trigger && trigger.type === "scheduled") {
+				throw new Error(
+					"Scheduled automations run without a triggering record — test without one"
+				);
+			}
 			if (triggerObjectType && args.record.entityType !== triggerObjectType) {
 				throw new Error(
 					`This automation runs on ${triggerObjectType} records — pick a ${triggerObjectType} to test with`

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -35,6 +35,7 @@ import {
 	FETCH_SCAN_CEILING,
 	MAX_DELAY_MS,
 	MAX_FETCH_LIMIT,
+	MAX_LOOP_ITEM_ERRORS,
 	MAX_LOOP_ITERATIONS,
 	objectTypeValidator,
 	type ActionTarget,
@@ -43,6 +44,7 @@ import {
 	type AutomationTrigger,
 	type ExecutedNode,
 	type FormulaResource,
+	type LoopSummary,
 	type WorkflowNodeConfig,
 } from "./lib/workflowTypes";
 
@@ -792,6 +794,19 @@ type WalkEnv = {
 	nodeStartedAt: number;
 	/** True for real runs (not test/dry); gates failure notifications. */
 	isProduction: boolean;
+	/**
+	 * Per-loop item tallies, keyed by loop node id and carried across chunk
+	 * boundaries via workflowExecutions.loopSummary. Authoritative — the entry
+	 * log truncates and compacts, these counts never do.
+	 */
+	loopSummaries: LoopSummary[];
+	/** The loop iteration currently executing; stamps identity onto its entries. */
+	currentLoop?: {
+		nodeId: string;
+		index: number;
+		itemId: string;
+		label?: string;
+	};
 };
 
 type WalkOutcome =
@@ -807,14 +822,27 @@ const MAX_EXECUTED_ENTRIES = 400;
 function pushEntry(env: WalkEnv, entry: ExecEntry): void {
 	// Stamp per-node timing: startedAt = when the walk began this node,
 	// completedAt = now. Both feed the runs viewer's per-step durations.
+	// Inside a loop body, also stamp which iteration and record produced it —
+	// without that a mid-loop failure can't be traced back to a record.
+	const loop = env.currentLoop;
 	const stamped: ExecEntry = {
 		...entry,
 		startedAt: entry.startedAt ?? env.nodeStartedAt,
 		completedAt: entry.completedAt ?? Date.now(),
+		...(loop
+			? {
+					loopNodeId: loop.nodeId,
+					loopIndex: loop.index,
+					loopItemId: loop.itemId,
+					loopItemLabel: loop.label,
+				}
+			: {}),
 	};
 	if (env.nodesExecuted.length >= MAX_EXECUTED_ENTRIES) {
 		if (!env.logTruncated) {
 			env.logTruncated = true;
+			// Synthetic marker: no loop stamp, or it renders as a phantom
+			// iteration of whichever node happened to overflow the log.
 			env.nodesExecuted.push({
 				nodeId: stamped.nodeId,
 				result: "skipped",
@@ -826,6 +854,80 @@ function pushEntry(env: WalkEnv, entry: ExecEntry): void {
 		return;
 	}
 	env.nodesExecuted.push(stamped);
+}
+
+/**
+ * Iterations whose per-step entries are kept in full. Past this, successful
+ * iterations are rolled back out of the log (their outcome is still counted in
+ * loopSummary) so the 400-entry cap can't swallow the failures further down —
+ * which are the entries anyone reading the log actually came for.
+ */
+const LOOP_LOG_FULL_ITERATIONS = 50;
+
+/**
+ * Consecutive failures, with no success anywhere, that mean the loop is
+ * misconfigured rather than fed bad data (a renamed field, a status value that
+ * matches nothing). Below LOOP_CHUNK_SIZE, so it always trips inside the first
+ * chunk — before any of it commits.
+ */
+const LOOP_FAILURE_CIRCUIT_BREAK = 10;
+
+/** Stored error strings are display copy; keep one item's error from bloating the row. */
+const MAX_ITEM_ERROR_CHARS = 500;
+
+/**
+ * A throw that means the transaction is already doomed — every remaining item
+ * would hit it too, and calling it "item 13 failed" would be a lie. These are
+ * rethrown even when the loop is set to continue; everything else (a schema
+ * validation throw, a plan-limit throw, a ConvexError from a handler) is a
+ * genuine per-item failure and is caught.
+ */
+function isFatalExecutionError(error: unknown): boolean {
+	const message = error instanceof Error ? error.message : String(error);
+	return (
+		/too many (reads|writes|bytes|documents|function calls|scheduled functions)/i.test(
+			message
+		) ||
+		/execution timed out/i.test(message) ||
+		/transaction.*too large/i.test(message)
+	);
+}
+
+function loopSummaryFor(env: WalkEnv, nodeId: string): LoopSummary {
+	let summary = env.loopSummaries.find((s) => s.nodeId === nodeId);
+	if (!summary) {
+		summary = {
+			nodeId,
+			total: 0,
+			succeeded: 0,
+			failed: 0,
+			skipped: 0,
+			errors: [],
+		};
+		env.loopSummaries.push(summary);
+	}
+	return summary;
+}
+
+/** True when any loop in this run skipped past a failing item. */
+function hasLoopItemFailures(env: WalkEnv): boolean {
+	return env.loopSummaries.some((s) => s.failed > 0);
+}
+
+/** Loop tallies for an execution patch; undefined when the run had no loops. */
+function loopSummaryPatch(env: WalkEnv): LoopSummary[] | undefined {
+	return env.loopSummaries.length > 0 ? env.loopSummaries : undefined;
+}
+
+/**
+ * Drop the entries a compacted iteration appended. The truncation marker may be
+ * among them, so logTruncated is re-derived rather than left latched — a stale
+ * true makes pushEntry drop everything afterwards with nothing in the log to
+ * show for it.
+ */
+function rollbackEntries(env: WalkEnv, mark: number): void {
+	env.nodesExecuted.length = mark;
+	env.logTruncated = env.nodesExecuted.length >= MAX_EXECUTED_ENTRIES;
 }
 
 /**
@@ -976,6 +1078,7 @@ export const executeAutomation = systemMutation({
 			nodesExecuted: [],
 			logTruncated: false,
 			dataTruncated: false,
+			loopSummaries: [],
 			fetchScanBudget: WALK_SCAN_BUDGET,
 			trigger: { objectType: args.objectType, objectId: args.objectId },
 			nodeStartedAt: Date.now(),
@@ -1006,6 +1109,7 @@ export const executeAutomation = systemMutation({
 				completedAt: Date.now(),
 				nodesExecuted: env.nodesExecuted,
 				dataTruncated: env.dataTruncated,
+				loopSummary: loopSummaryPatch(env),
 				error: message,
 			});
 			if (isProduction) {
@@ -1168,8 +1272,14 @@ export const resumeExecution = systemMutation({
 			},
 			fetchOutputs: {},
 			nodesExecuted: [...execution.nodesExecuted],
-			logTruncated: false,
+			// Derived, not reset: the log carries over from the previous chunk, so
+			// a false here makes every later chunk append its own truncation marker.
+			logTruncated: execution.nodesExecuted.length >= MAX_EXECUTED_ENTRIES,
 			dataTruncated: execution.dataTruncated ?? false,
+			loopSummaries: (execution.loopSummary ?? []).map((l) => ({
+				...l,
+				errors: [...l.errors],
+			})),
 			fetchScanBudget: WALK_SCAN_BUDGET,
 			trigger: { objectType: resume.objectType, objectId: resume.objectId },
 			nodeStartedAt: Date.now(),
@@ -1213,6 +1323,7 @@ export const resumeExecution = systemMutation({
 				status: "failed",
 				completedAt: Date.now(),
 				nodesExecuted: env.nodesExecuted,
+				loopSummary: loopSummaryPatch(env),
 				error: message,
 				resumeState: undefined,
 				currentNodeId: undefined,
@@ -1241,6 +1352,7 @@ export const resumeExecution = systemMutation({
 						status: "failed",
 						completedAt: Date.now(),
 						nodesExecuted: env.nodesExecuted,
+						loopSummary: loopSummaryPatch(env),
 						error: message,
 						resumeState: undefined,
 						currentNodeId: undefined,
@@ -1273,6 +1385,7 @@ export const resumeExecution = systemMutation({
 				completedAt: Date.now(),
 				nodesExecuted: env.nodesExecuted,
 				dataTruncated: env.dataTruncated,
+				loopSummary: loopSummaryPatch(env),
 				error: message,
 				resumeState: undefined,
 				currentNodeId: undefined,
@@ -1305,6 +1418,9 @@ async function finishWalk(
 			completedAt: Date.now(),
 			nodesExecuted: env.nodesExecuted,
 			dataTruncated: env.dataTruncated,
+			// Earlier chunks already committed their writes — say how many items
+			// got through rather than implying the run did nothing.
+			loopSummary: loopSummaryPatch(env),
 			error: outcome.error,
 			resumeState: undefined,
 			currentNodeId: undefined,
@@ -1326,14 +1442,34 @@ async function finishWalk(
 		lastTriggeredAt: Date.now(),
 		triggerCount: (env.automation.triggerCount || 0) + 1,
 	});
+
+	// The walk reached the end, but a loop may have skipped past failing items.
+	// This has to be checked on every non-failed outcome — an End step inside a
+	// loop body lands here too, and would otherwise report a clean run.
+	const itemFailures = hasLoopItemFailures(env);
 	await ctx.db.patch(env.executionId, {
-		status: "completed",
+		status: itemFailures ? "completed_with_errors" : "completed",
 		completedAt: Date.now(),
 		nodesExecuted: env.nodesExecuted,
 		dataTruncated: env.dataTruncated,
+		loopSummary: loopSummaryPatch(env),
 		resumeState: undefined,
 		currentNodeId: undefined,
 	});
+
+	if (itemFailures && env.isProduction) {
+		const failed = env.loopSummaries.reduce((n, l) => n + l.failed, 0);
+		const total = env.loopSummaries.reduce((n, l) => n + l.total, 0);
+		const first = env.loopSummaries.find((l) => l.errors.length > 0)?.errors[0];
+		await notifyAutomationFailure(
+			ctx,
+			env.automation,
+			`${failed} of ${total} items failed${
+				first ? ` — ${first.label ?? "an item"}: ${first.error}` : ""
+			}`,
+			env.executionId
+		);
+	}
 }
 
 /**
@@ -1474,6 +1610,7 @@ async function runWalk(
 			await ctx.db.patch(env.executionId, {
 				nodesExecuted: env.nodesExecuted,
 				dataTruncated: env.dataTruncated,
+				loopSummary: loopSummaryPatch(env),
 				currentNodeId: node.nextNodeId,
 				resumeState: {
 					resumeNodeId: node.nextNodeId,
@@ -1586,6 +1723,8 @@ async function runLoopNode(
 		return { kind: "failed", error };
 	}
 
+	const summary = loopSummaryFor(env, node.id);
+
 	let queue: { item: Record<string, unknown>; index: number }[];
 	if (resumeFrom) {
 		// Continue a chunked run. Items are matched by id so records deleted
@@ -1596,6 +1735,10 @@ async function runLoopNode(
 			const item = byId.get(id);
 			return item ? [{ item, index: resumeFrom.nextIndex + offset }] : [];
 		});
+		// Records deleted since the last chunk. They count against `total`, so
+		// without this succeeded + failed + skipped wouldn't add up and
+		// "updated 12 of 50" would be a lie.
+		summary.skipped += resumeFrom.remainingItemIds.length - queue.length;
 	} else {
 		const cap = Math.min(
 			config.maxIterations ?? MAX_LOOP_ITERATIONS,
@@ -1603,6 +1746,7 @@ async function runLoopNode(
 		);
 		const items = source.records.slice(0, Math.max(cap, 0));
 		if (source.truncated) env.dataTruncated = true;
+		summary.total = items.length;
 		// Logged once for the whole loop; continuation chunks don't re-log it.
 		pushEntry(env, {
 			nodeId: node.id,
@@ -1617,6 +1761,11 @@ async function runLoopNode(
 		return { kind: "chain_done" };
 	}
 
+	// Absent means "abort": every snapshot published before onItemError existed
+	// stopped the whole run at the first failing item, and republishing an
+	// untouched loop must not quietly change that.
+	const continueOnItemError = config.onItemError === "continue";
+
 	env.scope.loops ??= {};
 	try {
 		for (let qi = 0; qi < queue.length; qi++) {
@@ -1629,23 +1778,43 @@ async function runLoopNode(
 				return { kind: "waiting" };
 			}
 			const { item, index } = queue[qi];
+			const itemId = String(item._id);
+			const label = sampleRecordLabel(source.objectType, item);
 			env.scope.loops[node.id] = { item, index };
+			env.currentLoop = { nodeId: node.id, index, itemId, label };
 			const itemScope: ScopeRecord = {
 				type: source.objectType,
-				id: String(item._id),
+				id: itemId,
 				record: item,
 			};
-			const outcome = await runWalk(
-				ctx,
-				env,
-				node.bodyStartNodeId,
-				itemScope,
-				node.id
-			);
-			// "next_item" and "chain_done" both continue with the next record.
-			if (outcome.kind === "failed" || outcome.kind === "ended") {
-				return outcome;
+
+			// Items processed across every chunk so far — the log window and the
+			// compaction boundary are global to the loop, not per chunk.
+			const processedBefore = summary.succeeded + summary.failed;
+			const withinLogWindow = processedBefore < LOOP_LOG_FULL_ITERATIONS;
+			const entryMark = env.nodesExecuted.length;
+
+			let outcome: WalkOutcome;
+			try {
+				outcome = await runWalk(
+					ctx,
+					env,
+					node.bodyStartNodeId,
+					itemScope,
+					node.id
+				);
+			} catch (error) {
+				// An unexpected throw (a schema-validation reject, a plan-limit
+				// throw) is this item's failure, not the run's — unless the
+				// transaction itself is spent, in which case every remaining item
+				// would hit it too.
+				if (!continueOnItemError || isFatalExecutionError(error)) throw error;
+				outcome = {
+					kind: "failed",
+					error: error instanceof Error ? error.message : "Unknown error",
+				};
 			}
+
 			if (outcome.kind === "waiting") {
 				// Unreachable: delays are rejected inside loop bodies.
 				return {
@@ -1653,10 +1822,93 @@ async function runLoopNode(
 					error: "Delay steps are not supported inside loops",
 				};
 			}
+
+			if (outcome.kind === "failed") {
+				summary.failed += 1;
+				if (!continueOnItemError) {
+					// Record the item that stopped the run before bailing: the failed
+					// patch persists this, so the run can name the record it died on.
+					summary.errors.push({
+						index,
+						itemId,
+						label,
+						error: outcome.error.slice(0, MAX_ITEM_ERROR_CHARS),
+					});
+					return outcome;
+				}
+
+				if (summary.errors.length < MAX_LOOP_ITEM_ERRORS) {
+					summary.errors.push({
+						index,
+						itemId,
+						label,
+						error: outcome.error.slice(0, MAX_ITEM_ERROR_CHARS),
+						// Convex has no sub-transaction: body steps that already ran
+						// for this item are committed and stay applied. Only actions
+						// write, so a condition that passed before the failure doesn't
+						// make the item partially applied.
+						partial: env.nodesExecuted
+							.slice(entryMark)
+							.some(
+								(e) =>
+									e.result === "success" &&
+									env.nodesById.get(e.nodeId)?.config?.kind === "action"
+							),
+					});
+				}
+
+				// Nothing has succeeded and the first N items all failed: this is a
+				// broken configuration, not bad data. Stop before it burns through
+				// the rest of the records.
+				if (
+					summary.succeeded === 0 &&
+					summary.failed >= LOOP_FAILURE_CIRCUIT_BREAK
+				) {
+					return {
+						kind: "failed",
+						error:
+							`The first ${summary.failed} items all failed, so this looks like a ` +
+							`configuration problem rather than bad data. First error: ` +
+							`${summary.errors[0]?.error ?? outcome.error}`,
+					};
+				}
+				continue;
+			}
+
+			// "next_item" and "chain_done" both mean this item is done with.
+			summary.succeeded += 1;
+
+			// An End step inside the body stops the whole run, by design. Keep its
+			// entries whatever the log window says — they're where the run stopped.
+			if (outcome.kind === "ended") return outcome;
+
+			// Past the log window a successful iteration leaves no per-step trace —
+			// its outcome is already counted above, and keeping it would push the
+			// failures that follow out past MAX_EXECUTED_ENTRIES.
+			if (!withinLogWindow) {
+				rollbackEntries(env, entryMark);
+			}
 		}
 	} finally {
 		// Loop variables are only valid inside the body.
 		delete env.scope.loops[node.id];
+		env.currentLoop = undefined;
+	}
+
+	// Reached only when the last chunk drains the queue, so this lands once per
+	// loop however many chunks it took — and regardless of whether the item that
+	// crossed the boundary succeeded. Says why the log stops short of the tally,
+	// which otherwise just looks like missing steps.
+	if (summary.succeeded + summary.failed > LOOP_LOG_FULL_ITERATIONS) {
+		pushEntry(env, {
+			nodeId: node.id,
+			result: "success",
+			output: {
+				note:
+					`Step-by-step log covers the first ${LOOP_LOG_FULL_ITERATIONS} items. ` +
+					`Later items are counted in this loop's totals; failures are logged in full.`,
+			},
+		});
 	}
 
 	return { kind: "chain_done" };
@@ -1677,6 +1929,7 @@ async function checkpointLoopChunk(
 	await ctx.db.patch(env.executionId, {
 		nodesExecuted: env.nodesExecuted,
 		dataTruncated: env.dataTruncated,
+		loopSummary: loopSummaryPatch(env),
 		currentNodeId: node.id,
 		resumeState: {
 			resumeNodeId: node.id,
@@ -3159,6 +3412,11 @@ export const getExecutionStats = internalQuery({
 			total: recentExecutions.length,
 			completed: recentExecutions.filter((e) => e.status === "completed")
 				.length,
+			// Ran to the end with some loop items skipped — counted apart from
+			// `completed` so the buckets still sum to `total`.
+			withErrors: recentExecutions.filter(
+				(e) => e.status === "completed_with_errors"
+			).length,
 			failed: recentExecutions.filter((e) => e.status === "failed").length,
 			skipped: recentExecutions.filter((e) => e.status === "skipped").length,
 		};
@@ -3167,6 +3425,9 @@ export const getExecutionStats = internalQuery({
 			total: weeklyExecutions.length,
 			completed: weeklyExecutions.filter((e) => e.status === "completed")
 				.length,
+			withErrors: weeklyExecutions.filter(
+				(e) => e.status === "completed_with_errors"
+			).length,
 			failed: weeklyExecutions.filter((e) => e.status === "failed").length,
 			skipped: weeklyExecutions.filter((e) => e.status === "skipped").length,
 		};
@@ -3189,6 +3450,8 @@ export const getExecutionStats = internalQuery({
 const TEST_STEP_INTERVAL_MS = 150;
 /** Loop iterations sampled per loop in a dry run (keeps the reveal snappy). */
 const DRY_LOOP_SAMPLE = 3;
+
+type DryWalkOutcome = "chain_done" | "ended" | "next_item" | "failed";
 /** A test run stuck "running" past this is presumed dropped and marked failed. */
 const STALE_TEST_RUN_MS = 5 * 60 * 1000;
 
@@ -3206,6 +3469,15 @@ type DryEnv = {
 	fetchScanBudget: number;
 	/** Wall-clock start of the node currently executing; stamped onto each entry. */
 	nodeStartedAt: number;
+	/** Per-loop item tallies, same shape production records. */
+	loopSummaries: LoopSummary[];
+	/** The loop iteration currently executing; stamps identity onto its entries. */
+	currentLoop?: {
+		nodeId: string;
+		index: number;
+		itemId: string;
+		label?: string;
+	};
 };
 
 /** Char ceiling (~4KB) for a stored input/output snapshot. */
@@ -3228,12 +3500,21 @@ function boundSnapshot(value: unknown): unknown {
 }
 
 function pushDry(env: DryEnv, entry: ExecutedNode): void {
+	const loop = env.currentLoop;
 	const stamped: ExecutedNode = {
 		...entry,
 		input: boundSnapshot(entry.input),
 		output: boundSnapshot(entry.output),
 		startedAt: entry.startedAt ?? env.nodeStartedAt,
 		completedAt: entry.completedAt ?? Date.now(),
+		...(loop
+			? {
+					loopNodeId: loop.nodeId,
+					loopIndex: loop.index,
+					loopItemId: loop.itemId,
+					loopItemLabel: loop.label,
+				}
+			: {}),
 	};
 	if (env.entries.length >= MAX_EXECUTED_ENTRIES) {
 		if (!env.truncated) {
@@ -3567,14 +3848,32 @@ async function dryRunLoopNode(
 		return "chain_done";
 	}
 
+	// Absent means "abort" — the same reading production uses.
+	const continueOnItemError = config.onItemError === "continue";
+	// `sampled`, not `total`: a preview only walks the first few items, and a
+	// summary claiming the full match count would have the test run reporting
+	// items it never attempted.
+	const summary: LoopSummary = {
+		nodeId: node.id,
+		total: sampled,
+		succeeded: 0,
+		failed: 0,
+		skipped: 0,
+		errors: [],
+	};
+	env.loopSummaries.push(summary);
+
 	env.scope.loops ??= {};
 	try {
 		for (let index = 0; index < sampled; index++) {
 			const item = source.records[index];
+			const itemId = String(item._id);
+			const label = sampleRecordLabel(source.objectType, item);
 			env.scope.loops[node.id] = { item, index };
+			env.currentLoop = { nodeId: node.id, index, itemId, label };
 			const itemScope: ScopeRecord = {
 				type: source.objectType,
-				id: String(item._id),
+				id: itemId,
 				record: item,
 			};
 			const outcome = await dryRunWalk(
@@ -3584,11 +3883,33 @@ async function dryRunLoopNode(
 				itemScope,
 				true
 			);
+
+			if (outcome === "failed") {
+				summary.failed += 1;
+				if (summary.errors.length < MAX_LOOP_ITEM_ERRORS) {
+					const error =
+						[...env.entries]
+							.reverse()
+							.find((e) => e.result === "failed" && e.loopIndex === index)
+							?.error ?? "Step failed";
+					summary.errors.push({
+						index,
+						itemId,
+						label,
+						error: error.slice(0, MAX_ITEM_ERROR_CHARS),
+					});
+				}
+				if (!continueOnItemError) return "failed";
+				continue;
+			}
+
 			// "next_item"/"chain_done" continue with the next sampled record.
-			if (outcome === "failed" || outcome === "ended") return outcome;
+			summary.succeeded += 1;
+			if (outcome === "ended") return outcome;
 		}
 	} finally {
 		delete env.scope.loops[node.id];
+		env.currentLoop = undefined;
 	}
 
 	return "chain_done";
@@ -3605,7 +3926,7 @@ async function dryRunWalk(
 	startNodeId: string | undefined,
 	scopeRecord: ScopeRecord | undefined,
 	inLoop: boolean
-): Promise<"chain_done" | "ended" | "next_item" | "failed"> {
+): Promise<DryWalkOutcome> {
 	let currentNodeId = startNodeId;
 	const visited = new Set<string>();
 
@@ -3791,7 +4112,12 @@ async function buildDryPlan(
 	eventOldValue: string | undefined,
 	eventNewValue: string | undefined,
 	globals: Pick<VariableScope, "workflow" | "org" | "user">
-): Promise<ExecutedNode[]> {
+): Promise<{
+	plan: ExecutedNode[];
+	/** The walk stopped on a failure, rather than running past skipped items. */
+	aborted: boolean;
+	loopSummaries: LoopSummary[];
+}> {
 	const env: DryEnv = {
 		orgId: automation.orgId,
 		automationName: automation.name,
@@ -3813,12 +4139,18 @@ async function buildDryPlan(
 		dataTruncated: false,
 		fetchScanBudget: WALK_SCAN_BUDGET,
 		nodeStartedAt: Date.now(),
+		loopSummaries: [],
 	};
 
+	let outcome: DryWalkOutcome = "chain_done";
 	if (automation.nodes.length > 0) {
-		await dryRunWalk(ctx, env, automation.nodes[0].id, scopeRecord, false);
+		outcome = await dryRunWalk(ctx, env, automation.nodes[0].id, scopeRecord, false);
 	}
-	return env.entries;
+	return {
+		plan: env.entries,
+		aborted: outcome === "failed",
+		loopSummaries: env.loopSummaries,
+	};
 }
 
 /**
@@ -3900,7 +4232,7 @@ export const startTestRun = userMutation({
 			user: { id: ctx.user._id, name: ctx.user.name, email: ctx.user.email },
 		};
 
-		const plan = await buildDryPlan(
+		const { plan, aborted, loopSummaries } = await buildDryPlan(
 			ctx,
 			automation,
 			scopeRecord,
@@ -3914,12 +4246,22 @@ export const startTestRun = userMutation({
 		const done = plan.length === 0;
 		const dataTruncated = plan.some((e) => e.truncated);
 
+		// A failed step no longer implies a failed run: a loop set to continue
+		// records the failure and carries on. `aborted` is the only thing that
+		// separates the two, so it's decided here and carried on the cursor —
+		// executeTestStep only ever sees the entries, which can't tell them apart.
+		const terminalStatus = aborted
+			? ("failed" as const)
+			: failed
+				? ("completed_with_errors" as const)
+				: ("completed" as const);
+
 		const executionId = await ctx.db.insert("workflowExecutions", {
 			orgId: ctx.orgId,
 			automationId: args.automationId,
 			triggeredBy: `test:${ctx.user._id}`,
 			triggeredAt: now,
-			status: done ? (failed ? "failed" : "completed") : "running",
+			status: done ? terminalStatus : "running",
 			completedAt: done ? now : undefined,
 			mode: "test",
 			dryRun: true,
@@ -3927,9 +4269,10 @@ export const startTestRun = userMutation({
 			triggerRecord,
 			nodesExecuted: [],
 			dataTruncated,
-			testCursor: done ? undefined : { plan },
+			loopSummary: loopSummaries.length > 0 ? loopSummaries : undefined,
+			testCursor: done ? undefined : { plan, terminalStatus },
 			error:
-				done && failed
+				done && aborted
 					? plan.find((e) => e.result === "failed")?.error
 					: undefined,
 		});
@@ -3961,10 +4304,18 @@ export const executeTestStep = systemMutation({
 		const plan = execution.testCursor.plan;
 		const index = execution.nodesExecuted.length;
 
+		// Legacy cursors (written before terminalStatus existed) fall back to the
+		// old derivation, but over `plan` — nodesExecuted excludes the entry this
+		// call is about to reveal, so a run failing on its last step read clean.
+		const terminalStatus =
+			execution.testCursor.terminalStatus ??
+			(plan.some((e) => e.result === "failed")
+				? ("failed" as const)
+				: ("completed" as const));
+
 		if (index >= plan.length) {
-			const failed = execution.nodesExecuted.some((e) => e.result === "failed");
 			await ctx.db.patch(args.executionId, {
-				status: failed ? "failed" : "completed",
+				status: terminalStatus,
 				completedAt: Date.now(),
 				currentNodeId: undefined,
 				testCursor: undefined,
@@ -3988,16 +4339,16 @@ export const executeTestStep = systemMutation({
 			return;
 		}
 
-		const failed = revealed.some((e) => e.result === "failed");
 		await ctx.db.patch(args.executionId, {
 			nodesExecuted: revealed,
-			status: failed ? "failed" : "completed",
+			status: terminalStatus,
 			completedAt: Date.now(),
 			currentNodeId: undefined,
 			testCursor: undefined,
-			error: failed
-				? revealed.find((e) => e.result === "failed")?.error
-				: undefined,
+			error:
+				terminalStatus === "failed"
+					? revealed.find((e) => e.result === "failed")?.error
+					: undefined,
 		});
 	},
 });

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -932,7 +932,9 @@ function loopSummaryPatch(env: WalkEnv): LoopSummary[] | undefined {
  */
 function rollbackEntries(env: WalkEnv, mark: number): void {
 	env.nodesExecuted.length = mark;
-	env.logTruncated = env.nodesExecuted.length >= MAX_EXECUTED_ENTRIES;
+	// > not >=: the marker lives past index MAX, so an exactly-full log has
+	// no marker yet — latching true here would drop later entries unmarked.
+	env.logTruncated = env.nodesExecuted.length > MAX_EXECUTED_ENTRIES;
 }
 
 /**
@@ -1279,7 +1281,7 @@ export const resumeExecution = systemMutation({
 			nodesExecuted: [...execution.nodesExecuted],
 			// Derived, not reset: the log carries over from the previous chunk, so
 			// a false here makes every later chunk append its own truncation marker.
-			logTruncated: execution.nodesExecuted.length >= MAX_EXECUTED_ENTRIES,
+			logTruncated: execution.nodesExecuted.length > MAX_EXECUTED_ENTRIES,
 			dataTruncated: execution.dataTruncated ?? false,
 			loopSummaries: (execution.loopSummary ?? []).map((l) => ({
 				...l,

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -4583,5 +4583,77 @@ export const failStaleTestRuns = internalMutation({
 	},
 });
 
+/**
+ * A production run idle past this is presumed stranded by a dropped scheduler
+ * hop. Applies to both the run's age (stuck mid-walk with no resumeState) and
+ * a parked run's missed wake time.
+ */
+const STALE_PRODUCTION_RUN_MS = 30 * 60 * 1000;
+
+/**
+ * Watchdog: rescue production runs stranded by a dropped scheduler hop. Two
+ * shapes: stuck mid-walk (`running`, no resumeState, older than the cutoff)
+ * and parked runs whose resumeState wake time passed the cutoff without the
+ * resume ever firing. Legitimately parked runs (future wake) are skipped.
+ * Without this, a wedged run shows "running" forever and is excluded from
+ * retention cleanup, and the owner is never told.
+ */
+export const failStaleProductionRuns = internalMutation({
+	args: {},
+	handler: async (ctx): Promise<{ failed: number }> => {
+		const now = Date.now();
+		const cutoff = now - STALE_PRODUCTION_RUN_MS;
+		// resumeAt >= triggeredAt always (wake times are computed at park time),
+		// so triggeredAt < cutoff catches both shapes in one indexed read.
+		const candidates = await ctx.db
+			.query("workflowExecutions")
+			.withIndex("by_triggeredAt", (q) => q.lt("triggeredAt", cutoff))
+			.filter((q) =>
+				q.and(
+					q.eq(q.field("status"), "running"),
+					q.neq(q.field("mode"), "test")
+				)
+			)
+			.take(100);
+
+		let failed = 0;
+		for (const execution of candidates) {
+			const resume = execution.resumeState;
+			// Parked with the wake still ahead (or recently passed): leave it be.
+			if (resume && resume.resumeAt >= cutoff) continue;
+
+			// A parked run's wait is honest pause, not activity — fold it in so
+			// the derived activeMs stays truthful (mirrors resumeExecution).
+			const pausedMs = resume
+				? (execution.pausedMs ?? 0) + (now - (resume.checkpointAt ?? now))
+				: execution.pausedMs;
+
+			const message = resume
+				? "Run never woke from its scheduled resume and was marked failed by the watchdog"
+				: "Run stalled without completing and was marked failed by the watchdog";
+
+			await ctx.db.patch(execution._id, {
+				status: "failed",
+				completedAt: now,
+				currentNodeId: undefined,
+				resumeState: undefined,
+				pausedMs,
+				error: execution.error ?? message,
+			});
+			failed++;
+
+			// Legacy dry-run rows can carry mode !== "test": clean them up above,
+			// but never alert on a run that wrote nothing.
+			if (execution.dryRun) continue;
+			const automation = await ctx.db.get(execution.automationId);
+			if (automation && automation.orgId === execution.orgId) {
+				await notifyAutomationFailure(ctx, automation, message, execution._id);
+			}
+			// else: no automation doc to name the alert; skip (deleted automation).
+		}
+		return { failed };
+	},
+});
+
 /** Exposed for tests; not part of the public API. */
 export const __testUtils = { resolveMemberUserIds };

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -21,6 +21,7 @@ import {
 	resolveValueRef,
 	type VariableScope,
 } from "./lib/conditionEval";
+import { calendarDayEpoch } from "./lib/formula";
 import {
 	RELATION_FIELD,
 	getFieldDefinition,
@@ -1922,8 +1923,9 @@ function roundCents(n: number): number {
 	return Math.round(n * 100) / 100;
 }
 
-/** Epoch ms from a number (as-is) or a parseable date string; else NaN. */
+/** Epoch ms from a Date, a number (as-is), or a parseable date string; else NaN. */
 function valueToEpochMs(value: unknown): number {
+	if (value instanceof Date) return value.getTime();
 	if (typeof value === "number") return value;
 	if (typeof value === "string") return Date.parse(value);
 	return NaN;
@@ -2029,13 +2031,7 @@ function computeDelayResume(
 		return { ok: true, resumeAt: Date.now() + ms };
 	}
 
-	const raw = resolveValueRef(config.until, scope);
-	const resumeAt =
-		typeof raw === "number"
-			? raw
-			: typeof raw === "string"
-				? Date.parse(raw)
-				: NaN;
+	const resumeAt = valueToEpochMs(resolveValueRef(config.until, scope));
 	if (Number.isNaN(resumeAt)) {
 		return {
 			ok: false,
@@ -2335,7 +2331,9 @@ async function applyStatusUpdate(
  */
 function coerceFieldValue(
 	fieldDef: FieldDefinition,
-	raw: unknown
+	raw: unknown,
+	/** Run timezone — decides which calendar day an instant falls on. */
+	tz: string
 ): { ok: true; value: unknown } | { ok: false; error: string } {
 	if (raw === undefined || raw === null) {
 		return { ok: true, value: null };
@@ -2385,14 +2383,25 @@ function coerceFieldValue(
 			};
 		}
 		case "date": {
-			const n = typeof raw === "number" ? raw : Date.parse(String(raw));
+			const n =
+				raw instanceof Date
+					? raw.getTime()
+					: typeof raw === "number"
+						? raw
+						: Date.parse(String(raw));
 			if (Number.isNaN(n)) {
 				return {
 					ok: false,
 					error: `"${String(raw)}" is not a valid date for field "${fieldDef.key}"`,
 				};
 			}
-			return { ok: true, value: n };
+			// Every WRITABLE date field is a calendar date (the instants — paidAt,
+			// sentAt, approvedAt, ... — are all writable:false), and calendar dates
+			// are stored at UTC midnight. Normalizing here is the chokepoint that
+			// keeps a formula which produced an instant (e.g. ADDDAYS(NOW(), 3))
+			// from writing one into a date field, where it would be misread as an
+			// instant from then on.
+			return { ok: true, value: calendarDayEpoch(n, tz) };
 		}
 		case "id":
 			return { ok: true, value: String(raw) };
@@ -2465,7 +2474,11 @@ async function executeActionNodeV2(
 	}
 
 	const rawValue = resolveValueRef(action.value, env.scope);
-	const coerced = coerceFieldValue(fieldDef, rawValue);
+	const coerced = coerceFieldValue(
+		fieldDef,
+		rawValue,
+		env.scope.workflow?.tz ?? "UTC"
+	);
 	if (!coerced.ok) {
 		return { success: false, error: coerced.error };
 	}
@@ -3324,7 +3337,11 @@ async function dryExecuteAction(
 				};
 			}
 			const raw = resolveValueRef(action.value, env.scope);
-			const coerced = coerceFieldValue(fieldDef, raw);
+			const coerced = coerceFieldValue(
+				fieldDef,
+				raw,
+				env.scope.workflow?.tz ?? "UTC"
+			);
 			if (!coerced.ok) {
 				return { success: false, error: coerced.error };
 			}

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -2492,6 +2492,7 @@ async function executeActionNodeV2(
 	if (!targetObject) {
 		return { success: false, error: "Target object not found" };
 	}
+	const previousValue = (targetObject as Record<string, unknown>)[action.field];
 
 	try {
 		const updatePayload: Record<string, any> = {
@@ -2533,6 +2534,36 @@ async function executeActionNodeV2(
 				);
 				break;
 			// Clients and tasks don't have aggregate field tracking
+		}
+
+		// Emit record_updated so automations chained on this field actually fire
+		// (status writes emit their own event via applyStatusUpdate). The chain
+		// rides in metadata — the emitRecordUpdatedEvent helper would drop it and
+		// defeat the recursion guard. Same shape as the create_task emit below.
+		if (previousValue !== coerced.value) {
+			await ctx.db.insert("domainEvents", {
+				orgId,
+				eventType: "entity.record_updated",
+				eventSource: "automationExecutor.executeActionNodeV2",
+				payload: {
+					entityType: targetInfo.type,
+					entityId: targetInfo.id,
+					field: action.field,
+					oldValue: previousValue,
+					newValue: coerced.value,
+					metadata: {
+						changedFields: [action.field],
+						executionChain,
+						recursionDepth,
+						isCascade: true,
+					},
+				},
+				status: "pending",
+				correlationId: `cascade-${executionChain.join("-")}-${Date.now()}`,
+				createdAt: Date.now(),
+				attemptCount: 0,
+			});
+			await ctx.scheduler.runAfter(0, internal.eventBus.processEvents, {});
 		}
 
 		return { success: true };

--- a/packages/backend/convex/automationRuns.test.ts
+++ b/packages/backend/convex/automationRuns.test.ts
@@ -889,4 +889,315 @@ describe("automation runs (test + manual)", () => {
 			expect(rows.prod?.status).toBe("running");
 		});
 	});
+
+	describe("failStaleProductionRuns", () => {
+		async function makeAutomation(
+			asUser: ReturnType<typeof t.withIdentity>,
+			name: string
+		) {
+			return await asUser.mutation(api.automations.create, {
+				name,
+				trigger: clientCreatedTrigger,
+				nodes: [
+					{ id: "end-1", type: "end" as const, config: { kind: "end" as const } },
+				],
+			});
+		}
+
+		async function automationFailedNotes(userId: Id<"users">) {
+			return await t.run(async (ctx) =>
+				ctx.db
+					.query("notifications")
+					.withIndex("by_user_read", (q) => q.eq("userId", userId))
+					.filter((q) =>
+						q.eq(q.field("notificationType"), "automation_failed")
+					)
+					.collect()
+			);
+		}
+
+		it("fails stuck production runs (mode unset or 'production'), notifies admins, and leaves fresh/parked-future/test/completed runs alone", async () => {
+			const { asUser, orgId, userId } = await setupUser();
+			const now = Date.now();
+			const STALE = 45 * 60 * 1000;
+
+			const recordTriggeredId = await makeAutomation(
+				asUser,
+				"Record-triggered watchdog target"
+			);
+			const stuckModeUnset = await t.run(async (ctx) =>
+				ctx.db.insert("workflowExecutions", {
+					orgId,
+					automationId: recordTriggeredId,
+					triggeredBy: "status_changed",
+					triggeredAt: now - STALE,
+					status: "running",
+					nodesExecuted: [],
+					// mode intentionally unset — record-triggered runs leave it unset.
+				})
+			);
+
+			const scheduledId = await makeAutomation(
+				asUser,
+				"Scheduled watchdog target"
+			);
+			const stuckModeProd = await t.run(async (ctx) =>
+				ctx.db.insert("workflowExecutions", {
+					orgId,
+					automationId: scheduledId,
+					triggeredBy: "schedule",
+					triggeredAt: now - STALE,
+					status: "running",
+					mode: "production",
+					nodesExecuted: [],
+				})
+			);
+
+			const parkedFutureAutomationId = await makeAutomation(
+				asUser,
+				"Parked future"
+			);
+			const parkedFuture = await t.run(async (ctx) =>
+				ctx.db.insert("workflowExecutions", {
+					orgId,
+					automationId: parkedFutureAutomationId,
+					triggeredBy: "schedule",
+					triggeredAt: now - STALE,
+					status: "running",
+					mode: "production",
+					nodesExecuted: [],
+					resumeState: {
+						resumeNodeId: "delay-1",
+						resumeAt: now + 60 * 60 * 1000,
+						checkpointAt: now - STALE,
+						fetchOutputs: [],
+					},
+				})
+			);
+
+			const freshAutomationId = await makeAutomation(asUser, "Fresh");
+			const fresh = await t.run(async (ctx) =>
+				ctx.db.insert("workflowExecutions", {
+					orgId,
+					automationId: freshAutomationId,
+					triggeredBy: "schedule",
+					triggeredAt: now,
+					status: "running",
+					mode: "production",
+					nodesExecuted: [],
+				})
+			);
+
+			const staleTestAutomationId = await makeAutomation(asUser, "Stale test");
+			const staleTest = await t.run(async (ctx) =>
+				ctx.db.insert("workflowExecutions", {
+					orgId,
+					automationId: staleTestAutomationId,
+					triggeredBy: "test:x",
+					triggeredAt: now - STALE,
+					status: "running",
+					mode: "test",
+					dryRun: true,
+					nodesExecuted: [],
+				})
+			);
+
+			const completedAutomationId = await makeAutomation(asUser, "Completed");
+			const oldCompleted = await t.run(async (ctx) =>
+				ctx.db.insert("workflowExecutions", {
+					orgId,
+					automationId: completedAutomationId,
+					triggeredBy: "schedule",
+					triggeredAt: now - STALE,
+					status: "completed",
+					completedAt: now - STALE + 1000,
+					mode: "production",
+					nodesExecuted: [],
+				})
+			);
+
+			const result = await t.mutation(
+				internal.automationExecutor.failStaleProductionRuns,
+				{}
+			);
+			expect(result.failed).toBe(2);
+
+			const rows = await t.run(async (ctx) => ({
+				stuckModeUnset: await ctx.db.get(stuckModeUnset),
+				stuckModeProd: await ctx.db.get(stuckModeProd),
+				parkedFuture: await ctx.db.get(parkedFuture),
+				fresh: await ctx.db.get(fresh),
+				staleTest: await ctx.db.get(staleTest),
+				oldCompleted: await ctx.db.get(oldCompleted),
+			}));
+
+			expect(rows.stuckModeUnset?.status).toBe("failed");
+			expect(rows.stuckModeUnset?.error).toMatch(/stalled without completing/i);
+			expect(rows.stuckModeUnset?.completedAt).toBe(now);
+
+			expect(rows.stuckModeProd?.status).toBe("failed");
+			expect(rows.stuckModeProd?.error).toMatch(/stalled without completing/i);
+
+			expect(rows.parkedFuture?.status).toBe("running");
+			expect(rows.fresh?.status).toBe("running");
+			expect(rows.staleTest?.status).toBe("running");
+			expect(rows.oldCompleted?.status).toBe("completed");
+
+			const notes = await automationFailedNotes(userId);
+			expect(notes).toHaveLength(2);
+			expect(notes.map((n) => n.title).sort()).toEqual(
+				["Record-triggered watchdog target", "Scheduled watchdog target"].sort()
+			);
+		});
+
+		it("fails a parked run whose wake passed more than 30 minutes ago, folding the elapsed pause into pausedMs", async () => {
+			const { asUser, orgId } = await setupUser();
+			const now = Date.now();
+			const automationId = await makeAutomation(asUser, "Parked expired");
+
+			const checkpointAt = now - 2 * 60 * 60 * 1000; // parked 2h ago
+			const resumeAt = now - 45 * 60 * 1000; // wake was due 45min ago
+			const executionId = await t.run(async (ctx) =>
+				ctx.db.insert("workflowExecutions", {
+					orgId,
+					automationId,
+					triggeredBy: "schedule",
+					triggeredAt: now - 3 * 60 * 60 * 1000,
+					status: "running",
+					mode: "production",
+					nodesExecuted: [],
+					pausedMs: 1000,
+					resumeState: {
+						resumeNodeId: "delay-1",
+						resumeAt,
+						checkpointAt,
+						fetchOutputs: [],
+					},
+				})
+			);
+
+			const result = await t.mutation(
+				internal.automationExecutor.failStaleProductionRuns,
+				{}
+			);
+			expect(result.failed).toBe(1);
+
+			const row = await t.run(async (ctx) => ctx.db.get(executionId));
+			expect(row?.status).toBe("failed");
+			expect(row?.error).toMatch(/never woke/i);
+			expect(row?.resumeState).toBeUndefined();
+			expect(row?.currentNodeId).toBeUndefined();
+			expect(row?.completedAt).toBe(now);
+			// seeded 1000 + elapsed since checkpoint (>= 30min, per task instruction
+			// — avoid asserting the exact ms under fake timers).
+			expect(row?.pausedMs).toBeGreaterThanOrEqual(1000 + 30 * 60 * 1000);
+		});
+
+		it("still marks a stranded run failed when its automation was deleted, without throwing or notifying", async () => {
+			const { asUser, orgId, userId } = await setupUser();
+			const now = Date.now();
+			const automationId = await makeAutomation(asUser, "Deleted mid-flight");
+
+			const executionId = await t.run(async (ctx) =>
+				ctx.db.insert("workflowExecutions", {
+					orgId,
+					automationId,
+					triggeredBy: "schedule",
+					triggeredAt: now - 45 * 60 * 1000,
+					status: "running",
+					mode: "production",
+					nodesExecuted: [],
+				})
+			);
+			await t.run(async (ctx) => ctx.db.delete(automationId));
+
+			await expect(
+				t.mutation(internal.automationExecutor.failStaleProductionRuns, {})
+			).resolves.toEqual({ failed: 1 });
+
+			const row = await t.run(async (ctx) => ctx.db.get(executionId));
+			expect(row?.status).toBe("failed");
+
+			const notes = await automationFailedNotes(userId);
+			expect(notes).toHaveLength(0);
+		});
+
+		it("a late resume after the watchdog failed the run is a no-op", async () => {
+			const { asUser, orgId } = await setupUser();
+			const now = Date.now();
+			const automationId = await makeAutomation(asUser, "Late wake");
+
+			const executionId = await t.run(async (ctx) =>
+				ctx.db.insert("workflowExecutions", {
+					orgId,
+					automationId,
+					triggeredBy: "schedule",
+					triggeredAt: now - 3 * 60 * 60 * 1000,
+					status: "running",
+					mode: "production",
+					nodesExecuted: [],
+					pausedMs: 1000,
+					resumeState: {
+						resumeNodeId: "delay-1",
+						resumeAt: now - 45 * 60 * 1000,
+						checkpointAt: now - 2 * 60 * 60 * 1000,
+						fetchOutputs: [],
+					},
+				})
+			);
+
+			const result = await t.mutation(
+				internal.automationExecutor.failStaleProductionRuns,
+				{}
+			);
+			expect(result.failed).toBe(1);
+
+			const afterWatchdog = await t.run(async (ctx) => ctx.db.get(executionId));
+			expect(afterWatchdog?.status).toBe("failed");
+			const watchdogPausedMs = afterWatchdog?.pausedMs;
+
+			// The dropped scheduler hop finally fires — must not revive the run
+			// or re-accumulate pause time.
+			await t.mutation(internal.automationExecutor.resumeExecution, {
+				orgId,
+				executionId,
+				automationId,
+			});
+
+			const afterResume = await t.run(async (ctx) => ctx.db.get(executionId));
+			expect(afterResume?.status).toBe("failed");
+			expect(afterResume?.pausedMs).toBe(watchdogPausedMs);
+			expect(afterResume?.resumeState).toBeUndefined();
+		});
+
+		it("one sweep failing two stuck runs of the same automation notifies the admin only once (dedupe)", async () => {
+			const { asUser, orgId, userId } = await setupUser();
+			const now = Date.now();
+			const automationId = await makeAutomation(asUser, "Flapping");
+
+			for (let i = 0; i < 2; i++) {
+				await t.run(async (ctx) =>
+					ctx.db.insert("workflowExecutions", {
+						orgId,
+						automationId,
+						triggeredBy: "status_changed",
+						triggeredAt: now - 45 * 60 * 1000,
+						status: "running",
+						mode: "production",
+						nodesExecuted: [],
+					})
+				);
+			}
+
+			const result = await t.mutation(
+				internal.automationExecutor.failStaleProductionRuns,
+				{}
+			);
+			expect(result.failed).toBe(2);
+
+			const notes = await automationFailedNotes(userId);
+			expect(notes).toHaveLength(1);
+			expect(notes[0].title).toBe("Flapping");
+		});
+	});
 });

--- a/packages/backend/convex/automationRuns.test.ts
+++ b/packages/backend/convex/automationRuns.test.ts
@@ -1088,9 +1088,8 @@ describe("automation runs (test + manual)", () => {
 			expect(row?.resumeState).toBeUndefined();
 			expect(row?.currentNodeId).toBeUndefined();
 			expect(row?.completedAt).toBe(now);
-			// seeded 1000 + elapsed since checkpoint (>= 30min, per task instruction
-			// — avoid asserting the exact ms under fake timers).
-			expect(row?.pausedMs).toBeGreaterThanOrEqual(1000 + 30 * 60 * 1000);
+			// seeded 1000 + exact elapsed since checkpoint (fake timers freeze now).
+			expect(row?.pausedMs).toBe(1000 + (now - checkpointAt));
 		});
 
 		it("still marks a stranded run failed when its automation was deleted, without throwing or notifying", async () => {

--- a/packages/backend/convex/automationRunsMetrics.test.ts
+++ b/packages/backend/convex/automationRunsMetrics.test.ts
@@ -118,6 +118,7 @@ describe("automation runs & latency (Slice 5)", () => {
 			mode?: "production" | "test";
 			nodesExecuted?: Doc<"workflowExecutions">["nodesExecuted"];
 			error?: string;
+			loopSummary?: Doc<"workflowExecutions">["loopSummary"];
 		}
 	): Promise<Id<"workflowExecutions">> {
 		return await t.run(async (ctx) =>
@@ -132,6 +133,7 @@ describe("automation runs & latency (Slice 5)", () => {
 				mode: fields.mode,
 				error: fields.error,
 				nodesExecuted: fields.nodesExecuted ?? [],
+				loopSummary: fields.loopSummary,
 			})
 		);
 	}
@@ -492,6 +494,40 @@ describe("automation runs & latency (Slice 5)", () => {
 			expect(m.avgActiveMs).toBe(0);
 			expect(m.p50ActiveMs).toBe(0);
 		});
+
+		it("counts completed_with_errors in withErrorsCount, excludes it from successCount, and it lowers successRate", async () => {
+			const now = 1_700_000_500_000;
+			vi.setSystemTime(now);
+			const { orgId, asUser } = await setupUser();
+			const auto = await asUser.mutation(api.automations.create, {
+				name: "Partial",
+				trigger: clientCreatedTrigger,
+				nodes: [notesActionNode("act-1", "x")],
+			});
+
+			const b = now - 60_000;
+			await seedRun({ orgId, automationId: auto, triggeredAt: b, status: "completed", completedAt: b + 100 });
+			await seedRun({
+				orgId,
+				automationId: auto,
+				triggeredAt: b,
+				status: "completed_with_errors",
+				completedAt: b + 200,
+				loopSummary: [
+					{ nodeId: "loop-1", total: 5, succeeded: 3, failed: 2, skipped: 0, errors: [] },
+				],
+			});
+
+			const m = await asUser.query(api.automations.getRunMetrics, {});
+			expect(m.totalRuns).toBe(2);
+			expect(m.successCount).toBe(1);
+			expect(m.withErrorsCount).toBe(1);
+			expect(m.failedCount).toBe(0);
+			// successRate = successCount / (successCount + failedCount + withErrorsCount) = 1/2.
+			expect(m.successRate).toBeCloseTo(0.5);
+			// completed_with_errors runs DID complete — their latency joins the same distribution.
+			expect(m.avgActiveMs).toBe(150); // (100 + 200) / 2
+		});
 	});
 
 	describe("getRunThroughput", () => {
@@ -526,6 +562,41 @@ describe("automation runs & latency (Slice 5)", () => {
 			expect(buckets[1]).toMatchObject({ success: 0, failed: 0, skipped: 0 });
 			// 07-04: one success + one skipped (test excluded).
 			expect(buckets[2]).toMatchObject({ success: 1, failed: 0, skipped: 1 });
+		});
+
+		it("buckets a completed_with_errors run into withErrors and nowhere else", async () => {
+			const now = Date.UTC(2026, 6, 4, 12, 0, 0); // 2026-07-04T12:00Z
+			vi.setSystemTime(now);
+			const todayMidnight = Date.UTC(2026, 6, 4);
+
+			const { orgId, asUser } = await setupUser();
+			const auto = await asUser.mutation(api.automations.create, {
+				name: "Throughput partial",
+				trigger: clientCreatedTrigger,
+				nodes: [notesActionNode("act-1", "x")],
+			});
+
+			await seedRun({
+				orgId,
+				automationId: auto,
+				triggeredAt: todayMidnight + 3600_000,
+				status: "completed_with_errors",
+				completedAt: todayMidnight + 3700_000,
+				loopSummary: [
+					{ nodeId: "loop-1", total: 3, succeeded: 2, failed: 1, skipped: 0, errors: [] },
+				],
+			});
+
+			const buckets = await asUser.query(api.automations.getRunThroughput, {
+				windowDays: 1,
+			});
+			expect(buckets).toHaveLength(1);
+			expect(buckets[0]).toMatchObject({
+				success: 0,
+				failed: 0,
+				withErrors: 1,
+				skipped: 0,
+			});
 		});
 	});
 
@@ -590,6 +661,44 @@ describe("automation runs & latency (Slice 5)", () => {
 
 			const asA = await orgA.asUser.query(api.automations.getRecentFailures, {});
 			expect(asA).toHaveLength(0);
+		});
+
+		it("includes completed_with_errors runs alongside failed runs, newest first, tagged with status", async () => {
+			const { orgId, asUser } = await setupUser();
+			const auto = await asUser.mutation(api.automations.create, {
+				name: "Mixed failures",
+				trigger: clientCreatedTrigger,
+				nodes: [notesActionNode("act-1", "x")],
+			});
+			const base = 1_700_000_000_000;
+
+			await seedRun({
+				orgId,
+				automationId: auto,
+				triggeredAt: base,
+				status: "failed",
+				completedAt: base + 5,
+				error: "boom",
+				nodesExecuted: [{ nodeId: "n1", result: "failed", error: "boom" }],
+			});
+			await seedRun({
+				orgId,
+				automationId: auto,
+				triggeredAt: base + 10,
+				status: "completed_with_errors",
+				completedAt: base + 15,
+				loopSummary: [
+					{ nodeId: "loop-1", total: 4, succeeded: 2, failed: 2, skipped: 0, errors: [] },
+				],
+			});
+
+			const failures = await asUser.query(api.automations.getRecentFailures, {});
+			expect(failures).toHaveLength(2);
+			// Newest first.
+			expect(failures[0].status).toBe("completed_with_errors");
+			expect(failures[0].error).toBe("2 of 4 items failed");
+			expect(failures[1].status).toBe("failed");
+			expect(failures[1].error).toBe("boom");
 		});
 	});
 

--- a/packages/backend/convex/automations.test.ts
+++ b/packages/backend/convex/automations.test.ts
@@ -117,6 +117,22 @@ function createTaskNode(
 	};
 }
 
+/** A step a scheduled run can execute: no record scope needed. */
+function notifyNode(id: string, message = "Scheduled run fired") {
+	return {
+		id,
+		type: "action" as const,
+		config: {
+			kind: "action" as const,
+			action: {
+				type: "send_notification" as const,
+				recipient: "org_admins" as const,
+				message,
+			},
+		},
+	};
+}
+
 function actionNode(id: string, statusValue = "inactive") {
 	return {
 		id,
@@ -227,7 +243,7 @@ describe("Automations", () => {
 						time: "09:00",
 					},
 				},
-				nodes: [actionNode("act-1", "inactive")],
+				nodes: [notifyNode("notify-1")],
 				isActive: true,
 			});
 
@@ -433,6 +449,203 @@ describe("Automations", () => {
 			});
 			const automation = await asUser.query(api.automations.get, { id });
 			expect(automation?.status).toBe("draft");
+		});
+	});
+
+	describe("scheduled triggers have no record (A1)", () => {
+		const schedule = {
+			frequency: "daily" as const,
+			timezone: "UTC",
+			time: "09:00",
+		};
+		const scheduledTrigger = { type: "scheduled" as const, schedule };
+
+		/** A condition whose left side is a scope value, not a record field. */
+		function varLeftConditionNode(id: string, path: string) {
+			return {
+				id,
+				type: "condition" as const,
+				config: {
+					kind: "condition" as const,
+					logic: "and" as const,
+					groups: [
+						{
+							logic: "and" as const,
+							rules: [
+								{
+									field: "",
+									left: { kind: "var" as const, path },
+									operator: "greater_than" as const,
+									value: { kind: "static" as const, value: 100 },
+								},
+							],
+						},
+					],
+				},
+			};
+		}
+
+		it("rejects a top-level update_field on update, not just create", async () => {
+			const { asUser } = await setupUser();
+
+			// Starts life as a record trigger, where update_field(self) is fine.
+			const id = await asUser.mutation(api.automations.create, {
+				name: "Switcher",
+				trigger: clientTrigger,
+				nodes: [actionNode("act-1")],
+			});
+
+			await expect(
+				asUser.mutation(api.automations.update, {
+					id,
+					trigger: scheduledTrigger,
+				})
+			).rejects.toThrow(/no record to update/i);
+		});
+
+		it("rejects a condition that reads a record field", async () => {
+			const { asUser } = await setupUser();
+
+			await expect(
+				asUser.mutation(api.automations.create, {
+					name: "Record-reading condition",
+					trigger: scheduledTrigger,
+					nodes: [conditionNode("cond-1")],
+				})
+			).rejects.toThrow(/nothing to test/i);
+		});
+
+		it("accepts a top-level condition whose left side is a variable", async () => {
+			const { asUser } = await setupUser();
+
+			const id = await asUser.mutation(api.automations.create, {
+				name: "Aggregate threshold",
+				trigger: scheduledTrigger,
+				nodes: [varLeftConditionNode("cond-1", "node.agg-1.result")],
+			});
+
+			expect(await asUser.query(api.automations.get, { id })).toBeTruthy();
+		});
+
+		it("rejects a {{trigger.record.*}} token inside a message template", async () => {
+			const { asUser } = await setupUser();
+
+			await expect(
+				asUser.mutation(api.automations.create, {
+					name: "Dead token in a template",
+					trigger: scheduledTrigger,
+					// Not a ValueRef — a path-only scan would sail right past this.
+					nodes: [notifyNode("notify-1", "Total: {{trigger.record.total}}")],
+				})
+			).rejects.toThrow(/always empty/i);
+		});
+
+		it("rejects a formula that reads the trigger record", async () => {
+			const { asUser } = await setupUser();
+
+			await expect(
+				asUser.mutation(api.automations.create, {
+					name: "Dead formula",
+					trigger: scheduledTrigger,
+					nodes: [notifyNode("notify-1")],
+					formulas: [
+						{
+							id: "f1",
+							name: "Doubled",
+							returnType: "number" as const,
+							expression: "{trigger.record.budget} * 2",
+						},
+					],
+				})
+			).rejects.toThrow(/always empty/i);
+		});
+
+		it("rejects switching to a schedule when a stored formula reads the record", async () => {
+			const { asUser } = await setupUser();
+
+			// Formulas are automation-level: changing only the trigger has to
+			// re-check them, or a live formula is stranded reading nothing.
+			const id = await asUser.mutation(api.automations.create, {
+				name: "Formula stranded by a trigger switch",
+				trigger: clientTrigger,
+				nodes: [notifyNode("notify-1")],
+				formulas: [
+					{
+						id: "f1",
+						name: "Doubled",
+						returnType: "number" as const,
+						expression: "{trigger.record.budget} * 2",
+					},
+				],
+			});
+
+			await expect(
+				asUser.mutation(api.automations.update, { id, trigger: scheduledTrigger })
+			).rejects.toThrow(/always empty/i);
+		});
+
+		it("rejects a variable left side in a fetch filter", async () => {
+			const { asUser } = await setupUser();
+
+			await expect(
+				asUser.mutation(api.automations.create, {
+					name: "Var left in a filter",
+					trigger: scheduledTrigger,
+					nodes: [
+						{
+							id: "fetch-1",
+							type: "fetch_records" as const,
+							config: {
+								kind: "fetch_records" as const,
+								objectType: "client" as const,
+								filters: [
+									{
+										logic: "and" as const,
+										rules: [
+											{
+												field: "",
+												left: { kind: "var" as const, path: "node.x.count" },
+												operator: "greater_than" as const,
+												value: { kind: "static" as const, value: 1 },
+											},
+										],
+									},
+								],
+							},
+						},
+					],
+				})
+			).rejects.toThrow(/must compare a field/i);
+		});
+
+		it("rejects a variable left side in trigger entry criteria", async () => {
+			const { asUser } = await setupUser();
+
+			await expect(
+				asUser.mutation(api.automations.create, {
+					name: "Var left in entry criteria",
+					trigger: {
+						...clientTrigger,
+						entryCriteria: {
+							logic: "and" as const,
+							groups: [
+								{
+									logic: "and" as const,
+									rules: [
+										{
+											field: "",
+											left: { kind: "var" as const, path: "node.x.count" },
+											operator: "greater_than" as const,
+											value: { kind: "static" as const, value: 1 },
+										},
+									],
+								},
+							],
+						},
+					},
+					nodes: [notifyNode("notify-1")],
+				})
+			).rejects.toThrow(/must compare a field/i);
 		});
 	});
 
@@ -872,7 +1085,7 @@ describe("Automations", () => {
 			const id = await asUser.mutation(api.automations.create, {
 				name: "Resume trigger check",
 				trigger: { type: "scheduled", schedule: originalSchedule },
-				nodes: [actionNode("act-1")],
+				nodes: [notifyNode("notify-1")],
 				isActive: true,
 			});
 

--- a/packages/backend/convex/automations.test.ts
+++ b/packages/backend/convex/automations.test.ts
@@ -618,6 +618,39 @@ describe("Automations", () => {
 			).rejects.toThrow(/must compare a field/i);
 		});
 
+		it("refuses to resume a snapshot that breaks the rules", async () => {
+			// toggleActive resumes the PUBLISHED snapshot. It never re-checked it, so
+			// an automation published before this rule landed could be switched back
+			// on and fail every tick.
+			const { asUser, orgId } = await setupUser();
+
+			const trigger = { type: "scheduled" as const, schedule };
+			const nodes = [actionNode("act-1")]; // update_field(self) — no record to act on
+
+			const id = await t.run(async (ctx) => {
+				const user = await ctx.db.query("users").first();
+				const now = Date.now();
+				return ctx.db.insert("workflowAutomations", {
+					orgId,
+					name: "Broken scheduled, paused",
+					trigger,
+					nodes,
+					status: "paused" as const,
+					publishedSnapshot: { trigger, nodes, version: 1, publishedAt: now },
+					createdBy: user!._id,
+					createdAt: now,
+					updatedAt: now,
+				});
+			});
+
+			await expect(
+				asUser.mutation(api.automations.toggleActive, { id })
+			).rejects.toThrow(/no record to update/i);
+
+			const after = await t.run(async (ctx) => ctx.db.get(id));
+			expect(after?.status).toBe("paused");
+		});
+
 		it("rejects a variable left side in trigger entry criteria", async () => {
 			const { asUser } = await setupUser();
 

--- a/packages/backend/convex/automations.test.ts
+++ b/packages/backend/convex/automations.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { setupConvexTest } from "./test.setup";
 import { createTestOrg, createTestIdentity } from "./test.helpers";
-import { api } from "./_generated/api";
+import { api, internal } from "./_generated/api";
 import { computeNextRunAt } from "./lib/schedule";
 
 // Valid v2 trigger: client statuses are lead/active/inactive/archived
@@ -1219,6 +1219,109 @@ describe("Automations", () => {
 			);
 			expect(automation).toBeNull();
 			expect(execution).toBeNull();
+		});
+	});
+
+	describe("remove — batched execution cleanup", () => {
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it("deletes an automation with >100 execution rows fully once scheduled batches finish, leaving only the 100-row inline batch gone right after remove", async () => {
+			const { asUser, orgId } = await setupUser();
+
+			const id = await asUser.mutation(api.automations.create, {
+				name: "Heavy history",
+				trigger: clientTrigger,
+				nodes: [actionNode("act-1")],
+				isActive: true,
+			});
+
+			const TOTAL_EXECUTIONS = 120;
+			await t.run(async (ctx) => {
+				for (let i = 0; i < TOTAL_EXECUTIONS; i++) {
+					await ctx.db.insert("workflowExecutions", {
+						orgId,
+						automationId: id,
+						triggeredBy: "status_changed",
+						triggeredAt: Date.now(),
+						status: "completed",
+						nodesExecuted: [],
+					});
+				}
+			});
+
+			await asUser.mutation(api.automations.remove, { id });
+
+			// Inline batch deletes exactly REMOVE_EXECUTIONS_BATCH (100) rows before
+			// the scheduled follow-up runs — 20 should remain right now.
+			const remainingAfterInline = await t.run(async (ctx) =>
+				ctx.db
+					.query("workflowExecutions")
+					.withIndex("by_automation", (q) => q.eq("automationId", id))
+					.collect()
+			);
+			expect(remainingAfterInline).toHaveLength(
+				TOTAL_EXECUTIONS - 100
+			);
+
+			await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+			const [automation, remainingAfterDrain] = await t.run(async (ctx) =>
+				Promise.all([
+					ctx.db.get(id),
+					ctx.db
+						.query("workflowExecutions")
+						.withIndex("by_automation", (q) => q.eq("automationId", id))
+						.collect(),
+				])
+			);
+			expect(automation).toBeNull();
+			expect(remainingAfterDrain).toHaveLength(0);
+		});
+
+		it("removeExecutionsBatch is a no-op guard when the automation still exists", async () => {
+			const { asUser, orgId } = await setupUser();
+
+			const id = await asUser.mutation(api.automations.create, {
+				name: "Still alive",
+				trigger: clientTrigger,
+				nodes: [actionNode("act-1")],
+				isActive: true,
+			});
+
+			await t.run(async (ctx) => {
+				for (let i = 0; i < 5; i++) {
+					await ctx.db.insert("workflowExecutions", {
+						orgId,
+						automationId: id,
+						triggeredBy: "status_changed",
+						triggeredAt: Date.now(),
+						status: "completed",
+						nodesExecuted: [],
+					});
+				}
+			});
+
+			await t.mutation(internal.automations.removeExecutionsBatch, {
+				automationId: id,
+			});
+
+			const [automation, executions] = await t.run(async (ctx) =>
+				Promise.all([
+					ctx.db.get(id),
+					ctx.db
+						.query("workflowExecutions")
+						.withIndex("by_automation", (q) => q.eq("automationId", id))
+						.collect(),
+				])
+			);
+			expect(automation).not.toBeNull();
+			expect(executions).toHaveLength(5);
 		});
 	});
 

--- a/packages/backend/convex/automations.ts
+++ b/packages/backend/convex/automations.ts
@@ -1077,6 +1077,7 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 const executionStatusValidator = v.union(
 	v.literal("running"),
 	v.literal("completed"),
+	v.literal("completed_with_errors"),
 	v.literal("failed"),
 	v.literal("skipped"),
 	v.literal("cancelled")
@@ -1242,6 +1243,7 @@ export const getRunMetrics = userQuery({
 		successCount: number;
 		failedCount: number;
 		skippedCount: number;
+		withErrorsCount: number;
 		successRate: number;
 		avgActiveMs: number;
 		p50ActiveMs: number;
@@ -1264,6 +1266,7 @@ export const getRunMetrics = userQuery({
 		let successCount = 0;
 		let failedCount = 0;
 		let skippedCount = 0;
+		let withErrorsCount = 0;
 		const activeDurations: number[] = [];
 
 		for (const e of executions) {
@@ -1273,6 +1276,11 @@ export const getRunMetrics = userQuery({
 				successCount++;
 				const { activeMs } = deriveDurations(e);
 				if (activeMs != null) activeDurations.push(activeMs);
+			} else if (e.status === "completed_with_errors") {
+				withErrorsCount++;
+				// Ran to the end, so its latency counts toward the same distribution.
+				const { activeMs } = deriveDurations(e);
+				if (activeMs != null) activeDurations.push(activeMs);
 			} else if (e.status === "failed") {
 				failedCount++;
 			} else if (e.status === "skipped") {
@@ -1280,7 +1288,8 @@ export const getRunMetrics = userQuery({
 			}
 		}
 
-		const decided = successCount + failedCount;
+		// A partial run drags the rate down without counting as a full failure.
+		const decided = successCount + failedCount + withErrorsCount;
 		const successRate = decided > 0 ? successCount / decided : 0;
 
 		activeDurations.sort((a, b) => a - b);
@@ -1305,6 +1314,7 @@ export const getRunMetrics = userQuery({
 			successCount,
 			failedCount,
 			skippedCount,
+			withErrorsCount,
 			successRate,
 			avgActiveMs,
 			p50ActiveMs: percentile(activeDurations, 50),
@@ -1325,7 +1335,13 @@ export const getRunThroughput = userQuery({
 		ctx,
 		args
 	): Promise<
-		Array<{ day: number; success: number; failed: number; skipped: number }>
+		Array<{
+			day: number;
+			success: number;
+			failed: number;
+			withErrors: number;
+			skipped: number;
+		}>
 	> => {
 		await ctx.requireLevel("automations", "view");
 		const orgId = ctx.orgId;
@@ -1344,10 +1360,22 @@ export const getRunThroughput = userQuery({
 		// Seed every UTC day (incl. zero-count) in chronological order.
 		const buckets = new Map<
 			number,
-			{ day: number; success: number; failed: number; skipped: number }
+			{
+				day: number;
+				success: number;
+				failed: number;
+				withErrors: number;
+				skipped: number;
+			}
 		>();
 		for (let day = firstDay; day <= todayMidnight; day += DAY_MS) {
-			buckets.set(day, { day, success: 0, failed: 0, skipped: 0 });
+			buckets.set(day, {
+				day,
+				success: 0,
+				failed: 0,
+				withErrors: 0,
+				skipped: 0,
+			});
 		}
 
 		for (const e of executions) {
@@ -1357,6 +1385,7 @@ export const getRunThroughput = userQuery({
 			if (!bucket) continue; // outside the seeded window
 			if (e.status === "completed") bucket.success++;
 			else if (e.status === "failed") bucket.failed++;
+			else if (e.status === "completed_with_errors") bucket.withErrors++;
 			else if (e.status === "skipped") bucket.skipped++;
 		}
 
@@ -1365,9 +1394,28 @@ export const getRunThroughput = userQuery({
 });
 
 /**
- * The most recent failed PRODUCTION runs (org-scoped, newest first) for the
- * recent-failures timeline. failedNodeId = the last nodesExecuted entry whose
- * result is "failed" (undefined for pre-walk failures like a missing record).
+ * Sensible one-line message for a completed_with_errors run, which has no
+ * top-level `error` field — summed across every loop node's failed count.
+ */
+function deriveLoopSummaryError(
+	loopSummary: Doc<"workflowExecutions">["loopSummary"]
+): string {
+	if (!loopSummary || loopSummary.length === 0) return "Some items failed";
+	let total = 0;
+	let totalFailed = 0;
+	for (const s of loopSummary) {
+		total += s.total;
+		totalFailed += s.failed;
+	}
+	if (totalFailed === 0) return "Some items failed";
+	return `${totalFailed} of ${total} items failed`;
+}
+
+/**
+ * The most recent failed or partially-failed PRODUCTION runs (org-scoped,
+ * newest first) for the recent-failures timeline. failedNodeId = the last
+ * nodesExecuted entry whose result is "failed" (undefined for pre-walk
+ * failures like a missing record).
  */
 export const getRecentFailures = userQuery({
 	args: { limit: v.optional(v.number()) },
@@ -1379,6 +1427,7 @@ export const getRecentFailures = userQuery({
 			executionId: Id<"workflowExecutions">;
 			automationId: Id<"workflowAutomations">;
 			automationName: string;
+			status: "failed" | "completed_with_errors";
 			error: string;
 			failedNodeId?: string;
 			triggeredAt: number;
@@ -1397,17 +1446,38 @@ export const getRecentFailures = userQuery({
 			.filter((q) => q.neq(q.field("mode"), "test"))
 			.take(limit);
 
+		// A partially-failed run (loop continued past skipped items) also
+		// belongs in the recent-failures timeline.
+		const partialFailures = await ctx.db
+			.query("workflowExecutions")
+			.withIndex("by_org_status_triggeredAt", (q) =>
+				q.eq("orgId", orgId).eq("status", "completed_with_errors")
+			)
+			.order("desc")
+			.filter((q) => q.neq(q.field("mode"), "test"))
+			.take(limit);
+
+		const merged = [...failures, ...partialFailures]
+			.sort((a, b) => b.triggeredAt - a.triggeredAt)
+			.slice(0, limit);
+
 		const resolveName = makeAutomationNameResolver(ctx, orgId);
 		const rows = [];
-		for (const e of failures) {
+		for (const e of merged) {
 			const failedNode = [...e.nodesExecuted]
 				.reverse()
 				.find((n) => n.result === "failed");
+			const status = e.status as "failed" | "completed_with_errors";
+			const error =
+				status === "completed_with_errors"
+					? deriveLoopSummaryError(e.loopSummary)
+					: (e.error ?? "Unknown error");
 			rows.push({
 				executionId: e._id,
 				automationId: e.automationId,
 				automationName: await resolveName(e.automationId),
-				error: e.error ?? "Unknown error",
+				status,
+				error,
 				failedNodeId: failedNode?.nodeId,
 				triggeredAt: e.triggeredAt,
 			});

--- a/packages/backend/convex/automations.ts
+++ b/packages/backend/convex/automations.ts
@@ -1,4 +1,5 @@
-import { QueryCtx, MutationCtx } from "./_generated/server";
+import { QueryCtx, MutationCtx, internalMutation } from "./_generated/server";
+import { internal } from "./_generated/api";
 import { v } from "convex/values";
 import { paginationOptsValidator, type PaginationResult } from "convex/server";
 import { Doc, Id } from "./_generated/dataModel";
@@ -1191,8 +1192,39 @@ export const toggleActive = userMutation({
 	},
 });
 
+/** Execution rows deleted per transaction while removing an automation. */
+const REMOVE_EXECUTIONS_BATCH = 100;
+
 /**
- * Delete an automation (hard delete)
+ * Delete one bounded batch of a removed automation's execution rows and
+ * reschedule while more remain. Rows still present during the handoff window
+ * render as "(deleted automation)" in run listings.
+ */
+async function deleteExecutionsBatch(
+	ctx: MutationCtx,
+	automationId: AutomationId
+): Promise<void> {
+	const batch = await ctx.db
+		.query("workflowExecutions")
+		.withIndex("by_automation", (q) => q.eq("automationId", automationId))
+		.take(REMOVE_EXECUTIONS_BATCH);
+	for (const execution of batch) {
+		await ctx.db.delete(execution._id);
+	}
+	if (batch.length === REMOVE_EXECUTIONS_BATCH) {
+		await ctx.scheduler.runAfter(
+			0,
+			internal.automations.removeExecutionsBatch,
+			{ automationId }
+		);
+	}
+}
+
+/**
+ * Delete an automation (hard delete). The doc goes immediately — lists and
+ * the scheduled dispatcher stop seeing it in this transaction — but a
+ * long-lived automation's run history can exceed one transaction's limits,
+ * so it is chewed through in self-rescheduling batches.
  */
 export const remove = userMutation({
 	args: { id: v.id("workflowAutomations") },
@@ -1200,18 +1232,21 @@ export const remove = userMutation({
 		await ctx.requireLevel("automations", "delete");
 		await getAutomationOrThrow(ctx, args.id); // Validate access
 
-		// Also delete associated execution logs
-		const executions = await ctx.db
-			.query("workflowExecutions")
-			.withIndex("by_automation", (q) => q.eq("automationId", args.id))
-			.collect();
-
-		for (const execution of executions) {
-			await ctx.db.delete(execution._id);
-		}
-
 		await ctx.db.delete(args.id);
+		await deleteExecutionsBatch(ctx, args.id);
 		return args.id;
+	},
+});
+
+/** Follow-up batches for `remove` — only ever runs on orphaned rows. */
+export const removeExecutionsBatch = internalMutation({
+	args: { automationId: v.id("workflowAutomations") },
+	handler: async (ctx, args): Promise<void> => {
+		// Refuse to touch history of a live automation: this only cleans up
+		// after a hard delete, so a still-present doc means a bad caller.
+		const automation = await ctx.db.get(args.automationId);
+		if (automation) return;
+		await deleteExecutionsBatch(ctx, args.automationId);
 	},
 });
 

--- a/packages/backend/convex/automations.ts
+++ b/packages/backend/convex/automations.ts
@@ -21,8 +21,10 @@ import {
 	recordUpdatedTriggerValidator,
 	scheduledTriggerValidator,
 	statusChangedTriggerValidator,
+	triggerRecordObjectType,
 	type AutomationObjectType,
 	type AutomationTrigger,
+	type ConditionGroup,
 	type FormulaResource,
 	type WorkflowNodeConfig,
 } from "./lib/workflowTypes";
@@ -195,21 +197,128 @@ function validateTrigger(trigger: AutomationTrigger): void {
 	}
 }
 
-function triggerObjectType(
-	trigger: AutomationTrigger
-): AutomationObjectType | undefined {
-	if ("objectType" in trigger && trigger.objectType) {
-		return trigger.objectType;
+function isScheduledTrigger(trigger: AutomationTrigger): boolean {
+	return "type" in trigger && trigger.type === "scheduled";
+}
+
+/**
+ * Scheduled triggers store no object type: it was never read at runtime, but
+ * the builder used to stamp one on every scheduled trigger, and anything that
+ * reads it starts claiming a record scope the run does not have. Stripping on
+ * write heals stored rows the next time they are saved.
+ */
+function sanitizeTrigger<T>(trigger: T): T {
+	if (
+		!trigger ||
+		typeof trigger !== "object" ||
+		(trigger as { type?: string }).type !== "scheduled" ||
+		!("objectType" in trigger)
+	) {
+		return trigger;
 	}
-	return undefined;
+	const rest = { ...(trigger as Record<string, unknown>) };
+	delete rest.objectType;
+	return rest as T;
+}
+
+const TEMPLATE_TOKEN = /\{\{\s*([^}]+?)\s*\}\}/g;
+
+/**
+ * Every scope path a config reads: `{kind:"var"}` refs plus `{{token}}`s inside
+ * static strings. A message template is not a ValueRef but resolves the same
+ * paths at runtime, so a path-only scan would miss `{{trigger.record.total}}`
+ * sitting in a notification body.
+ */
+function collectConfigPaths(value: unknown, out: string[] = []): string[] {
+	if (typeof value === "string") {
+		for (const match of value.matchAll(TEMPLATE_TOKEN)) {
+			out.push(match[1].trim());
+		}
+		return out;
+	}
+	if (Array.isArray(value)) {
+		for (const item of value) collectConfigPaths(item, out);
+		return out;
+	}
+	if (value !== null && typeof value === "object") {
+		const obj = value as Record<string, unknown>;
+		if (obj.kind === "var" && typeof obj.path === "string") {
+			out.push(obj.path);
+		}
+		for (const key of Object.keys(obj)) collectConfigPaths(obj[key], out);
+	}
+	return out;
+}
+
+/** Paths that only resolve when the run has a triggering record. */
+function readsTriggerRecord(path: string): boolean {
+	return /^trigger\.(record|event)\b/.test(path);
+}
+
+const NO_RECORD = "a scheduled automation has no triggering record";
+
+/**
+ * A scheduled run walks with `trigger.record` = {} — the dispatcher passes no
+ * record. So anything reading or acting on the trigger record is dead at
+ * runtime: an action hard-fails, a condition silently takes the wrong branch.
+ * Reject at save time and point at fetch + loop.
+ *
+ * Loop bodies are exempt — there the record in scope IS the loop item. The
+ * predicate is "not in a loop body", never "source === trigger": a legacy
+ * in-loop condition with no stored source works fine at runtime, and keying on
+ * source would refuse to save it.
+ */
+function validateScheduledRecordScope(
+	nodes: NodeArg[],
+	bodyScopeType: Map<string, AutomationObjectType | undefined>
+): void {
+	for (const node of nodes) {
+		for (const path of collectConfigPaths(node.config)) {
+			if (readsTriggerRecord(path)) {
+				throw new Error(
+					`Node ${node.id}: "${path}" is always empty — ${NO_RECORD}. Add a "Find records" step and read the loop item instead.`
+				);
+			}
+		}
+
+		if (bodyScopeType.has(node.id)) continue;
+
+		const config = node.config;
+		if (
+			config.kind === "condition" &&
+			config.groups.some((group) => group.rules.some((rule) => !rule.left))
+		) {
+			throw new Error(
+				`Node ${node.id}: this condition has nothing to test — ${NO_RECORD}. Compare a step result instead (a "Find records" count or an aggregate), or move the condition inside a loop.`
+			);
+		}
+		if (config.kind === "action") {
+			// Both update_field targets (self and related) resolve off the record in
+			// scope, so neither can work outside a loop.
+			if (config.action.type === "update_field") {
+				throw new Error(
+					`Node ${node.id}: there is no record to update — ${NO_RECORD}. Add a "Find records" step and put this action inside a loop.`
+				);
+			}
+			if (config.action.type === "create_task" && config.action.linkToRecord) {
+				throw new Error(
+					`Node ${node.id}: there is no record to link this task to — ${NO_RECORD}. Put it inside a loop, or turn off "Link to record".`
+				);
+			}
+		}
+	}
 }
 
 function validateConditionGroups(
 	nodeId: string,
-	groups: { logic: "and" | "or"; rules: { field: string; operator: string; value?: unknown }[] }[],
+	groups: ConditionGroup[],
 	objectType: AutomationObjectType | undefined,
-	context: string
+	context: "condition" | "filter" | "entry criteria"
 ): void {
+	// A variable left-hand side is only meaningful on a condition node. A fetch
+	// filter and trigger entry criteria both run against records being scanned,
+	// so their rules must name a real field.
+	const allowVarLeft = context === "condition";
 	if (groups.length > MAX_CONDITION_GROUPS) {
 		throw new Error(
 			`Node ${nodeId}: at most ${MAX_CONDITION_GROUPS} ${context} groups allowed`
@@ -222,21 +331,37 @@ function validateConditionGroups(
 			);
 		}
 		for (const rule of group.rules) {
-			if (!rule.field.trim()) {
-				throw new Error(`Node ${nodeId}: rule is missing a field`);
-			}
-			if (objectType) {
-				const def = getFieldDefinition(objectType, rule.field);
-				if (!def) {
+			if (rule.left) {
+				if (!allowVarLeft) {
 					throw new Error(
-						`Node ${nodeId}: unknown field "${rule.field}" for ${objectType}`
+						`Node ${nodeId}: a ${context} rule must compare a field on the record`
 					);
 				}
-				const operators = operatorsForField(objectType, rule.field);
-				if (!operators.includes(rule.operator as never)) {
+				if (rule.left.kind !== "var") {
 					throw new Error(
-						`Node ${nodeId}: operator "${rule.operator}" is not valid for field "${rule.field}"`
+						`Node ${nodeId}: a condition's left side must be a variable`
 					);
+				}
+				if (!rule.left.path.trim()) {
+					throw new Error(`Node ${nodeId}: rule is missing a variable to test`);
+				}
+			} else {
+				if (!rule.field.trim()) {
+					throw new Error(`Node ${nodeId}: rule is missing a field`);
+				}
+				if (objectType) {
+					const def = getFieldDefinition(objectType, rule.field);
+					if (!def) {
+						throw new Error(
+							`Node ${nodeId}: unknown field "${rule.field}" for ${objectType}`
+						);
+					}
+					const operators = operatorsForField(objectType, rule.field);
+					if (!operators.includes(rule.operator as never)) {
+						throw new Error(
+							`Node ${nodeId}: operator "${rule.operator}" is not valid for field "${rule.field}"`
+						);
+					}
 				}
 			}
 			const valueless = (VALUELESS_OPERATORS as readonly string[]).includes(
@@ -340,7 +465,7 @@ function validateWorkflowDefinition(
 ): void {
 	validateTrigger(trigger);
 
-	const objectType = triggerObjectType(trigger);
+	const objectType = triggerRecordObjectType(trigger);
 	const nodeIds = new Set(nodes.map((n) => n.id));
 	if (nodeIds.size !== nodes.length) {
 		throw new Error("Node ids must be unique");
@@ -349,6 +474,10 @@ function validateWorkflowDefinition(
 	// Loop-body nodes act on the loop's fetched records, not the trigger
 	// record — validate their update_field configs against that object type.
 	const bodyScopeType = computeLoopBodyScopeTypes(nodes);
+
+	if (isScheduledTrigger(trigger)) {
+		validateScheduledRecordScope(nodes, bodyScopeType);
+	}
 
 	for (const node of nodes) {
 		const config = node.config;
@@ -680,8 +809,12 @@ function validateForActivation(
  * inputs are in scope) is handled in the builder; at runtime an out-of-scope
  * reference fails the run clearly.
  */
-function validateFormulas(formulas: FormulaResource[] | undefined): void {
+function validateFormulas(
+	formulas: FormulaResource[] | undefined,
+	trigger: AutomationTrigger
+): void {
 	if (!formulas || formulas.length === 0) return;
+	const scheduled = isScheduledTrigger(trigger);
 	if (formulas.length > MAX_FORMULAS) {
 		throw new Error(`An automation can have at most ${MAX_FORMULAS} formulas`);
 	}
@@ -704,6 +837,17 @@ function validateFormulas(formulas: FormulaResource[] | undefined): void {
 			const msg = err instanceof FormulaError ? err.message : "invalid expression";
 			throw new Error(`Formula "${f.name}" has a syntax error: ${msg}`);
 		}
+		// Formulas are automation-level, so a node-only scan never sees them: a
+		// formula reading the trigger record is dead at every use site.
+		if (scheduled) {
+			const dead = referenced.find(readsTriggerRecord);
+			if (dead) {
+				throw new Error(
+					`Formula "${f.name}" reads "${dead}", which is always empty — ${NO_RECORD}. Use a step result, or a loop item inside a loop.`
+				);
+			}
+		}
+
 		refs.set(
 			f.id,
 			referenced
@@ -765,7 +909,7 @@ function buildSnapshot(
 	>
 ): NonNullable<AutomationDocument["publishedSnapshot"]> {
 	return {
-		trigger: automation.trigger,
+		trigger: sanitizeTrigger(automation.trigger),
 		nodes: automation.nodes,
 		formulas: automation.formulas,
 		version: (automation.publishedSnapshot?.version ?? 0) + 1,
@@ -868,30 +1012,31 @@ export const create = userMutation({
 		} else {
 			validateWorkflowDefinition(args.trigger, args.nodes);
 		}
-		validateFormulas(args.formulas);
+		validateFormulas(args.formulas, args.trigger);
 
 		const userOrgId = await getCurrentUserOrgId(ctx);
 		const user = await getCurrentUserOrThrow(ctx);
 		const now = Date.now();
+		const trigger = sanitizeTrigger(args.trigger);
 
 		return await ctx.db.insert("workflowAutomations", {
 			orgId: userOrgId,
 			name: args.name.trim(),
 			description: args.description?.trim(),
-			trigger: args.trigger,
+			trigger,
 			nodes: args.nodes,
 			formulas: args.formulas,
 			status: activate ? "active" : "draft",
 			publishedSnapshot: activate
 				? {
-						trigger: args.trigger,
+						trigger,
 						nodes: args.nodes,
 						formulas: args.formulas,
 						version: 1,
 						publishedAt: now,
 					}
 				: undefined,
-			nextRunAt: scheduledNextRunAt(args.trigger, activate),
+			nextRunAt: scheduledNextRunAt(trigger, activate),
 			createdBy: user._id,
 			createdAt: now,
 			updatedAt: now,
@@ -924,8 +1069,9 @@ export const update = userMutation({
 			throw new Error("Automation name cannot be empty");
 		}
 
+		const nextTrigger = updates.trigger ?? automation.trigger;
+
 		if (updates.trigger !== undefined || updates.nodes !== undefined) {
-			const nextTrigger = updates.trigger ?? automation.trigger;
 			const nextNodes = (updates.nodes ?? automation.nodes) as NodeArg[];
 			if (updates.trigger !== undefined && !("type" in nextTrigger)) {
 				throw new Error("Legacy triggers can no longer be written");
@@ -942,8 +1088,10 @@ export const update = userMutation({
 			validateWorkflowDefinition(nextTrigger, nextNodes);
 		}
 
-		if (updates.formulas !== undefined) {
-			validateFormulas(updates.formulas);
+		// Also re-check stored formulas when the trigger changes: switching to a
+		// schedule can strand a formula that reads the trigger record.
+		if (updates.formulas !== undefined || updates.trigger !== undefined) {
+			validateFormulas(updates.formulas ?? automation.formulas, nextTrigger);
 		}
 
 		const patch: Partial<AutomationDocument> = { updatedAt: Date.now() };
@@ -952,7 +1100,9 @@ export const update = userMutation({
 		if (updates.description !== undefined) {
 			patch.description = updates.description.trim();
 		}
-		if (updates.trigger !== undefined) patch.trigger = updates.trigger;
+		if (updates.trigger !== undefined) {
+			patch.trigger = sanitizeTrigger(updates.trigger);
+		}
 		if (updates.nodes !== undefined) patch.nodes = updates.nodes;
 		if (updates.formulas !== undefined) patch.formulas = updates.formulas;
 
@@ -971,7 +1121,7 @@ export const publish = userMutation({
 		const automation = await getAutomationOrThrow(ctx, args.id);
 
 		validateForActivation(automation.trigger, automation.nodes as NodeArg[]);
-		validateFormulas(automation.formulas);
+		validateFormulas(automation.formulas, automation.trigger);
 
 		await ctx.db.patch(args.id, {
 			status: "active",
@@ -1025,7 +1175,7 @@ export const toggleActive = userMutation({
 
 		// Draft with no snapshot: publishing is the only way to go live.
 		validateForActivation(automation.trigger, automation.nodes as NodeArg[]);
-		validateFormulas(automation.formulas);
+		validateFormulas(automation.formulas, automation.trigger);
 		await ctx.db.patch(args.id, {
 			status: "active",
 			publishedSnapshot: buildSnapshot(automation),

--- a/packages/backend/convex/automations.ts
+++ b/packages/backend/convex/automations.ts
@@ -1162,12 +1162,16 @@ export const toggleActive = userMutation({
 
 		if (automation.publishedSnapshot) {
 			// Resume a previously-published automation on its published version.
+			// Re-validate it first: this path never re-checked the snapshot, so an
+			// automation published before a rule landed could be switched straight
+			// back on and fail every tick with nothing to stop it.
+			const snapshot = automation.publishedSnapshot;
+			validateForActivation(snapshot.trigger, snapshot.nodes as NodeArg[]);
+			validateFormulas(snapshot.formulas, snapshot.trigger);
+
 			await ctx.db.patch(args.id, {
 				status: "active",
-				nextRunAt: scheduledNextRunAt(
-					automation.publishedSnapshot.trigger,
-					true
-				),
+				nextRunAt: scheduledNextRunAt(snapshot.trigger, true),
 				updatedAt: Date.now(),
 			});
 			return args.id;

--- a/packages/backend/convex/automations.ts
+++ b/packages/backend/convex/automations.ts
@@ -334,7 +334,7 @@ function validateConditionGroups(
 			if (rule.left) {
 				if (!allowVarLeft) {
 					throw new Error(
-						`Node ${nodeId}: a ${context} rule must compare a field on the record`
+						`Node ${nodeId}: ${context} rules must compare a field on the record`
 					);
 				}
 				if (rule.left.kind !== "var") {
@@ -1383,8 +1383,8 @@ export const listRuns = userQuery({
 
 /**
  * Windowed cumulative run metrics for the KPI tiles (production runs only).
- * successRate is over decided runs (completed + failed); skipped/running are
- * excluded from the denominator. Latency stats are over completed runs' active
+ * successRate is over decided runs (completed + completed_with_errors +
+ * failed); skipped/running are excluded from the denominator. Latency stats are over completed runs' active
  * time. `activeAutomationCount` is the count of currently-active automations.
  */
 export const getRunMetrics = userQuery({

--- a/packages/backend/convex/communityPages.test.ts
+++ b/packages/backend/convex/communityPages.test.ts
@@ -321,6 +321,43 @@ describe("Community Pages", () => {
 		expect(tasks[0].type).toBe("internal");
 	});
 
+	it("submitInterest emits entity.record_created for the follow-up task", async () => {
+		// Public, unauthenticated submission \u2014 the lead-capture task still has to
+		// reach record_created automations. It used to be inserted silently.
+		const asUser = t.withIdentity(createTestIdentity(clerkUserId, clerkOrgId));
+
+		await asUser.mutation(api.communityPages.upsert, {
+			slug: "lead-event-test",
+			isPublic: true,
+			draftBioContent: {
+				type: "doc",
+				content: [{ type: "paragraph", content: [{ type: "text", text: "Bio" }] }],
+			},
+		});
+		await asUser.mutation(api.communityPages.publish, {});
+
+		await t.mutation(api.communityPages.submitInterest, {
+			slug: "lead-event-test",
+			name: "Lead Eventson",
+			email: "lead@example.com",
+		});
+
+		const taskId = await t.run(async (ctx) => {
+			const tasks = await ctx.db.query("tasks").collect();
+			return tasks[0]._id;
+		});
+
+		const events = await t.run(async (ctx) =>
+			ctx.db
+				.query("domainEvents")
+				.filter((q) => q.eq(q.field("eventType"), "entity.record_created"))
+				.collect()
+		);
+		const taskCreated = events.find((e) => e.payload.entityId === taskId);
+		expect(taskCreated).toBeDefined();
+		expect(taskCreated?.payload.entityType).toBe("task");
+	});
+
 	it("submitInterest assigns task to org admin", async () => {
 		const asUser = t.withIdentity(createTestIdentity(clerkUserId, clerkOrgId));
 

--- a/packages/backend/convex/communityPages.ts
+++ b/packages/backend/convex/communityPages.ts
@@ -8,6 +8,7 @@ import {
 import { getOptionalOrgId } from "./lib/queries";
 import { rateLimiter } from "./rateLimits";
 import { optionalUserQuery, userMutation } from "./lib/factories";
+import { emitRecordCreatedEvent } from "./eventBus";
 import { isAdminRole } from "./lib/permissions";
 
 // Type definitions
@@ -603,7 +604,7 @@ export const submitInterest = mutation({
 		}
 		nextDay.setHours(9, 0, 0, 0);
 
-		await ctx.db.insert("tasks", {
+		const taskId = await ctx.db.insert("tasks", {
 			orgId: page.orgId,
 			title: `Follow up: ${sanitizedName}`,
 			description: descParts.join("\n"),
@@ -612,6 +613,16 @@ export const submitInterest = mutation({
 			type: "internal",
 			assigneeUserId: assigneeUserId || undefined,
 		});
+
+		// Public submission — no actor user, but task record_created automations
+		// must still fire for lead-capture follow-ups.
+		await emitRecordCreatedEvent(
+			ctx,
+			page.orgId,
+			"task",
+			taskId,
+			"communityPages.submitInterest"
+		);
 
 		return { success: true };
 	},

--- a/packages/backend/convex/crons.ts
+++ b/packages/backend/convex/crons.ts
@@ -55,4 +55,13 @@ crons.interval(
 	{}
 );
 
+// Watchdog: fail production runs stranded by a dropped scheduler hop —
+// stuck mid-walk or never woken from a parked delay/loop checkpoint.
+crons.interval(
+	"fail stale automation production runs",
+	{ minutes: 15 },
+	internal.automationExecutor.failStaleProductionRuns,
+	{}
+);
+
 export default crons;

--- a/packages/backend/convex/invoices.test.ts
+++ b/packages/backend/convex/invoices.test.ts
@@ -318,6 +318,33 @@ describe("Invoices", () => {
 			expect(invoice?.discountAmount).toBe(41.67);
 			expect(invoice?.total).toBeCloseTo(291.66, 2);
 		});
+
+		it("emits entity.record_created so invoice automations see the conversion", async () => {
+			// Regression: quote\u2192invoice conversion emitted nothing, so a
+			// record_created trigger on `invoice` never fired for converted quotes.
+			const { quoteId, clerkUserId, clerkOrgId } = await setupApprovedQuote({
+				discountEnabled: false,
+				total: 5000,
+			});
+
+			const asUser = t.withIdentity(createTestIdentity(clerkUserId, clerkOrgId));
+			const invoiceId = await asUser.mutation(api.invoices.createFromQuote, {
+				quoteId,
+			});
+
+			const events = await t.run(async (ctx) =>
+				ctx.db
+					.query("domainEvents")
+					.filter((q) => q.eq(q.field("eventType"), "entity.record_created"))
+					.collect()
+			);
+			const invoiceCreated = events.find(
+				(e) => e.payload.entityId === invoiceId
+			);
+			expect(invoiceCreated).toBeDefined();
+			expect(invoiceCreated?.payload.entityType).toBe("invoice");
+			expect(invoiceCreated?.eventSource).toBe("invoices.createFromQuote");
+		});
 	});
 
 	describe("update", () => {

--- a/packages/backend/convex/invoices.ts
+++ b/packages/backend/convex/invoices.ts
@@ -1011,6 +1011,13 @@ export const createFromQuote = userMutation({
 				client?.companyName || "Unknown Client"
 			);
 			await AggregateHelpers.addInvoice(ctx, invoice as InvoiceDocument);
+			await emitRecordCreatedEvent(
+				ctx,
+				invoice.orgId,
+				"invoice",
+				invoice._id,
+				"invoices.createFromQuote"
+			);
 		}
 
 		// Create default payment for the full invoice amount

--- a/packages/backend/convex/lib/conditionEval.ts
+++ b/packages/backend/convex/lib/conditionEval.ts
@@ -351,7 +351,12 @@ export function evaluateRule(
 	record: Record<string, unknown>,
 	scope: VariableScope
 ): boolean {
-	const fieldValue = record[rule.field];
+	// A rule with an explicit `left` compares a scope value (aggregate result,
+	// fetch count) and never touches the record — that is how a record-less run
+	// branches at all.
+	const fieldValue = rule.left
+		? resolveValueRef(rule.left, scope)
+		: record[rule.field];
 	const compareValue = rule.value
 		? resolveValueRef(rule.value, scope)
 		: undefined;

--- a/packages/backend/convex/lib/conditionEval.ts
+++ b/packages/backend/convex/lib/conditionEval.ts
@@ -7,6 +7,7 @@ import type {
 } from "./workflowTypes";
 import {
 	evaluateFormula,
+	isCalendarDateEpoch,
 	parseFormula,
 	FormulaError,
 	type FormulaAst,
@@ -225,16 +226,21 @@ function applyFormulaReturnType(
  */
 const DATE_GLOBAL_PATHS = new Set(["workflow.now"]);
 
-/** Format an epoch-ms timestamp as a readable date/time in the given IANA tz. */
+/**
+ * Format an epoch-ms timestamp for display. A calendar date (UTC-midnight
+ * encoded) renders as a bare date read in UTC — rendering it in the run tz would
+ * show the PREVIOUS day plus a meaningless time (e.g. "Jul 13, 8:00 PM" for
+ * Jul 14). A real instant renders as a date and time in the run tz.
+ */
 function formatTimestampForDisplay(ms: number, tz: string): string {
+	const calendar = isCalendarDateEpoch(ms);
 	try {
 		return new Intl.DateTimeFormat("en-US", {
-			timeZone: tz,
+			timeZone: calendar ? "UTC" : tz,
 			year: "numeric",
 			month: "short",
 			day: "numeric",
-			hour: "numeric",
-			minute: "2-digit",
+			...(calendar ? {} : { hour: "numeric" as const, minute: "2-digit" as const }),
 		}).format(new Date(ms));
 	} catch {
 		// Invalid tz or ms — fall back to a stable ISO string rather than throw.
@@ -320,8 +326,9 @@ function compareNumeric(
 	return cmp(a, b);
 }
 
-/** Epoch ms from a number (as-is) or a string (Date.parse); else NaN. */
+/** Epoch ms from a Date, a number (as-is), or a string (Date.parse); else NaN. */
 function toEpochMs(value: unknown): number {
+	if (value instanceof Date) return value.getTime();
 	if (typeof value === "number") return value;
 	if (typeof value === "string") return Date.parse(value);
 	return NaN;

--- a/packages/backend/convex/lib/formula/coerce.ts
+++ b/packages/backend/convex/lib/formula/coerce.ts
@@ -88,25 +88,87 @@ export function guardStr(s: string): string {
 	return s;
 }
 
+/* ------------------ calendar dates vs instants (day-space) ----------------- */
+
+const DAY_MS = 86_400_000;
+
+/**
+ * OneTool stores calendar dates (task.date, project.startDate/endDate,
+ * quote.validUntil, invoice.issuedDate/dueDate) as UTC-midnight epoch ms, while
+ * true instants (paidAt, sentAt, approvedAt, ...) carry a real time of day.
+ * That storage convention IS the type tag: a value landing exactly on UTC
+ * midnight is a calendar date, anything else is an instant. fieldRegistry has no
+ * date/datetime split yet, so this is how the formula layer tells them apart.
+ *
+ * The rule every date operation below obeys: read a value in its OWN day-space —
+ * UTC for a calendar date, the run timezone for an instant. Mixing the two is
+ * the off-by-one that made `dueDate == TODAY()` silently false.
+ *
+ * Known limit: an instant landing on exact UTC midnight misclassifies as a
+ * calendar date. Phase C's registry date/datetime split replaces this heuristic
+ * with real type information.
+ */
+export function isCalendarDateEpoch(epochMs: number): boolean {
+	return Number.isFinite(epochMs) && epochMs % DAY_MS === 0;
+}
+
+/** UTC wall-clock parts — the day-space calendar dates live in. */
+function getUtcParts(epochMs: number): ZonedParts {
+	const d = new Date(epochMs);
+	return {
+		year: d.getUTCFullYear(),
+		month: d.getUTCMonth() + 1,
+		day: d.getUTCDate(),
+		hour: d.getUTCHours(),
+		minute: d.getUTCMinutes(),
+		second: d.getUTCSeconds(),
+	};
+}
+
+/** Wall-clock parts in the value's own day-space (see isCalendarDateEpoch). */
+export function partsFor(epochMs: number, tz: string): ZonedParts {
+	return isCalendarDateEpoch(epochMs)
+		? getUtcParts(epochMs)
+		: getZonedParts(epochMs, tz);
+}
+
+/**
+ * The calendar day a value denotes, encoded the way OneTool stores calendar
+ * dates (UTC midnight). Idempotent on values that already are calendar dates.
+ */
+export function calendarDayEpoch(epochMs: number, tz: string): number {
+	const p = partsFor(epochMs, tz);
+	return Date.UTC(p.year, p.month - 1, p.day);
+}
+
 /* ------------------------- equality & comparison -------------------------- */
 
-/** An invalid date (NaN epoch) must error, not silently mis-compare. */
-function assertValidDate(d: Date): void {
-	if (Number.isNaN(d.getTime())) {
-		throw new FormulaError("TYPE", "Cannot compare an invalid date");
-	}
+/**
+ * Do two dates denote the same thing? Same kind (both calendar dates or both
+ * instants) compares the exact instant. Mixed compares the calendar day each
+ * one denotes — which is what makes `dueDate == TODAY()` true on the due day in
+ * every run timezone, and `paidAt == TODAY()` mean "paid today".
+ */
+function dateEquals(a: number, b: number, tz: string): boolean {
+	if (isCalendarDateEpoch(a) === isCalendarDateEpoch(b)) return a === b;
+	return calendarDayEpoch(a, tz) === calendarDayEpoch(b, tz);
 }
 
 /** Value equality for == / !=. See module notes for the exact rules. */
-export function valuesEqual(a: Val, b: Val): boolean {
+export function valuesEqual(a: Val, b: Val, tz: string): boolean {
 	if (a === null || b === null) return a === null && b === null;
 
 	const aDate = a instanceof Date;
 	const bDate = b instanceof Date;
 	if (aDate || bDate) {
-		if (aDate) assertValidDate(a);
-		if (bDate) assertValidDate(b);
-		return aDate && bDate && a.getTime() === b.getTime();
+		// Record date fields reach formulas as raw epoch numbers, so a date must
+		// coerce the other side rather than report a silent `false`. A boolean has
+		// no date reading; an unparseable string throws inside toDate (loud beats
+		// silently-wrong).
+		if (typeof a === "boolean" || typeof b === "boolean") return false;
+		const da = toDate(a, "Left side of the comparison");
+		const db = toDate(b, "Right side of the comparison");
+		return dateEquals(da.getTime(), db.getTime(), tz);
 	}
 
 	if (typeof a === "boolean" || typeof b === "boolean") {
@@ -130,19 +192,26 @@ export function valuesEqual(a: Val, b: Val): boolean {
 
 /**
  * Ordered comparison for < <= > >=. Returns negative/zero/positive.
- * Both dates -> epoch compare; otherwise numeric compare (numeric strings ok).
- * Any other mix -> TYPE error.
+ * A date on either side coerces the other and compares in date space (matching
+ * valuesEqual's granularity, so ordering and equality stay consistent);
+ * otherwise numeric compare (numeric strings ok). Any other mix -> TYPE error.
  */
-export function compareValues(a: Val, b: Val): number {
+export function compareValues(a: Val, b: Val, tz: string): number {
 	const aDate = a instanceof Date;
 	const bDate = b instanceof Date;
-	if (aDate && bDate) {
-		assertValidDate(a);
-		assertValidDate(b);
-		return a.getTime() - b.getTime();
-	}
 	if (aDate || bDate) {
-		throw new FormulaError("TYPE", "Cannot compare a date with a non-date");
+		if (a === null || b === null || typeof a === "boolean" || typeof b === "boolean") {
+			throw new FormulaError(
+				"TYPE",
+				`Cannot order-compare ${describe(a)} and ${describe(b)}`
+			);
+		}
+		const da = toDate(a, "Left side of the comparison").getTime();
+		const db = toDate(b, "Right side of the comparison").getTime();
+		// Granularity must match dateEquals or trichotomy breaks (a value could be
+		// neither equal to, less than, nor greater than another).
+		if (isCalendarDateEpoch(da) === isCalendarDateEpoch(db)) return da - db;
+		return calendarDayEpoch(da, tz) - calendarDayEpoch(db, tz);
 	}
 	const na = toNumberOrNull(a);
 	const nb = toNumberOrNull(b);

--- a/packages/backend/convex/lib/formula/evaluator.ts
+++ b/packages/backend/convex/lib/formula/evaluator.ts
@@ -57,17 +57,18 @@ function evalBinary(
 	ctx: FormulaContext
 ): Val {
 	// Equality operators compare values directly (no numeric-only requirement).
+	// tz is threaded through because a date compares in its own day-space.
 	if (op === "==" || op === "!=") {
 		const l = evalNode(leftNode, ctx);
 		const r = evalNode(rightNode, ctx);
-		const eq = valuesEqual(l, r);
+		const eq = valuesEqual(l, r, ctx.tz);
 		return op === "==" ? eq : !eq;
 	}
 
 	if (op === "<" || op === "<=" || op === ">" || op === ">=") {
 		const l = evalNode(leftNode, ctx);
 		const r = evalNode(rightNode, ctx);
-		const c = compareValues(l, r);
+		const c = compareValues(l, r, ctx.tz);
 		switch (op) {
 			case "<":
 				return c < 0;

--- a/packages/backend/convex/lib/formula/formula.test.ts
+++ b/packages/backend/convex/lib/formula/formula.test.ts
@@ -222,9 +222,21 @@ describe("comparison and equality", () => {
 	});
 
 	it("throws TYPE on mismatched order comparison", () => {
-		expect(code(() => run("DATE(2026,1,1) < 5"))).toBe("TYPE");
 		expect(code(() => run('1 < "abc"'))).toBe("TYPE");
 		expect(code(() => run("true < false"))).toBe("TYPE");
+		// A date compared with a boolean has no reading.
+		expect(code(() => run("DATE(2026,1,1) < true"))).toBe("TYPE");
+		// ...and against a string that isn't a date it throws rather than silently
+		// answering false, which is what it used to do.
+		expect(code(() => run('DATE(2026,1,1) == "not-a-date"'))).toBe("TYPE");
+	});
+
+	it("reads a number compared against a date as an epoch timestamp", () => {
+		// Deliberate: record date fields reach formulas as raw epoch numbers, so
+		// `{dueDate} < NOW()` MUST work. The cost is that a nonsense literal like
+		// `DATE(...) < 5` now compares against 1970 instead of throwing.
+		expect(run("DATE(2026,1,1) > 5")).toBe(true);
+		expect(run("{d} == DATE(2026,1,1)", { d: Date.UTC(2026, 0, 1) })).toBe(true);
 	});
 
 	it("equality across types", () => {
@@ -395,9 +407,122 @@ describe("date functions (deterministic)", () => {
 		const nearBoundary = Date.UTC(2026, 6, 4, 2, 0, 0);
 		expect(run("DAY(NOW())", {}, { now: nearBoundary, tz: "America/New_York" })).toBe(3);
 		expect(run("DAY(NOW())", {}, { now: nearBoundary, tz: "UTC" })).toBe(4);
-		// TODAY in NY is midnight of Jul 3 NY = 2026-07-03T04:00:00Z.
+		// WHICH day it is, is still decided in the run tz — but the result is a
+		// calendar DATE (UTC-midnight encoded, like every stored date field), not a
+		// local-midnight instant. Encoding it locally is what made
+		// `dueDate == TODAY()` silently false outside UTC.
 		const todayNY = run("TODAY()", {}, { now: nearBoundary, tz: "America/New_York" }) as Date;
-		expect(todayNY.toISOString()).toBe("2026-07-03T04:00:00.000Z");
+		expect(todayNY.toISOString()).toBe("2026-07-03T00:00:00.000Z");
+	});
+});
+
+/* ------------- calendar dates vs instants (day-space semantics) ------------ */
+
+describe("calendar dates vs instants", () => {
+	const DAY = 86_400_000;
+	// How OneTool stores a calendar date: UTC midnight.
+	const dueJul4 = Date.UTC(2026, 6, 4);
+
+	it("a date field matches TODAY() on its due day, in a non-UTC run tz", () => {
+		// The headline bug. Note the boundary: at 2026-07-05T02:00Z it is still
+		// Jul 4 in New York, so a Jul 4 due date must still match.
+		const duringJul4NY = Date.UTC(2026, 6, 5, 2, 0, 0);
+		expect(
+			run(
+				"{dueDate} == TODAY()",
+				{ dueDate: dueJul4 },
+				{ now: duringJul4NY, tz: "America/New_York" }
+			)
+		).toBe(true);
+		expect(
+			run(
+				"{dueDate} == TODAY()",
+				{ dueDate: dueJul4 - DAY },
+				{ now: duringJul4NY, tz: "America/New_York" }
+			)
+		).toBe(false);
+	});
+
+	it("a date field orders against NOW() instead of throwing", () => {
+		// compareValues used to throw TYPE outright for Date-vs-number.
+		expect(run("{dueDate} < NOW()", { dueDate: Date.UTC(2026, 6, 1) })).toBe(true);
+		expect(run("{dueDate} > NOW()", { dueDate: Date.UTC(2026, 6, 9) })).toBe(true);
+	});
+
+	it("an instant compares to TODAY() as 'happened today' in the run tz", () => {
+		// 2026-07-05T02:00Z is Jul 4 22:00 in New York.
+		const paidLateJul4NY = Date.UTC(2026, 6, 5, 2, 0, 0);
+		expect(
+			run(
+				"{paidAt} == TODAY()",
+				{ paidAt: paidLateJul4NY },
+				{ now: paidLateJul4NY, tz: "America/New_York" }
+			)
+		).toBe(true);
+	});
+
+	it("keeps ==, < and > consistent across a mixed pair (trichotomy)", () => {
+		// An instant vs a calendar date (TODAY()) on the same day: equal, and
+		// neither before nor after. If == were day-granular but < instant-granular,
+		// all three would be false and ordering would be incoherent.
+		const midJul4 = Date.UTC(2026, 6, 4, 15, 30, 0);
+		const vars = { paidAt: midJul4 };
+		const opts = { now: midJul4, tz: "UTC" };
+		expect(run("{paidAt} == TODAY()", vars, opts)).toBe(true);
+		expect(run("{paidAt} < TODAY()", vars, opts)).toBe(false);
+		expect(run("{paidAt} > TODAY()", vars, opts)).toBe(false);
+	});
+
+	it("KNOWN LIMIT: two raw date fields still compare as exact epochs", () => {
+		// Classification only engages once one side is a real Date (produced by
+		// TODAY()/NOW()/DATE()/ADDDAYS). Two record fields arrive as plain numbers,
+		// so `dueDate == paidAt` is exact-instant equality and is false even when
+		// both fall on the same day. Fixing this needs real field types — Phase C's
+		// date/datetime registry split. Pinned here so it is a known gap, not a
+		// surprise.
+		const vars = { dueDate: dueJul4, paidAt: Date.UTC(2026, 6, 4, 15, 30, 0) };
+		expect(run("{dueDate} == {paidAt}", vars, { tz: "UTC" })).toBe(false);
+		// The workaround that does work today:
+		expect(run("DAYS_BETWEEN({dueDate}, {paidAt}) == 0", vars, { tz: "UTC" })).toBe(
+			true
+		);
+	});
+
+	it("ADDDAYS on a calendar date stays a calendar date across a DST boundary", () => {
+		// US DST springs forward 2026-03-08. Preserving wall-clock in the run tz
+		// (right for an instant) would land this off UTC midnight and silently
+		// reclassify it as an instant, corrupting any date field it is written to.
+		const result = run("ADDDAYS(DATE(2026,3,6), 5)", {}, {
+			tz: "America/New_York",
+		}) as Date;
+		expect(result.getTime() % DAY).toBe(0);
+		expect(result.toISOString()).toBe("2026-03-11T00:00:00.000Z");
+	});
+
+	it("ADDDAYS on an instant preserves its wall-clock time", () => {
+		const noonUTC = Date.UTC(2026, 6, 4, 12, 0, 0);
+		const result = run("ADDDAYS({t}, 1)", { t: noonUTC }, { tz: "UTC" }) as Date;
+		expect(result.toISOString()).toBe("2026-07-05T12:00:00.000Z");
+	});
+
+	it("DATE() builds the same calendar date in every timezone", () => {
+		// Building it from zoned parts broke outright where DST springs forward AT
+		// midnight (local midnight doesn't exist, so the epoch landed at 01:00).
+		for (const tz of ["UTC", "America/New_York", "America/Santiago", "Asia/Kolkata"]) {
+			const d = run("DATE(2026, 7, 4)", {}, { tz }) as Date;
+			expect(d.toISOString()).toBe("2026-07-04T00:00:00.000Z");
+		}
+	});
+
+	it("DAYS_BETWEEN does not go off-by-one between a date and an instant", () => {
+		// now = 2026-07-04T12:00Z, which is Jul 4 in New York.
+		expect(
+			run(
+				"DAYS_BETWEEN({d}, NOW())",
+				{ d: Date.UTC(2026, 6, 1) },
+				{ tz: "America/New_York" }
+			)
+		).toBe(3);
 	});
 });
 

--- a/packages/backend/convex/lib/formula/functions.ts
+++ b/packages/backend/convex/lib/formula/functions.ts
@@ -11,11 +11,13 @@ import type { Val } from "./ast";
 import type { FormulaContext } from "./context";
 import { FormulaError } from "./errors";
 import {
+	calendarDayEpoch,
 	getZonedParts,
 	guardNumber,
 	guardStr,
+	isCalendarDateEpoch,
+	partsFor,
 	requireString,
-	startOfDayEpoch,
 	stringify,
 	toDate,
 	toInt,
@@ -388,13 +390,16 @@ const SPECS: FunctionSpec[] = [
 		category: "date",
 		minArgs: 0,
 		maxArgs: 0,
-		fn: (_args, ctx) => new Date(startOfDayEpoch(ctx.now, ctx.tz)),
+		// Returns today's calendar DATE (UTC-midnight encoded), not a local-midnight
+		// instant — so it compares equal to stored date fields, which use the same
+		// encoding. Which day it is, is still decided in the workflow timezone.
+		fn: (_args, ctx) => new Date(calendarDayEpoch(ctx.now, ctx.tz)),
 		doc: {
 			name: "TODAY",
 			category: "date",
 			signature: "TODAY()",
-			description: "Start of the current day in the workflow timezone.",
-			example: "TODAY() → 2026-07-04T00:00:00 (local midnight)",
+			description: "The current date in the workflow timezone.",
+			example: "TODAY() → 2026-07-04",
 		},
 	},
 	{
@@ -416,23 +421,22 @@ const SPECS: FunctionSpec[] = [
 		category: "date",
 		minArgs: 3,
 		maxArgs: 3,
-		fn: (args, ctx) => {
+		fn: (args) => {
 			const year = toInt(args[0], "DATE(year)");
 			const month = toInt(args[1], "DATE(month)");
 			const day = toInt(args[2], "DATE(day)");
-			// Bounds-check before the epoch can reach getZonedParts (raw RangeError guard).
-			guardEpoch(Date.UTC(year, month - 1, day, 0, 0, 0), "DATE(year, month, day)");
-			const epoch = zonedPartsToEpoch(
-				{ year, month, day, hour: 0, minute: 0, second: 0 },
-				ctx.tz
-			);
-			return new Date(epoch);
+			// A calendar date is UTC-midnight by construction. Building it from
+			// zoned parts also broke outright in zones where DST springs forward AT
+			// midnight (e.g. America/Santiago): local midnight doesn't exist there,
+			// so the epoch landed at 01:00 local and was never a calendar date.
+			const epoch = Date.UTC(year, month - 1, day);
+			return new Date(guardEpoch(epoch, "DATE(year, month, day)"));
 		},
 		doc: {
 			name: "DATE",
 			category: "date",
 			signature: "DATE(year, month, day)",
-			description: "Construct a date at midnight in the workflow timezone (month is 1-12).",
+			description: "Construct a calendar date (month is 1-12).",
 			example: "DATE(2026, 7, 4) → 2026-07-04",
 		},
 	},
@@ -444,21 +448,29 @@ const SPECS: FunctionSpec[] = [
 		fn: (args, ctx) => {
 			const date = toDate(args[0], "ADDDAYS(date)");
 			const n = toInt(args[1], "ADDDAYS(n)");
-			const p = getZonedParts(date.getTime(), ctx.tz);
+			const ms = date.getTime();
+			// A calendar date advances in UTC, which has no DST — so the result is
+			// still exactly UTC midnight. Preserving wall-clock in the run timezone
+			// (what an instant needs) would land it off-midnight across a DST
+			// boundary, silently reclassifying it as an instant and corrupting the
+			// field it gets written to.
+			if (isCalendarDateEpoch(ms)) {
+				return new Date(guardEpoch(ms + n * 86_400_000, "ADDDAYS result"));
+			}
+			const p = getZonedParts(ms, ctx.tz);
 			const parts = { ...p, day: p.day + n };
 			// Bounds-check before the epoch can reach getZonedParts (raw RangeError guard).
 			guardEpoch(
 				Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second),
 				"ADDDAYS result"
 			);
-			const epoch = zonedPartsToEpoch(parts, ctx.tz);
-			return new Date(epoch);
+			return new Date(zonedPartsToEpoch(parts, ctx.tz));
 		},
 		doc: {
 			name: "ADDDAYS",
 			category: "date",
 			signature: "ADDDAYS(date, n)",
-			description: "Add n whole days to a date (preserving wall-clock time).",
+			description: "Add n whole days to a date (a time of day, if any, is preserved).",
 			example: "ADDDAYS(DATE(2026,7,4), 3) → 2026-07-07",
 		},
 	},
@@ -470,8 +482,10 @@ const SPECS: FunctionSpec[] = [
 		fn: (args, ctx) => {
 			const a = toDate(args[0], "DAYS_BETWEEN(a)");
 			const b = toDate(args[1], "DAYS_BETWEEN(b)");
-			const midA = startOfDayEpoch(a.getTime(), ctx.tz);
-			const midB = startOfDayEpoch(b.getTime(), ctx.tz);
+			// Each side is read in its own day-space, so a calendar date and an
+			// instant diff correctly instead of coming out one day apart.
+			const midA = calendarDayEpoch(a.getTime(), ctx.tz);
+			const midB = calendarDayEpoch(b.getTime(), ctx.tz);
 			return Math.round((midB - midA) / 86_400_000);
 		},
 		doc: {
@@ -487,7 +501,7 @@ const SPECS: FunctionSpec[] = [
 		category: "date",
 		minArgs: 1,
 		maxArgs: 1,
-		fn: (args, ctx) => getZonedParts(toDate(args[0], "YEAR(date)").getTime(), ctx.tz).year,
+		fn: (args, ctx) => partsFor(toDate(args[0], "YEAR(date)").getTime(), ctx.tz).year,
 		doc: {
 			name: "YEAR",
 			category: "date",
@@ -501,7 +515,7 @@ const SPECS: FunctionSpec[] = [
 		category: "date",
 		minArgs: 1,
 		maxArgs: 1,
-		fn: (args, ctx) => getZonedParts(toDate(args[0], "MONTH(date)").getTime(), ctx.tz).month,
+		fn: (args, ctx) => partsFor(toDate(args[0], "MONTH(date)").getTime(), ctx.tz).month,
 		doc: {
 			name: "MONTH",
 			category: "date",
@@ -515,7 +529,7 @@ const SPECS: FunctionSpec[] = [
 		category: "date",
 		minArgs: 1,
 		maxArgs: 1,
-		fn: (args, ctx) => getZonedParts(toDate(args[0], "DAY(date)").getTime(), ctx.tz).day,
+		fn: (args, ctx) => partsFor(toDate(args[0], "DAY(date)").getTime(), ctx.tz).day,
 		doc: {
 			name: "DAY",
 			category: "date",

--- a/packages/backend/convex/lib/formula/index.ts
+++ b/packages/backend/convex/lib/formula/index.ts
@@ -22,3 +22,7 @@ export { evaluateFormula, runFormula } from "./evaluator";
 
 export { FORMULA_FUNCTIONS } from "./functions";
 export type { FormulaFnDoc } from "./functions";
+
+// Calendar-date vs instant classification. Callers that read or write date
+// fields need it to stay in the same day-space the formula layer uses.
+export { calendarDayEpoch, isCalendarDateEpoch } from "./coerce";

--- a/packages/backend/convex/lib/workflowTypes.ts
+++ b/packages/backend/convex/lib/workflowTypes.ts
@@ -128,6 +128,15 @@ export const conditionRuleValidator = v.object({
 	field: v.string(),
 	operator: conditionOperatorValidator,
 	value: v.optional(valueRefValidator),
+	/**
+	 * Left-hand side. Absent => the rule reads `field` off the in-scope record.
+	 * Set => the rule compares a scope value (an aggregate result, a fetch count)
+	 * and `field` is ignored, which is the only way to branch without a record —
+	 * e.g. a scheduled automation asking "is unpaid total over $10k?".
+	 * Only legal on condition nodes: a fetch filter and trigger entry criteria
+	 * must name a real field, so both reject it.
+	 */
+	left: v.optional(valueRefValidator),
 });
 
 export const conditionGroupValidator = v.object({
@@ -445,8 +454,11 @@ export const scheduledTriggerValidator = v.object({
 	type: v.literal("scheduled"),
 	schedule: scheduleValidator,
 	/**
-	 * When set, the automation runs once per record matching the first
-	 * fetch_records node (or once with no record scope if none).
+	 * @deprecated Ignored. A scheduled run has no triggering record — the
+	 * dispatcher passes none, so `trigger.record` is `{}` for the whole walk.
+	 * Record scope comes from a fetch_records + loop instead. Still accepted so
+	 * stored rows parse; `triggerRecordObjectType()` returns undefined for
+	 * scheduled, and writes strip it.
 	 */
 	objectType: v.optional(objectTypeValidator),
 });
@@ -466,6 +478,24 @@ export type AutomationTriggerV2 =
 	| Infer<typeof recordCreatedTriggerValidator>
 	| Infer<typeof recordUpdatedTriggerValidator>
 	| Infer<typeof scheduledTriggerValidator>;
+
+/**
+ * The object type of the record the trigger binds to `trigger.record`, or
+ * undefined when there is none. Scheduled triggers always return undefined:
+ * their stored `objectType` is a dead field (see scheduledTriggerValidator).
+ *
+ * Single chokepoint — read the trigger's object type through this, never off
+ * the trigger directly, or scheduled automations start claiming a record scope
+ * the runtime never gives them.
+ */
+export function triggerRecordObjectType(
+	trigger: AutomationTrigger
+): AutomationObjectType | undefined {
+	if (!("type" in trigger) || trigger.type === "scheduled") return undefined;
+	return "objectType" in trigger && trigger.objectType
+		? trigger.objectType
+		: undefined;
+}
 
 // ---------------------------------------------------------------------------
 // Formula resources — reusable named expressions (Slice 4.6). Defined once on

--- a/packages/backend/convex/lib/workflowTypes.ts
+++ b/packages/backend/convex/lib/workflowTypes.ts
@@ -242,6 +242,13 @@ export const loopNodeConfigValidator = v.object({
 	sourceNodeId: v.string(),
 	/** Engine enforces MAX_LOOP_ITERATIONS regardless. */
 	maxIterations: v.optional(v.number()),
+	/**
+	 * What a failing item does to the run. Absent = "abort", which is what every
+	 * snapshot published before this field existed did — so old automations keep
+	 * their exact semantics until someone changes this control by hand. The
+	 * builder writes "continue" on new loops.
+	 */
+	onItemError: v.optional(v.union(v.literal("continue"), v.literal("abort"))),
 });
 
 export const delayNodeConfigValidator = v.object({
@@ -539,6 +546,48 @@ export const executedNodeValidator = v.object({
 	// Bounded (~4KB) input/output snapshots for the runs viewer.
 	input: v.optional(v.any()),
 	output: v.optional(v.any()),
+	// Set on entries pushed from inside a loop body: which loop, which iteration,
+	// and which record. Without these a mid-loop failure can't be traced back to
+	// the record that caused it.
+	loopNodeId: v.optional(v.string()),
+	loopIndex: v.optional(v.number()),
+	loopItemId: v.optional(v.string()),
+	loopItemLabel: v.optional(v.string()),
 });
 
 export type ExecutedNode = Infer<typeof executedNodeValidator>;
+
+// ---------------------------------------------------------------------------
+// Per-loop outcome tallies (workflowExecutions.loopSummary)
+// ---------------------------------------------------------------------------
+
+/** Item errors kept per loop node; the rest are counted, not listed. */
+export const MAX_LOOP_ITEM_ERRORS = 10;
+
+/**
+ * Authoritative per-item tallies for one loop node. The execution log is lossy
+ * (it truncates at MAX_EXECUTED_ENTRIES and compacts long loops), so counts
+ * live here instead of being re-derived from it at read time.
+ */
+export const loopSummaryValidator = v.object({
+	nodeId: v.string(),
+	/** Items the loop set out to process, frozen when the first chunk started. */
+	total: v.number(),
+	succeeded: v.number(),
+	failed: v.number(),
+	/** Items deleted between chunks — present in `total`, never processed. */
+	skipped: v.number(),
+	/** First MAX_LOOP_ITEM_ERRORS failures, in item order. */
+	errors: v.array(
+		v.object({
+			index: v.number(),
+			itemId: v.string(),
+			label: v.optional(v.string()),
+			error: v.string(),
+			/** True when earlier steps for this item were already applied. */
+			partial: v.optional(v.boolean()),
+		})
+	),
+});
+
+export type LoopSummary = Infer<typeof loopSummaryValidator>;

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import {
 	automationStatusValidator,
 	executedNodeValidator,
+	loopSummaryValidator,
 	formulaResourceValidator,
 	nodeConfigValidator,
 	nodeTypeValidator,
@@ -1329,6 +1330,9 @@ export default defineSchema({
 		status: v.union(
 			v.literal("running"),
 			v.literal("completed"),
+			// Ran to the end, but a loop configured to continue skipped one or
+			// more failing items. See loopSummary for which.
+			v.literal("completed_with_errors"),
 			v.literal("failed"),
 			v.literal("skipped"),
 			v.literal("cancelled")
@@ -1357,6 +1361,9 @@ export default defineSchema({
 		// True when any node in this run consumed a fetch scan that stopped at
 		// its scan cap with org rows still unscanned — results may be partial.
 		dataTruncated: v.optional(v.boolean()),
+		// Per-loop item tallies. Authoritative (nodesExecuted truncates and
+		// compacts); drives the partial-progress banner and the terminal status.
+		loopSummary: v.optional(v.array(loopSummaryValidator)),
 		// Test runs (dry-run) precompute the full walk, then reveal one entry
 		// per transaction so the getExecution subscription streams per-node
 		// status live. `plan` holds the remaining-and-revealed ordered entries;
@@ -1364,6 +1371,16 @@ export default defineSchema({
 		testCursor: v.optional(
 			v.object({
 				plan: v.array(executedNodeValidator),
+				// Decided when the plan is built: a failed entry no longer implies a
+				// failed run (a loop set to continue records it and carries on), and
+				// the revealed entries alone can't tell the two apart.
+				terminalStatus: v.optional(
+					v.union(
+						v.literal("completed"),
+						v.literal("completed_with_errors"),
+						v.literal("failed")
+					)
+				),
 			})
 		),
 		error: v.optional(v.string()),


### PR DESCRIPTION
This pull request introduces several improvements to the Automations editor, focusing on better error reporting, timeline grouping, and more accurate timezone handling for formula previews. It also refines how object types are determined and displayed throughout the automation configuration UI.

**Debug panel and timeline improvements:**

- Enhanced error reporting in the debug panel: Adds a `PartialProgressBanner` that summarizes loop node failures, including details about failed items and partial updates, and improves the status line to distinguish between completed runs with and without errors. [[1]](diffhunk://#diff-c3f393b17424aa2c2f361e08b7813177b189fadc3cb6f290960d920ffd8fb048L76-R95) [[2]](diffhunk://#diff-c3f393b17424aa2c2f361e08b7813177b189fadc3cb6f290960d920ffd8fb048R110-R116) [[3]](diffhunk://#diff-c3f393b17424aa2c2f361e08b7813177b189fadc3cb6f290960d920ffd8fb048R151-R229) [[4]](diffhunk://#diff-c3f393b17424aa2c2f361e08b7813177b189fadc3cb6f290960d920ffd8fb048R341-R344)
- Timeline grouping: The debug timeline now groups consecutive steps from the same loop iteration, showing a collapsed row with a worst-result icon and expandable details, making it easier to trace failures to specific records. [[1]](diffhunk://#diff-3a1252b83121435874f301070e486540124c4a03728dd97bb991e877221c1c5aR63-R128) [[2]](diffhunk://#diff-3a1252b83121435874f301070e486540124c4a03728dd97bb991e877221c1c5aL115-R195) [[3]](diffhunk://#diff-3a1252b83121435874f301070e486540124c4a03728dd97bb991e877221c1c5aR299-R342)

**Formula editor and timezone handling:**

- Formula preview timezone accuracy: Formula previews now display dates in the actual timezone the automation will run in (UTC or the schedule’s timezone), instead of the browser’s local timezone, preventing confusion for non-local users. The preview UI also communicates this explicitly. [[1]](diffhunk://#diff-d7bbb6dbc6a767dc9d487a12bdcf2da9877e299d3681af8f12756f5c525525f1L93-R121) [[2]](diffhunk://#diff-d7bbb6dbc6a767dc9d487a12bdcf2da9877e299d3681af8f12756f5c525525f1L192-R217) [[3]](diffhunk://#diff-d7bbb6dbc6a767dc9d487a12bdcf2da9877e299d3681af8f12756f5c525525f1L250-R275) [[4]](diffhunk://#diff-d7bbb6dbc6a767dc9d487a12bdcf2da9877e299d3681af8f12756f5c525525f1L371-R401)

**Object type scoping and display:**

- Consistent object type resolution: Introduces and uses `triggerScopeObjectType` to consistently determine the relevant object type for triggers across the workflow drawer and trigger node summary, ensuring correct labels and options are shown. [[1]](diffhunk://#diff-f327898dc29e9bf9606d1aff64aaef49670b9ce4efc91c3fffe0b9faadb44712R30) [[2]](diffhunk://#diff-f327898dc29e9bf9606d1aff64aaef49670b9ce4efc91c3fffe0b9faadb44712L490-R491) [[3]](diffhunk://#diff-3fa0986c3dceff16c0fb9e99d6bde5c0231895441ca25dd941f3a62280a3e7dfR12) [[4]](diffhunk://#diff-3fa0986c3dceff16c0fb9e99d6bde5c0231895441ca25dd941f3a62280a3e7dfL24-R25) [[5]](diffhunk://#diff-3fa0986c3dceff16c0fb9e99d6bde5c0231895441ca25dd941f3a62280a3e7dfL35-R44)

**Condition node summary improvements:**

- Improved condition summaries: The condition node summary now uses variable path descriptions when available, providing clearer titles for rules based on variables. [[1]](diffhunk://#diff-dc7887b39c4e8f6cf7c3cae35902970518deacf290e0389940673348e4531d8bL15-R15) [[2]](diffhunk://#diff-dc7887b39c4e8f6cf7c3cae35902970518deacf290e0389940673348e4531d8bL30-R35)

**Other technical improvements:**

- Various type and import cleanups to support the above features, such as importing new utility functions and types. [[1]](diffhunk://#diff-c3f393b17424aa2c2f361e08b7813177b189fadc3cb6f290960d920ffd8fb048L3-R3) [[2]](diffhunk://#diff-c3f393b17424aa2c2f361e08b7813177b189fadc3cb6f290960d920ffd8fb048R29) [[3]](diffhunk://#diff-d7bbb6dbc6a767dc9d487a12bdcf2da9877e299d3681af8f12756f5c525525f1R13)

These changes collectively improve the clarity, accuracy, and usability of the Automations editor, especially for debugging and authoring automations that involve loops, formulas, and scheduled triggers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added partial-success reporting for automation runs, including per-loop item failure summaries and warning indicators.
  * Added loop failure handling options to continue or stop when an item fails.
  * Improved debugging timelines with grouped loop iterations and clearer progress details.
  * Added variable-based conditions and improved condition labels.
  * Scheduled automations now clearly identify unavailable record-based actions and conditions.
  * Formula date previews and comparisons now respect the automation’s run timezone.

* **Bug Fixes**
  * Improved automation metrics, throughput charts, recent failures, and run filtering for partially failed runs.
  * Added safeguards for stalled automation runs and improved record-update event triggering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up several significant automation engine improvements: loop error continuability (`onItemError: \"continue\"`), per-item failure tracking in `loopSummary`, a new `completed_with_errors` terminal status, timezone-correct formula date comparisons using a calendar-date-vs-instant heuristic, cascade domain-event emission from `update_field` actions, save-time validation blocking scheduled automations that reference `trigger.record`, and a 15-minute watchdog cron for stuck production runs.

- **Loop error handling**: adds `onItemError` to the loop config, tracks per-item failures in `loopSummaries` carried across chunk boundaries, circuit-breaks misconfigured loops after 10 consecutive failures, and surfaces the breakdown in a new `PartialProgressBanner` and grouped debug timeline.
- **Formula date semantics**: unifies calendar-date (UTC-midnight encoded) and instant comparisons across `valuesEqual`, `compareValues`, `TODAY()`, `DATE()`, `ADDDAYS()`, and `DAYS_BETWEEN()`, and mirrors the same logic in the formula-preview modal so authoring-time results match production.
- **Cascade event emission**: `executeActionNodeV2` now inserts a `domainEvents` row and schedules `processEvents` when a field value changes, enabling chained automations to fire on field-update writes from action nodes.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the core loop engine, formula comparisons, and schema changes are well-structured with backward-compatible defaults.

The loop continuability, circuit-break, and completed_with_errors plumbing are thorough and backed by a large test suite. The calendar-date vs instant heuristic is clearly documented with its known limit. The cascade event emission inside executeActionNodeV2 introduces two minor quality issues: Date.now() is constant within a Convex transaction so two action nodes in the same chunk produce identical correlationId values; and isFatalExecutionError pattern-matches against undocumented Convex error strings. The frontend runtimeTimezone helper duplicates automationFormulaTz without a shared module. The skipped throughput-chart series is quietly removed while the backend still returns the data.

The cascade event emission in automationExecutor.ts (lines 2545-2591) and the run-throughput-chart.tsx skipped series omission deserve a second look before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/backend/convex/automationExecutor.ts | Largest change — adds loop error tracking, circuit-break, `completed_with_errors` terminal status, cascade domain-event emission, date-field timezone normalization, and `failStaleProductionRuns` watchdog. `isFatalExecutionError` and `correlationId` have minor fragility concerns. |
| packages/backend/convex/lib/formula/coerce.ts | Introduces `isCalendarDateEpoch`, `calendarDayEpoch`, and `partsFor`. Rewrites `valuesEqual` and `compareValues` to accept `tz` and compare mixed calendar/instant values in each value's own day-space. Known heuristic limit is documented. |
| packages/backend/convex/lib/formula/functions.ts | Updates date functions to use calendar-date-aware helpers. `DATE` now builds at UTC midnight directly, fixing DST edge cases in zones like America/Santiago. |
| packages/backend/convex/automations.ts | Adds `validateScheduledRecordScope`, `sanitizeTrigger`, trigger-aware formula validation, batched execution cleanup, and re-validation on `toggleActive` resume. All backward-compatible. |
| packages/backend/convex/lib/workflowTypes.ts | Adds `left` to `conditionRuleValidator`, `onItemError` to `loopNodeConfigValidator`, `loopSummaryValidator`/`LoopSummary`, and `triggerRecordObjectType`. All new fields are optional. |
| packages/backend/convex/schema.ts | Adds `completed_with_errors` status, `loopSummary` field, and `terminalStatus` in `testCursor`. All additions are additive and backward-compatible. |
| apps/web/src/app/(workspace)/automations/components/editor/formula-editor-modal.tsx | Switches formula preview timezone to the automation's runtime timezone. Adds `runtimeTimezone` helper that mirrors backend `automationFormulaTz` without a shared module, creating a maintenance coupling risk. |
| apps/web/src/app/(workspace)/automations/components/editor/debug-panel.tsx | Adds `PartialProgressBanner` for loop-level failure detail and extends `StatusLine` with a fully typed status map for `completed_with_errors`. |
| apps/web/src/app/(workspace)/automations/components/editor/debug-timeline.tsx | Groups consecutive loop-iteration entries into collapsible rows with worst-result icon and auto-open on failure. Logic is clean and safe. |
| apps/web/src/app/(workspace)/automations/components/run-throughput-chart.tsx | Adds `withErrors` stacked area series. Drops the `skipped` series from the old `RUN_CHART_SERIES`, silently removing skipped-run visibility from the chart. |
| apps/web/src/app/(workspace)/automations/lib/run-format.ts | Adds `completed_with_errors` to `RunStatus`/`RUN_STATUS_META`, adds `summarizeLoopFailures`, removes the now-unused `RUN_CHART_SERIES`/`RunThroughputKey` exports. |
| packages/backend/convex/crons.ts | Registers a 15-minute `failStaleProductionRuns` cron using the existing `by_triggeredAt` index. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Automation Trigger] --> B[runWalk]
    B --> C{Node Type}
    C -->|loop| D[runLoopNode]
    C -->|action| E[executeActionNodeV2]
    C -->|condition| F[evaluateRule]
    C -->|fetch| G[fetchRecordsNode]
    D --> H{onItemError}
    H -->|abort default| I[Item fails - return failed]
    H -->|continue| J[Item fails - log error, continue]
    J --> K{Circuit break? succeeded==0 AND failed>=10}
    K -->|yes| I
    K -->|no| L[Next item]
    L --> D
    D --> M[loopSummaryFor - update tallies]
    M --> N[checkpointLoopChunk - save state]
    E --> O{previousValue != coerced.value}
    O -->|yes| P[Insert domainEvent - Schedule processEvents]
    O -->|no| Q[No cascade event]
    B --> R{Walk outcome}
    R -->|chain_done| S{hasLoopItemFailures?}
    S -->|yes| T[status = completed_with_errors]
    S -->|no| U[status = completed]
    R -->|failed| V[status = failed]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Automation Trigger] --> B[runWalk]
    B --> C{Node Type}
    C -->|loop| D[runLoopNode]
    C -->|action| E[executeActionNodeV2]
    C -->|condition| F[evaluateRule]
    C -->|fetch| G[fetchRecordsNode]
    D --> H{onItemError}
    H -->|abort default| I[Item fails - return failed]
    H -->|continue| J[Item fails - log error, continue]
    J --> K{Circuit break? succeeded==0 AND failed>=10}
    K -->|yes| I
    K -->|no| L[Next item]
    L --> D
    D --> M[loopSummaryFor - update tallies]
    M --> N[checkpointLoopChunk - save state]
    E --> O{previousValue != coerced.value}
    O -->|yes| P[Insert domainEvent - Schedule processEvents]
    O -->|no| Q[No cascade event]
    B --> R{Walk outcome}
    R -->|chain_done| S{hasLoopItemFailures?}
    S -->|yes| T[status = completed_with_errors]
    S -->|no| U[status = completed]
    R -->|failed| V[status = failed]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/backend/convex/automationExecutor.ts`, line 2549 ([link](https://github.com/xcarter93/onetool/blob/75b3856ac4fa5579ea8462e3a8c1a04c920fb8c5/packages/backend/convex/automationExecutor.ts#L2549)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Collision-prone `correlationId` within a single Convex transaction**

   `Date.now()` returns a constant value for all calls within the same Convex mutation. An automation with two `update_field` action nodes running in the same loop chunk (before the first checkpoint) would produce identical `correlationId` values — `cascade-<autoId>-<timestamp>` — for both emitted events. If the event bus ever uses `correlationId` for deduplication or idempotency, the second cascade event would be silently dropped, and the chained automation would not fire for that field change.

   Consider appending a per-call counter to guarantee uniqueness across events emitted in the same mutation.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/backend/convex/automationExecutor.ts
   Line: 2549

   Comment:
   **Collision-prone `correlationId` within a single Convex transaction**

   `Date.now()` returns a constant value for all calls within the same Convex mutation. An automation with two `update_field` action nodes running in the same loop chunk (before the first checkpoint) would produce identical `correlationId` values — `cascade-<autoId>-<timestamp>` — for both emitted events. If the event bus ever uses `correlationId` for deduplication or idempotency, the second cascade event would be silently dropped, and the chained automation would not fire for that field change.

   Consider appending a per-call counter to guarantee uniqueness across events emitted in the same mutation.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `packages/backend/convex/automationExecutor.ts`, line 109-122 ([link](https://github.com/xcarter93/onetool/blob/75b3856ac4fa5579ea8462e3a8c1a04c920fb8c5/packages/backend/convex/automationExecutor.ts#L109-L122)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`isFatalExecutionError` relies on regex-matching undocumented Convex error strings**

   The function categorises errors as fatal by matching against hard-coded substrings of Convex runtime error messages. These messages are internal implementation details and are not part of any stable public API. A future Convex release changing the wording would silently cause per-item transaction exhaustion errors to be treated as item-level failures, continuing the loop past items that should have halted the run and potentially applying partial updates across many records.

   Consider surfacing these patterns behind a shared `FATAL_PATTERNS` constant and pairing it with an integration test against a known Convex error fixture so the gap becomes visible at upgrade time.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/backend/convex/automationExecutor.ts
   Line: 109-122

   Comment:
   **`isFatalExecutionError` relies on regex-matching undocumented Convex error strings**

   The function categorises errors as fatal by matching against hard-coded substrings of Convex runtime error messages. These messages are internal implementation details and are not part of any stable public API. A future Convex release changing the wording would silently cause per-item transaction exhaustion errors to be treated as item-level failures, continuing the loop past items that should have halted the run and potentially applying partial updates across many records.

   Consider surfacing these patterns behind a shared `FATAL_PATTERNS` constant and pairing it with an integration test against a known Convex error fixture so the gap becomes visible at upgrade time.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
packages/backend/convex/automationExecutor.ts:2549
**Collision-prone `correlationId` within a single Convex transaction**

`Date.now()` returns a constant value for all calls within the same Convex mutation. An automation with two `update_field` action nodes running in the same loop chunk (before the first checkpoint) would produce identical `correlationId` values — `cascade-<autoId>-<timestamp>` — for both emitted events. If the event bus ever uses `correlationId` for deduplication or idempotency, the second cascade event would be silently dropped, and the chained automation would not fire for that field change.

Consider appending a per-call counter to guarantee uniqueness across events emitted in the same mutation.

### Issue 2 of 4
packages/backend/convex/automationExecutor.ts:109-122
**`isFatalExecutionError` relies on regex-matching undocumented Convex error strings**

The function categorises errors as fatal by matching against hard-coded substrings of Convex runtime error messages. These messages are internal implementation details and are not part of any stable public API. A future Convex release changing the wording would silently cause per-item transaction exhaustion errors to be treated as item-level failures, continuing the loop past items that should have halted the run and potentially applying partial updates across many records.

Consider surfacing these patterns behind a shared `FATAL_PATTERNS` constant and pairing it with an integration test against a known Convex error fixture so the gap becomes visible at upgrade time.

### Issue 3 of 4
apps/web/src/app/(workspace)/automations/components/editor/formula-editor-modal.tsx:107-117
**`runtimeTimezone` duplicates `automationFormulaTz` with different null-safety**

The frontend's `runtimeTimezone` and the backend's `automationFormulaTz` (in `automationExecutor.ts`, line 98) implement the same rule; the comment here explicitly says they must stay in lockstep. They diverge in one detail: the backend returns `trigger.schedule.timezone` without a null guard, while this function adds `trigger.schedule?.timezone ? ... : "UTC"`. If `timezone` can be absent from a draft schedule config, the backend would pass `undefined` as `tz` to `Intl.DateTimeFormat`, causing formula evaluation to throw or silently fall back to the local system timezone. If the logic for non-scheduled triggers ever changes on one side, formula previews would diverge from production results without any compile-time signal.

These two functions should share a single source of truth or at minimum have a cross-checking test.

### Issue 4 of 4
apps/web/src/app/(workspace)/automations/components/run-throughput-chart.tsx:24-27
**`skipped` series silently dropped from the throughput chart**

The previous implementation used `RUN_CHART_SERIES` from `run-format.ts`, which included a `skipped` series. The new inline `SERIES` constant omits it. `getRunThroughput` still returns a `skipped` count per day, but the data is now fetched and silently discarded — users lose visibility into how often automations are skipped.

If dropping skipped is intentional, remove the `skipped` field from the `getRunThroughput` return type to avoid fetching unused data. If unintentional, add it back as a series.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["omitting graphify from git tracking"](https://github.com/xcarter93/onetool/commit/75b3856ac4fa5579ea8462e3a8c1a04c920fb8c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44331602)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->