### PR TITLE
fix(rbac): stop mobile launch crash under PERMISSIONS_ENFORCE

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -8,6 +8,10 @@ import { resolveAuthDestination } from "@/lib/postAuthRouting";
 import { useDevice } from "@/lib/use-device";
 import { IpadShell } from "@/components/ipad/ipad-shell";
 
+// Tab-level error boundary: a screen throw (e.g. a Convex FORBIDDEN) recovers
+// here without tearing down the root providers/auth session.
+export { ErrorScreen as ErrorBoundary } from "@/components/ErrorScreen";
+
 export default function TabLayout() {
   const { isSignedIn, isLoaded: authLoaded } = useAuth();
   const { organization, isLoaded: orgLoaded } = useOrganization();

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -5,7 +5,12 @@ import {
 	useOrganization,
 } from "@clerk/expo";
 import { ConvexProviderWithClerk } from "convex/react-clerk";
-import { ConvexReactClient, useMutation, useQuery } from "convex/react";
+import {
+	ConvexReactClient,
+	useConvexAuth,
+	useMutation,
+	useQuery,
+} from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
 import * as Notifications from "expo-notifications";
 import { Stack } from "expo-router";
@@ -45,18 +50,22 @@ SplashScreen.setOptions({
 
 const convex = new ConvexReactClient(process.env.EXPO_PUBLIC_CONVEX_URL!);
 
+// Root error boundary (expo-router convention): catches any render throw in the
+// app — including Convex useQuery errors, which throw during render — and shows
+// a recoverable error screen instead of hard-crashing the app.
+export { ErrorScreen as ErrorBoundary } from "@/components/ErrorScreen";
+
 function ConvexClerkProvider({ children }: PropsWithChildren) {
 	const { organization } = useOrganization();
-	const [convexKey, setConvexKey] = useState(0);
 
-	// Force ConvexProvider to reinitialize when organization changes
-	// This ensures we get a fresh auth token with the new organization context
-	useEffect(() => {
-		setConvexKey((prevKey) => prevKey + 1);
-	}, [organization?.id]);
-
+	// Keying on the active org id remounts the provider on org change, so we get
+	// a fresh auth token with the new organization context.
 	return (
-		<ConvexProviderWithClerk key={convexKey} client={convex} useAuth={useAuth}>
+		<ConvexProviderWithClerk
+			key={organization?.id ?? "no-org"}
+			client={convex}
+			useAuth={useAuth}
+		>
 			{children as any}
 		</ConvexProviderWithClerk>
 	);
@@ -69,6 +78,7 @@ function ConvexClerkProvider({ children }: PropsWithChildren) {
 // notifications screen is open — PUSH-06). Remounts harmlessly on org switch.
 function PushConvexChild() {
 	const { registerMarkRead, pushToken } = usePushBridge();
+	const { isAuthenticated } = useConvexAuth();
 	const registerToken = useMutation(api.push.registerToken);
 	const markRead = useMutation(api.notifications.markRead);
 	const notificationData = useQuery(api.notifications.listForCurrentUser, {
@@ -82,10 +92,12 @@ function PushConvexChild() {
 	}, [registerMarkRead, markRead]);
 
 	// Idempotent upsert-by-token — a remount-driven re-write is harmless (plan 01).
+	// registerToken is a raw mutation that throws when unauthenticated, so wait
+	// for the Convex identity to attach (a cached push token can resolve first).
 	useEffect(() => {
-		if (!pushToken) return;
+		if (!pushToken || !isAuthenticated) return;
 		void registerToken({ token: pushToken, platform: "ios" });
-	}, [pushToken, registerToken]);
+	}, [pushToken, registerToken, isAuthenticated]);
 
 	// TODO(cross-org badge): unreadCount is ACTIVE-ORG scoped (Pitfall 5), so a
 	// multi-org user sees only the active org's unread count. A cross-org

--- a/apps/mobile/components/ErrorScreen.tsx
+++ b/apps/mobile/components/ErrorScreen.tsx
@@ -1,0 +1,82 @@
+import {
+	Pressable,
+	StyleSheet,
+	Text,
+	useColorScheme,
+	View,
+} from "react-native";
+import type { ErrorBoundaryProps } from "expo-router";
+import { ConvexError } from "convex/values";
+import { fontFamily } from "@/lib/theme";
+
+// Route-level error screen (expo-router ErrorBoundary convention). Deliberately
+// self-contained — the root boundary can render while app providers are down,
+// so no useTokens/context, just static styling with a color-scheme check.
+export function ErrorScreen({ error, retry }: ErrorBoundaryProps) {
+	const dark = useColorScheme() === "dark";
+	const forbidden =
+		error instanceof ConvexError &&
+		(error.data as { code?: string } | undefined)?.code === "FORBIDDEN";
+
+	const title = forbidden ? "No access" : "Something went wrong";
+	const message = forbidden
+		? "Your account doesn't have permission to view this. Ask an admin to update your access."
+		: "An unexpected error occurred. Your data is safe — try again.";
+
+	return (
+		<View
+			style={[styles.container, { backgroundColor: dark ? "#0b1220" : "#f6f8fa" }]}
+		>
+			<Text style={[styles.title, { color: dark ? "#f1f5f9" : "#0f172a" }]}>
+				{title}
+			</Text>
+			<Text style={[styles.message, { color: dark ? "#94a3b8" : "#475569" }]}>
+				{message}
+			</Text>
+			<Pressable
+				onPress={() => void retry()}
+				accessibilityRole="button"
+				accessibilityLabel="Try again"
+				style={({ pressed }) => [styles.button, pressed && styles.pressed]}
+			>
+				<Text style={styles.buttonLabel}>Try again</Text>
+			</Pressable>
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		alignItems: "center",
+		justifyContent: "center",
+		paddingHorizontal: 32,
+		gap: 10,
+	},
+	title: {
+		fontSize: 20,
+		fontFamily: fontFamily.bold,
+		textAlign: "center",
+	},
+	message: {
+		fontSize: 14,
+		fontFamily: fontFamily.regular,
+		textAlign: "center",
+		lineHeight: 21,
+	},
+	button: {
+		marginTop: 14,
+		paddingHorizontal: 22,
+		paddingVertical: 12,
+		borderRadius: 999,
+		backgroundColor: "#1d4ed8",
+	},
+	pressed: {
+		opacity: 0.85,
+	},
+	buttonLabel: {
+		color: "#ffffff",
+		fontSize: 14,
+		fontFamily: fontFamily.semibold,
+	},
+});

--- a/apps/mobile/components/JourneyCard.tsx
+++ b/apps/mobile/components/JourneyCard.tsx
@@ -18,6 +18,9 @@ export function JourneyCard() {
 	const pct = Math.round((completed / total) * 100);
 	const loading = progress === undefined;
 
+	// null = caller lacks the view grants behind the checklist (RBAC) — hide it.
+	if (progress === null) return null;
+
 	return (
 		<Pressable
 			onPress={() => router.push("/journey" as Href)}

--- a/packages/backend/convex/homeStats.ts
+++ b/packages/backend/convex/homeStats.ts
@@ -963,7 +963,7 @@ export interface JourneyProgress {
 
 export const getJourneyProgress = optionalUserQuery({
 	args: {},
-	handler: async (ctx): Promise<JourneyProgress> => {
+	handler: async (ctx): Promise<JourneyProgress | null> => {
 		if (!ctx.orgId) {
 			return {
 				hasOrganization: false,
@@ -977,11 +977,17 @@ export const getJourneyProgress = optionalUserQuery({
 			};
 		}
 		const userOrgId = ctx.orgId;
-		await ctx.requireLevel("clients", "view");
-		await ctx.requireLevel("projects", "view");
-		await ctx.requireLevel("quotes", "view");
-		await ctx.requireLevel("documents", "view");
-		await ctx.requireLevel("invoices", "view");
+		// Cross-object onboarding checklist: callers missing any view grant get
+		// null (checklist hidden) instead of FORBIDDEN — mobile/web render it
+		// unconditionally and older shipped mobile builds can't skip-guard.
+		const gates = await Promise.all([
+			ctx.gateRead("clients"),
+			ctx.gateRead("projects"),
+			ctx.gateRead("quotes"),
+			ctx.gateRead("documents"),
+			ctx.gateRead("invoices"),
+		]);
+		if (gates.some((ok) => !ok)) return null;
 
 		// Get organization to check metadata completion and Stripe Connect
 		const organization = await ctx.db.get(userOrgId);

--- a/packages/backend/convex/permissionsGating.test.ts
+++ b/packages/backend/convex/permissionsGating.test.ts
@@ -715,4 +715,44 @@ describe("granular RBAC domain-function gating", () => {
 			scope: true,
 		});
 	});
+
+	// ── homeStats.getJourneyProgress: cross-object read degrades to null ──
+	// Regression for the mobile launch crash: shipped clients render the journey
+	// checklist unconditionally, so missing view grants must yield null, never
+	// FORBIDDEN.
+
+	it("enforced: member with default permissions gets null from getJourneyProgress (no FORBIDDEN)", async () => {
+		process.env.PERMISSIONS_ENFORCE = "true";
+		const { asMember } = await seedOrgWithMember(
+			"org_journey_1",
+			"user_journey_1"
+		);
+
+		await expect(
+			asMember.query(api.homeStats.getJourneyProgress, {})
+		).resolves.toBeNull();
+	});
+
+	it("enforced: admin still gets full journey progress", async () => {
+		process.env.PERMISSIONS_ENFORCE = "true";
+		const { asAdmin } = await seedOrgWithMember(
+			"org_journey_2",
+			"user_journey_2"
+		);
+
+		await expect(
+			asAdmin.query(api.homeStats.getJourneyProgress, {})
+		).resolves.toMatchObject({ hasClient: false, hasOrganization: false });
+	});
+
+	it("shadow: member with default permissions still gets journey progress", async () => {
+		const { asMember } = await seedOrgWithMember(
+			"org_journey_3",
+			"user_journey_3"
+		);
+
+		await expect(
+			asMember.query(api.homeStats.getJourneyProgress, {})
+		).resolves.toMatchObject({ hasClient: false });
+	});
 });


### PR DESCRIPTION
- getJourneyProgress degrades to null via gateRead instead of throwing FORBIDDEN (shipped mobile binaries render the checklist unconditionally; web nav-getting-started already hides on falsy)
- gate root-layout push.registerToken on useConvexAuth().isAuthenticated (raw mutation threw "User not authenticated" on cached push tokens)
- add expo-router ErrorBoundary (root + tabs) with a recoverable ErrorScreen; FORBIDDEN ConvexErrors render a "No access" state instead of crashing
- hide JourneyCard when journey progress is null
- key ConvexProviderWithClerk on organization id (drops set-state-in-effect)
- regression tests: enforced member gets null, admin/shadow keep data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer error screens for unexpected errors and access-denied situations, with a “Try again” option.
  * Improved recovery from errors within mobile app sections without disrupting the active session.

* **Bug Fixes**
  * Prevented journey progress cards from appearing when required access is unavailable.
  * Prevented push token registration before authentication is complete.

* **Tests**
  * Added coverage for permission-based journey progress behavior in enforced and shadow modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a mobile launch crash that occurred when `PERMISSIONS_ENFORCE` is active by replacing hard `requireLevel` throws in `getJourneyProgress` with soft `gateRead` checks that return `null`, and adds expo-router `ErrorBoundary` screens so any remaining render-time Convex throws degrade gracefully instead of hard-crashing.

- `homeStats.getJourneyProgress` now returns `null` when any of the five view gates fail; `JourneyCard` hides itself on `null`, and regression tests cover the enforced-member/admin/shadow cases.
- Push-token registration in `PushConvexChild` is now gated on `useConvexAuth().isAuthenticated` to prevent the "User not authenticated" mutation error when a cached token resolves before the Convex identity attaches.
- `ConvexProviderWithClerk` drops the `setState`-in-effect pattern and keys directly on `organization?.id` for a cleaner, effect-free remount on org switch.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the changes are tightly scoped crash fixes with regression test coverage.

All core paths (null propagation, isAuthenticated guard, key-based remount, error boundary) are correct. The only finding is a leftover useState import that no longer has a use site after the refactor — harmless at runtime but will fail lint if the project enforces no-unused-vars.

apps/mobile/app/_layout.tsx — the unused useState import should be removed before merging if CI runs lint.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/mobile/app/_layout.tsx | Removes setState-in-effect org-switch pattern in favor of key prop on ConvexProviderWithClerk, and gates registerToken on isAuthenticated — unused useState import remains after the refactor. |
| apps/mobile/app/(tabs)/_layout.tsx | Adds tab-level ErrorBoundary re-export for FORBIDDEN recovery; change is minimal and correct. |
| apps/mobile/components/ErrorScreen.tsx | New self-contained error boundary screen; FORBIDDEN detection matches the object shape thrown by ConvexError in the codebase, useColorScheme is provider-independent, retry is correctly voided. |
| apps/mobile/components/JourneyCard.tsx | Adds null guard to hide the card when the caller lacks RBAC grants; countCompletedSteps already handles null safely so pre-guard calculations are harmless. |
| packages/backend/convex/homeStats.ts | Switches from requireLevel (throws FORBIDDEN) to gateRead (returns bool) for the journey checklist, returning null when any permission gate fails — correct fix for the mobile crash scenario. |
| packages/backend/convex/permissionsGating.test.ts | Three regression tests cover enforced-member→null, enforced-admin→data, and shadow-member→data; process.env.PERMISSIONS_ENFORCE is properly restored by the existing afterEach hook. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App as RootLayout
    participant CCP as ConvexClerkProvider(key=org.id)
    participant PCC as PushConvexChild
    participant CA as useConvexAuth
    participant Convex as Convex Backend
    participant JC as JourneyCard

    App->>CCP: "render (key="no-org")"
    Note over CCP: Clerk org loads → key becomes org_id → remount
    CCP->>PCC: mount
    PCC->>CA: isAuthenticated?
    CA-->>PCC: false (token not yet attached)
    Note over PCC: skip registerToken (was crashing here)
    CA-->>PCC: true (Convex identity attached)
    PCC->>Convex: "registerToken({token, platform})"

    JC->>Convex: getJourneyProgress()
    alt "PERMISSIONS_ENFORCE=true and missing view grant"
        Convex-->>JC: null (gateRead false)
        JC-->>App: render nothing (hidden)
    else admin or shadow mode
        Convex-->>JC: JourneyProgress object
        JC-->>App: render gauge card
    end

    alt render throw (any FORBIDDEN ConvexError)
        App->>App: ErrorBoundary catches
        App-->>App: show ErrorScreen
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App as RootLayout
    participant CCP as ConvexClerkProvider(key=org.id)
    participant PCC as PushConvexChild
    participant CA as useConvexAuth
    participant Convex as Convex Backend
    participant JC as JourneyCard

    App->>CCP: "render (key="no-org")"
    Note over CCP: Clerk org loads → key becomes org_id → remount
    CCP->>PCC: mount
    PCC->>CA: isAuthenticated?
    CA-->>PCC: false (token not yet attached)
    Note over PCC: skip registerToken (was crashing here)
    CA-->>PCC: true (Convex identity attached)
    PCC->>Convex: "registerToken({token, platform})"

    JC->>Convex: getJourneyProgress()
    alt "PERMISSIONS_ENFORCE=true and missing view grant"
        Convex-->>JC: null (gateRead false)
        JC-->>App: render nothing (hidden)
    else admin or shadow mode
        Convex-->>JC: JourneyProgress object
        JC-->>App: render gauge card
    end

    alt render throw (any FORBIDDEN ConvexError)
        App->>App: ErrorBoundary catches
        App-->>App: show ErrorScreen
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/mobile/app/_layout.tsx`, line 19 ([link](https://github.com/xcarter93/onetool/blob/60139f13ad3bdff5c377e63f408cf4e539f75d6f/apps/mobile/app/_layout.tsx#L19)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `useState` is imported but no longer used after the `setConvexKey` pattern was replaced by the `key` prop approach. Most strict-lint configs will flag this as an error and fail CI.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/mobile/app/_layout.tsx
   Line: 19

   Comment:
   `useState` is imported but no longer used after the `setConvexKey` pattern was replaced by the `key` prop approach. Most strict-lint configs will flag this as an error and fail CI.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/mobile/app/_layout.tsx:19
`useState` is imported but no longer used after the `setConvexKey` pattern was replaced by the `key` prop approach. Most strict-lint configs will flag this as an error and fail CI.

```suggestion
import { useEffect, type PropsWithChildren } from "react";
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rbac): stop mobile launch crash unde..."](https://github.com/xcarter93/onetool/commit/60139f13ad3bdff5c377e63f408cf4e539f75d6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44776166)</sub>

<!-- /greptile_comment -->