### PR TITLE
Add multi-field update and create record automation actions

### DIFF
--- a/apps/web/src/app/(workspace)/automations/components/editor/debug-panel.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/editor/debug-panel.tsx
@@ -168,7 +168,9 @@ function PartialProgressBanner({ execution }: { execution: ExecutionDoc }) {
 		<div className="space-y-2">
 			{loopsWithFailures.map((summary) => {
 				const shown = summary.errors.slice(0, MAX_SHOWN);
-				const hiddenCount = summary.errors.length - shown.length;
+				// Count against `failed`, not `errors` — the server caps the stored
+				// error list, so failures past the cap have no entry here.
+				const hiddenCount = summary.failed - shown.length;
 				const anyPartial = summary.errors.some((e) => e.partial);
 				return (
 					<div

--- a/apps/web/src/app/(workspace)/automations/components/flow/action-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/action-node-rf.tsx
@@ -20,7 +20,7 @@ function getSummary(config: ActionNodeConfig | undefined): {
 
 	const action = config.action;
 	const targetLabel =
-		action.type === "update_field"
+		action.type === "update_field" || action.type === "update_fields"
 			? action.target === "self"
 				? "this record"
 				: OBJECT_TYPE_LABELS[action.target.related]
@@ -35,6 +35,25 @@ function getSummary(config: ActionNodeConfig | undefined): {
 			return {
 				title: `Update ${action.field}`,
 				description: `on ${targetLabel} → ${value ?? "..."}`,
+				isConfigured: true,
+			};
+		}
+		case "update_fields": {
+			const rows = action.fields.filter((row) => row.field);
+			if (rows.length === 0) {
+				return { title: "Update Record", description: "Choose a field...", isConfigured: false };
+			}
+			if (rows.length === 1) {
+				const value = rows[0].value.kind === "static" ? rows[0].value.value : "...";
+				return {
+					title: `Update ${rows[0].field}`,
+					description: `on ${targetLabel} → ${value ?? "..."}`,
+					isConfigured: true,
+				};
+			}
+			return {
+				title: `Update ${rows.length} fields`,
+				description: `on ${targetLabel} → ${rows.map((r) => r.field).join(", ")}`,
 				isConfigured: true,
 			};
 		}

--- a/apps/web/src/app/(workspace)/automations/components/flow/action-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/action-node-rf.tsx
@@ -43,18 +43,26 @@ function getSummary(config: ActionNodeConfig | undefined): {
 			if (rows.length === 0) {
 				return { title: "Update Record", description: "Choose a field...", isConfigured: false };
 			}
+			// Configured only when every row has a field and a non-empty value —
+			// mirrors save validation so the node's solid border matches what passes.
+			const isComplete = action.fields.every(
+				(row) =>
+					!!row.field &&
+					(row.value.kind !== "static" ||
+						(row.value.value !== null && row.value.value !== "")),
+			);
 			if (rows.length === 1) {
 				const value = rows[0].value.kind === "static" ? rows[0].value.value : "...";
 				return {
 					title: `Update ${rows[0].field}`,
 					description: `on ${targetLabel} → ${value ?? "..."}`,
-					isConfigured: true,
+					isConfigured: isComplete,
 				};
 			}
 			return {
 				title: `Update ${rows.length} fields`,
 				description: `on ${targetLabel} → ${rows.map((r) => r.field).join(", ")}`,
-				isConfigured: true,
+				isConfigured: isComplete,
 			};
 		}
 		case "create_task": {

--- a/apps/web/src/app/(workspace)/automations/components/flow/action-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/action-node-rf.tsx
@@ -65,6 +65,23 @@ function getSummary(config: ActionNodeConfig | undefined): {
 				isConfigured: action.title.kind === "var" || !!title,
 			};
 		}
+		case "create_record": {
+			const label = OBJECT_TYPE_LABELS[action.objectType];
+			const rows = action.fields.filter((row) => row.field);
+			const linked = action.linkToScope ? " · linked to record in scope" : "";
+			if (rows.length === 0 && !action.linkToScope) {
+				return {
+					title: `Create ${label}`,
+					description: "Choose fields to set...",
+					isConfigured: false,
+				};
+			}
+			return {
+				title: `Create ${label}`,
+				description: `${rows.map((r) => r.field).join(", ")}${linked}`.trim(),
+				isConfigured: true,
+			};
+		}
 		case "send_notification":
 			return {
 				title: "Send Notification",

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/action-config.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/action-config.tsx
@@ -21,12 +21,18 @@ import {
 } from "@/components/ui/select";
 import { MultiSelector } from "@/components/shared/multi-selector";
 import {
+	CREATABLE_OBJECT_TYPE_OPTIONS,
 	MAX_DUE_IN_DAYS,
+	OBJECT_TYPE_LABELS,
+	RELATION_FIELD,
+	getCreatableFields,
+	getRequiredCreateFields,
 	getTargetOptions,
 	getWritableFields,
 	type ActionNodeConfig,
 	type AutomationObjectType,
 	type AutomationTrigger,
+	type CreateRecordAction,
 	type CreateTaskAction,
 	type FormulaResource,
 	type SendNotificationAction,
@@ -312,6 +318,250 @@ function UpdateFieldsFields({
 					})}
 
 					{action.fields.length < writableFields.length && (
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							onClick={addRow}
+							className="w-full gap-1.5 border-dashed text-muted-foreground hover:text-foreground"
+						>
+							<Plus className="h-3.5 w-3.5" /> Add field
+						</Button>
+					)}
+				</div>
+			</PanelField>
+		</PanelSection>
+	);
+}
+
+function CreateRecordFields({
+	config,
+	action,
+	triggerObjectType,
+	nodes,
+	trigger,
+	nodeId,
+	formulas,
+	commit,
+}: ActionFieldsProps<CreateRecordAction> & {
+	triggerObjectType: AutomationObjectType | null;
+}) {
+	const objectType = action.objectType;
+	const scope = getScopeObjectType(nodes, nodeId, triggerObjectType);
+	const scopeObjectType = scope.objectType;
+
+	const creatableFields = getCreatableFields(objectType);
+	const requiredKeys = new Set(
+		getRequiredCreateFields(objectType).map((f) => f.key)
+	);
+
+	// linkToScope is offered only when a record is in scope AND the new record
+	// has a direct FK to that type (e.g. a project → its client).
+	const linkFk = scopeObjectType
+		? RELATION_FIELD[objectType]?.[scopeObjectType]
+		: undefined;
+	// The FK a live link fills is hidden from the field rows so it can't be
+	// double-set.
+	const linkedFk = action.linkToScope ? linkFk : undefined;
+	const availableFields = creatableFields.filter((f) => f.key !== linkedFk);
+	const chosenFields = new Set(action.fields.map((row) => row.field));
+
+	const commitAction = (next: CreateRecordAction) => {
+		commit({ ...config, action: next });
+	};
+
+	const defaultValueFor = (field?: { type: string }) => ({
+		kind: "static" as const,
+		value: field?.type === "boolean" ? false : null,
+	});
+
+	const seedRequiredRows = (nextType: AutomationObjectType) =>
+		getRequiredCreateFields(nextType).map((f) => ({
+			field: f.key,
+			value: defaultValueFor(f),
+		}));
+
+	const updateObjectType = (value: string) => {
+		const nextType = value as AutomationObjectType;
+		if (nextType === objectType) return;
+		// Rows name the old type's fields (and a link may no longer apply) —
+		// reseed from scratch with the new type's required rows.
+		commitAction({
+			type: "create_record",
+			objectType: nextType,
+			fields: seedRequiredRows(nextType),
+		});
+	};
+
+	const toggleLink = (on: boolean) => {
+		if (on) {
+			// The link supplies the FK; drop any manual row for it.
+			const fields = linkFk
+				? action.fields.filter((r) => r.field !== linkFk)
+				: action.fields;
+			commitAction({ ...action, linkToScope: true, fields });
+			return;
+		}
+		// Turning off: restore an empty row for a required FK the link had covered.
+		let fields = action.fields;
+		if (
+			linkFk &&
+			requiredKeys.has(linkFk) &&
+			!fields.some((r) => r.field === linkFk)
+		) {
+			fields = [
+				...fields,
+				{
+					field: linkFk,
+					value: defaultValueFor(creatableFields.find((f) => f.key === linkFk)),
+				},
+			];
+		}
+		commitAction({ type: "create_record", objectType, fields });
+	};
+
+	const updateRowField = (index: number, field: string) => {
+		const nextField = creatableFields.find((f) => f.key === field);
+		commitAction({
+			...action,
+			fields: action.fields.map((row, i) =>
+				i === index ? { field, value: defaultValueFor(nextField) } : row
+			),
+		});
+	};
+
+	const updateRowValue = (
+		index: number,
+		value: CreateRecordAction["fields"][number]["value"]
+	) => {
+		commitAction({
+			...action,
+			fields: action.fields.map((row, i) =>
+				i === index ? { ...row, value } : row
+			),
+		});
+	};
+
+	const addRow = () => {
+		const nextField = availableFields.find((f) => !chosenFields.has(f.key));
+		if (!nextField) return;
+		commitAction({
+			...action,
+			fields: [
+				...action.fields,
+				{ field: nextField.key, value: defaultValueFor(nextField) },
+			],
+		});
+	};
+
+	const removeRow = (index: number) => {
+		commitAction({
+			...action,
+			fields: action.fields.filter((_, i) => i !== index),
+		});
+	};
+
+	return (
+		<PanelSection title="Create">
+			<PanelField
+				label="Record type"
+				helper="A brand-new record is created each time this step runs."
+			>
+				<Select
+					value={objectType}
+					onValueChange={(value) => value && updateObjectType(value)}
+				>
+					<SelectTrigger>
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{CREATABLE_OBJECT_TYPE_OPTIONS.map((option) => (
+							<SelectItem key={option.value} value={option.value}>
+								{option.label}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</PanelField>
+
+			{linkFk && scopeObjectType && (
+				<PanelField
+					label={`Link to ${OBJECT_TYPE_LABELS[scopeObjectType]}`}
+					helper={
+						scope.inLoop
+							? `Sets the new ${OBJECT_TYPE_LABELS[objectType]}'s ${OBJECT_TYPE_LABELS[scopeObjectType]} to the current loop item.`
+							: `Sets the new ${OBJECT_TYPE_LABELS[objectType]}'s ${OBJECT_TYPE_LABELS[scopeObjectType]} to the triggering ${OBJECT_TYPE_LABELS[scopeObjectType]}.`
+					}
+				>
+					<Switch
+						checked={!!action.linkToScope}
+						onCheckedChange={toggleLink}
+					/>
+				</PanelField>
+			)}
+
+			<PanelField label="Fields">
+				<div className="space-y-2">
+					{action.fields.map((row, index) => {
+						const fieldDef = creatableFields.find((f) => f.key === row.field);
+						const isRequired = requiredKeys.has(row.field);
+						return (
+							<div key={index} className="flex items-start gap-2">
+								<div className="flex-1 space-y-2">
+									<Select
+										value={row.field}
+										disabled={isRequired}
+										onValueChange={(value) =>
+											value && updateRowField(index, value)
+										}
+									>
+										<SelectTrigger>
+											<SelectValue placeholder="Select field" />
+										</SelectTrigger>
+										<SelectContent>
+											{availableFields.map((field) => (
+												<SelectItem
+													key={field.key}
+													value={field.key}
+													disabled={
+														field.key !== row.field &&
+														chosenFields.has(field.key)
+													}
+												>
+													{field.label}
+													{requiredKeys.has(field.key) ? " *" : ""}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+
+									{fieldDef && (
+										<ValueInput
+											field={fieldDef}
+											value={row.value}
+											onChange={(value) => updateRowValue(index, value)}
+											nodes={nodes}
+											trigger={trigger}
+											targetNodeId={nodeId}
+											formulas={formulas}
+										/>
+									)}
+								</div>
+								{!isRequired && (
+									<button
+										type="button"
+										onClick={() => removeRow(index)}
+										className="mt-2 text-muted-foreground hover:text-destructive"
+										aria-label="Remove field"
+									>
+										<X className="h-3.5 w-3.5" />
+									</button>
+								)}
+							</div>
+						);
+					})}
+
+					{action.fields.length < availableFields.length && (
 						<Button
 							type="button"
 							variant="outline"
@@ -667,6 +917,18 @@ export function ActionConfigPanel({
 			<div className="flex-1">
 				{config.action.type === "update_fields" && (
 					<UpdateFieldsFields
+						config={config}
+						action={config.action}
+						triggerObjectType={triggerObjectType}
+						nodes={workflowNodes}
+						trigger={trigger}
+						nodeId={nodeId}
+						formulas={formulas}
+						commit={commit}
+					/>
+				)}
+				{config.action.type === "create_record" && (
+					<CreateRecordFields
 						config={config}
 						action={config.action}
 						triggerObjectType={triggerObjectType}

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/action-config.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/action-config.tsx
@@ -2,9 +2,12 @@
 
 import React, { useRef } from "react";
 import { useQuery } from "convex/react";
+import { Plus, X } from "lucide-react";
 import { api } from "@onetool/backend/convex/_generated/api";
 import { ACTION_META } from "../../../lib/action-meta";
+import { normalizeNodeConfig } from "../../../lib/legacy-load";
 import { NextStepTree } from "../next-step-tree";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
@@ -29,7 +32,7 @@ import {
 	type SendNotificationAction,
 	type SendTeamMessageAction,
 	type TriggerConfig,
-	type UpdateFieldAction,
+	type UpdateFieldsAction,
 	type WorkflowNode,
 	triggerScopeObjectType,
 } from "../../../lib/node-types";
@@ -48,10 +51,17 @@ function defaultConfig(objectType: AutomationObjectType): ActionNodeConfig {
 	return {
 		kind: "action",
 		action: {
-			type: "update_field",
+			type: "update_fields",
 			target: "self",
-			field: firstWritable?.key ?? "",
-			value: { kind: "static", value: firstWritable?.type === "boolean" ? false : null },
+			fields: [
+				{
+					field: firstWritable?.key ?? "",
+					value: {
+						kind: "static",
+						value: firstWritable?.type === "boolean" ? false : null,
+					},
+				},
+			],
 		},
 	};
 }
@@ -91,7 +101,7 @@ interface ActionFieldsProps<TAction> {
 	commit: (next: ActionNodeConfig) => void;
 }
 
-function UpdateFieldFields({
+function UpdateFieldsFields({
 	config,
 	action,
 	triggerObjectType,
@@ -100,7 +110,7 @@ function UpdateFieldFields({
 	nodeId,
 	formulas,
 	commit,
-}: ActionFieldsProps<UpdateFieldAction> & {
+}: ActionFieldsProps<UpdateFieldsAction> & {
 	triggerObjectType: AutomationObjectType | null;
 }) {
 	// Inside a loop body, `target: "self"` (and its related FKs) resolve against
@@ -110,7 +120,7 @@ function UpdateFieldFields({
 
 	// Both targets — self and related — resolve off the record in scope, so with
 	// no record there is nothing this action can update. The engine hard-fails on
-	// it, and save-time validation now rejects it.
+	// it, and save-time validation rejects it.
 	if (!scopeObjectType) {
 		return (
 			<PanelSection title="Inputs">
@@ -127,37 +137,87 @@ function UpdateFieldFields({
 	const targetObjectType =
 		targetOptions.find((t) => t.value === targetValue)?.objectType ?? scopeObjectType;
 	const writableFields = getWritableFields(targetObjectType);
-	const fieldDef = writableFields.find((f) => f.key === action.field);
+	const chosenFields = new Set(action.fields.map((row) => row.field));
+
+	const commitAction = (next: UpdateFieldsAction) => {
+		commit({ ...config, action: next });
+	};
+
+	const seedRow = (objectType: AutomationObjectType) => {
+		const first = getWritableFields(objectType)[0];
+		return {
+			field: first?.key ?? "",
+			value: {
+				kind: "static" as const,
+				value: first?.type === "boolean" ? false : null,
+			},
+		};
+	};
 
 	const updateTarget = (value: string) => {
 		const nextTarget = targetOptions.find((t) => t.value === value);
 		if (!nextTarget) return;
-		const nextWritable = getWritableFields(nextTarget.objectType);
-		commit({
-			...config,
-			action: {
-				...action,
-				target: value === "self" ? "self" : { related: nextTarget.objectType },
-				field: nextWritable[0]?.key ?? "",
-				value: { kind: "static", value: nextWritable[0]?.type === "boolean" ? false : null },
-			},
+		// The rows name fields on the old target's type — reseed with one row.
+		commitAction({
+			...action,
+			target: value === "self" ? "self" : { related: nextTarget.objectType },
+			fields: [seedRow(nextTarget.objectType)],
 		});
 	};
 
-	const updateField = (field: string) => {
+	const updateRowField = (index: number, field: string) => {
 		const nextField = writableFields.find((f) => f.key === field);
-		commit({
-			...config,
-			action: {
-				...action,
-				field,
-				value: { kind: "static", value: nextField?.type === "boolean" ? false : null },
-			},
+		commitAction({
+			...action,
+			fields: action.fields.map((row, i) =>
+				i === index
+					? {
+							field,
+							value: {
+								kind: "static",
+								value: nextField?.type === "boolean" ? false : null,
+							},
+						}
+					: row
+			),
 		});
 	};
 
-	const updateValue = (value: UpdateFieldAction["value"]) => {
-		commit({ ...config, action: { ...action, value } });
+	const updateRowValue = (
+		index: number,
+		value: UpdateFieldsAction["fields"][number]["value"]
+	) => {
+		commitAction({
+			...action,
+			fields: action.fields.map((row, i) =>
+				i === index ? { ...row, value } : row
+			),
+		});
+	};
+
+	const addRow = () => {
+		const nextField = writableFields.find((f) => !chosenFields.has(f.key));
+		if (!nextField) return;
+		commitAction({
+			...action,
+			fields: [
+				...action.fields,
+				{
+					field: nextField.key,
+					value: {
+						kind: "static",
+						value: nextField.type === "boolean" ? false : null,
+					},
+				},
+			],
+		});
+	};
+
+	const removeRow = (index: number) => {
+		commitAction({
+			...action,
+			fields: action.fields.filter((_, i) => i !== index),
+		});
 	};
 
 	return (
@@ -193,37 +253,77 @@ function UpdateFieldFields({
 				</Select>
 			</PanelField>
 
-			<PanelField label="Field">
-				<Select
-					value={action.field}
-					onValueChange={(value) => value && updateField(value)}
-				>
-					<SelectTrigger>
-						<SelectValue placeholder="Select field" />
-					</SelectTrigger>
-					<SelectContent>
-						{writableFields.map((field) => (
-							<SelectItem key={field.key} value={field.key}>
-								{field.label}
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
-			</PanelField>
+			<PanelField label="Fields">
+				<div className="space-y-2">
+					{action.fields.map((row, index) => {
+						const fieldDef = writableFields.find((f) => f.key === row.field);
+						return (
+							<div key={index} className="flex items-start gap-2">
+								<div className="flex-1 space-y-2">
+									<Select
+										value={row.field}
+										onValueChange={(value) =>
+											value && updateRowField(index, value)
+										}
+									>
+										<SelectTrigger>
+											<SelectValue placeholder="Select field" />
+										</SelectTrigger>
+										<SelectContent>
+											{writableFields.map((field) => (
+												<SelectItem
+													key={field.key}
+													value={field.key}
+													disabled={
+														field.key !== row.field &&
+														chosenFields.has(field.key)
+													}
+												>
+													{field.label}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
 
-			{fieldDef && (
-				<PanelField label="Set value to">
-					<ValueInput
-						field={fieldDef}
-						value={action.value}
-						onChange={updateValue}
-						nodes={nodes}
-						trigger={trigger}
-						targetNodeId={nodeId}
-						formulas={formulas}
-					/>
-				</PanelField>
-			)}
+									{fieldDef && (
+										<ValueInput
+											field={fieldDef}
+											value={row.value}
+											onChange={(value) => updateRowValue(index, value)}
+											nodes={nodes}
+											trigger={trigger}
+											targetNodeId={nodeId}
+											formulas={formulas}
+										/>
+									)}
+								</div>
+								{action.fields.length > 1 && (
+									<button
+										type="button"
+										onClick={() => removeRow(index)}
+										className="mt-2 text-muted-foreground hover:text-destructive"
+										aria-label="Remove field"
+									>
+										<X className="h-3.5 w-3.5" />
+									</button>
+								)}
+							</div>
+						);
+					})}
+
+					{action.fields.length < writableFields.length && (
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							onClick={addRow}
+							className="w-full gap-1.5 border-dashed text-muted-foreground hover:text-foreground"
+						>
+							<Plus className="h-3.5 w-3.5" /> Add field
+						</Button>
+					)}
+				</div>
+			</PanelField>
 		</PanelSection>
 	);
 }
@@ -541,8 +641,12 @@ export function ActionConfigPanel({
 	const seedObjectType =
 		getScopeObjectType(workflowNodes, nodeId, triggerObjectType).objectType ??
 		"client";
+	// normalizeNodeConfig upgrades a legacy single-field update_field to a
+	// one-row update_fields; load already does this, so it only bites if a
+	// config reached editor state some other way.
 	const config =
-		(node.config as ActionNodeConfig | undefined) ?? defaultConfig(seedObjectType);
+		(normalizeNodeConfig(node.config) as ActionNodeConfig | undefined) ??
+		defaultConfig(seedObjectType);
 	const meta = ACTION_META[config.action.type];
 
 	const commit = (next: ActionNodeConfig) => {
@@ -561,8 +665,8 @@ export function ActionConfigPanel({
 			/>
 
 			<div className="flex-1">
-				{config.action.type === "update_field" && (
-					<UpdateFieldFields
+				{config.action.type === "update_fields" && (
+					<UpdateFieldsFields
 						config={config}
 						action={config.action}
 						triggerObjectType={triggerObjectType}

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/action-config.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/action-config.tsx
@@ -495,7 +495,23 @@ function CreateRecordFields({
 				>
 					<Switch
 						checked={!!action.linkToScope}
+						aria-label={`Link the new ${OBJECT_TYPE_LABELS[objectType]} to the ${OBJECT_TYPE_LABELS[scopeObjectType]} in scope`}
 						onCheckedChange={toggleLink}
+					/>
+				</PanelField>
+			)}
+
+			{action.linkToScope && !(linkFk && scopeObjectType) && (
+				// linkToScope is on but the current scope has no matching FK (scope
+				// changed after it was set) — keep it removable so it can't get stuck.
+				<PanelField
+					label="Link to record in scope"
+					helper={`This step no longer has a matching record in scope to link the new ${OBJECT_TYPE_LABELS[objectType]} to. Turn it off to clear the stale link.`}
+				>
+					<Switch
+						checked
+						aria-label={`Clear the stale scope link on this new ${OBJECT_TYPE_LABELS[objectType]}`}
+						onCheckedChange={() => toggleLink(false)}
 					/>
 				</PanelField>
 			)}

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/filter-groups-editor.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/filter-groups-editor.tsx
@@ -59,7 +59,7 @@ function emptyVariableRule(path: string): ConditionRule {
 	return {
 		field: "",
 		left: { kind: "var", path },
-		operator: "greater_than",
+		operator: "equals",
 		value: { kind: "static", value: "" },
 	};
 }
@@ -349,7 +349,7 @@ export function FilterGroupsEditor({
 				</div>
 			))}
 
-			{groups.length < MAX_CONDITION_GROUPS && (
+			{canAddRule && groups.length < MAX_CONDITION_GROUPS && (
 				<Button
 					type="button"
 					variant="outline"

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/step-picker.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/step-picker.tsx
@@ -10,6 +10,7 @@ import {
 	Search,
 	X,
 	ListTodo,
+	FilePlus,
 	Bell,
 	MessagesSquare,
 	Timer,
@@ -66,6 +67,13 @@ export const STEP_GROUPS: StepGroup[] = [
 				actionType: "create_task",
 				label: "Create Task",
 				icon: ListTodo,
+				color: "bg-green-50 text-green-600 dark:bg-green-950/40 dark:text-green-400",
+			},
+			{
+				type: "action",
+				actionType: "create_record",
+				label: "Create Record",
+				icon: FilePlus,
 				color: "bg-green-50 text-green-600 dark:bg-green-950/40 dark:text-green-400",
 			},
 			{

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/step-picker.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/step-picker.tsx
@@ -56,6 +56,7 @@ export const STEP_GROUPS: StepGroup[] = [
 		items: [
 			{
 				type: "action",
+				actionType: "update_fields",
 				label: "Update Record",
 				icon: Play,
 				color: "bg-green-50 text-green-600 dark:bg-green-950/40 dark:text-green-400",
@@ -181,7 +182,9 @@ export function StepPicker({
 				return item.label.toLowerCase().includes(lowerSearch);
 			})
 			.map((item) =>
-				noRecordInScope && item.type === "action" && !item.actionType
+				noRecordInScope &&
+				item.type === "action" &&
+				(!item.actionType || item.actionType === "update_fields")
 					? {
 							...item,
 							disabledReason: "Needs a record — add Find Records, then a Loop",

--- a/apps/web/src/app/(workspace)/automations/hooks/use-automation-editor.ts
+++ b/apps/web/src/app/(workspace)/automations/hooks/use-automation-editor.ts
@@ -7,6 +7,7 @@ import { api } from "@onetool/backend/convex/_generated/api";
 import type { Id } from "@onetool/backend/convex/_generated/dataModel";
 import { useToast } from "@/hooks/use-toast";
 import {
+	getRequiredCreateFields,
 	getStatusOptions,
 	triggerScopeObjectType,
 	type AutomationAction,
@@ -114,6 +115,17 @@ function buildConditionNode(id: string): WorkflowNode {
 
 function buildAction(actionType?: string): AutomationAction {
 	switch (actionType) {
+		case "create_record":
+			// Born as a client create with its required rows pre-seeded; the panel
+			// reseeds when the object type changes.
+			return {
+				type: "create_record",
+				objectType: "client",
+				fields: getRequiredCreateFields("client").map((f) => ({
+					field: f.key,
+					value: { kind: "static", value: null },
+				})),
+			};
 		case "create_task":
 			return { type: "create_task", title: { kind: "static", value: "" } };
 		case "send_notification":

--- a/apps/web/src/app/(workspace)/automations/hooks/use-automation-editor.ts
+++ b/apps/web/src/app/(workspace)/automations/hooks/use-automation-editor.ts
@@ -126,12 +126,14 @@ function buildAction(actionType?: string): AutomationAction {
 				message: "",
 			};
 		case "update_field":
+		case "update_fields":
 		default:
+			// New Update Record steps are always born multi-field; the legacy
+			// single-field shape only exists in already-stored automations.
 			return {
-				type: "update_field",
+				type: "update_fields",
 				target: "self",
-				field: "",
-				value: { kind: "static", value: null },
+				fields: [{ field: "", value: { kind: "static", value: null } }],
 			};
 	}
 }

--- a/apps/web/src/app/(workspace)/automations/lib/action-meta.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/action-meta.ts
@@ -1,5 +1,6 @@
 import {
 	Bell,
+	FilePlus,
 	ListTodo,
 	MessagesSquare,
 	Play,
@@ -55,6 +56,15 @@ export const ACTION_META: Record<
 		badge: "Actions",
 		name: "Create Task",
 		description: "Add a task to your workspace.",
+	},
+	create_record: {
+		icon: FilePlus,
+		bg: "bg-green-100 dark:bg-green-400/15",
+		fg: "text-green-700 dark:text-green-300",
+		accent: "border-l-green-500 dark:border-l-green-400",
+		badge: "Actions",
+		name: "Create Record",
+		description: "Create a new client, project, or task.",
 	},
 	send_notification: {
 		icon: Bell,

--- a/apps/web/src/app/(workspace)/automations/lib/action-meta.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/action-meta.ts
@@ -36,6 +36,17 @@ export const ACTION_META: Record<
 		name: "Update Record",
 		description: "Set a field on the record in scope.",
 	},
+	// The multi-field successor; the editor upgrades update_field to this on
+	// load, so it shares Update Record's identity.
+	update_fields: {
+		icon: Play,
+		bg: "bg-green-100 dark:bg-green-400/15",
+		fg: "text-green-700 dark:text-green-300",
+		accent: "border-l-green-500 dark:border-l-green-400",
+		badge: "Actions",
+		name: "Update Record",
+		description: "Set one or more fields on the record in scope.",
+	},
 	create_task: {
 		icon: ListTodo,
 		bg: "bg-green-100 dark:bg-green-400/15",

--- a/apps/web/src/app/(workspace)/automations/lib/editor-signature.test.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/editor-signature.test.ts
@@ -3,8 +3,9 @@ import { definitionSignature } from "./editor-signature";
 import {
 	automationToReactFlow,
 	reactFlowToFlatArray,
+	serializeEditorNodes,
 } from "./flow-adapter";
-import { legacyTriggerToDraft } from "./legacy-load";
+import { legacyNodeToV2, legacyTriggerToDraft } from "./legacy-load";
 import type {
 	AutomationTrigger,
 	ConditionNodeConfig,
@@ -213,8 +214,13 @@ describe("definitionSignature — load round-trip stability", () => {
 	];
 
 	it("keeps the signature stable across automationToReactFlow -> reactFlowToFlatArray", () => {
-		// Load-time signature (editor state right after the row loads).
-		const loadedSig = definitionSignature(invoiceTrigger, nodes);
+		// Load-time signature (editor state right after the row loads — the real
+		// editor always maps stored nodes through legacyNodeToV2 first, which
+		// canonicalizes legacy configs).
+		const loadedSig = definitionSignature(
+			invoiceTrigger,
+			nodes.map(legacyNodeToV2)
+		);
 
 		// Working signature: what the editor re-signs after the RF round-trip.
 		const { nodes: rfNodes, edges: rfEdges } = automationToReactFlow(
@@ -263,5 +269,51 @@ describe("stored scheduled triggers with a legacy objectType (A1)", () => {
 			nodes
 		);
 		expect(legacySig).toBe(cleanSig);
+	});
+});
+
+describe("stored single-field update_field upgrades (B2)", () => {
+	it("signs identically at load and at save — never permanently dirty", () => {
+		// The editor upgrades a legacy single-field config to a one-row
+		// update_fields. Load (legacyNodeToV2) and save (serializeEditorNodes)
+		// must BOTH apply it, or every stored automation with an update_field
+		// wears an "unsaved changes" badge it can never shed.
+		const stored = node("n1");
+		const loaded = [legacyNodeToV2(stored)];
+		const savedSig = definitionSignature(trigger, loaded);
+		const workingSig = definitionSignature(
+			trigger,
+			serializeEditorNodes(loaded)
+		);
+		expect(workingSig).toBe(savedSig);
+
+		// And the upgrade really happened: both sides sign the multi-field shape.
+		const upgraded: WorkflowNode = {
+			...stored,
+			config: {
+				kind: "action",
+				action: {
+					type: "update_fields",
+					target: "self",
+					fields: [{ field: "notes", value: { kind: "static", value: "hi" } }],
+				},
+			},
+		};
+		expect(savedSig).toBe(definitionSignature(trigger, [upgraded]));
+	});
+
+	it("save normalizes even when a raw update_field sneaks into editor state", () => {
+		// serializeEditorNodes must canonicalize on its own — signature symmetry
+		// cannot depend on every state producer having gone through load.
+		const raw = node("n1");
+		const serialized = serializeEditorNodes([raw]);
+		expect(serialized[0].config).toEqual({
+			kind: "action",
+			action: {
+				type: "update_fields",
+				target: "self",
+				fields: [{ field: "notes", value: { kind: "static", value: "hi" } }],
+			},
+		});
 	});
 });

--- a/apps/web/src/app/(workspace)/automations/lib/flow-adapter.test.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/flow-adapter.test.ts
@@ -24,23 +24,27 @@ const makeTrigger = (overrides?: Partial<TriggerConfig>): TriggerConfig => ({
 	...overrides,
 });
 
+// The canonical editor shape — legacy single-field update_field configs are
+// upgraded to this on load/save, so round-trip fixtures use it directly.
 const updateStatusAction = (newStatus: string): ActionNodeConfig => ({
 	kind: "action",
 	action: {
-		type: "update_field",
+		type: "update_fields",
 		target: "self",
-		field: "status",
-		value: { kind: "static", value: newStatus },
+		fields: [
+			{ field: "status", value: { kind: "static", value: newStatus } },
+		],
 	},
 });
 
 const updateClientStatusAction = (newStatus: string): ActionNodeConfig => ({
 	kind: "action",
 	action: {
-		type: "update_field",
+		type: "update_fields",
 		target: { related: "client" },
-		field: "status",
-		value: { kind: "static", value: newStatus },
+		fields: [
+			{ field: "status", value: { kind: "static", value: newStatus } },
+		],
 	},
 });
 

--- a/apps/web/src/app/(workspace)/automations/lib/flow-adapter.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/flow-adapter.ts
@@ -15,7 +15,7 @@ import type {
 	WorkflowNodeConfig,
 } from "./node-types";
 import { triggerScopeObjectType } from "./node-types";
-import { legacyNodeToV2 } from "./legacy-load";
+import { legacyNodeToV2, normalizeNodeConfig } from "./legacy-load";
 import { collectLoopBody } from "./graph-utils";
 import {
 	computeDerivedLayout,
@@ -531,7 +531,9 @@ export function serializeEditorNodes(nodes: EditorNode[]): WorkflowNode[] {
 			return {
 				id: node.id,
 				type: node.type,
-				config: node.config,
+				// Same canonicalization as load (legacyNodeToV2) — the saved and
+				// working signatures must hash identical configs.
+				config: normalizeNodeConfig(node.config),
 				nextNodeId: node.nextNodeId,
 				elseNodeId: node.elseNodeId,
 				bodyStartNodeId: node.bodyStartNodeId,

--- a/apps/web/src/app/(workspace)/automations/lib/legacy-load.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/legacy-load.ts
@@ -26,12 +26,35 @@ export type DbWorkflowNode = {
 	position?: { x: number; y: number };
 };
 
+/**
+ * Canonicalize a config for the editor: a legacy single-field update_field
+ * becomes a one-row update_fields. Applied symmetrically on load
+ * (legacyNodeToV2) and save (serializeEditorNodes) — normalizing on only one
+ * side would make every stored single-field automation read as permanently
+ * dirty, exactly like the scheduled-trigger objectType drop below.
+ */
+export function normalizeNodeConfig(
+	config: WorkflowNodeConfig | undefined
+): WorkflowNodeConfig | undefined {
+	if (config?.kind === "action" && config.action.type === "update_field") {
+		return {
+			kind: "action",
+			action: {
+				type: "update_fields",
+				target: config.action.target,
+				fields: [{ field: config.action.field, value: config.action.value }],
+			},
+		};
+	}
+	return config;
+}
+
 /** Adapt a stored DB / in-editor node to the editor's WorkflowNode. */
 export function legacyNodeToV2(node: DbWorkflowNode): WorkflowNode {
 	return {
 		id: node.id,
 		type: node.type,
-		config: node.config,
+		config: normalizeNodeConfig(node.config),
 		nextNodeId: node.nextNodeId,
 		elseNodeId: node.elseNodeId,
 		bodyStartNodeId: node.bodyStartNodeId,

--- a/apps/web/src/app/(workspace)/automations/lib/node-types.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/node-types.ts
@@ -138,6 +138,10 @@ export type DelayUntilNodeConfig = Extract<
 
 /** Per-action-type aliases (narrowed from the shared action union). */
 export type UpdateFieldAction = Extract<AutomationAction, { type: "update_field" }>;
+export type UpdateFieldsAction = Extract<
+	AutomationAction,
+	{ type: "update_fields" }
+>;
 export type CreateTaskAction = Extract<AutomationAction, { type: "create_task" }>;
 export type SendNotificationAction = Extract<
 	AutomationAction,

--- a/apps/web/src/app/(workspace)/automations/lib/node-types.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/node-types.ts
@@ -18,7 +18,10 @@ import type {
 	ConditionGroup,
 } from "@onetool/backend/convex/lib/workflowTypes";
 import { AUTOMATION_OBJECT_TYPES } from "@onetool/backend/convex/lib/workflowTypes";
-import { RELATED_OBJECTS } from "@onetool/backend/convex/lib/fieldRegistry";
+import {
+	RELATED_OBJECTS,
+	CREATABLE_OBJECT_TYPES,
+} from "@onetool/backend/convex/lib/fieldRegistry";
 
 // ---------------------------------------------------------------------------
 // 1. Shared model re-exports
@@ -68,9 +71,13 @@ export {
 	OPERATORS_BY_TYPE,
 	RELATED_OBJECTS,
 	RELATION_FIELD,
+	CREATABLE_OBJECT_TYPES,
 	getFieldDefinition,
 	getWritableFields,
 	getFilterableFields,
+	getCreatableFields,
+	getRequiredCreateFields,
+	isCreatableObjectType,
 	operatorsForField,
 	getStatusOptions,
 } from "@onetool/backend/convex/lib/fieldRegistry";
@@ -104,6 +111,15 @@ export const OBJECT_TYPE_OPTIONS: {
 	value: AutomationObjectType;
 	label: string;
 }[] = AUTOMATION_OBJECT_TYPES.map((value) => ({
+	value,
+	label: OBJECT_TYPE_LABELS[value],
+}));
+
+/** Object types a create_record action may insert (client/project/task today). */
+export const CREATABLE_OBJECT_TYPE_OPTIONS: {
+	value: AutomationObjectType;
+	label: string;
+}[] = CREATABLE_OBJECT_TYPES.map((value) => ({
 	value,
 	label: OBJECT_TYPE_LABELS[value],
 }));
@@ -143,6 +159,10 @@ export type UpdateFieldsAction = Extract<
 	{ type: "update_fields" }
 >;
 export type CreateTaskAction = Extract<AutomationAction, { type: "create_task" }>;
+export type CreateRecordAction = Extract<
+	AutomationAction,
+	{ type: "create_record" }
+>;
 export type SendNotificationAction = Extract<
 	AutomationAction,
 	{ type: "send_notification" }

--- a/apps/web/src/app/(workspace)/automations/lib/validation.test.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/validation.test.ts
@@ -712,6 +712,35 @@ describe("validateWorkflowForSave — update_fields (B2)", () => {
 		).toBe(true);
 	});
 
+	it("rejects a null value on a boolean row", () => {
+		const result = validateWorkflowForSave(clientTrigger, [
+			updateFieldsNode("act1", [{ field: "isActive", value: null }]),
+		]);
+		expect(
+			result.errors.some(
+				(e) => e.nodeId === "act1" && /set a value/i.test(e.message)
+			)
+		).toBe(true);
+	});
+
+	it("rejects an empty-string value on a boolean row", () => {
+		const result = validateWorkflowForSave(clientTrigger, [
+			updateFieldsNode("act1", [{ field: "isActive", value: "" }]),
+		]);
+		expect(
+			result.errors.some(
+				(e) => e.nodeId === "act1" && /set a value/i.test(e.message)
+			)
+		).toBe(true);
+	});
+
+	it("accepts a false value on a boolean row", () => {
+		const result = validateWorkflowForSave(clientTrigger, [
+			updateFieldsNode("act1", [{ field: "isActive", value: false }]),
+		]);
+		expect(result.errors.filter((e) => e.nodeId === "act1")).toHaveLength(0);
+	});
+
 	it("rejects a top-level update_fields on a scheduled trigger", () => {
 		const scheduled: TriggerConfig = {
 			type: "scheduled",

--- a/apps/web/src/app/(workspace)/automations/lib/validation.test.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/validation.test.ts
@@ -724,3 +724,97 @@ describe("validateWorkflowForSave — update_fields (B2)", () => {
 		expect(error?.type).toBe("no_trigger_record");
 	});
 });
+
+describe("validateWorkflowForSave — create_record (Phase B1)", () => {
+	const taskTrigger: TriggerConfig = {
+		type: "record_created",
+		objectType: "task",
+	};
+	const clientTrigger: TriggerConfig = {
+		type: "record_created",
+		objectType: "client",
+	};
+	const scheduled: TriggerConfig = {
+		type: "scheduled",
+		schedule: { frequency: "daily", timezone: "UTC", time: "09:00" },
+	};
+
+	function createRecordNode(
+		id: string,
+		objectType: "client" | "project" | "quote" | "invoice" | "task",
+		fields: Array<{ field: string; value: string | number | boolean | null }>,
+		linkToScope?: boolean
+	): WorkflowNode {
+		return {
+			id,
+			type: "action",
+			config: {
+				kind: "action",
+				action: {
+					type: "create_record",
+					objectType,
+					fields: fields.map((f) => ({
+						field: f.field,
+						value: { kind: "static", value: f.value },
+					})),
+					linkToScope,
+				},
+			},
+		};
+	}
+
+	it("accepts a task create with a title", () => {
+		const result = validateWorkflowForSave(taskTrigger, [
+			createRecordNode("act1", "task", [{ field: "title", value: "Do it" }]),
+		]);
+		expect(result.errors.some((e) => e.nodeId === "act1")).toBe(false);
+	});
+
+	it("rejects a project create missing its required client", () => {
+		const result = validateWorkflowForSave(taskTrigger, [
+			createRecordNode("act1", "project", [{ field: "title", value: "X" }]),
+		]);
+		const error = result.errors.find((e) => e.nodeId === "act1");
+		expect(error?.message).toMatch(/client is required/i);
+	});
+
+	it("accepts a project create when linkToScope supplies the client", () => {
+		const result = validateWorkflowForSave(clientTrigger, [
+			createRecordNode(
+				"act1",
+				"project",
+				[{ field: "title", value: "X" }],
+				true
+			),
+		]);
+		expect(result.errors.some((e) => e.nodeId === "act1")).toBe(false);
+	});
+
+	it("rejects a non-creatable object type (quote)", () => {
+		const result = validateWorkflowForSave(taskTrigger, [
+			createRecordNode("act1", "quote", [{ field: "title", value: "X" }]),
+		]);
+		const error = result.errors.find((e) => e.nodeId === "act1");
+		expect(error?.message).toMatch(/isn't supported/i);
+	});
+
+	it("rejects linkToScope on a scheduled top-level create", () => {
+		const result = validateWorkflowForSave(scheduled, [
+			createRecordNode(
+				"act1",
+				"task",
+				[{ field: "title", value: "X" }],
+				true
+			),
+		]);
+		const error = result.errors.find((e) => e.nodeId === "act1");
+		expect(error?.type).toBe("no_trigger_record");
+	});
+
+	it("allows an unlinked create on a scheduled top-level", () => {
+		const result = validateWorkflowForSave(scheduled, [
+			createRecordNode("act1", "task", [{ field: "title", value: "X" }]),
+		]);
+		expect(result.errors.some((e) => e.nodeId === "act1")).toBe(false);
+	});
+});

--- a/apps/web/src/app/(workspace)/automations/lib/validation.test.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/validation.test.ts
@@ -638,3 +638,89 @@ describe("validateWorkflowForSave — scheduled triggers have no record (A1)", (
 		expect(result.errors.some((e) => e.type === "no_trigger_record")).toBe(false);
 	});
 });
+
+describe("validateWorkflowForSave — update_fields (B2)", () => {
+	const clientTrigger: TriggerConfig = {
+		type: "record_created",
+		objectType: "client",
+	};
+
+	function updateFieldsNode(
+		id: string,
+		fields: Array<{ field: string; value: string | number | boolean | null }>
+	): WorkflowNode {
+		return {
+			id,
+			type: "action",
+			config: {
+				kind: "action",
+				action: {
+					type: "update_fields",
+					target: "self",
+					fields: fields.map(({ field, value }) => ({
+						field,
+						value: { kind: "static", value },
+					})),
+				},
+			},
+		};
+	}
+
+	it("accepts a multi-field update", () => {
+		const result = validateWorkflowForSave(clientTrigger, [
+			updateFieldsNode("act1", [
+				{ field: "notes", value: "swept" },
+				{ field: "status", value: "inactive" },
+			]),
+		]);
+		expect(result.errors.filter((e) => e.nodeId === "act1")).toHaveLength(0);
+	});
+
+	it("rejects a duplicated field", () => {
+		const result = validateWorkflowForSave(clientTrigger, [
+			updateFieldsNode("act1", [
+				{ field: "notes", value: "a" },
+				{ field: "notes", value: "b" },
+			]),
+		]);
+		expect(
+			result.errors.some(
+				(e) => e.nodeId === "act1" && /more than once/i.test(e.message)
+			)
+		).toBe(true);
+	});
+
+	it("rejects an empty row list", () => {
+		const result = validateWorkflowForSave(clientTrigger, [
+			updateFieldsNode("act1", []),
+		]);
+		expect(
+			result.errors.some(
+				(e) => e.nodeId === "act1" && /at least one field/i.test(e.message)
+			)
+		).toBe(true);
+	});
+
+	it("rejects an empty value on a non-boolean row", () => {
+		const result = validateWorkflowForSave(clientTrigger, [
+			updateFieldsNode("act1", [{ field: "notes", value: null }]),
+		]);
+		expect(
+			result.errors.some(
+				(e) => e.nodeId === "act1" && /set a value/i.test(e.message)
+			)
+		).toBe(true);
+	});
+
+	it("rejects a top-level update_fields on a scheduled trigger", () => {
+		const scheduled: TriggerConfig = {
+			type: "scheduled",
+			schedule: { frequency: "daily", timezone: "UTC", time: "09:00" },
+		};
+		const result = validateWorkflowForSave(scheduled, [
+			updateFieldsNode("act1", [{ field: "notes", value: "x" }]),
+		]);
+		const error = result.errors.find((e) => e.nodeId === "act1");
+		expect(error?.type).toBe("no_trigger_record");
+	});
+});

--- a/apps/web/src/app/(workspace)/automations/lib/validation.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/validation.ts
@@ -220,6 +220,11 @@ function validateActionNode(
 	// The object type `target: "self"` resolves to at this node — the loop item
 	// inside a loop body, else the trigger record (see getScopeObjectType).
 	scopeObjectType: AutomationObjectType | null,
+	// True for a scheduled trigger outside a loop — the one null-scope case that
+	// deserves the "runs on a schedule" guidance. The others (no trigger, record
+	// trigger without an object type, unconfigured fetch feeding a loop) are
+	// already flagged at their own source.
+	scheduledTopLevel: boolean,
 	errors: ValidationResult["errors"]
 ): void {
 	if (!config) {
@@ -236,14 +241,16 @@ function validateActionNode(
 	switch (action.type) {
 		case "update_field": {
 			if (!scopeObjectType) {
-				// Reached on a scheduled automation outside a loop — the trigger is
-				// fine, there is simply no record for the action to touch.
-				errors.push({
-					type: "no_trigger_record",
-					message:
-						"This automation runs on a schedule, so there is no record to update. Add a Find records step and move this action inside a Loop.",
-					nodeId,
-				});
+				if (scheduledTopLevel) {
+					// The trigger is fine — there is simply no record for the action
+					// to touch.
+					errors.push({
+						type: "no_trigger_record",
+						message:
+							"This automation runs on a schedule, so there is no record to update. Add a Find records step and move this action inside a Loop.",
+						nodeId,
+					});
+				}
 				return;
 			}
 
@@ -274,12 +281,14 @@ function validateActionNode(
 		}
 		case "update_fields": {
 			if (!scopeObjectType) {
-				errors.push({
-					type: "no_trigger_record",
-					message:
-						"This automation runs on a schedule, so there is no record to update. Add a Find records step and move this action inside a Loop.",
-					nodeId,
-				});
+				if (scheduledTopLevel) {
+					errors.push({
+						type: "no_trigger_record",
+						message:
+							"This automation runs on a schedule, so there is no record to update. Add a Find records step and move this action inside a Loop.",
+						nodeId,
+					});
+				}
 				return;
 			}
 
@@ -844,14 +853,17 @@ export function validateWorkflowForSave(
 				);
 				break;
 			}
-			case "action":
+			case "action": {
+				const scope = getScopeObjectType(workflowNodes, node.id, objectType);
 				validateActionNode(
 					node.id,
 					config as ActionNodeConfig | undefined,
-					getScopeObjectType(workflowNodes, node.id, objectType).objectType,
+					scope.objectType,
+					trigger?.type === "scheduled" && !scope.inLoop,
 					errors
 				);
 				break;
+			}
 			case "fetch_records":
 				validateFetchNode(
 					node.id,

--- a/apps/web/src/app/(workspace)/automations/lib/validation.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/validation.ts
@@ -21,8 +21,12 @@ import {
 	MAX_FETCH_LIMIT,
 	MAX_LOOP_ITERATIONS,
 	VALUELESS_OPERATORS,
+	RELATION_FIELD,
+	getCreatableFields,
 	getFieldDefinition,
+	getRequiredCreateFields,
 	getWritableFields,
+	isCreatableObjectType,
 	operatorsForField,
 	validateSchedule,
 	type ActionNodeConfig,
@@ -337,6 +341,98 @@ function validateActionNode(
 					});
 					return;
 				}
+			}
+			break;
+		}
+		case "create_record": {
+			const objectType = action.objectType;
+			if (!isCreatableObjectType(objectType)) {
+				errors.push({
+					type: "missing_required_config",
+					message: `Creating ${objectType} records from automations isn't supported yet`,
+					nodeId,
+				});
+				return;
+			}
+
+			// linkToScope needs a record in scope; on a scheduled top-level step
+			// there is none.
+			if (action.linkToScope && !scopeObjectType) {
+				if (scheduledTopLevel) {
+					errors.push({
+						type: "no_trigger_record",
+						message: `This automation runs on a schedule, so there is no record to link this new ${objectType} to. Turn off "Link to record", or move this inside a Loop.`,
+						nodeId,
+					});
+					return;
+				}
+			}
+
+			const creatable = getCreatableFields(objectType);
+			const requiredKeys = new Set(
+				getRequiredCreateFields(objectType).map((f) => f.key)
+			);
+			const linkFk =
+				action.linkToScope && scopeObjectType
+					? RELATION_FIELD[objectType]?.[scopeObjectType]
+					: undefined;
+			if (action.linkToScope && scopeObjectType && !linkFk) {
+				errors.push({
+					type: "missing_required_config",
+					message: `A new ${objectType} can't be linked to a ${scopeObjectType}`,
+					nodeId,
+				});
+				return;
+			}
+
+			const seen = new Set<string>();
+			for (const row of action.fields) {
+				if (row.field && seen.has(row.field)) {
+					errors.push({
+						type: "missing_required_config",
+						message: `Field "${row.field}" appears more than once — remove one of the rows`,
+						nodeId,
+					});
+					return;
+				}
+				if (row.field) seen.add(row.field);
+
+				const field = creatable.find((f) => f.key === row.field);
+				if (!field) {
+					errors.push({
+						type: "missing_required_config",
+						message: "Choose a field to set",
+						nodeId,
+					});
+					return;
+				}
+
+				const isEmpty =
+					row.value.kind === "static" &&
+					(row.value.value === null || row.value.value === "");
+				if (field.type !== "boolean" && isEmpty) {
+					errors.push({
+						type: "missing_required_config",
+						message: `Set a value for ${field.label}`,
+						nodeId,
+					});
+					return;
+				}
+			}
+
+			// Required fields must be supplied as a row or via the scope link.
+			for (const key of requiredKeys) {
+				if (action.fields.some((r) => r.field === key)) continue;
+				if (linkFk === key) continue;
+				// An unresolved link (scope type unknown) may still fill it — defer.
+				if (action.linkToScope && !scopeObjectType) continue;
+				const def = creatable.find((f) => f.key === key);
+				errors.push({
+					type: "missing_required_config",
+					message: `${def?.label ?? key} is required to create a ${objectType}`,
+					nodeId,
+				});
+				return;
 			}
 			break;
 		}

--- a/apps/web/src/app/(workspace)/automations/lib/validation.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/validation.ts
@@ -333,7 +333,7 @@ function validateActionNode(
 				const isEmpty =
 					row.value.kind === "static" &&
 					(row.value.value === null || row.value.value === "");
-				if (field.type !== "boolean" && isEmpty) {
+				if (isEmpty) {
 					errors.push({
 						type: "missing_required_config",
 						message: `Set a value for ${field.label}`,
@@ -410,7 +410,7 @@ function validateActionNode(
 				const isEmpty =
 					row.value.kind === "static" &&
 					(row.value.value === null || row.value.value === "");
-				if (field.type !== "boolean" && isEmpty) {
+				if (isEmpty) {
 					errors.push({
 						type: "missing_required_config",
 						message: `Set a value for ${field.label}`,

--- a/apps/web/src/app/(workspace)/automations/lib/validation.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/validation.ts
@@ -272,6 +272,65 @@ function validateActionNode(
 			}
 			break;
 		}
+		case "update_fields": {
+			if (!scopeObjectType) {
+				errors.push({
+					type: "no_trigger_record",
+					message:
+						"This automation runs on a schedule, so there is no record to update. Add a Find records step and move this action inside a Loop.",
+					nodeId,
+				});
+				return;
+			}
+
+			if (action.fields.length === 0) {
+				errors.push({
+					type: "missing_required_config",
+					message: "Add at least one field to update",
+					nodeId,
+				});
+				return;
+			}
+
+			const targetObjectType: AutomationObjectType =
+				action.target === "self" ? scopeObjectType : action.target.related;
+			const writable = getWritableFields(targetObjectType);
+			const seen = new Set<string>();
+			for (const row of action.fields) {
+				if (row.field && seen.has(row.field)) {
+					errors.push({
+						type: "missing_required_config",
+						message: `Field "${row.field}" appears more than once — remove one of the rows`,
+						nodeId,
+					});
+					return;
+				}
+				if (row.field) seen.add(row.field);
+
+				const field = writable.find((f) => f.key === row.field);
+				if (!field) {
+					errors.push({
+						type: "missing_required_config",
+						message: "Choose a field to update",
+						nodeId,
+					});
+					return;
+				}
+
+				const isEmpty =
+					row.value.kind === "static" &&
+					(row.value.value === null || row.value.value === "");
+				if (field.type !== "boolean" && isEmpty) {
+					errors.push({
+						type: "missing_required_config",
+						message: `Set a value for ${field.label}`,
+						nodeId,
+					});
+					return;
+				}
+			}
+			break;
+		}
 		case "create_task": {
 			const title = action.title;
 			const titleEmpty =

--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -4360,4 +4360,362 @@ describe("automationExecutor (v2 engine)", () => {
 			expect(client?.notes).toBeUndefined();
 		});
 	});
+
+	describe("create_record — generic record creation (Phase B1)", () => {
+		function createRecordActionNode(
+			id: string,
+			opts: {
+				objectType: "client" | "project" | "quote" | "invoice" | "task";
+				fields?: Array<{
+					field: string;
+					value:
+						| { kind: "static"; value: string | number | boolean | null }
+						| { kind: "var"; path: string };
+				}>;
+				linkToScope?: boolean;
+				nextNodeId?: string;
+			}
+		) {
+			return {
+				id,
+				type: "action" as const,
+				config: {
+					kind: "action" as const,
+					action: {
+						type: "create_record" as const,
+						objectType: opts.objectType,
+						fields: opts.fields ?? [],
+						linkToScope: opts.linkToScope,
+					},
+				},
+				nextNodeId: opts.nextNodeId,
+			};
+		}
+
+		async function makeOrgPremium(orgId: Id<"organizations">) {
+			await t.run(async (ctx) =>
+				ctx.db.patch(orgId, {
+					clerkPlanSlug: "onetool_business_plan_org",
+					subscriptionStatus: "active",
+				})
+			);
+		}
+
+		async function runScheduledOnce(automationId: Id<"workflowAutomations">) {
+			await t.run(async (ctx) =>
+				ctx.db.patch(automationId, { nextRunAt: Date.now() - 1000 })
+			);
+			await t.mutation(
+				internal.automationExecutor.dispatchScheduledAutomations,
+				{}
+			);
+			await t.finishAllScheduledFunctions(vi.runAllTimers);
+		}
+
+		it("creates a project linked to the scope client, with defaults, activity, aggregate, and a record_created emit", async () => {
+			const { asUser, orgId } = await setupUser();
+
+			await asUser.mutation(api.automations.create, {
+				name: "Onboard project",
+				trigger: { type: "record_created", objectType: "client" },
+				nodes: [
+					createRecordActionNode("act-1", {
+						objectType: "project",
+						linkToScope: true,
+						fields: [
+							{ field: "title", value: { kind: "static", value: "Onboarding" } },
+						],
+					}),
+				],
+				isActive: true,
+			});
+
+			const clientId = await asUser.mutation(api.clients.create, {
+				portalAccessId: crypto.randomUUID(),
+				companyName: "Acme Co",
+				status: "active",
+			});
+
+			await drainEvents();
+
+			const projects = await t.run(async (ctx) =>
+				ctx.db.query("projects").collect()
+			);
+			expect(projects).toHaveLength(1);
+			const project = projects[0];
+			expect(project.clientId).toBe(clientId);
+			expect(project.title).toBe("Onboarding");
+			expect(project.status).toBe("planned");
+			expect(project.projectType).toBe("one-off");
+			expect(project.orgId).toBe(orgId);
+
+			// Aggregate kept in sync: the new planned project is counted.
+			const count = await t.run(async (ctx) =>
+				projectCountsAggregate.count(ctx, {
+					namespace: orgId,
+					bounds: {
+						lower: { key: ["planned", 0], inclusive: true },
+						upper: {
+							key: ["planned", Number.MAX_SAFE_INTEGER],
+							inclusive: true,
+						},
+					},
+				})
+			);
+			expect(count).toBe(1);
+
+			// Activity logged.
+			const activities = await t.run(async (ctx) =>
+				ctx.db.query("activities").collect()
+			);
+			expect(
+				activities.some(
+					(a) => a.activityType === "project_created" && a.entityId === project._id
+				)
+			).toBe(true);
+
+			// record_created emitted for the new project so cascades can fire.
+			const events = await t.run(async (ctx) =>
+				ctx.db.query("domainEvents").collect()
+			);
+			expect(
+				events.some(
+					(e) =>
+						e.eventType === "entity.record_created" &&
+						e.payload.entityType === "project" &&
+						e.payload.entityId === project._id
+				)
+			).toBe(true);
+		});
+
+		it("creates an unlinked task at a scheduled top-level, defaulting type/status/date", async () => {
+			const { asUser, orgId } = await setupUser();
+			await makeOrgPremium(orgId);
+
+			const automationId = await asUser.mutation(api.automations.create, {
+				name: "Daily task",
+				trigger: {
+					type: "scheduled",
+					schedule: { frequency: "daily", timezone: "UTC", time: "09:00" },
+				},
+				nodes: [
+					createRecordActionNode("act-1", {
+						objectType: "task",
+						fields: [
+							{ field: "title", value: { kind: "static", value: "Standup" } },
+						],
+					}),
+				],
+				isActive: true,
+			});
+
+			await runScheduledOnce(automationId);
+
+			const tasks = await t.run(async (ctx) => ctx.db.query("tasks").collect());
+			expect(tasks).toHaveLength(1);
+			const task = tasks[0];
+			expect(task.title).toBe("Standup");
+			expect(task.type).toBe("internal");
+			expect(task.status).toBe("pending");
+			expect(task.clientId).toBeUndefined();
+			expect(task.date % 86_400_000).toBe(0);
+
+			const executions = await t.run(async (ctx) =>
+				ctx.db.query("workflowExecutions").collect()
+			);
+			expect(executions).toHaveLength(1);
+			expect(executions[0].status).toBe("completed");
+		});
+
+		it("enforces the free-plan client cap: an 11th create_record client fails without inserting", async () => {
+			const { asUser } = await setupUser(); // free org (no premium)
+
+			// Ten clients already exist.
+			for (let i = 0; i < 10; i++) {
+				await asUser.mutation(api.clients.create, {
+					portalAccessId: crypto.randomUUID(),
+					companyName: `Client ${i}`,
+					status: "active",
+				});
+			}
+			const anchorClient = await t.run(async (ctx) => {
+				const rows = await ctx.db.query("clients").collect();
+				return rows[0]._id;
+			});
+
+			await asUser.mutation(api.automations.create, {
+				name: "Overflow client",
+				trigger: { type: "record_created", objectType: "project" },
+				nodes: [
+					createRecordActionNode("act-1", {
+						objectType: "client",
+						fields: [
+							{
+								field: "companyName",
+								value: { kind: "static", value: "Eleventh" },
+							},
+						],
+					}),
+				],
+				isActive: true,
+			});
+
+			// Firing a project create drives the automation.
+			await asUser.mutation(api.projects.create, {
+				clientId: anchorClient,
+				title: "Trigger",
+				status: "planned",
+				projectType: "one-off",
+			});
+			await drainEvents();
+
+			const clients = await t.run(async (ctx) =>
+				ctx.db.query("clients").collect()
+			);
+			expect(clients).toHaveLength(10); // no 11th
+			expect(clients.some((c) => c.companyName === "Eleventh")).toBe(false);
+
+			const executions = await t.run(async (ctx) =>
+				ctx.db.query("workflowExecutions").collect()
+			);
+			expect(executions).toHaveLength(1);
+			expect(executions[0].status).toBe("failed");
+			expect(executions[0].error ?? "").toMatch(/limit|plan|upgrade/i);
+		});
+
+		it("rejects a cross-tenant FK: a supplied clientId from another org is not found", async () => {
+			const { asUser } = await setupUser();
+			const other = await setupUser({
+				clerkUserId: "user-other",
+				clerkOrgId: "org-other",
+			});
+			const foreignClient = await other.asUser.mutation(api.clients.create, {
+				portalAccessId: crypto.randomUUID(),
+				companyName: "Foreign Co",
+				status: "active",
+			});
+
+			const anchorClient = await asUser.mutation(api.clients.create, {
+				portalAccessId: crypto.randomUUID(),
+				companyName: "Home Co",
+				status: "active",
+			});
+
+			await asUser.mutation(api.automations.create, {
+				name: "Bad FK task",
+				trigger: { type: "record_created", objectType: "project" },
+				nodes: [
+					createRecordActionNode("act-1", {
+						objectType: "task",
+						fields: [
+							{ field: "title", value: { kind: "static", value: "T" } },
+							{
+								field: "clientId",
+								value: { kind: "static", value: foreignClient },
+							},
+						],
+					}),
+				],
+				isActive: true,
+			});
+
+			await asUser.mutation(api.projects.create, {
+				clientId: anchorClient,
+				title: "Trigger",
+				status: "planned",
+				projectType: "one-off",
+			});
+			await drainEvents();
+
+			const tasks = await t.run(async (ctx) => ctx.db.query("tasks").collect());
+			expect(tasks).toHaveLength(0);
+
+			const executions = await t.run(async (ctx) =>
+				ctx.db.query("workflowExecutions").collect()
+			);
+			expect(executions[0].status).toBe("failed");
+			expect(executions[0].error ?? "").toMatch(/client.*not found/i);
+		});
+
+		it("publish validation rejects a project create missing its required client", async () => {
+			const { asUser } = await setupUser();
+			await expect(
+				asUser.mutation(api.automations.create, {
+					name: "Bad project create",
+					trigger: { type: "record_created", objectType: "task" },
+					nodes: [
+						createRecordActionNode("act-1", {
+							objectType: "project",
+							fields: [
+								{ field: "title", value: { kind: "static", value: "X" } },
+							],
+						}),
+					],
+					isActive: true,
+				})
+			).rejects.toThrow(/client is required/i);
+		});
+
+		it("publish validation rejects creating a non-creatable object type (quote)", async () => {
+			const { asUser } = await setupUser();
+			await expect(
+				asUser.mutation(api.automations.create, {
+					name: "Bad quote create",
+					trigger: { type: "record_created", objectType: "task" },
+					nodes: [
+						createRecordActionNode("act-1", {
+							objectType: "quote",
+							fields: [
+								{ field: "title", value: { kind: "static", value: "X" } },
+							],
+						}),
+					],
+					isActive: true,
+				})
+			).rejects.toThrow(/isn't supported/i);
+		});
+
+		it("publish validation rejects a non-creatable field and an invalid select option", async () => {
+			const { asUser } = await setupUser();
+			await expect(
+				asUser.mutation(api.automations.create, {
+					name: "Bad field",
+					trigger: { type: "record_created", objectType: "task" },
+					nodes: [
+						createRecordActionNode("act-1", {
+							objectType: "task",
+							fields: [
+								{ field: "title", value: { kind: "static", value: "X" } },
+								{
+									field: "completedAt",
+									value: { kind: "static", value: 0 },
+								},
+							],
+						}),
+					],
+					isActive: true,
+				})
+			).rejects.toThrow(/completedAt.*can't be set/i);
+
+			await expect(
+				asUser.mutation(api.automations.create, {
+					name: "Bad status",
+					trigger: { type: "record_created", objectType: "task" },
+					nodes: [
+						createRecordActionNode("act-1", {
+							objectType: "task",
+							fields: [
+								{ field: "title", value: { kind: "static", value: "X" } },
+								{
+									field: "status",
+									value: { kind: "static", value: "nonsense" },
+								},
+							],
+						}),
+					],
+					isActive: true,
+				})
+			).rejects.toThrow(/not a valid value/i);
+		});
+	});
 });

--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -1074,6 +1074,278 @@ describe("automationExecutor (v2 engine)", () => {
 		});
 	});
 
+	describe("update_fields — multi-field update (Phase B2)", () => {
+		function updateFieldsActionNode(
+			id: string,
+			fields: Array<{ field: string; value: string | number | boolean }>,
+			opts: { nextNodeId?: string } = {}
+		) {
+			return {
+				id,
+				type: "action" as const,
+				config: {
+					kind: "action" as const,
+					action: {
+						type: "update_fields" as const,
+						target: "self" as const,
+						fields: fields.map(({ field, value }) => ({
+							field,
+							value: { kind: "static" as const, value },
+						})),
+					},
+				},
+				nextNodeId: opts.nextNodeId,
+			};
+		}
+
+		async function makeProject(asUser: ReturnType<typeof t.withIdentity>) {
+			const clientId = await asUser.mutation(api.clients.create, {
+				portalAccessId: crypto.randomUUID(),
+				companyName: "Acme Co",
+				status: "active",
+			});
+			return await asUser.mutation(api.projects.create, {
+				clientId,
+				title: "Kitchen remodel",
+				status: "planned",
+				projectType: "one-off",
+			});
+		}
+
+		async function recordUpdatedCascades() {
+			return await t.run(async (ctx) =>
+				ctx.db
+					.query("domainEvents")
+					.filter((q) =>
+						q.and(
+							q.eq(q.field("eventType"), "entity.record_updated"),
+							q.eq(
+								q.field("eventSource"),
+								"automationExecutor.executeActionNodeV2"
+							)
+						)
+					)
+					.collect()
+			);
+		}
+
+		it("writes every field in one action; a chained automation watching one of them fires exactly once", async () => {
+			const { asUser } = await setupUser();
+			const startDate = Date.UTC(2026, 6, 20);
+
+			await asUser.mutation(api.automations.create, {
+				name: "A — stamp description and start date",
+				trigger: { type: "record_created", objectType: "project" },
+				nodes: [
+					updateFieldsActionNode("act-1", [
+						{ field: "description", value: "Multi ran" },
+						{ field: "startDate", value: startDate },
+					]),
+				],
+				isActive: true,
+			});
+
+			await asUser.mutation(api.automations.create, {
+				name: "B — react to the start date",
+				trigger: {
+					type: "record_updated",
+					objectType: "project",
+					fields: ["startDate"],
+				},
+				nodes: [updateFieldActionNode("act-1", "title", "B ran")],
+				isActive: true,
+			});
+
+			const projectId = await makeProject(asUser);
+			await drainEvents();
+
+			const project = await t.run(async (ctx) => ctx.db.get(projectId));
+			expect(project?.description).toBe("Multi ran");
+			expect(project?.startDate).toBe(startDate);
+			// B saw A's one emit and ran exactly once.
+			expect(project?.title).toBe("B ran");
+
+			const executions = await t.run(async (ctx) =>
+				ctx.db.query("workflowExecutions").collect()
+			);
+			expect(executions).toHaveLength(2);
+			expect(executions.every((e) => e.status === "completed")).toBe(true);
+
+			const cascadeEvents = await recordUpdatedCascades();
+			const multi = cascadeEvents.find(
+				(e) =>
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					((e.payload.metadata as any)?.changedFields ?? []).length === 2
+			);
+			expect(multi).toBeDefined();
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			expect((multi?.payload.metadata as any)?.changedFields).toEqual([
+				"description",
+				"startDate",
+			]);
+			// With more than one changed field there is no single field to name.
+			expect(multi?.payload.field).toBeUndefined();
+		});
+
+		it("a status row cascades once and the rest emit one record_updated", async () => {
+			const { asUser, orgId } = await setupUser();
+
+			await asUser.mutation(api.automations.create, {
+				name: "Complete and describe",
+				trigger: { type: "record_created", objectType: "project" },
+				nodes: [
+					updateFieldsActionNode("act-1", [
+						{ field: "status", value: "completed" },
+						{ field: "description", value: "done" },
+					]),
+				],
+				isActive: true,
+			});
+
+			const projectId = await makeProject(asUser);
+			await drainEvents();
+
+			const project = await t.run(async (ctx) => ctx.db.get(projectId));
+			expect(project?.status).toBe("completed");
+			expect(project?.description).toBe("done");
+			expect(project?.completedAt).toBeDefined();
+
+			const statusEvents = await t.run(async (ctx) =>
+				ctx.db
+					.query("domainEvents")
+					.filter((q) => q.eq(q.field("eventType"), "entity.status_changed"))
+					.collect()
+			);
+			const projectStatus = statusEvents.filter(
+				(e) => e.payload.entityId === projectId
+			);
+			expect(projectStatus).toHaveLength(1);
+			expect(projectStatus[0].payload.oldValue).toBe("planned");
+			expect(projectStatus[0].payload.newValue).toBe("completed");
+
+			const updatedEvents = await recordUpdatedCascades();
+			expect(updatedEvents).toHaveLength(1);
+			// Status rides its own status_changed event, never record_updated.
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			expect((updatedEvents[0].payload.metadata as any)?.changedFields).toEqual([
+				"description",
+			]);
+
+			// Aggregate replace fired: the project now counts as "completed".
+			const completedCount = await t.run(async (ctx) =>
+				projectCountsAggregate.count(ctx, {
+					namespace: orgId,
+					bounds: {
+						lower: { key: ["completed", 0], inclusive: true },
+						upper: {
+							key: ["completed", Number.MAX_SAFE_INTEGER],
+							inclusive: true,
+						},
+					},
+				})
+			);
+			expect(completedCount).toBe(1);
+		});
+
+		it("a bad row fails the whole action before anything is written", async () => {
+			const { asUser } = await setupUser();
+
+			await asUser.mutation(api.automations.create, {
+				name: "Good field, bad date",
+				trigger: { type: "record_created", objectType: "project" },
+				nodes: [
+					updateFieldsActionNode("act-1", [
+						{ field: "description", value: "should not land" },
+						{ field: "endDate", value: "not-a-date" },
+					]),
+				],
+				isActive: true,
+			});
+
+			const projectId = await makeProject(asUser);
+			await drainEvents();
+
+			// Rows validate before the first write — the good row must not land.
+			const project = await t.run(async (ctx) => ctx.db.get(projectId));
+			expect(project?.description).toBeUndefined();
+			expect(project?.endDate).toBeUndefined();
+
+			const executions = await t.run(async (ctx) =>
+				ctx.db.query("workflowExecutions").collect()
+			);
+			expect(executions).toHaveLength(1);
+			expect(executions[0].status).toBe("failed");
+			expect(executions[0].error).toMatch(/not a valid date/i);
+
+			const cascadeEvents = await recordUpdatedCascades();
+			expect(cascadeEvents).toHaveLength(0);
+		});
+
+		it("a one-row update_fields emits the legacy single-field event shape", async () => {
+			const { asUser } = await setupUser();
+
+			await asUser.mutation(api.automations.create, {
+				name: "One row",
+				trigger: { type: "record_created", objectType: "client" },
+				nodes: [
+					updateFieldsActionNode("act-1", [{ field: "notes", value: "hello" }]),
+				],
+				isActive: true,
+			});
+
+			await asUser.mutation(api.clients.create, {
+				portalAccessId: crypto.randomUUID(),
+				companyName: "Acme Co",
+				status: "lead",
+			});
+			await drainEvents();
+
+			const cascadeEvents = await recordUpdatedCascades();
+			expect(cascadeEvents).toHaveLength(1);
+			expect(cascadeEvents[0].payload.field).toBe("notes");
+			expect(cascadeEvents[0].payload.oldValue).toBeUndefined();
+			expect(cascadeEvents[0].payload.newValue).toBe("hello");
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			expect((cascadeEvents[0].payload.metadata as any)?.changedFields).toEqual([
+				"notes",
+			]);
+		});
+
+		it("rows whose value already matches are left out of the emit", async () => {
+			const { asUser } = await setupUser();
+
+			await asUser.mutation(api.automations.create, {
+				name: "Half no-op",
+				trigger: { type: "record_created", objectType: "client" },
+				nodes: [
+					updateFieldsActionNode("act-1", [
+						{ field: "notes", value: "Preset note" },
+						{ field: "companyDescription", value: "fresh" },
+					]),
+				],
+				isActive: true,
+			});
+
+			await asUser.mutation(api.clients.create, {
+				portalAccessId: crypto.randomUUID(),
+				companyName: "Acme Co",
+				status: "lead",
+				notes: "Preset note",
+			});
+			await drainEvents();
+
+			const cascadeEvents = await recordUpdatedCascades();
+			expect(cascadeEvents).toHaveLength(1);
+			// Only the real change is announced — and with exactly one change the
+			// event names it, same as a single-field write.
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			expect((cascadeEvents[0].payload.metadata as any)?.changedFields).toEqual([
+				"companyDescription",
+			]);
+			expect(cascadeEvents[0].payload.field).toBe("companyDescription");
+		});
+	});
+
 	describe("date writes are normalized to the calendar-date encoding", () => {
 		it("stores an instant written into a date field as UTC midnight", async () => {
 			const { asUser } = await setupUser();

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -24,8 +24,11 @@ import {
 import { calendarDayEpoch, toEpochMs } from "./lib/formula";
 import {
 	RELATION_FIELD,
+	getCreatableFields,
 	getFieldDefinition,
+	getRequiredCreateFields,
 	getStatusOptions,
+	isCreatableObjectType,
 	type FieldDefinition,
 } from "./lib/fieldRegistry";
 import {
@@ -2698,6 +2701,8 @@ async function executeActionNodeV2(
 			);
 		case "create_task":
 			return executeCreateTaskAction(ctx, action, scopeRecord, env);
+		case "create_record":
+			return executeCreateRecordAction(ctx, action, scopeRecord, env);
 		case "send_notification":
 			return executeSendNotificationAction(ctx, action, scopeRecord, env);
 		case "send_team_message":
@@ -3176,6 +3181,348 @@ async function resolveTaskLink(
 	}
 
 	return { projectId, clientId };
+}
+
+// ---------------------------------------------------------------------------
+// create_record: generic record creation (client / project / task)
+// ---------------------------------------------------------------------------
+
+/**
+ * Free-plan ceilings, mirrored from apps/web/src/lib/plan-limits.ts (the values
+ * live only in the web app — the backend never enforced them). A create_record
+ * on a free org honors the same caps the UI shows so an automation can't be a
+ * back door around them.
+ */
+const FREE_MAX_CLIENTS = 10;
+const FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT = 3;
+
+/**
+ * Resolve a supplied FK value on a create_record field against the org. The
+ * executor runs unscoped, so an arbitrary id string must be checked before it
+ * becomes a stored relationship (cross-tenant or garbage ids are rejected).
+ */
+async function resolveCreateFk(
+	ctx: MutationCtx,
+	refType: NonNullable<FieldDefinition["refType"]>,
+	rawId: unknown,
+	orgId: Id<"organizations">
+): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+	const raw = String(rawId);
+	const table =
+		refType === "user" ? "users" : refType === "client" ? "clients" : "projects";
+	const normalized = ctx.db.normalizeId(table, raw);
+	if (!normalized) {
+		return { ok: false, error: `Referenced ${refType} is not a valid id` };
+	}
+	if (refType === "user") {
+		const membership = await getMembership(
+			ctx,
+			normalized as Id<"users">,
+			orgId
+		);
+		if (!membership) {
+			return {
+				ok: false,
+				error: "Assignee is not a member of this organization",
+			};
+		}
+		return { ok: true, id: normalized };
+	}
+	const doc = await ctx.db.get(normalized as Id<"clients"> | Id<"projects">);
+	if (!doc || doc.orgId !== orgId) {
+		return { ok: false, error: `Referenced ${refType} was not found` };
+	}
+	return { ok: true, id: normalized };
+}
+
+/**
+ * Schema-required fields that have a sensible code default (so they are NOT
+ * requiredOnCreate). Applied only when the user didn't supply the field.
+ */
+function applyCreateDefaults(
+	objectType: AutomationObjectType,
+	payload: Record<string, unknown>,
+	supplied: Set<string>,
+	tz: string
+): void {
+	const setDefault = (key: string, value: unknown) => {
+		if (!supplied.has(key)) {
+			payload[key] = value;
+			supplied.add(key);
+		}
+	};
+	switch (objectType) {
+		case "client":
+			setDefault("status", "lead");
+			break;
+		case "project":
+			setDefault("status", "planned");
+			setDefault("projectType", "one-off");
+			break;
+		case "task":
+			setDefault("status", "pending");
+			setDefault("type", "internal");
+			setDefault("date", calendarDayEpoch(Date.now(), tz));
+			break;
+	}
+}
+
+/**
+ * Free-plan cap check for a create_record. Returns an error string when the
+ * insert would exceed a ceiling, or null when it's allowed. Reads only.
+ */
+async function checkCreateRecordPlanCap(
+	ctx: MutationCtx,
+	objectType: AutomationObjectType,
+	payload: Record<string, unknown>,
+	orgId: Id<"organizations">
+): Promise<string | null> {
+	if (objectType === "client") {
+		const clients = await ctx.db
+			.query("clients")
+			.withIndex("by_org", (q) => q.eq("orgId", orgId))
+			.collect();
+		const active = clients.filter((c) => c.status !== "archived").length;
+		if (active >= FREE_MAX_CLIENTS) {
+			return `Your plan is limited to ${FREE_MAX_CLIENTS} clients — upgrade to add more.`;
+		}
+	}
+	if (objectType === "project") {
+		const clientId = payload.clientId as Id<"clients"> | undefined;
+		if (clientId) {
+			const projects = await ctx.db
+				.query("projects")
+				.withIndex("by_client", (q) => q.eq("clientId", clientId))
+				.collect();
+			const active = projects.filter(
+				(p) => p.status === "planned" || p.status === "in-progress"
+			).length;
+			if (active >= FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT) {
+				return `Your plan allows ${FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT} active projects per client — upgrade to add more.`;
+			}
+		}
+	}
+	return null;
+}
+
+/**
+ * Validate + assemble the insert payload for a create_record action. Shared by
+ * the real executor and the dry mirror, so a test run surfaces the exact same
+ * failures (missing required field, bad FK, unsupported field) the run would.
+ * Reads only — never writes. `orgId` is included; `portalAccessId` is added at
+ * insert time (it's generated, not a user field).
+ */
+async function buildCreateRecordPayload(
+	ctx: MutationCtx,
+	action: Extract<AutomationAction, { type: "create_record" }>,
+	scopeRecord: ScopeRecord | undefined,
+	env: { orgId: Id<"organizations">; scope: VariableScope }
+): Promise<
+	| { ok: true; payload: Record<string, unknown> }
+	| { ok: false; error: string }
+> {
+	const objectType = action.objectType;
+	const tz = env.scope.workflow?.tz ?? "UTC";
+	const payload: Record<string, unknown> = { orgId: env.orgId };
+	const supplied = new Set<string>();
+
+	// linkToScope: set the new record's FK to the record in scope via the
+	// registry relation map (e.g. a project created off a client gets clientId).
+	let linkedFk: string | undefined;
+	if (action.linkToScope) {
+		if (!scopeRecord) {
+			return {
+				ok: false,
+				error: `There is no record in scope to link this new ${objectType} to`,
+			};
+		}
+		linkedFk = RELATION_FIELD[objectType]?.[scopeRecord.type];
+		if (!linkedFk) {
+			return {
+				ok: false,
+				error: `A new ${objectType} can't be linked to a ${scopeRecord.type}`,
+			};
+		}
+		payload[linkedFk] = scopeRecord.id;
+		supplied.add(linkedFk);
+	}
+
+	const seen = new Set<string>();
+	for (const { field, value } of action.fields) {
+		if (seen.has(field)) {
+			return { ok: false, error: `Field "${field}" appears more than once` };
+		}
+		seen.add(field);
+		if (field === linkedFk) {
+			return {
+				ok: false,
+				error: `Field "${field}" is already set by linking to the record in scope`,
+			};
+		}
+		const def = getFieldDefinition(objectType, field);
+		if (!def || !def.creatable) {
+			return {
+				ok: false,
+				error: `Field "${field}" can't be set when creating a ${objectType}`,
+			};
+		}
+		const raw = resolveValueRef(value, env.scope);
+		const coerced = coerceFieldValue(def, raw, tz);
+		if (!coerced.ok) {
+			return { ok: false, error: coerced.error };
+		}
+		// null means "resolved to nothing" — leave it out so requiredOnCreate and
+		// defaults still apply (a supplied-but-empty row shouldn't defeat them).
+		if (coerced.value === null) continue;
+		if (def.refType) {
+			const fk = await resolveCreateFk(ctx, def.refType, coerced.value, env.orgId);
+			if (!fk.ok) return { ok: false, error: fk.error };
+			payload[field] = fk.id;
+		} else {
+			payload[field] = coerced.value;
+		}
+		supplied.add(field);
+	}
+
+	applyCreateDefaults(objectType, payload, supplied, tz);
+
+	for (const def of getRequiredCreateFields(objectType)) {
+		if (!supplied.has(def.key)) {
+			return {
+				ok: false,
+				error: `${def.label} is required to create a ${objectType}`,
+			};
+		}
+	}
+
+	// Domain rule mirrored from tasks.ts: an external task must name a client.
+	if (
+		objectType === "task" &&
+		payload.type === "external" &&
+		!payload.clientId
+	) {
+		return { ok: false, error: "External tasks require a client" };
+	}
+
+	return { ok: true, payload };
+}
+
+async function executeCreateRecordAction(
+	ctx: MutationCtx,
+	action: Extract<AutomationAction, { type: "create_record" }>,
+	scopeRecord: ScopeRecord | undefined,
+	env: WalkEnv
+): Promise<{ success: boolean; skipped?: boolean; error?: string }> {
+	const objectType = action.objectType;
+	if (!isCreatableObjectType(objectType)) {
+		return {
+			success: false,
+			error: `Creating ${objectType} records from automations isn't supported`,
+		};
+	}
+
+	const built = await buildCreateRecordPayload(ctx, action, scopeRecord, env);
+	if (!built.ok) return { success: false, error: built.error };
+	const { payload } = built;
+
+	const org = await ctx.db.get(env.orgId);
+	if (!orgHasPremiumPlan(org)) {
+		const capError = await checkCreateRecordPlanCap(
+			ctx,
+			objectType,
+			payload,
+			env.orgId
+		);
+		if (capError) return { success: false, error: capError };
+	}
+
+	try {
+		let newId: Id<"clients"> | Id<"projects"> | Id<"tasks">;
+		switch (objectType) {
+			case "client":
+				// Portal links need an access id; the create mutation takes a
+				// caller-supplied one for retry-determinism, harmless to mint here.
+				payload.portalAccessId = crypto.randomUUID();
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				newId = await ctx.db.insert("clients", payload as any);
+				break;
+			case "project":
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				newId = await ctx.db.insert("projects", payload as any);
+				break;
+			case "task":
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				newId = await ctx.db.insert("tasks", payload as any);
+				break;
+			default:
+				return {
+					success: false,
+					error: `Creating ${objectType} records from automations isn't supported`,
+				};
+		}
+
+		const doc = await ctx.db.get(newId);
+		if (doc) {
+			// Attribute the activity to the automation's creator — a scheduled (cron)
+			// run has no ambient authenticated user, so createActivity's default
+			// getCurrentUserOrThrow would throw and fail the create. If that creator
+			// has since left the org, fall back to the org owner.
+			const creatorId = env.automation.createdBy;
+			const creatorMembership = await getMembership(ctx, creatorId, env.orgId);
+			const actor = {
+				userId: creatorMembership ? creatorId : (org?.ownerUserId ?? creatorId),
+				orgId: env.orgId,
+			};
+			switch (objectType) {
+				case "client":
+					await ActivityHelpers.clientCreated(ctx, doc as Doc<"clients">, actor);
+					await AggregateHelpers.addClient(ctx, doc as Doc<"clients">);
+					break;
+				case "project":
+					await ActivityHelpers.projectCreated(
+						ctx,
+						doc as Doc<"projects">,
+						actor
+					);
+					await AggregateHelpers.addProject(ctx, doc as Doc<"projects">);
+					break;
+				case "task":
+					// Tasks have no aggregate.
+					await ActivityHelpers.taskCreated(ctx, doc as Doc<"tasks">, actor);
+					break;
+			}
+
+			// Emit record_created with the execution chain in metadata so cascading
+			// automations keep recursion protection (mirrors executeCreateTaskAction).
+			await ctx.db.insert("domainEvents", {
+				orgId: env.orgId,
+				eventType: "entity.record_created",
+				eventSource: "automationExecutor.executeCreateRecordAction",
+				payload: {
+					entityType: objectType,
+					entityId: newId,
+					metadata: {
+						executionChain: env.executionChain,
+						recursionDepth: env.recursionDepth,
+						isCascade: true,
+					},
+				},
+				status: "pending",
+				correlationId: `cascade-${env.executionChain.join("-")}-${Date.now()}`,
+				createdAt: Date.now(),
+				attemptCount: 0,
+			});
+			await ctx.scheduler.runAfter(0, internal.eventBus.processEvents, {});
+		}
+
+		return { success: true };
+	} catch (error) {
+		return {
+			success: false,
+			error:
+				error instanceof Error ? error.message : "Failed to create record",
+		};
+	}
 }
 
 /** List org member user ids, optionally restricted to admins. */
@@ -3766,6 +4113,47 @@ async function dryUpdateFieldsAction(
 }
 
 /**
+ * Dry mirror of executeCreateRecordAction: same validation and cap checks (all
+ * reads), no insert/emit. Previews the assembled field set.
+ */
+async function dryCreateRecordAction(
+	ctx: MutationCtx,
+	action: Extract<AutomationAction, { type: "create_record" }>,
+	scopeRecord: ScopeRecord | undefined,
+	env: DryEnv
+): Promise<DryNodeResult> {
+	const objectType = action.objectType;
+	if (!isCreatableObjectType(objectType)) {
+		return {
+			success: false,
+			error: `Creating ${objectType} records from automations isn't supported`,
+		};
+	}
+	const built = await buildCreateRecordPayload(ctx, action, scopeRecord, env);
+	if (!built.ok) return { success: false, error: built.error };
+
+	const org = await ctx.db.get(env.orgId);
+	if (!orgHasPremiumPlan(org)) {
+		const capError = await checkCreateRecordPlanCap(
+			ctx,
+			objectType,
+			built.payload,
+			env.orgId
+		);
+		if (capError) return { success: false, error: capError };
+	}
+
+	// Preview the field set without orgId (internal) — portalAccessId isn't set
+	// until insert.
+	const { orgId: _orgId, ...preview } = built.payload;
+	return {
+		success: true,
+		output: { summary: `Would create a ${objectType}` },
+		input: { objectType, fields: preview },
+	};
+}
+
+/**
  * Describe (without executing) what an action would do. Mirrors the real
  * executors' validation so a test surfaces the same failures/skips, but never
  * writes, emits events, or touches aggregates.
@@ -3818,6 +4206,8 @@ async function dryExecuteAction(
 				input: { title, assigneeUserId: action.assigneeUserId },
 			};
 		}
+		case "create_record":
+			return dryCreateRecordAction(ctx, action, scopeRecord, env);
 		case "send_notification": {
 			let count: number;
 			if (action.recipient === "org_admins") {

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -41,6 +41,7 @@ import {
 	triggerRecordObjectType,
 	type ActionTarget,
 	type AutomationAction,
+	type ValueRef,
 	type AutomationObjectType,
 	type AutomationTrigger,
 	type ExecutedNode,
@@ -2681,7 +2682,22 @@ async function executeActionNodeV2(
 ): Promise<{ success: boolean; skipped?: boolean; error?: string }> {
 	switch (action.type) {
 		case "update_field":
-			break; // handled below
+			// Legacy single-field variant: same engine as update_fields, one row.
+			return executeUpdateFieldsAction(
+				ctx,
+				action.target,
+				[{ field: action.field, value: action.value }],
+				scopeRecord,
+				env
+			);
+		case "update_fields":
+			return executeUpdateFieldsAction(
+				ctx,
+				action.target,
+				action.fields,
+				scopeRecord,
+				env
+			);
 		case "create_task":
 			return executeCreateTaskAction(ctx, action, scopeRecord, env);
 		case "send_notification":
@@ -2693,7 +2709,25 @@ async function executeActionNodeV2(
 			return _exhaustive;
 		}
 	}
+}
 
+/**
+ * Shared engine behind update_field / update_fields. Every row is validated
+ * and coerced BEFORE the first write so a bad row can't leave a half-updated
+ * record. Non-status fields land in one ctx.db.patch and emit one
+ * record_updated — changedFields carries the full set, and field/oldValue/
+ * newValue are included only when exactly one field changed, so a one-row
+ * action emits the same event a legacy update_field always did. A status row
+ * goes through applyStatusUpdate's validation + aggregate + cascade flow,
+ * exactly once, after the field patch.
+ */
+async function executeUpdateFieldsAction(
+	ctx: MutationCtx,
+	target: ActionTarget,
+	fields: Array<{ field: string; value: ValueRef }>,
+	scopeRecord: ScopeRecord | undefined,
+	env: WalkEnv
+): Promise<{ success: boolean; skipped?: boolean; error?: string }> {
 	if (!scopeRecord) {
 		return { success: false, error: NO_SCOPE_RECORD_ERROR };
 	}
@@ -2702,7 +2736,7 @@ async function executeActionNodeV2(
 
 	const targetInfo = await resolveTargetV2(
 		ctx,
-		action.target,
+		target,
 		objectType,
 		objectId,
 		triggerObject,
@@ -2712,140 +2746,199 @@ async function executeActionNodeV2(
 	if (!targetInfo) {
 		// Target not found - skip this action (e.g., task has no client)
 		console.warn(
-			`[AutomationExecutor] Target not found: target=${JSON.stringify(action.target)}, objectType=${objectType}, objectId=${objectId}`
+			`[AutomationExecutor] Target not found: target=${JSON.stringify(target)}, objectType=${objectType}, objectId=${objectId}`
 		);
 		return { success: true, skipped: true };
 	}
 
-	const fieldDef = getFieldDefinition(targetInfo.type, action.field);
-	if (!fieldDef) {
-		return {
-			success: false,
-			error: `Unknown field "${action.field}" for ${targetInfo.type}`,
-		};
-	}
-	if (!fieldDef.writable) {
-		return {
-			success: false,
-			error: `Field "${action.field}" is not writable${
-				fieldDef.writeExclusionReason ? `: ${fieldDef.writeExclusionReason}` : ""
-			}`,
-		};
+	if (fields.length === 0) {
+		return { success: false, error: "No fields to update" };
 	}
 
-	const rawValue = resolveValueRef(action.value, env.scope);
-	const coerced = coerceFieldValue(
-		fieldDef,
-		rawValue,
-		env.scope.workflow?.tz ?? "UTC"
-	);
-	if (!coerced.ok) {
-		return { success: false, error: coerced.error };
+	const writes: Array<{ field: string; value: unknown }> = [];
+	const seen = new Set<string>();
+	for (const { field, value } of fields) {
+		if (seen.has(field)) {
+			return {
+				success: false,
+				error: `Field "${field}" appears more than once`,
+			};
+		}
+		seen.add(field);
+
+		const fieldDef = getFieldDefinition(targetInfo.type, field);
+		if (!fieldDef) {
+			return {
+				success: false,
+				error: `Unknown field "${field}" for ${targetInfo.type}`,
+			};
+		}
+		if (!fieldDef.writable) {
+			return {
+				success: false,
+				error: `Field "${field}" is not writable${
+					fieldDef.writeExclusionReason ? `: ${fieldDef.writeExclusionReason}` : ""
+				}`,
+			};
+		}
+
+		const rawValue = resolveValueRef(value, env.scope);
+		const coerced = coerceFieldValue(
+			fieldDef,
+			rawValue,
+			env.scope.workflow?.tz ?? "UTC"
+		);
+		if (!coerced.ok) {
+			return { success: false, error: coerced.error };
+		}
+		writes.push({ field, value: coerced.value });
 	}
 
-	// Status writes reuse the existing validation + aggregate + cascade flow.
-	if (action.field === "status") {
-		if (typeof coerced.value !== "string") {
+	// Status is fully special-cased below; validate it up front — after the
+	// non-status patch commits it would be too late to fail atomically.
+	const statusWrite = writes.find((w) => w.field === "status");
+	if (statusWrite) {
+		if (typeof statusWrite.value !== "string") {
 			return {
 				success: false,
 				error: `Status value for ${targetInfo.type} must be a string`,
 			};
 		}
+		if (!isValidStatus(targetInfo.type, statusWrite.value)) {
+			return {
+				success: false,
+				error: `Invalid status "${statusWrite.value}" for ${targetInfo.type}`,
+			};
+		}
+	}
+	const fieldWrites = writes.filter((w) => w.field !== "status");
+
+	if (fieldWrites.length > 0) {
+		const targetObject = await getObject(
+			ctx,
+			targetInfo.type,
+			targetInfo.id,
+			orgId
+		);
+		if (!targetObject) {
+			return { success: false, error: "Target object not found" };
+		}
+
+		try {
+			const updatePayload: Record<string, any> = {};
+			const changed: Array<{
+				field: string;
+				oldValue: unknown;
+				newValue: unknown;
+			}> = [];
+			for (const write of fieldWrites) {
+				updatePayload[write.field] = write.value;
+				const previousValue = (targetObject as Record<string, unknown>)[
+					write.field
+				];
+				if (previousValue !== write.value) {
+					changed.push({
+						field: write.field,
+						oldValue: previousValue,
+						newValue: write.value,
+					});
+				}
+			}
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			await ctx.db.patch(targetInfo.id, updatePayload as any);
+
+			const updatedObject = await ctx.db.get(targetInfo.id);
+			if (!updatedObject) {
+				return {
+					success: false,
+					error: "Target object was deleted during update",
+				};
+			}
+
+			// Keep aggregates in sync; each helper no-ops unless a field it
+			// tracks (status/completedAt/approvedAt/paidAt/total) changed.
+			switch (targetInfo.type) {
+				case "project":
+					await AggregateHelpers.updateProject(
+						ctx,
+						targetObject as Doc<"projects">,
+						updatedObject as Doc<"projects">
+					);
+					break;
+				case "quote":
+					await AggregateHelpers.updateQuote(
+						ctx,
+						targetObject as Doc<"quotes">,
+						updatedObject as Doc<"quotes">
+					);
+					break;
+				case "invoice":
+					await AggregateHelpers.updateInvoice(
+						ctx,
+						targetObject as Doc<"invoices">,
+						updatedObject as Doc<"invoices">
+					);
+					break;
+				// Clients and tasks don't have aggregate field tracking
+			}
+
+			// Emit record_updated so automations chained on these fields actually
+			// fire (a status row emits its own event via applyStatusUpdate below).
+			// The chain rides in metadata — the emitRecordUpdatedEvent helper would
+			// drop it and defeat the recursion guard. One event per action, so a
+			// trigger watching any of the changed fields fires exactly once.
+			if (changed.length > 0) {
+				const single = changed.length === 1 ? changed[0] : undefined;
+				await ctx.db.insert("domainEvents", {
+					orgId,
+					eventType: "entity.record_updated",
+					eventSource: "automationExecutor.executeActionNodeV2",
+					payload: {
+						entityType: targetInfo.type,
+						entityId: targetInfo.id,
+						...(single
+							? {
+									field: single.field,
+									oldValue: single.oldValue,
+									newValue: single.newValue,
+								}
+							: {}),
+						metadata: {
+							changedFields: changed.map((c) => c.field),
+							executionChain,
+							recursionDepth,
+							isCascade: true,
+						},
+					},
+					status: "pending",
+					correlationId: `cascade-${executionChain.join("-")}-${Date.now()}`,
+					createdAt: Date.now(),
+					attemptCount: 0,
+				});
+				await ctx.scheduler.runAfter(0, internal.eventBus.processEvents, {});
+			}
+		} catch (error) {
+			return {
+				success: false,
+				error:
+					error instanceof Error ? error.message : "Failed to update field",
+			};
+		}
+	}
+
+	// Status writes reuse the existing validation + aggregate + cascade flow.
+	if (statusWrite) {
 		return applyStatusUpdate(
 			ctx,
 			targetInfo,
-			coerced.value,
+			statusWrite.value as string,
 			orgId,
 			executionChain,
 			recursionDepth
 		);
 	}
 
-	const targetObject = await getObject(ctx, targetInfo.type, targetInfo.id, orgId);
-	if (!targetObject) {
-		return { success: false, error: "Target object not found" };
-	}
-	const previousValue = (targetObject as Record<string, unknown>)[action.field];
-
-	try {
-		const updatePayload: Record<string, any> = {
-			[action.field]: coerced.value,
-		};
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		await ctx.db.patch(targetInfo.id, updatePayload as any);
-
-		const updatedObject = await ctx.db.get(targetInfo.id);
-		if (!updatedObject) {
-			return {
-				success: false,
-				error: "Target object was deleted during update",
-			};
-		}
-
-		// Keep aggregates in sync; each helper no-ops unless a field it
-		// tracks (status/completedAt/approvedAt/paidAt/total) changed.
-		switch (targetInfo.type) {
-			case "project":
-				await AggregateHelpers.updateProject(
-					ctx,
-					targetObject as Doc<"projects">,
-					updatedObject as Doc<"projects">
-				);
-				break;
-			case "quote":
-				await AggregateHelpers.updateQuote(
-					ctx,
-					targetObject as Doc<"quotes">,
-					updatedObject as Doc<"quotes">
-				);
-				break;
-			case "invoice":
-				await AggregateHelpers.updateInvoice(
-					ctx,
-					targetObject as Doc<"invoices">,
-					updatedObject as Doc<"invoices">
-				);
-				break;
-			// Clients and tasks don't have aggregate field tracking
-		}
-
-		// Emit record_updated so automations chained on this field actually fire
-		// (status writes emit their own event via applyStatusUpdate). The chain
-		// rides in metadata — the emitRecordUpdatedEvent helper would drop it and
-		// defeat the recursion guard. Same shape as the create_task emit below.
-		if (previousValue !== coerced.value) {
-			await ctx.db.insert("domainEvents", {
-				orgId,
-				eventType: "entity.record_updated",
-				eventSource: "automationExecutor.executeActionNodeV2",
-				payload: {
-					entityType: targetInfo.type,
-					entityId: targetInfo.id,
-					field: action.field,
-					oldValue: previousValue,
-					newValue: coerced.value,
-					metadata: {
-						changedFields: [action.field],
-						executionChain,
-						recursionDepth,
-						isCascade: true,
-					},
-				},
-				status: "pending",
-				correlationId: `cascade-${executionChain.join("-")}-${Date.now()}`,
-				createdAt: Date.now(),
-				attemptCount: 0,
-			});
-			await ctx.scheduler.runAfter(0, internal.eventBus.processEvents, {});
-		}
-
-		return { success: true };
-	} catch (error) {
-		return {
-			success: false,
-			error: error instanceof Error ? error.message : "Failed to update field",
-		};
-	}
+	return { success: true };
 }
 
 /**
@@ -3577,6 +3670,104 @@ type DryNodeResult = {
 };
 
 /**
+ * Dry mirror of executeUpdateFieldsAction: same per-row validation and
+ * coercion, no writes. A one-row action previews with the exact summary and
+ * input shape legacy update_field test runs always produced.
+ */
+async function dryUpdateFieldsAction(
+	ctx: MutationCtx,
+	target: ActionTarget,
+	fields: Array<{ field: string; value: ValueRef }>,
+	scopeRecord: ScopeRecord | undefined,
+	env: DryEnv
+): Promise<DryNodeResult> {
+	if (!scopeRecord) {
+		return { success: false, error: NO_SCOPE_RECORD_ERROR };
+	}
+	const targetInfo = await resolveTargetV2(
+		ctx,
+		target,
+		scopeRecord.type,
+		scopeRecord.id,
+		scopeRecord.record,
+		env.orgId
+	);
+	if (!targetInfo) {
+		return {
+			success: true,
+			skipped: true,
+			output: { note: "Related record not found — would skip" },
+		};
+	}
+	if (fields.length === 0) {
+		return { success: false, error: "No fields to update" };
+	}
+
+	const writes: Array<{ field: string; value: unknown }> = [];
+	const seen = new Set<string>();
+	for (const { field, value } of fields) {
+		if (seen.has(field)) {
+			return {
+				success: false,
+				error: `Field "${field}" appears more than once`,
+			};
+		}
+		seen.add(field);
+
+		const fieldDef = getFieldDefinition(targetInfo.type, field);
+		if (!fieldDef) {
+			return {
+				success: false,
+				error: `Unknown field "${field}" for ${targetInfo.type}`,
+			};
+		}
+		if (!fieldDef.writable) {
+			return {
+				success: false,
+				error: `Field "${field}" is not writable${
+					fieldDef.writeExclusionReason
+						? `: ${fieldDef.writeExclusionReason}`
+						: ""
+				}`,
+			};
+		}
+		const raw = resolveValueRef(value, env.scope);
+		const coerced = coerceFieldValue(
+			fieldDef,
+			raw,
+			env.scope.workflow?.tz ?? "UTC"
+		);
+		if (!coerced.ok) {
+			return { success: false, error: coerced.error };
+		}
+		if (
+			field === "status" &&
+			typeof coerced.value === "string" &&
+			!isValidStatus(targetInfo.type, coerced.value)
+		) {
+			return {
+				success: false,
+				error: `Invalid status "${coerced.value}" for ${targetInfo.type}`,
+			};
+		}
+		writes.push({ field, value: coerced.value });
+	}
+
+	return {
+		success: true,
+		output: {
+			summary: `Would set ${writes
+				.map((w) => `${w.field} to ${JSON.stringify(w.value)}`)
+				.join(", ")} on the ${targetInfo.type}`,
+		},
+		input:
+			writes.length === 1
+				? { target, field: writes[0].field, value: writes[0].value }
+				: { target, fields: writes },
+	};
+}
+
+/**
  * Describe (without executing) what an action would do. Mirrors the real
  * executors' validation so a test surfaces the same failures/skips, but never
  * writes, emits events, or touches aggregates.
@@ -3588,73 +3779,23 @@ async function dryExecuteAction(
 	env: DryEnv
 ): Promise<DryNodeResult> {
 	switch (action.type) {
-		case "update_field": {
-			if (!scopeRecord) {
-				return { success: false, error: NO_SCOPE_RECORD_ERROR };
-			}
-			const targetInfo = await resolveTargetV2(
+		case "update_field":
+			// Legacy single-field variant: same dry engine, one row.
+			return dryUpdateFieldsAction(
 				ctx,
 				action.target,
-				scopeRecord.type,
-				scopeRecord.id,
-				scopeRecord.record,
-				env.orgId
+				[{ field: action.field, value: action.value }],
+				scopeRecord,
+				env
 			);
-			if (!targetInfo) {
-				return {
-					success: true,
-					skipped: true,
-					output: { note: "Related record not found — would skip" },
-				};
-			}
-			const fieldDef = getFieldDefinition(targetInfo.type, action.field);
-			if (!fieldDef) {
-				return {
-					success: false,
-					error: `Unknown field "${action.field}" for ${targetInfo.type}`,
-				};
-			}
-			if (!fieldDef.writable) {
-				return {
-					success: false,
-					error: `Field "${action.field}" is not writable${
-						fieldDef.writeExclusionReason
-							? `: ${fieldDef.writeExclusionReason}`
-							: ""
-					}`,
-				};
-			}
-			const raw = resolveValueRef(action.value, env.scope);
-			const coerced = coerceFieldValue(
-				fieldDef,
-				raw,
-				env.scope.workflow?.tz ?? "UTC"
+		case "update_fields":
+			return dryUpdateFieldsAction(
+				ctx,
+				action.target,
+				action.fields,
+				scopeRecord,
+				env
 			);
-			if (!coerced.ok) {
-				return { success: false, error: coerced.error };
-			}
-			if (
-				action.field === "status" &&
-				typeof coerced.value === "string" &&
-				!isValidStatus(targetInfo.type, coerced.value)
-			) {
-				return {
-					success: false,
-					error: `Invalid status "${coerced.value}" for ${targetInfo.type}`,
-				};
-			}
-			return {
-				success: true,
-				output: {
-					summary: `Would set ${action.field} to ${JSON.stringify(coerced.value)} on the ${targetInfo.type}`,
-				},
-				input: {
-					target: action.target,
-					field: action.field,
-					value: coerced.value,
-				},
-			};
-		}
 		case "create_task": {
 			const title = resolveTextValue(action.title, env.scope);
 			if (!title) {

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -884,6 +884,17 @@ const MAX_ITEM_ERROR_CHARS = 500;
 let cascadeEventSeq = 0;
 
 /**
+ * Correlation id for a cascade domain event. Date.now() is frozen inside a Convex
+ * transaction, so the per-module counter is what keeps ids unique when one run
+ * emits several cascade events (e.g. two sequential update_fields/create_record
+ * nodes) — without it the event bus could dedupe the second event by correlationId.
+ */
+function nextCascadeCorrelationId(executionChain: string[]): string {
+	cascadeEventSeq += 1;
+	return `cascade-${executionChain.join("-")}-${Date.now()}-${cascadeEventSeq}`;
+}
+
+/**
  * A throw that means the transaction is already doomed — every remaining item
  * would hit it too, and calling it "item 13 failed" would be a lie. These are
  * rethrown even when the loop is set to continue; everything else (a schema
@@ -2547,8 +2558,7 @@ async function applyStatusUpdate(
 			// Create correlation ID that includes chain info for the event bus.
 			// Date.now() is frozen within a Convex transaction, so a per-module
 			// counter keeps IDs unique when one run emits several cascade events.
-			cascadeEventSeq += 1;
-			const correlationId = `cascade-${executionChain.join("-")}-${Date.now()}-${cascadeEventSeq}`;
+			const correlationId = nextCascadeCorrelationId(executionChain);
 
 			await ctx.db.insert("domainEvents", {
 				orgId,
@@ -2914,7 +2924,7 @@ async function executeUpdateFieldsAction(
 						},
 					},
 					status: "pending",
-					correlationId: `cascade-${executionChain.join("-")}-${Date.now()}`,
+					correlationId: nextCascadeCorrelationId(executionChain),
 					createdAt: Date.now(),
 					attemptCount: 0,
 				});
@@ -3118,7 +3128,7 @@ async function executeCreateTaskAction(
 					},
 				},
 				status: "pending",
-				correlationId: `cascade-${env.executionChain.join("-")}-${Date.now()}`,
+				correlationId: nextCascadeCorrelationId(env.executionChain),
 				createdAt: Date.now(),
 				attemptCount: 0,
 			});
@@ -3277,7 +3287,7 @@ async function checkCreateRecordPlanCap(
 	payload: Record<string, unknown>,
 	orgId: Id<"organizations">
 ): Promise<string | null> {
-	if (objectType === "client") {
+	if (objectType === "client" && (payload.status as string | undefined) !== "archived") {
 		const clients = await ctx.db
 			.query("clients")
 			.withIndex("by_org", (q) => q.eq("orgId", orgId))
@@ -3288,8 +3298,11 @@ async function checkCreateRecordPlanCap(
 		}
 	}
 	if (objectType === "project") {
+		// Only an active candidate (planned/in-progress) consumes a per-client slot.
+		const status = payload.status as string | undefined;
+		const projectActive = status === "planned" || status === "in-progress";
 		const clientId = payload.clientId as Id<"clients"> | undefined;
-		if (clientId) {
+		if (clientId && projectActive) {
 			const projects = await ctx.db
 				.query("projects")
 				.withIndex("by_client", (q) => q.eq("clientId", clientId))
@@ -3374,6 +3387,19 @@ async function buildCreateRecordPayload(
 		// null means "resolved to nothing" — leave it out so requiredOnCreate and
 		// defaults still apply (a supplied-but-empty row shouldn't defeat them).
 		if (coerced.value === null) continue;
+		// A required text field set to a blank/whitespace value doesn't satisfy the
+		// requirement — reject instead of marking it supplied.
+		if (
+			def.requiredOnCreate &&
+			def.type === "text" &&
+			typeof coerced.value === "string" &&
+			coerced.value.trim() === ""
+		) {
+			return {
+				ok: false,
+				error: `${def.label} is required to create a ${objectType}`,
+			};
+		}
 		if (def.refType) {
 			const fk = await resolveCreateFk(ctx, def.refType, coerced.value, env.orgId);
 			if (!fk.ok) return { ok: false, error: fk.error };
@@ -3508,7 +3534,7 @@ async function executeCreateRecordAction(
 					},
 				},
 				status: "pending",
-				correlationId: `cascade-${env.executionChain.join("-")}-${Date.now()}`,
+				correlationId: nextCascadeCorrelationId(env.executionChain),
 				createdAt: Date.now(),
 				attemptCount: 0,
 			});
@@ -4085,16 +4111,20 @@ async function dryUpdateFieldsAction(
 		if (!coerced.ok) {
 			return { success: false, error: coerced.error };
 		}
-		if (
-			field === "status" &&
-			typeof coerced.value === "string" &&
-			!isValidStatus(targetInfo.type, coerced.value)
-		) {
-			return {
-				success: false,
-				error: `Invalid status "${coerced.value}" for ${targetInfo.type}`,
-			};
-		}
+		if (field === "status") {
+				if (typeof coerced.value !== "string") {
+					return {
+						success: false,
+						error: `Status value for ${targetInfo.type} must be a string`,
+					};
+				}
+				if (!isValidStatus(targetInfo.type, coerced.value)) {
+					return {
+						success: false,
+						error: `Invalid status "${coerced.value}" for ${targetInfo.type}`,
+					};
+				}
+			}
 		writes.push({ field, value: coerced.value });
 	}
 

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -21,7 +21,7 @@ import {
 	resolveValueRef,
 	type VariableScope,
 } from "./lib/conditionEval";
-import { calendarDayEpoch } from "./lib/formula";
+import { calendarDayEpoch, toEpochMs } from "./lib/formula";
 import {
 	RELATION_FIELD,
 	getFieldDefinition,
@@ -876,6 +876,9 @@ const LOOP_FAILURE_CIRCUIT_BREAK = 10;
 
 /** Stored error strings are display copy; keep one item's error from bloating the row. */
 const MAX_ITEM_ERROR_CHARS = 500;
+
+/** Uniquifies cascade correlationIds within a transaction (Date.now() is frozen there). */
+let cascadeEventSeq = 0;
 
 /**
  * A throw that means the transaction is already doomed — every remaining item
@@ -2184,14 +2187,6 @@ function roundCents(n: number): number {
 	return Math.round(n * 100) / 100;
 }
 
-/** Epoch ms from a Date, a number (as-is), or a parseable date string; else NaN. */
-function valueToEpochMs(value: unknown): number {
-	if (value instanceof Date) return value.getTime();
-	if (typeof value === "number") return value;
-	if (typeof value === "string") return Date.parse(value);
-	return NaN;
-}
-
 /**
  * Aggregate a fetched collection's numeric field. Sums/averages are computed in
  * integer cents to keep currency math exact. Writes node.<id>.result. Read-only
@@ -2249,7 +2244,7 @@ function runAdjustTimeNode(
 	nodeId: string,
 	config: Extract<WorkflowNodeConfig, { kind: "adjust_time" }>
 ): { ok: true; value: number } | { ok: false; error: string } {
-	const baseMs = valueToEpochMs(resolveValueRef(config.base, scope));
+	const baseMs = toEpochMs(resolveValueRef(config.base, scope));
 	if (Number.isNaN(baseMs)) {
 		return {
 			ok: false,
@@ -2292,7 +2287,7 @@ function computeDelayResume(
 		return { ok: true, resumeAt: Date.now() + ms };
 	}
 
-	const resumeAt = valueToEpochMs(resolveValueRef(config.until, scope));
+	const resumeAt = toEpochMs(resolveValueRef(config.until, scope));
 	if (Number.isNaN(resumeAt)) {
 		return {
 			ok: false,
@@ -2546,8 +2541,11 @@ async function applyStatusUpdate(
 		// Emit cascading status change event with execution chain context
 		// The event bus will handle dispatching to automation handler with recursion protection
 		if (oldStatus && oldStatus !== newStatus) {
-			// Create correlation ID that includes chain info for the event bus
-			const correlationId = `cascade-${executionChain.join("-")}-${Date.now()}`;
+			// Create correlation ID that includes chain info for the event bus.
+			// Date.now() is frozen within a Convex transaction, so a per-module
+			// counter keeps IDs unique when one run emits several cascade events.
+			cascadeEventSeq += 1;
+			const correlationId = `cascade-${executionChain.join("-")}-${Date.now()}-${cascadeEventSeq}`;
 
 			await ctx.db.insert("domainEvents", {
 				orgId,

--- a/packages/backend/convex/automationRuns.test.ts
+++ b/packages/backend/convex/automationRuns.test.ts
@@ -263,6 +263,60 @@ describe("automation runs (test + manual)", () => {
 			expect(tasks).toHaveLength(0);
 		});
 
+		it("previews update_fields without writing and lists every field (B2)", async () => {
+			const { asUser } = await setupUser();
+			const clientId = await makeClient(asUser);
+
+			const automationId = await asUser.mutation(api.automations.create, {
+				name: "Multi-field preview",
+				trigger: clientCreatedTrigger,
+				nodes: [
+					{
+						id: "act-1",
+						type: "action" as const,
+						config: {
+							kind: "action" as const,
+							action: {
+								type: "update_fields" as const,
+								target: "self" as const,
+								fields: [
+									{
+										field: "notes",
+										value: { kind: "static" as const, value: "hello" },
+									},
+									{
+										field: "companyDescription",
+										value: { kind: "static" as const, value: "desc" },
+									},
+								],
+							},
+						},
+					},
+				],
+			});
+
+			const executionId = await asUser.mutation(
+				api.automationExecutor.startTestRun,
+				{ automationId, record: { entityType: "client", entityId: clientId } }
+			);
+			await drainScheduled();
+
+			const done = await asUser.query(api.automationExecutor.getExecution, {
+				executionId,
+			});
+			expect(done?.status).toBe("completed");
+			expect(done?.nodesExecuted[0].result).toBe("success");
+			expect(
+				(done?.nodesExecuted[0].output as { summary?: string })?.summary
+			).toBe(
+				'Would set notes to "hello", companyDescription to "desc" on the client'
+			);
+
+			const client = await t.run(async (ctx) => ctx.db.get(clientId));
+			expect(client?.notes).toBeUndefined();
+			expect(client?.companyDescription).toBeUndefined();
+		});
+
 		it("reveals only the taken branch of a condition", async () => {
 			const { asUser } = await setupUser();
 			const clientId = await makeClient(asUser, "Globex");

--- a/packages/backend/convex/automationRunsMetrics.test.ts
+++ b/packages/backend/convex/automationRunsMetrics.test.ts
@@ -557,11 +557,13 @@ describe("automation runs & latency (Slice 5)", () => {
 			expect(buckets[0].day).toBe(todayMidnight - 2 * DAY_MS);
 			expect(buckets[2].day).toBe(todayMidnight);
 			// 07-02: one failed.
-			expect(buckets[0]).toMatchObject({ success: 0, failed: 1, skipped: 0 });
+			expect(buckets[0]).toMatchObject({ success: 0, failed: 1 });
 			// 07-03: empty (zero-count day present).
-			expect(buckets[1]).toMatchObject({ success: 0, failed: 0, skipped: 0 });
-			// 07-04: one success + one skipped (test excluded).
-			expect(buckets[2]).toMatchObject({ success: 1, failed: 0, skipped: 1 });
+			expect(buckets[1]).toMatchObject({ success: 0, failed: 0 });
+			// 07-04: one success; the skipped run (and the test run) is excluded —
+			// the chart tracks executed runs only.
+			expect(buckets[2]).toMatchObject({ success: 1, failed: 0 });
+			expect(buckets[2]).not.toHaveProperty("skipped");
 		});
 
 		it("buckets a completed_with_errors run into withErrors and nowhere else", async () => {
@@ -595,7 +597,6 @@ describe("automation runs & latency (Slice 5)", () => {
 				success: 0,
 				failed: 0,
 				withErrors: 1,
-				skipped: 0,
 			});
 		});
 	});

--- a/packages/backend/convex/automations.test.ts
+++ b/packages/backend/convex/automations.test.ts
@@ -149,6 +149,27 @@ function actionNode(id: string, statusValue = "inactive") {
 	};
 }
 
+function updateFieldsNode(
+	id: string,
+	fields: Array<{ field: string; value: string | number | boolean }>
+) {
+	return {
+		id,
+		type: "action" as const,
+		config: {
+			kind: "action" as const,
+			action: {
+				type: "update_fields" as const,
+				target: "self" as const,
+				fields: fields.map(({ field, value }) => ({
+					field,
+					value: { kind: "static" as const, value },
+				})),
+			},
+		},
+	};
+}
+
 describe("Automations", () => {
 	let t: ReturnType<typeof setupConvexTest>;
 
@@ -346,6 +367,83 @@ describe("Automations", () => {
 			).rejects.toThrow(/not a valid value/i);
 		});
 
+		it("accepts a multi-field update_fields action (Phase B2)", async () => {
+			const { asUser } = await setupUser();
+
+			const id = await asUser.mutation(api.automations.create, {
+				name: "Multi-field update",
+				trigger: clientTrigger,
+				nodes: [
+					updateFieldsNode("act-1", [
+						{ field: "notes", value: "swept" },
+						{ field: "status", value: "inactive" },
+					]),
+				],
+			});
+
+			expect(await asUser.query(api.automations.get, { id })).toBeTruthy();
+		});
+
+		it("rejects update_fields with a duplicated field", async () => {
+			const { asUser } = await setupUser();
+
+			await expect(
+				asUser.mutation(api.automations.create, {
+					name: "Twice the notes",
+					trigger: clientTrigger,
+					nodes: [
+						updateFieldsNode("act-1", [
+							{ field: "notes", value: "a" },
+							{ field: "notes", value: "b" },
+						]),
+					],
+				})
+			).rejects.toThrow(/appears more than once/i);
+		});
+
+		it("rejects update_fields with no rows", async () => {
+			const { asUser } = await setupUser();
+
+			await expect(
+				asUser.mutation(api.automations.create, {
+					name: "Empty update",
+					trigger: clientTrigger,
+					nodes: [updateFieldsNode("act-1", [])],
+				})
+			).rejects.toThrow(/at least one field/i);
+		});
+
+		it("rejects update_fields writing a non-writable field", async () => {
+			const { asUser } = await setupUser();
+
+			await expect(
+				asUser.mutation(api.automations.create, {
+					name: "Hands off completedAt",
+					trigger: { type: "record_created", objectType: "project" },
+					nodes: [
+						updateFieldsNode("act-1", [
+							{ field: "description", value: "fine" },
+							{ field: "completedAt", value: 0 },
+						]),
+					],
+				})
+			).rejects.toThrow(/cannot be updated/i);
+		});
+
+		it("rejects an invalid static select value in update_fields", async () => {
+			const { asUser } = await setupUser();
+
+			await expect(
+				asUser.mutation(api.automations.create, {
+					name: "Bogus status",
+					trigger: clientTrigger,
+					nodes: [
+						updateFieldsNode("act-1", [{ field: "status", value: "bogus" }]),
+					],
+				})
+			).rejects.toThrow(/not a valid value/i);
+		});
+
 		it("rejects a scheduled trigger with an invalid IANA timezone", async () => {
 			const { asUser } = await setupUser();
 
@@ -501,6 +599,37 @@ describe("Automations", () => {
 					trigger: scheduledTrigger,
 				})
 			).rejects.toThrow(/no record to update/i);
+		});
+
+		it("rejects a top-level update_fields, same as update_field (B2)", async () => {
+			const { asUser } = await setupUser();
+
+			await expect(
+				asUser.mutation(api.automations.create, {
+					name: "Multi on a schedule",
+					trigger: scheduledTrigger,
+					nodes: [updateFieldsNode("act-1", [{ field: "notes", value: "x" }])],
+				})
+			).rejects.toThrow(/no record to update/i);
+		});
+
+		it("accepts update_fields inside a fetch → loop body (B2)", async () => {
+			const { asUser } = await setupUser();
+
+			const id = await asUser.mutation(api.automations.create, {
+				name: "Bulk sweep on a schedule",
+				trigger: scheduledTrigger,
+				nodes: [
+					fetchNode("fetch-1", "project", { nextNodeId: "loop-1" }),
+					loopNode("loop-1", "fetch-1", { bodyStartNodeId: "upd-1" }),
+					updateFieldsNode("upd-1", [
+						{ field: "description", value: "swept" },
+						{ field: "title", value: "Renamed" },
+					]),
+				],
+			});
+
+			expect(await asUser.query(api.automations.get, { id })).toBeTruthy();
 		});
 
 		it("rejects a condition that reads a record field", async () => {

--- a/packages/backend/convex/automations.ts
+++ b/packages/backend/convex/automations.ts
@@ -1558,7 +1558,6 @@ export const getRunThroughput = userQuery({
 			success: number;
 			failed: number;
 			withErrors: number;
-			skipped: number;
 		}>
 	> => {
 		await ctx.requireLevel("automations", "view");
@@ -1583,7 +1582,6 @@ export const getRunThroughput = userQuery({
 				success: number;
 				failed: number;
 				withErrors: number;
-				skipped: number;
 			}
 		>();
 		for (let day = firstDay; day <= todayMidnight; day += DAY_MS) {
@@ -1592,7 +1590,6 @@ export const getRunThroughput = userQuery({
 				success: 0,
 				failed: 0,
 				withErrors: 0,
-				skipped: 0,
 			});
 		}
 
@@ -1601,10 +1598,11 @@ export const getRunThroughput = userQuery({
 			const day = Math.floor(e.triggeredAt / DAY_MS) * DAY_MS;
 			const bucket = buckets.get(day);
 			if (!bucket) continue; // outside the seeded window
+			// Skipped runs are deliberately not returned — the throughput chart
+			// tracks executed runs only.
 			if (e.status === "completed") bucket.success++;
 			else if (e.status === "failed") bucket.failed++;
 			else if (e.status === "completed_with_errors") bucket.withErrors++;
-			else if (e.status === "skipped") bucket.skipped++;
 		}
 
 		return Array.from(buckets.values());

--- a/packages/backend/convex/automations.ts
+++ b/packages/backend/convex/automations.ts
@@ -296,7 +296,10 @@ function validateScheduledRecordScope(
 		if (config.kind === "action") {
 			// Both update_field targets (self and related) resolve off the record in
 			// scope, so neither can work outside a loop.
-			if (config.action.type === "update_field") {
+			if (
+				config.action.type === "update_field" ||
+				config.action.type === "update_fields"
+			) {
 				throw new Error(
 					`Node ${node.id}: there is no record to update — ${NO_RECORD}. Add a "Find records" step and put this action inside a loop.`
 				);
@@ -381,10 +384,32 @@ function validateUpdateFieldAction(
 	nodeId: string,
 	action: Extract<
 		Extract<WorkflowNodeConfig, { kind: "action" }>["action"],
-		{ type: "update_field" }
+		{ type: "update_field" } | { type: "update_fields" }
 	>,
 	scopeObjectType: AutomationObjectType | undefined
 ): void {
+	const fields =
+		action.type === "update_field"
+			? [{ field: action.field, value: action.value }]
+			: action.fields;
+
+	// Shape rules hold even when the scope type is unresolvable (e.g. a loop
+	// whose fetch node is missing) — an empty or duplicated row is never valid.
+	if (action.type === "update_fields") {
+		if (fields.length === 0) {
+			throw new Error(`Node ${nodeId}: add at least one field to update`);
+		}
+		const seen = new Set<string>();
+		for (const { field } of fields) {
+			if (seen.has(field)) {
+				throw new Error(
+					`Node ${nodeId}: field "${field}" appears more than once`
+				);
+			}
+			seen.add(field);
+		}
+	}
+
 	if (!scopeObjectType) return;
 
 	let targetObjectType: AutomationObjectType = scopeObjectType;
@@ -397,28 +422,29 @@ function validateUpdateFieldAction(
 		targetObjectType = action.target.related;
 	}
 
-	const def = getFieldDefinition(targetObjectType, action.field);
-	if (!def) {
-		throw new Error(
-			`Node ${nodeId}: unknown field "${action.field}" for ${targetObjectType}`
-		);
-	}
-	if (!def.writable) {
-		throw new Error(
-			`Node ${nodeId}: field "${action.field}" cannot be updated${def.writeExclusionReason ? ` (${def.writeExclusionReason})` : ""}`
-		);
-	}
-	const value = action.value;
-	if (
-		def.type === "select" &&
-		value.kind === "static" &&
-		typeof value.value === "string" &&
-		def.options &&
-		!def.options.some((o) => o.value === value.value)
-	) {
-		throw new Error(
-			`Node ${nodeId}: "${String(value.value)}" is not a valid value for "${action.field}"`
-		);
+	for (const { field, value } of fields) {
+		const def = getFieldDefinition(targetObjectType, field);
+		if (!def) {
+			throw new Error(
+				`Node ${nodeId}: unknown field "${field}" for ${targetObjectType}`
+			);
+		}
+		if (!def.writable) {
+			throw new Error(
+				`Node ${nodeId}: field "${field}" cannot be updated${def.writeExclusionReason ? ` (${def.writeExclusionReason})` : ""}`
+			);
+		}
+		if (
+			def.type === "select" &&
+			value.kind === "static" &&
+			typeof value.value === "string" &&
+			def.options &&
+			!def.options.some((o) => o.value === value.value)
+		) {
+			throw new Error(
+				`Node ${nodeId}: "${String(value.value)}" is not a valid value for "${field}"`
+			);
+		}
 	}
 }
 
@@ -532,7 +558,10 @@ function validateWorkflowDefinition(
 				break;
 			}
 			case "action": {
-				if (config.action.type === "update_field") {
+				if (
+					config.action.type === "update_field" ||
+					config.action.type === "update_fields"
+				) {
 					const scopeType = bodyScopeType.has(node.id)
 						? bodyScopeType.get(node.id)
 						: objectType;

--- a/packages/backend/convex/automations.ts
+++ b/packages/backend/convex/automations.ts
@@ -36,8 +36,11 @@ import {
 } from "./lib/formula";
 import {
 	RELATED_OBJECTS,
+	RELATION_FIELD,
 	getFieldDefinition,
+	getRequiredCreateFields,
 	getStatusOptions,
+	isCreatableObjectType,
 	operatorsForField,
 } from "./lib/fieldRegistry";
 import { computeNextRunAt, validateSchedule } from "./lib/schedule";
@@ -309,6 +312,11 @@ function validateScheduledRecordScope(
 					`Node ${node.id}: there is no record to link this task to — ${NO_RECORD}. Put it inside a loop, or turn off "Link to record".`
 				);
 			}
+			if (config.action.type === "create_record" && config.action.linkToScope) {
+				throw new Error(
+					`Node ${node.id}: there is no record to link this new ${config.action.objectType} to — ${NO_RECORD}. Put it inside a loop, or turn off "Link to record".`
+				);
+			}
 		}
 	}
 }
@@ -448,6 +456,77 @@ function validateUpdateFieldAction(
 	}
 }
 
+function validateCreateRecordAction(
+	nodeId: string,
+	action: Extract<
+		Extract<WorkflowNodeConfig, { kind: "action" }>["action"],
+		{ type: "create_record" }
+	>,
+	scopeObjectType: AutomationObjectType | undefined
+): void {
+	const objectType = action.objectType;
+	if (!isCreatableObjectType(objectType)) {
+		throw new Error(
+			`Node ${nodeId}: creating ${objectType} records from automations isn't supported yet`
+		);
+	}
+
+	// The FK linkToScope would fill — only resolvable when the scope type is known.
+	let linkedFk: string | undefined;
+	if (action.linkToScope && scopeObjectType) {
+		linkedFk = RELATION_FIELD[objectType]?.[scopeObjectType];
+		if (!linkedFk) {
+			throw new Error(
+				`Node ${nodeId}: a new ${objectType} can't be linked to a ${scopeObjectType}`
+			);
+		}
+	}
+
+	const seen = new Set<string>();
+	for (const { field, value } of action.fields) {
+		if (seen.has(field)) {
+			throw new Error(
+				`Node ${nodeId}: field "${field}" appears more than once`
+			);
+		}
+		seen.add(field);
+		if (field === linkedFk) {
+			throw new Error(
+				`Node ${nodeId}: field "${field}" is already set by linking to the record in scope`
+			);
+		}
+		const def = getFieldDefinition(objectType, field);
+		if (!def || !def.creatable) {
+			throw new Error(
+				`Node ${nodeId}: "${field}" can't be set when creating a ${objectType}`
+			);
+		}
+		if (
+			def.type === "select" &&
+			value.kind === "static" &&
+			typeof value.value === "string" &&
+			def.options &&
+			!def.options.some((o) => o.value === value.value)
+		) {
+			throw new Error(
+				`Node ${nodeId}: "${String(value.value)}" is not a valid value for "${field}"`
+			);
+		}
+	}
+
+	// Required fields must be supplied — either as a row or via the scope link.
+	// When linkToScope is set but the scope type is unknown (can't tell what it
+	// fills), defer to runtime rather than false-reject a valid automation.
+	for (const def of getRequiredCreateFields(objectType)) {
+		if (action.fields.some((f) => f.field === def.key)) continue;
+		if (linkedFk === def.key) continue;
+		if (action.linkToScope && !scopeObjectType) continue;
+		throw new Error(
+			`Node ${nodeId}: ${def.label} is required to create a ${objectType}`
+		);
+	}
+}
+
 /**
  * Full structural validation of a workflow definition. Used on every write;
  * activation additionally requires at least one node (see validateForActivation).
@@ -566,6 +645,12 @@ function validateWorkflowDefinition(
 						? bodyScopeType.get(node.id)
 						: objectType;
 					validateUpdateFieldAction(node.id, config.action, scopeType);
+				}
+				if (config.action.type === "create_record") {
+					const scopeType = bodyScopeType.has(node.id)
+						? bodyScopeType.get(node.id)
+						: objectType;
+					validateCreateRecordAction(node.id, config.action, scopeType);
 				}
 				if (config.action.type === "create_task") {
 					const title = config.action.title;

--- a/packages/backend/convex/automations.ts
+++ b/packages/backend/convex/automations.ts
@@ -515,12 +515,29 @@ function validateCreateRecordAction(
 	}
 
 	// Required fields must be supplied — either as a row or via the scope link.
-	// When linkToScope is set but the scope type is unknown (can't tell what it
-	// fills), defer to runtime rather than false-reject a valid automation.
+	// A row explicitly set to a static null/blank value doesn't satisfy it.
+	const relationFks = new Set(Object.values(RELATION_FIELD[objectType] ?? {}));
 	for (const def of getRequiredCreateFields(objectType)) {
-		if (action.fields.some((f) => f.field === def.key)) continue;
+		const row = action.fields.find((f) => f.field === def.key);
+		if (row) {
+			const blank =
+				row.value.kind === "static" &&
+				(row.value.value === null ||
+					(typeof row.value.value === "string" &&
+						row.value.value.trim() === ""));
+			if (blank) {
+				throw new Error(
+					`Node ${nodeId}: ${def.label} is required to create a ${objectType}`
+				);
+			}
+			continue;
+		}
 		if (linkedFk === def.key) continue;
-		if (action.linkToScope && !scopeObjectType) continue;
+		// When the scope type is unknown, only the relationship FK a link would
+		// fill is deferrable — other missing required fields are still missing.
+		if (action.linkToScope && !scopeObjectType && relationFks.has(def.key)) {
+			continue;
+		}
 		throw new Error(
 			`Node ${nodeId}: ${def.label} is required to create a ${objectType}`
 		);

--- a/packages/backend/convex/communityPages.test.ts
+++ b/packages/backend/convex/communityPages.test.ts
@@ -353,9 +353,9 @@ describe("Community Pages", () => {
 				.filter((q) => q.eq(q.field("eventType"), "entity.record_created"))
 				.collect()
 		);
-		const taskCreated = events.find((e) => e.payload.entityId === taskId);
-		expect(taskCreated).toBeDefined();
-		expect(taskCreated?.payload.entityType).toBe("task");
+		const taskEvents = events.filter((e) => e.payload.entityId === taskId);
+		expect(taskEvents).toHaveLength(1);
+		expect(taskEvents[0].payload.entityType).toBe("task");
 	});
 
 	it("submitInterest assigns task to org admin", async () => {

--- a/packages/backend/convex/invoices.test.ts
+++ b/packages/backend/convex/invoices.test.ts
@@ -338,12 +338,12 @@ describe("Invoices", () => {
 					.filter((q) => q.eq(q.field("eventType"), "entity.record_created"))
 					.collect()
 			);
-			const invoiceCreated = events.find(
+			const invoiceEvents = events.filter(
 				(e) => e.payload.entityId === invoiceId
 			);
-			expect(invoiceCreated).toBeDefined();
-			expect(invoiceCreated?.payload.entityType).toBe("invoice");
-			expect(invoiceCreated?.eventSource).toBe("invoices.createFromQuote");
+			expect(invoiceEvents).toHaveLength(1);
+			expect(invoiceEvents[0].payload.entityType).toBe("invoice");
+			expect(invoiceEvents[0].eventSource).toBe("invoices.createFromQuote");
 		});
 	});
 

--- a/packages/backend/convex/lib/activities.ts
+++ b/packages/backend/convex/lib/activities.ts
@@ -23,6 +23,7 @@ export async function createActivity(
 		description,
 		metadata,
 		isVisible = true,
+		actor,
 	}: {
 		activityType: ActivityType;
 		entityType: EntityType;
@@ -31,10 +32,24 @@ export async function createActivity(
 		description: string;
 		metadata?: Record<string, unknown>;
 		isVisible?: boolean;
+		/**
+		 * Explicit actor + org for system contexts (e.g. automation runs) that have
+		 * no ambient authenticated user. When omitted, the acting user and org are
+		 * resolved from auth as before.
+		 */
+		actor?: { userId: Id<"users">; orgId: Id<"organizations"> };
 	}
 ): Promise<Id<"activities"> | null> {
-	const user = await getCurrentUserOrThrow(ctx);
-	const orgId = await getOptionalOrgId(ctx);
+	let userId: Id<"users">;
+	let orgId: Id<"organizations"> | null | undefined;
+	if (actor) {
+		userId = actor.userId;
+		orgId = actor.orgId;
+	} else {
+		const user = await getCurrentUserOrThrow(ctx);
+		userId = user._id;
+		orgId = await getOptionalOrgId(ctx);
+	}
 
 	// Skip activity logging for users without organizations
 	if (!orgId) {
@@ -43,7 +58,7 @@ export async function createActivity(
 
 	return await ctx.db.insert("activities", {
 		orgId,
-		userId: user._id,
+		userId,
 		activityType,
 		entityType,
 		entityId,
@@ -59,13 +74,18 @@ export async function createActivity(
  * Helper functions for common activity types
  */
 export const ActivityHelpers = {
-	async clientCreated(ctx: MutationCtx, client: Doc<"clients">) {
+	async clientCreated(
+		ctx: MutationCtx,
+		client: Doc<"clients">,
+		actor?: { userId: Id<"users">; orgId: Id<"organizations"> }
+	) {
 		return createActivity(ctx, {
 			activityType: "client_created",
 			entityType: "client",
 			entityId: client._id,
 			entityName: client.companyName,
 			description: `Created new client: ${client.companyName}`,
+			actor,
 		});
 	},
 
@@ -89,13 +109,18 @@ export const ActivityHelpers = {
 		});
 	},
 
-	async projectCreated(ctx: MutationCtx, project: Doc<"projects">) {
+	async projectCreated(
+		ctx: MutationCtx,
+		project: Doc<"projects">,
+		actor?: { userId: Id<"users">; orgId: Id<"organizations"> }
+	) {
 		return createActivity(ctx, {
 			activityType: "project_created",
 			entityType: "project",
 			entityId: project._id,
 			entityName: project.title,
 			description: `Created new project: ${project.title}`,
+			actor,
 		});
 	},
 
@@ -279,13 +304,18 @@ export const ActivityHelpers = {
 		});
 	},
 
-	async taskCreated(ctx: MutationCtx, task: Doc<"tasks">) {
+	async taskCreated(
+		ctx: MutationCtx,
+		task: Doc<"tasks">,
+		actor?: { userId: Id<"users">; orgId: Id<"organizations"> }
+	) {
 		return createActivity(ctx, {
 			activityType: "task_created",
 			entityType: "task",
 			entityId: task._id,
 			entityName: task.title,
 			description: `Created task: ${task.title}`,
+			actor,
 		});
 	},
 

--- a/packages/backend/convex/lib/conditionEval.ts
+++ b/packages/backend/convex/lib/conditionEval.ts
@@ -9,6 +9,7 @@ import {
 	evaluateFormula,
 	isCalendarDateEpoch,
 	parseFormula,
+	toEpochMs,
 	FormulaError,
 	type FormulaAst,
 	type FormulaContext,
@@ -324,14 +325,6 @@ function compareNumeric(
 	const b = Number(compareValue);
 	if (Number.isNaN(a) || Number.isNaN(b)) return false;
 	return cmp(a, b);
-}
-
-/** Epoch ms from a Date, a number (as-is), or a string (Date.parse); else NaN. */
-function toEpochMs(value: unknown): number {
-	if (value instanceof Date) return value.getTime();
-	if (typeof value === "number") return value;
-	if (typeof value === "string") return Date.parse(value);
-	return NaN;
 }
 
 function compareDates(

--- a/packages/backend/convex/lib/fieldRegistry.ts
+++ b/packages/backend/convex/lib/fieldRegistry.ts
@@ -36,14 +36,32 @@ export interface FieldDefinition {
 	writeExclusionReason?: string;
 	/** Whether the field can be used in condition rules / fetch filters. */
 	filterable: boolean;
+	/**
+	 * Whether a create_record action may set this field at insert time. Distinct
+	 * from `writable`: relationship FKs (clientId, projectId) are set-on-create
+	 * only, never editable afterwards, so they are `creatable` but not `writable`.
+	 */
+	creatable?: boolean;
+	/**
+	 * A creatable field the record can't be inserted without (and that has no
+	 * sensible code default). The executor and publish validation both require
+	 * it to be supplied — unless a `linkToScope` link satisfies the relation.
+	 */
+	requiredOnCreate?: boolean;
+	/**
+	 * For a creatable `id` field, the entity it points at. Used to org-validate
+	 * a supplied FK before insert (the executor runs unscoped, so an arbitrary
+	 * id string must be checked against the org). "user" resolves via membership.
+	 */
+	refType?: "client" | "project" | "user";
 }
 
 const opt = (value: string, label: string) => ({ value, label });
 
 export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 	client: [
-		{ key: "companyName", label: "Company Name", type: "text", writable: true, filterable: true },
-		{ key: "companyDescription", label: "Company Description", type: "text", writable: true, filterable: true },
+		{ key: "companyName", label: "Company Name", type: "text", writable: true, filterable: true, creatable: true, requiredOnCreate: true },
+		{ key: "companyDescription", label: "Company Description", type: "text", writable: true, filterable: true, creatable: true },
 		{
 			key: "status",
 			label: "Status",
@@ -56,6 +74,7 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 			],
 			writable: true,
 			filterable: true,
+			creatable: true,
 		},
 		{
 			key: "leadSource",
@@ -74,8 +93,9 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 			],
 			writable: true,
 			filterable: true,
+			creatable: true,
 		},
-		{ key: "isActive", label: "Is Active", type: "boolean", writable: true, filterable: true },
+		{ key: "isActive", label: "Is Active", type: "boolean", writable: true, filterable: true, creatable: true },
 		{
 			key: "communicationPreference",
 			label: "Communication Preference",
@@ -83,8 +103,9 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 			options: [opt("email", "Email"), opt("phone", "Phone"), opt("both", "Both")],
 			writable: true,
 			filterable: true,
+			creatable: true,
 		},
-		{ key: "notes", label: "Notes", type: "text", writable: true, filterable: true },
+		{ key: "notes", label: "Notes", type: "text", writable: true, filterable: true, creatable: true },
 		{
 			key: "archivedAt",
 			label: "Archived At",
@@ -96,8 +117,8 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 	],
 
 	project: [
-		{ key: "title", label: "Title", type: "text", writable: true, filterable: true },
-		{ key: "description", label: "Description", type: "text", writable: true, filterable: true },
+		{ key: "title", label: "Title", type: "text", writable: true, filterable: true, creatable: true, requiredOnCreate: true },
+		{ key: "description", label: "Description", type: "text", writable: true, filterable: true, creatable: true },
 		{
 			key: "projectNumber",
 			label: "Project Number",
@@ -118,6 +139,7 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 			],
 			writable: true,
 			filterable: true,
+			creatable: true,
 		},
 		{
 			key: "projectType",
@@ -126,9 +148,10 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 			options: [opt("one-off", "One-off"), opt("recurring", "Recurring")],
 			writable: true,
 			filterable: true,
+			creatable: true,
 		},
-		{ key: "startDate", label: "Start Date", type: "date", writable: true, filterable: true },
-		{ key: "endDate", label: "End Date", type: "date", writable: true, filterable: true },
+		{ key: "startDate", label: "Start Date", type: "date", writable: true, filterable: true, creatable: true },
+		{ key: "endDate", label: "End Date", type: "date", writable: true, filterable: true, creatable: true },
 		{
 			key: "completedAt",
 			label: "Completed At",
@@ -144,6 +167,9 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 			writable: false,
 			writeExclusionReason: "Relationship set when the project is created",
 			filterable: true,
+			creatable: true,
+			requiredOnCreate: true,
+			refType: "client",
 		},
 	],
 
@@ -364,8 +390,8 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 	],
 
 	task: [
-		{ key: "title", label: "Title", type: "text", writable: true, filterable: true },
-		{ key: "description", label: "Description", type: "text", writable: true, filterable: true },
+		{ key: "title", label: "Title", type: "text", writable: true, filterable: true, creatable: true, requiredOnCreate: true },
+		{ key: "description", label: "Description", type: "text", writable: true, filterable: true, creatable: true },
 		{
 			key: "type",
 			label: "Type",
@@ -373,6 +399,7 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 			options: [opt("internal", "Internal"), opt("external", "External")],
 			writable: true,
 			filterable: true,
+			creatable: true,
 		},
 		{
 			key: "status",
@@ -386,8 +413,9 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 			],
 			writable: true,
 			filterable: true,
+			creatable: true,
 		},
-		{ key: "date", label: "Date", type: "date", writable: true, filterable: true },
+		{ key: "date", label: "Date", type: "date", writable: true, filterable: true, creatable: true },
 		{ key: "startTime", label: "Start Time", type: "text", writable: true, filterable: true },
 		{ key: "endTime", label: "End Time", type: "text", writable: true, filterable: true },
 		{
@@ -420,6 +448,8 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 			writable: false,
 			writeExclusionReason: "References a user record; assign via dedicated actions",
 			filterable: true,
+			creatable: true,
+			refType: "user",
 		},
 		{
 			key: "projectId",
@@ -428,6 +458,8 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 			writable: false,
 			writeExclusionReason: "Relationship set when the task is created",
 			filterable: true,
+			creatable: true,
+			refType: "project",
 		},
 		{
 			key: "clientId",
@@ -436,6 +468,8 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 			writable: false,
 			writeExclusionReason: "Relationship set when the task is created",
 			filterable: true,
+			creatable: true,
+			refType: "client",
 		},
 	],
 };
@@ -479,6 +513,36 @@ export function getWritableFields(
 	objectType: AutomationObjectType
 ): FieldDefinition[] {
 	return FIELD_REGISTRY[objectType].filter((f) => f.writable);
+}
+
+/**
+ * Object types a create_record action can insert. Derived from the registry:
+ * a type with at least one creatable field. Quote/invoice have none (their
+ * required subtotal/total are computed from line items), so they're excluded
+ * until the line-item creation story exists.
+ */
+export const CREATABLE_OBJECT_TYPES: AutomationObjectType[] = (
+	Object.keys(FIELD_REGISTRY) as AutomationObjectType[]
+).filter((t) => FIELD_REGISTRY[t].some((f) => f.creatable));
+
+export function isCreatableObjectType(
+	objectType: AutomationObjectType
+): boolean {
+	return CREATABLE_OBJECT_TYPES.includes(objectType);
+}
+
+export function getCreatableFields(
+	objectType: AutomationObjectType
+): FieldDefinition[] {
+	return FIELD_REGISTRY[objectType].filter((f) => f.creatable);
+}
+
+export function getRequiredCreateFields(
+	objectType: AutomationObjectType
+): FieldDefinition[] {
+	return FIELD_REGISTRY[objectType].filter(
+		(f) => f.creatable && f.requiredOnCreate
+	);
 }
 
 export function getFilterableFields(

--- a/packages/backend/convex/lib/formula/coerce.ts
+++ b/packages/backend/convex/lib/formula/coerce.ts
@@ -92,6 +92,14 @@ export function guardStr(s: string): string {
 
 const DAY_MS = 86_400_000;
 
+/** Epoch ms from a Date, a number (as-is), or a parseable date string; else NaN. */
+export function toEpochMs(value: unknown): number {
+	if (value instanceof Date) return value.getTime();
+	if (typeof value === "number") return value;
+	if (typeof value === "string") return Date.parse(value);
+	return NaN;
+}
+
 /**
  * OneTool stores calendar dates (task.date, project.startDate/endDate,
  * quote.validUntil, invoice.issuedDate/dueDate) as UTC-midnight epoch ms, while

--- a/packages/backend/convex/lib/formula/functions.ts
+++ b/packages/backend/convex/lib/formula/functions.ts
@@ -429,8 +429,22 @@ const SPECS: FunctionSpec[] = [
 			// zoned parts also broke outright in zones where DST springs forward AT
 			// midnight (e.g. America/Santiago): local midnight doesn't exist there,
 			// so the epoch landed at 01:00 local and was never a calendar date.
-			const epoch = Date.UTC(year, month - 1, day);
-			return new Date(guardEpoch(epoch, "DATE(year, month, day)"));
+			// setUTCFullYear keeps a literal year 0-99 (Date.UTC would read 50 as
+			// 1950); the round-trip check rejects out-of-range parts instead of
+			// letting DATE(2026, 13, 1) silently roll into January 2027.
+			const d = new Date(0);
+			d.setUTCFullYear(year, month - 1, day);
+			if (
+				d.getUTCFullYear() !== year ||
+				d.getUTCMonth() !== month - 1 ||
+				d.getUTCDate() !== day
+			) {
+				throw new FormulaError(
+					"TYPE",
+					`DATE(${year}, ${month}, ${day}) is not a real calendar date`
+				);
+			}
+			return new Date(guardEpoch(d.getTime(), "DATE(year, month, day)"));
 		},
 		doc: {
 			name: "DATE",

--- a/packages/backend/convex/lib/formula/index.ts
+++ b/packages/backend/convex/lib/formula/index.ts
@@ -25,4 +25,4 @@ export type { FormulaFnDoc } from "./functions";
 
 // Calendar-date vs instant classification. Callers that read or write date
 // fields need it to stay in the same day-space the formula layer uses.
-export { calendarDayEpoch, isCalendarDateEpoch } from "./coerce";
+export { calendarDayEpoch, isCalendarDateEpoch, toEpochMs } from "./coerce";

--- a/packages/backend/convex/lib/workflowTypes.ts
+++ b/packages/backend/convex/lib/workflowTypes.ts
@@ -169,6 +169,23 @@ export const updateFieldActionValidator = v.object({
 	value: valueRefValidator,
 });
 
+/**
+ * Multi-field successor to update_field: one target, one atomic patch. The
+ * single-field variant stays valid forever — published snapshots keep running
+ * unmodified, and the web editor upgrades legacy configs to a one-row
+ * update_fields on load/save (symmetrically, so signatures stay stable).
+ */
+export const updateFieldsActionValidator = v.object({
+	type: v.literal("update_fields"),
+	target: actionTargetValidator,
+	fields: v.array(
+		v.object({
+			field: v.string(),
+			value: valueRefValidator,
+		})
+	),
+});
+
 export const createTaskActionValidator = v.object({
 	type: v.literal("create_task"),
 	title: valueRefValidator,
@@ -205,6 +222,7 @@ export const sendTeamMessageActionValidator = v.object({
 
 export const actionValidator = v.union(
 	updateFieldActionValidator,
+	updateFieldsActionValidator,
 	createTaskActionValidator,
 	sendNotificationActionValidator,
 	sendTeamMessageActionValidator

--- a/packages/backend/convex/lib/workflowTypes.ts
+++ b/packages/backend/convex/lib/workflowTypes.ts
@@ -197,6 +197,28 @@ export const createTaskActionValidator = v.object({
 	linkToRecord: v.optional(v.boolean()),
 });
 
+/**
+ * Generic record creation. Unlike update_fields there is no record in scope to
+ * write to — a brand-new record of `objectType` is inserted. Only object types
+ * the field registry marks creatable (client/project/task at launch) are
+ * accepted; publish validation rejects the rest, so the validator stays wide
+ * enough to grow into quote/invoice later without a schema migration.
+ * `linkToScope` sets the new record's FK to the in-scope record (e.g. a project
+ * created off a client automation gets that client) via the registry relation
+ * map — and, like create_task's linkToRecord, needs a record in scope.
+ */
+export const createRecordActionValidator = v.object({
+	type: v.literal("create_record"),
+	objectType: objectTypeValidator,
+	fields: v.array(
+		v.object({
+			field: v.string(),
+			value: valueRefValidator,
+		})
+	),
+	linkToScope: v.optional(v.boolean()),
+});
+
 export const sendNotificationActionValidator = v.object({
 	type: v.literal("send_notification"),
 	recipient: v.union(
@@ -224,6 +246,7 @@ export const actionValidator = v.union(
 	updateFieldActionValidator,
 	updateFieldsActionValidator,
 	createTaskActionValidator,
+	createRecordActionValidator,
 	sendNotificationActionValidator,
 	sendTeamMessageActionValidator
 );


### PR DESCRIPTION
This pull request introduces support for new multi-field update and create actions in the automations editor, improves legacy data handling to avoid "permanently dirty" automations, and updates UI logic and metadata to match these new actions. The main themes are canonicalizing action shapes for stability, adding support for creating records, and updating UI and metadata to reflect these features.

**Action shape canonicalization and legacy handling:**

* Added `normalizeNodeConfig` to convert legacy single-field `update_field` actions to the new multi-field `update_fields` shape, and applied this normalization symmetrically on both load (`legacyNodeToV2`) and save (`serializeEditorNodes`), ensuring the editor state and saved state always match and preventing false "unsaved changes" indicators. [[1]](diffhunk://#diff-9017aedc00f7914c4e32ff3c6f34a62c1599f7440ef80a28a1d985c839f2bf82R29-R57) [[2]](diffhunk://#diff-8d2ac3c95c980795c35d5094c3673b513c074129ddba08ed91eca6568c2307c5L18-R18) [[3]](diffhunk://#diff-8d2ac3c95c980795c35d5094c3673b513c074129ddba08ed91eca6568c2307c5L534-R536) [[4]](diffhunk://#diff-590bdb0e1f5498aef1cf988de4465d75eb98c05fbe2a01cd247374437b61320aL216-R223) [[5]](diffhunk://#diff-590bdb0e1f5498aef1cf988de4465d75eb98c05fbe2a01cd247374437b61320aR274-R319)
* Updated tests and fixtures to use the canonical `update_fields` shape, ensuring round-trip stability and correct signature comparisons. [[1]](diffhunk://#diff-d2a2d1cabf4852401b5b65e75765a0b40ee129e3135fd7a1620b4331404e2f64R27-R47) [[2]](diffhunk://#diff-590bdb0e1f5498aef1cf988de4465d75eb98c05fbe2a01cd247374437b61320aR274-R319)

**Support for new action types:**

* Added support for `create_record` actions, including type definitions, UI picker integration, and default value seeding using `getRequiredCreateFields`. [[1]](diffhunk://#diff-e3ab58d202efc7863fbaec52908884bf53e4a4170c325fca046f2765c5b6abdfR10) [[2]](diffhunk://#diff-e3ab58d202efc7863fbaec52908884bf53e4a4170c325fca046f2765c5b6abdfR118-R128) [[3]](diffhunk://#diff-e3ab58d202efc7863fbaec52908884bf53e4a4170c325fca046f2765c5b6abdfR141-R148) [[4]](diffhunk://#diff-bc4bc4813c725448683452a4e66f68648b4e72195be8cd6bde89bcba9a9d30eaR13) [[5]](diffhunk://#diff-bc4bc4813c725448683452a4e66f68648b4e72195be8cd6bde89bcba9a9d30eaR72-R78) [[6]](diffhunk://#diff-f94f6721324e2dbdc7e3214f5df19a8927d7c2af4b7e1b51752d1e9c124463a2R3) [[7]](diffhunk://#diff-f94f6721324e2dbdc7e3214f5df19a8927d7c2af4b7e1b51752d1e9c124463a2R60-R68) [[8]](diffhunk://#diff-0f753071641ca98373d2d153eb30abe04e10fd5bfdf79b2044d57d6daf159228L21-R24) [[9]](diffhunk://#diff-0f753071641ca98373d2d153eb30abe04e10fd5bfdf79b2044d57d6daf159228R74-R80) [[10]](diffhunk://#diff-0f753071641ca98373d2d153eb30abe04e10fd5bfdf79b2044d57d6daf159228R118-R126) [[11]](diffhunk://#diff-0f753071641ca98373d2d153eb30abe04e10fd5bfdf79b2044d57d6daf159228R157-R165)
* Added and exposed `CREATABLE_OBJECT_TYPES` and related UI options for use in create actions. [[1]](diffhunk://#diff-0f753071641ca98373d2d153eb30abe04e10fd5bfdf79b2044d57d6daf159228L21-R24) [[2]](diffhunk://#diff-0f753071641ca98373d2d153eb30abe04e10fd5bfdf79b2044d57d6daf159228R74-R80) [[3]](diffhunk://#diff-0f753071641ca98373d2d153eb30abe04e10fd5bfdf79b2044d57d6daf159228R118-R126)

**UI and metadata updates:**

* Updated the action picker and summary rendering logic to support both `update_fields` and `create_record` actions, including proper labels, icons, and descriptions. [[1]](diffhunk://#diff-bc4bc4813c725448683452a4e66f68648b4e72195be8cd6bde89bcba9a9d30eaR60) [[2]](diffhunk://#diff-bc4bc4813c725448683452a4e66f68648b4e72195be8cd6bde89bcba9a9d30eaR72-R78) [[3]](diffhunk://#diff-f94f6721324e2dbdc7e3214f5df19a8927d7c2af4b7e1b51752d1e9c124463a2R40-R50) [[4]](diffhunk://#diff-f94f6721324e2dbdc7e3214f5df19a8927d7c2af4b7e1b51752d1e9c124463a2R60-R68) [[5]](diffhunk://#diff-4a64d37ce12fef09287be3312f22d46531ef506ca3b99bf758e1065146172750L23-R23) [[6]](diffhunk://#diff-4a64d37ce12fef09287be3312f22d46531ef506ca3b99bf758e1065146172750R41-R59) [[7]](diffhunk://#diff-4a64d37ce12fef09287be3312f22d46531ef506ca3b99bf758e1065146172750R68-R84)
* Improved filtering and enabling logic in the step picker to handle the new action types and their requirements.

**Bug fixes and minor improvements:**

* Fixed the calculation of hidden error counts in the partial progress banner to count against all failures, not just those with stored error entries.
* Changed the default operator in `emptyVariableRule` to `equals` for better semantics.
* Improved rule addition logic in the filter groups editor to respect `canAddRule` in addition to the group count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Create Record** automation actions (with field mapping and optional linking to records in scope) for supported types.
  * Added **Update Record (multi-field)** actions to update multiple fields in a single step.
  * Updated action picking and configuration UI to reflect the new action types and better summaries.
* **Bug Fixes**
  * Fixed preview/summary handling for failure counts.
  * Strengthened validation for multi-field updates and create-record requirements (including scheduled/no-scope behavior).
  * Date formulas now reject invalid calendar dates.
* **Improvements**
  * Automation previews reliably show multi-field changes with no writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new automation action types (`update_fields` for multi-field atomic updates and `create_record` for inserting clients, projects, and tasks), canonicalizes legacy single-field `update_field` configs on both load and save to prevent permanently-dirty automation indicators, and ships comprehensive validation at the UI, publish, and execution layers.

- **Legacy normalization**: `normalizeNodeConfig` upgrades stored `update_field` configs to the `update_fields` shape symmetrically on load (`legacyNodeToV2`) and save (`serializeEditorNodes`), preventing false \"unsaved changes\" badges.
- **`create_record` action**: field registry gains `creatable`/`requiredOnCreate`/`refType` attributes; the executor builds and validates the insert payload (FK org-scoping, plan caps, required fields, defaults), logs activity, syncs aggregates, and emits a `record_created` cascade event.
- **Supporting fixes**: hidden error count in the partial-progress banner now counts against the total `failed` figure rather than the capped stored error list; `emptyVariableRule` defaults to `equals`; the filter-groups editor respects `canAddRule`; throughput metrics drop the `skipped` bucket.

<h3>Confidence Score: 3/5</h3>

Safe to merge with attention to the cascade event correlationId gap in the executor.

The normalization, validation, and UI logic are well-designed and thoroughly tested. The concern is in `executeUpdateFieldsAction` and `executeCreateRecordAction`: both insert cascade domain events using `cascade-<chain>-<frozen_Date.now()>` without the `cascadeEventSeq` increment that `applyStatusUpdate` uses. An automation with two sequential `update_fields` or `create_record` nodes in the same run emits identically-keyed events in the same Convex transaction. If the event bus deduplicates by correlationId, one event is silently dropped and any downstream automation watching the affected field never fires.

`packages/backend/convex/automationExecutor.ts` lines 2917 and 3511 where `cascadeEventSeq` should be incremented before constructing the correlationId.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/automationExecutor.ts | Adds `executeUpdateFieldsAction` and `executeCreateRecordAction`; routes legacy `update_field` through the new shared engine. Two new cascade event emitters omit the `cascadeEventSeq` increment that `applyStatusUpdate` uses, risking duplicate correlationIds in multi-action runs. |
| apps/web/src/app/(workspace)/automations/lib/legacy-load.ts | Introduces `normalizeNodeConfig` to upgrade legacy `update_field` configs to `update_fields`; applied symmetrically on load and save to keep signatures stable. |
| apps/web/src/app/(workspace)/automations/components/sidebar/panels/action-config.tsx | Replaces single-field `UpdateFieldFields` component with multi-row `UpdateFieldsFields` and adds new `CreateRecordFields` component with required-field seeding and linkToScope toggle. |
| packages/backend/convex/lib/workflowTypes.ts | Adds Convex validators for `update_fields` and `create_record` action types; both are appended to the `actionValidator` union. |
| packages/backend/convex/lib/fieldRegistry.ts | Adds `creatable`, `requiredOnCreate`, and `refType` field attributes and exposes `CREATABLE_OBJECT_TYPES`, `getCreatableFields`, `getRequiredCreateFields`, and `isCreatableObjectType`. |
| packages/backend/convex/automations.ts | Extends server-side publish validation with `validateCreateRecordAction` and expands `validateUpdateFieldAction` to handle both `update_field` and `update_fields`; removes `skipped` from throughput metrics. |
| apps/web/src/app/(workspace)/automations/lib/validation.ts | Adds client-side save-time validation for `update_fields` (duplicate rows, empty values) and `create_record` (required fields, invalid link). Introduces `scheduledTopLevel` guard to avoid false no-record errors for `create_record`. |
| apps/web/src/app/(workspace)/automations/components/editor/debug-panel.tsx | Fixes hidden error count in partial-progress banner to count against `failed` (total failures) rather than `errors.length` (capped stored list). |
| packages/backend/convex/lib/activities.ts | Adds optional `actor` parameter to `createActivity` and `clientCreated`/`projectCreated`/`taskCreated` helpers so automation runs can attribute activity without an ambient authenticated user. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Editor as Automation Editor
    participant Load as legacyNodeToV2
    participant Save as serializeEditorNodes
    participant Pub as automations.ts
    participant Exec as automationExecutor
    participant DB as Convex DB
    participant Bus as Event Bus

    Editor->>Load: load stored node (update_field)
    Load->>Load: normalizeNodeConfig
    Load-->>Editor: canonical update_fields node
    Editor->>Save: save editor state
    Save->>Save: normalizeNodeConfig (symmetric)
    Save-->>Pub: update_fields / create_record nodes
    Pub->>Pub: validateUpdateFieldAction / validateCreateRecordAction
    Pub-->>DB: store automation
    DB-->>Exec: trigger fires
    alt update_fields action
        Exec->>DB: ctx.db.patch (all non-status fields)
        Exec->>Bus: entity.record_updated
        opt status row
            Exec->>Exec: applyStatusUpdate (cascadeEventSeq++)
            Exec->>Bus: entity.status_changed
        end
    else create_record action
        Exec->>Exec: buildCreateRecordPayload
        Exec->>DB: ctx.db.insert
        Exec->>Bus: entity.record_created
    end
    Bus-->>Exec: cascade to chained automations
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Editor as Automation Editor
    participant Load as legacyNodeToV2
    participant Save as serializeEditorNodes
    participant Pub as automations.ts
    participant Exec as automationExecutor
    participant DB as Convex DB
    participant Bus as Event Bus

    Editor->>Load: load stored node (update_field)
    Load->>Load: normalizeNodeConfig
    Load-->>Editor: canonical update_fields node
    Editor->>Save: save editor state
    Save->>Save: normalizeNodeConfig (symmetric)
    Save-->>Pub: update_fields / create_record nodes
    Pub->>Pub: validateUpdateFieldAction / validateCreateRecordAction
    Pub-->>DB: store automation
    DB-->>Exec: trigger fires
    alt update_fields action
        Exec->>DB: ctx.db.patch (all non-status fields)
        Exec->>Bus: entity.record_updated
        opt status row
            Exec->>Exec: applyStatusUpdate (cascadeEventSeq++)
            Exec->>Bus: entity.status_changed
        end
    else create_record action
        Exec->>Exec: buildCreateRecordPayload
        Exec->>DB: ctx.db.insert
        Exec->>Bus: entity.record_created
    end
    Bus-->>Exec: cascade to chained automations
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/backend/convex/automationExecutor.ts:2917
**Duplicate cascade correlationIds for multi-action automation runs**

`Date.now()` is frozen inside a Convex transaction, so every `record_updated` event emitted in the same run shares the same timestamp. `applyStatusUpdate` already fixes this by appending `cascadeEventSeq`, but `executeUpdateFieldsAction` (line 2917) and `executeCreateRecordAction` (line 3511) do not. An automation with two sequential `update_fields` or `create_record` action nodes will emit two `entity.record_updated` / `entity.record_created` events with identical correlationIds (`cascade-<chain>-<frozen_timestamp>`). If the event bus deduplicates by correlationId, the second event is silently dropped and any chained automation watching a field from that second node will never fire.

The same `cascadeEventSeq` increment used in `applyStatusUpdate` (line 2550–2551) should be applied before inserting these events too.

### Issue 2 of 3
packages/backend/convex/automationExecutor.ts:3511
**Duplicate cascade correlationId — `executeCreateRecordAction`**

Same issue as line 2917: `Date.now()` is frozen in the transaction, so if an automation run reaches two `create_record` nodes (or one `create_record` + one `update_fields`), both emit `record_created` / `record_updated` domain events with the same `cascade-<chain>-<timestamp>` correlationId. The fix that was applied to `applyStatusUpdate` (`cascadeEventSeq++`) was not replicated here.

### Issue 3 of 3
packages/backend/convex/automationExecutor.ts:3196-3197
Free-plan client and project caps are hardcoded here with a comment that they're "mirrored from `apps/web/src/lib/plan-limits.ts`". If one side is updated and the other isn't, the automation engine and the UI will silently enforce different ceilings. Consider importing (or re-exporting) the constants from a single shared location.

```suggestion
// TODO: import these from a shared plan-limits package instead of mirroring.
const FREE_MAX_CLIENTS = 10;
const FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT = 3;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(automations): B1 create\_record acti..."](https://github.com/xcarter93/onetool/commit/6e31162bb08146b43a2615b7595315f70ea4d0e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44427980)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->