### PR TITLE
chore(mobile): bump app version to 1.0.1 for App Store release

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "OneTool",
     "slug": "onetool-mg3hyu",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "scheme": "onetool",
     "orientation": "default",
     "icon": "./assets/icon.png",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the mobile app version to 1.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the Expo app version from `1.0.0` to `1.0.1` in `app.json` ahead of an App Store release. The app is configured as iOS-only, and no other fields require changes.

- The `version` field (`CFBundleShortVersionString`) is updated to `1.0.1`, satisfying App Store versioning requirements for a new submission.
- Since `ios.buildNumber` is not explicitly set, Expo uses the `version` string as the build number (`CFBundleBuildVersion`), so the build number effectively changes from `1.0.0` to `1.0.1` as well. If a second build for this same version ever needs to be submitted (e.g., a binary-only fix), a distinct `buildNumber` will need to be set manually.

<h3>Confidence Score: 5/5</h3>

This is a single-field version bump in a config file with no code logic changes; safe to merge as-is.

The only change is the version string from 1.0.0 to 1.0.1. The app is iOS-only and the build config looks intact. The implicit buildNumber behavior (defaulting to version) means both the marketing version and the build number advance together, which is valid for a fresh App Store submission.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/mobile/app.json | Bumps the Expo version field from 1.0.0 to 1.0.1; iOS-only app with no explicit buildNumber set (defaults to version string). |

<sub>Reviews (1): Last reviewed commit: ["chore(mobile): bump app version to 1.0.1..."](https://github.com/xcarter93/onetool/commit/8988d239f5fd41aa4bfbc9d375267344b870ebae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44658762)</sub>

<!-- /greptile_comment -->