### PR TITLE
Redesign canvas and implement merge continuation for workflows

### DIFF
--- a/apps/web/src/app/(workspace)/automations/components/editor/automation-editor-screen.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/editor/automation-editor-screen.tsx
@@ -11,6 +11,7 @@ import { useSidebarState } from "../../hooks/use-sidebar-state";
 import {
 	TRIGGER_NODE_ID,
 	TRIGGER_PLACEHOLDER_ID,
+	isGhostId,
 	isTerminalId,
 } from "../../lib/flow-adapter";
 import { EditorTopBar } from "./editor-top-bar";
@@ -80,16 +81,21 @@ export function AutomationEditorScreen({ automationId }: { automationId: string 
 		[editor.layoutedEdges, handleEdgeInsert]
 	);
 
-	// Paint each node's live run status onto its React Flow wrapper (ring/pulse).
+	// Paint each node's live run status onto its React Flow wrapper (ring/pulse);
+	// ghost "Choose a step" cards get the insert callback (they insert via
+	// their incoming branch edge, same flow as the "+" buttons).
 	const flowNodes = useMemo(
 		() =>
 			editor.layoutedNodes.map((node) => {
+				const withInsert = isGhostId(node.id)
+					? { ...node, data: { ...node.data, onInsertNode: handleEdgeInsert } }
+					: node;
 				const ring = runStatusRingClass(editor.runStatuses[node.id]);
 				return ring
-					? { ...node, className: cn(node.className, ring) }
-					: node;
+					? { ...withInsert, className: cn(withInsert.className, ring) }
+					: withInsert;
 			}),
-		[editor.layoutedNodes, editor.runStatuses]
+		[editor.layoutedNodes, editor.runStatuses, handleEdgeInsert]
 	);
 
 	const handleNodeClick = useCallback(

--- a/apps/web/src/app/(workspace)/automations/components/flow/add-step-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/add-step-node-rf.tsx
@@ -14,12 +14,12 @@ export const TerminalNodeRF = memo((_props: NodeProps) => {
 			<Handle
 				type="target"
 				position={Position.Top}
-				className="bg-transparent! w-0! h-0! border-0!"
+				className="bg-transparent! w-0! h-0! min-w-0! min-h-0! border-0!"
 			/>
 			<Handle
 				type="source"
 				position={Position.Bottom}
-				className="bg-transparent! w-0! h-0! border-0!"
+				className="bg-transparent! w-0! h-0! min-w-0! min-h-0! border-0!"
 			/>
 		</div>
 	);

--- a/apps/web/src/app/(workspace)/automations/components/flow/automation-flow.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/automation-flow.tsx
@@ -18,6 +18,8 @@ import { ZoomSlider } from "@/components/zoom-slider";
 import {
 	applyDerivedLayout,
 	isContainerId,
+	isGhostId,
+	isMergeId,
 	isTerminalId,
 	TRIGGER_NODE_ID,
 	TRIGGER_PLACEHOLDER_ID,
@@ -44,10 +46,13 @@ import { TerminalNodeRF } from "./add-step-node-rf";
 import { TriggerPlaceholderNodeRF } from "./trigger-placeholder-node-rf";
 import { PlaceholderNodeRF } from "./placeholder-node-rf";
 import { LoopContainerNodeRF } from "./loop-container-node-rf";
+import { MergeNodeRF } from "./merge-node-rf";
+import { BranchGhostNodeRF } from "./branch-ghost-node-rf";
 import { PlusButtonEdge } from "./plus-button-edge";
 import { BranchLabelEdge } from "./branch-label-edge";
 import { LoopBackEdge } from "./loop-back-edge";
 import { AfterLastEdge } from "./after-last-edge";
+import { MergeInEdge } from "./merge-in-edge";
 
 // CRITICAL: Define outside component to avoid React Flow re-render warnings
 const nodeTypes = {
@@ -66,6 +71,8 @@ const nodeTypes = {
 	triggerPlaceholderNode: TriggerPlaceholderNodeRF,
 	placeholderNode: PlaceholderNodeRF,
 	loopContainerNode: LoopContainerNodeRF,
+	mergeNode: MergeNodeRF,
+	branchGhostNode: BranchGhostNodeRF,
 };
 
 const edgeTypes = {
@@ -73,6 +80,7 @@ const edgeTypes = {
 	branchLabelEdge: BranchLabelEdge,
 	loopBackEdge: LoopBackEdge,
 	afterLastEdge: AfterLastEdge,
+	mergeInEdge: MergeInEdge,
 };
 
 const LAYOUT_ANIMATION_MS = 220;
@@ -291,7 +299,9 @@ function AutomationFlowInner({
 
 	const handleNodeClick: NodeMouseHandler = useCallback(
 		(_event, node) => {
-			if (isContainerId(node.id)) return;
+			// Ghost cards handle their own click (insert via their edge).
+			if (isContainerId(node.id) || isMergeId(node.id) || isGhostId(node.id))
+				return;
 			onNodeClick?.(node.id);
 		},
 		[onNodeClick]
@@ -313,8 +323,14 @@ function AutomationFlowInner({
 	const handleNodeContextMenu = useCallback(
 		(event: React.MouseEvent, node: Node) => {
 			event.preventDefault();
-			// Don't show context menu for terminal stubs or container frames
-			if (isTerminalId(node.id) || isContainerId(node.id)) return;
+			// Don't show context menu for synthetic nodes (stubs, frames, merges, ghosts)
+			if (
+				isTerminalId(node.id) ||
+				isContainerId(node.id) ||
+				isMergeId(node.id) ||
+				isGhostId(node.id)
+			)
+				return;
 			setContextMenu({ nodeId: node.id, x: event.clientX, y: event.clientY });
 		},
 		[]

--- a/apps/web/src/app/(workspace)/automations/components/flow/branch-ghost-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/branch-ghost-node-rf.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { memo } from "react";
+import { Position, type NodeProps } from "@xyflow/react";
+import { Plus } from "lucide-react";
+import { BaseNode, BaseNodeContent } from "@/components/base-node";
+import { BaseHandle } from "@/components/base-handle";
+import type { BranchGhostRFNode } from "../../lib/node-types";
+
+/**
+ * Ghost "Choose a step" card in an empty condition branch or loop body —
+ * visually identical to a transient placeholder so lanes read the same
+ * whether or not an insert has started. Clicking inserts a placeholder via
+ * the incoming branch edge (same flow as the "+" buttons).
+ */
+export const BranchGhostNodeRF = memo(({ data }: NodeProps<BranchGhostRFNode>) => {
+	return (
+		<BaseNode
+			className="w-[280px] cursor-pointer border-dashed border-muted-foreground/30 hover:border-primary/50"
+			aria-label="Empty branch -- click to add a step"
+			onClick={(e) => {
+				e.stopPropagation();
+				data.onInsertNode?.(data.edgeId, "placeholder");
+			}}
+		>
+			<BaseHandle type="target" position={Position.Top} />
+			<BaseNodeContent className="p-3">
+				<div className="flex items-center gap-3">
+					<div className="w-8 h-8 rounded-lg bg-muted/50 flex items-center justify-center shrink-0">
+						<Plus className="h-5 w-5 text-muted-foreground" />
+					</div>
+					<span className="text-sm text-muted-foreground">Choose a step</span>
+				</div>
+			</BaseNodeContent>
+			<BaseHandle type="source" position={Position.Bottom} className="opacity-0!" />
+		</BaseNode>
+	);
+});
+BranchGhostNodeRF.displayName = "BranchGhostNodeRF";

--- a/apps/web/src/app/(workspace)/automations/components/flow/branch-ghost-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/branch-ghost-node-rf.tsx
@@ -17,8 +17,17 @@ export const BranchGhostNodeRF = memo(({ data }: NodeProps<BranchGhostRFNode>) =
 	return (
 		<BaseNode
 			className="w-[280px] cursor-pointer border-dashed border-muted-foreground/30 hover:border-primary/50"
-			aria-label="Empty branch -- click to add a step"
+			role="button"
+			aria-label="Empty branch: add a step"
 			onClick={(e) => {
+				e.stopPropagation();
+				data.onInsertNode?.(data.edgeId, "placeholder");
+			}}
+			onKeyDown={(e) => {
+				// BaseNode is a focusable div — without this the card is reachable
+				// by keyboard but not activatable.
+				if (e.key !== "Enter" && e.key !== " ") return;
+				e.preventDefault();
 				e.stopPropagation();
 				data.onInsertNode?.(data.edgeId, "placeholder");
 			}}

--- a/apps/web/src/app/(workspace)/automations/components/flow/branch-label-edge.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/branch-label-edge.tsx
@@ -3,14 +3,17 @@
 import {
 	BaseEdge,
 	EdgeLabelRenderer,
-	getStraightPath,
+	getSmoothStepPath,
+	Position,
 	type EdgeProps,
 } from "@xyflow/react";
-import { ButtonEdge as RFButtonEdge } from "@/components/button-edge";
 import { Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { NextItemMarker } from "./next-item-marker";
 import { EDGE_STYLE, LOOP_EDGE_STYLE } from "./edge-style";
+
+/** Vertical stem below the source before the fan-out turns toward its lane. */
+const FAN_DROP = 24;
 
 /** Map raw branch labels to user-friendly text */
 function displayLabel(label: string | undefined, branchType: string): string {
@@ -21,61 +24,72 @@ function displayLabel(label: string | undefined, branchType: string): string {
 	return label || "";
 }
 
+/**
+ * Condition/loop branch edge, Salesforce-Flow style: a short stem drops from
+ * the source, turns toward the branch lane with rounded corners, and runs
+ * down the lane. The label pill sits on the fan-out corner at the lane's top;
+ * the "+" lives in the lane (always visible on empty branches, hover-revealed
+ * on populated ones).
+ */
 export function BranchLabelEdge(props: EdgeProps) {
-	const {
-		id,
-		sourceX,
-		sourceY,
-		targetX,
-		targetY,
-		data,
-		style,
-	} = props;
+	const { id, sourceX, sourceY, targetX, targetY, data, style } = props;
 	const branchType =
 		(data?.branchType as string) || (data?.variant as string) || "yes";
 	const rawLabel = data?.label as string | undefined;
 	const label = displayLabel(rawLabel, branchType);
 	const isTerminal = data?.isTerminal === true;
+	// The lane ends in a ghost "Choose a step" card — the card is the insert
+	// affordance, so the edge renders no "+".
+	const ghostTarget = data?.ghostTarget === true;
 	const impliedNextItem = data?.impliedNextItem === true;
 	const isLoopBranch = branchType === "each";
-	const edgeStyle = isLoopBranch ? LOOP_EDGE_STYLE : EDGE_STYLE;
+	const edgeStyle =
+		isLoopBranch || data?.inLoop === true ? LOOP_EDGE_STYLE : EDGE_STYLE;
 	const onInsertNode = data?.onInsertNode as
 		| ((edgeId: string, nodeType: string) => void)
 		| undefined;
 
-	// Only terminal edges need custom rendering (shortened path + always-visible "+" button)
-	if (isTerminal) {
-		// Fixed-length stub below source (ignore target position to prevent flip on drag)
-		const TERMINAL_LENGTH = 50;
-		const fixedTargetY = sourceY + TERMINAL_LENGTH;
-		const [edgePath, labelX, labelY] = getStraightPath({
-			sourceX,
-			sourceY,
-			targetX: sourceX,
-			targetY: fixedTargetY,
-		});
-		const plusX = sourceX;
-		const plusY = fixedTargetY;
+	// Empty branches keep a fixed-length lane below the fan-out (the terminal
+	// node's position is layout-derived from the same constant).
+	const TERMINAL_LENGTH = 50;
+	const effectiveTargetY = isTerminal ? sourceY + TERMINAL_LENGTH : targetY;
 
-		return (
-			<>
-				<BaseEdge
-					path={edgePath}
-					style={{ ...style, ...edgeStyle }}
-				/>
-				<EdgeLabelRenderer>
-					{label && (
-						<div
-							className="nodrag nopan pointer-events-none absolute"
-							style={{
-								transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
-							}}
-						>
-							<span className="text-xs text-muted-foreground bg-background px-1.5 py-0.5 rounded select-none">
-								{label}
-							</span>
-						</div>
-					)}
+	const [edgePath] = getSmoothStepPath({
+		sourceX,
+		sourceY,
+		sourcePosition: Position.Bottom,
+		targetX,
+		targetY: effectiveTargetY,
+		targetPosition: Position.Top,
+		borderRadius: 12,
+		centerY: sourceY + FAN_DROP,
+	});
+
+	// Pill on the fan-out corner (top of the lane); "+" further down the lane.
+	const labelX = targetX;
+	const labelY = sourceY + FAN_DROP;
+	const plusX = targetX;
+	const plusY = isTerminal
+		? effectiveTargetY
+		: (sourceY + FAN_DROP + effectiveTargetY) / 2;
+
+	return (
+		<>
+			<BaseEdge path={edgePath} style={{ ...style, ...edgeStyle }} />
+			<EdgeLabelRenderer>
+				{label && (
+					<div
+						className="nodrag nopan pointer-events-none absolute"
+						style={{
+							transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+						}}
+					>
+						<span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-muted text-muted-foreground select-none whitespace-nowrap">
+							{label}
+						</span>
+					</div>
+				)}
+				{!ghostTarget && (
 					<div
 						className="nodrag nopan pointer-events-auto absolute"
 						style={{
@@ -99,38 +113,9 @@ export function BranchLabelEdge(props: EdgeProps) {
 							<Plus className="h-3.5 w-3.5 text-muted-foreground" />
 						</button>
 					</div>
-					{impliedNextItem && <NextItemMarker x={plusX} y={plusY + 18} />}
-				</EdgeLabelRenderer>
-			</>
-		);
-	}
-
-	// Simple yes/each branches: use RF UI ButtonEdge
-	return (
-		<RFButtonEdge
-			{...props}
-			style={{ ...style, ...edgeStyle }}
-		>
-			<div className="flex flex-col items-center gap-1">
-				{label && (
-					<span className="text-xs text-muted-foreground bg-background px-1.5 py-0.5 rounded select-none pointer-events-none">
-						{label}
-					</span>
 				)}
-				<button
-					onClick={(e) => {
-						e.stopPropagation();
-						onInsertNode?.(id, "placeholder");
-					}}
-					className={cn(
-						"nodrag nopan w-7 h-7 rounded-full bg-background border border-border hover:border-primary flex items-center justify-center shadow-sm transition-colors cursor-pointer",
-						"opacity-0 hover:opacity-100 focus:opacity-100",
-					)}
-					aria-label="Add step"
-				>
-					<Plus className="h-3.5 w-3.5 text-muted-foreground" />
-				</button>
-			</div>
-		</RFButtonEdge>
+				{impliedNextItem && <NextItemMarker x={plusX} y={plusY + 18} />}
+			</EdgeLabelRenderer>
+		</>
 	);
 }

--- a/apps/web/src/app/(workspace)/automations/components/flow/edge-style.ts
+++ b/apps/web/src/app/(workspace)/automations/components/flow/edge-style.ts
@@ -10,6 +10,7 @@ import type { CSSProperties } from "react";
 export const EDGE_STYLE: CSSProperties = {
 	stroke: "color-mix(in oklch, var(--muted-foreground) 60%, transparent)",
 	strokeWidth: 1.5,
+	strokeDasharray: "6 3",
 };
 
 /** Loop iteration lanes (each / loop-back / after-last) — dashed orange, dark-safe. */

--- a/apps/web/src/app/(workspace)/automations/components/flow/loop-back-edge.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/loop-back-edge.tsx
@@ -19,7 +19,8 @@ export function LoopBackEdge({
 		typeof data?.routeLeftX === "number" ? (data.routeLeftX as number) : undefined;
 	const leftX = routeLeftX ?? Math.min(sourceX, targetX) - offsetX;
 	const cornerRadius = 16;
-	// Extend below source to clear the terminal "+" stub button (50px below source)
+	// Extend below source to clear the terminal "+" stub button (50px below
+	// source) — plain chain tails and merge dots both carry one.
 	const extendBelow = 70;
 	const bottomY = sourceY + extendBelow;
 

--- a/apps/web/src/app/(workspace)/automations/components/flow/merge-in-edge.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/merge-in-edge.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import {
+	BaseEdge,
+	getSmoothStepPath,
+	Position,
+	type EdgeProps,
+} from "@xyflow/react";
+import { EDGE_STYLE, LOOP_EDGE_STYLE } from "./edge-style";
+
+/**
+ * Clearance below a terminal stub's "+" button before the connector starts:
+ * the stub sits at the button's center, the button is a 28px circle, so 13px
+ * lands flush against its lower edge.
+ */
+const STUB_CLEARANCE = 13;
+/** Slight extension past the (invisible) merge point so the join is seamless. */
+const JOIN_OVERSHOOT = 4;
+
+/**
+ * Branch tail → merge point connector: curves inward from the lane back to
+ * the spine. Non-interactive — inserting at the convergence happens on the
+ * merge point's OUTGOING edge, not here.
+ */
+export function MergeInEdge({
+	sourceX,
+	sourceY,
+	targetX,
+	targetY,
+	data,
+	style,
+}: EdgeProps) {
+	const startY =
+		data?.fromTerminalStub === true ? sourceY + STUB_CLEARANCE : sourceY;
+	const [edgePath] = getSmoothStepPath({
+		sourceX,
+		sourceY: startY,
+		sourcePosition: Position.Bottom,
+		targetX,
+		targetY: targetY + JOIN_OVERSHOOT,
+		targetPosition: Position.Top,
+		borderRadius: 12,
+	});
+
+	return (
+		<BaseEdge
+			path={edgePath}
+			style={{
+				...style,
+				...(data?.inLoop === true ? LOOP_EDGE_STYLE : EDGE_STYLE),
+			}}
+		/>
+	);
+}

--- a/apps/web/src/app/(workspace)/automations/components/flow/merge-node-rf.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/merge-node-rf.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { memo } from "react";
+import { Handle, Position } from "@xyflow/react";
+
+/**
+ * Invisible convergence point below a condition: both branch lanes reconverge
+ * here before flow continues (merge chain, loop-back, or "+" stub). Purely a
+ * routing anchor for edges — no visual, never serialized, never interactive.
+ */
+export const MergeNodeRF = memo(() => {
+	return (
+		<div aria-hidden className="h-px w-px">
+			<Handle
+				type="target"
+				position={Position.Top}
+				className="bg-transparent! w-0! h-0! min-w-0! min-h-0! border-0!"
+			/>
+			<Handle
+				type="source"
+				position={Position.Bottom}
+				className="bg-transparent! w-0! h-0! min-w-0! min-h-0! border-0!"
+			/>
+		</div>
+	);
+});
+MergeNodeRF.displayName = "MergeNodeRF";

--- a/apps/web/src/app/(workspace)/automations/components/flow/plus-button-edge.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/plus-button-edge.tsx
@@ -10,7 +10,7 @@ import { ButtonEdge as RFButtonEdge } from "@/components/button-edge";
 import { Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { NextItemMarker } from "./next-item-marker";
-import { EDGE_STYLE } from "./edge-style";
+import { EDGE_STYLE, LOOP_EDGE_STYLE } from "./edge-style";
 
 export function PlusButtonEdge(props: EdgeProps) {
 	const {
@@ -24,6 +24,7 @@ export function PlusButtonEdge(props: EdgeProps) {
 	} = props;
 	const isTerminal = data?.isTerminal === true;
 	const impliedNextItem = data?.impliedNextItem === true;
+	const edgeStyle = data?.inLoop === true ? LOOP_EDGE_STYLE : EDGE_STYLE;
 	const onInsertNode = data?.onInsertNode as
 		| ((edgeId: string, nodeType: string, actionType?: string) => void)
 		| undefined;
@@ -43,7 +44,7 @@ export function PlusButtonEdge(props: EdgeProps) {
 
 		return (
 			<>
-				<BaseEdge path={edgePath} style={{ ...style, ...EDGE_STYLE }} />
+				<BaseEdge path={edgePath} style={{ ...style, ...edgeStyle }} />
 				<EdgeLabelRenderer>
 					<div
 						className="nodrag nopan pointer-events-auto absolute"
@@ -73,7 +74,7 @@ export function PlusButtonEdge(props: EdgeProps) {
 	return (
 		<RFButtonEdge
 			{...props}
-			style={{ ...style, ...EDGE_STYLE }}
+			style={{ ...style, ...edgeStyle }}
 		>
 			<button
 				onClick={(e) => {

--- a/apps/web/src/app/(workspace)/automations/hooks/use-automation-editor.test.ts
+++ b/apps/web/src/app/(workspace)/automations/hooks/use-automation-editor.test.ts
@@ -69,6 +69,32 @@ describe("toSavableNodes condition source derivation", () => {
 		const saved = toSavableNodes([staleCondition]);
 		expect(saved[0].config).toMatchObject({ source: "trigger" });
 	});
+
+	// Regression: toSavableNodes is the real save path (serializeEditorNodes
+	// only feeds it). Dropping mergeNodeId here silently discarded every
+	// condition continuation on save AND left the automation permanently dirty
+	// — the editor signature keeps the field the round-trip loses.
+	it("persists a condition's mergeNodeId continuation", () => {
+		const saved = toSavableNodes([
+			{
+				...conditionInLoop,
+				id: "cond3",
+				nextNodeId: "a1",
+				elseNodeId: "a2",
+				mergeNodeId: "m1",
+			} as unknown as WorkflowNode,
+		]);
+		expect(saved[0]).toMatchObject({
+			nextNodeId: "a1",
+			elseNodeId: "a2",
+			mergeNodeId: "m1",
+		});
+	});
+
+	it("omits mergeNodeId entirely when a condition has no continuation", () => {
+		const saved = toSavableNodes([conditionInLoop]);
+		expect("mergeNodeId" in saved[0]).toBe(false);
+	});
 });
 
 describe("multi-level undo/redo", () => {

--- a/apps/web/src/app/(workspace)/automations/hooks/use-automation-editor.ts
+++ b/apps/web/src/app/(workspace)/automations/hooks/use-automation-editor.ts
@@ -332,6 +332,9 @@ export function toSavableNodes(nodes: WorkflowNode[]) {
 			...(node.bodyStartNodeId !== undefined
 				? { bodyStartNodeId: node.bodyStartNodeId }
 				: {}),
+			...(node.mergeNodeId !== undefined
+				? { mergeNodeId: node.mergeNodeId }
+				: {}),
 		};
 	});
 }
@@ -760,16 +763,23 @@ export function useAutomationEditor(automationId: string | null) {
 			pushHistory();
 
 			if (nodeToDelete.type === "condition") {
-				const subtreeIds = collectSubtree(nodeId, nodes);
+				// Both branches go with the condition, but its merge continuation
+				// is downstream of it — splice that chain onto the parent instead
+				// of deleting it (same shape as a loop's After-Last child below).
+				const subtreeIds = collectSubtree(nodeId, nodes, {
+					excludeRootMerge: true,
+				});
+				const continuationId = nodeToDelete.mergeNodeId;
 
 				setNodes((prev) => {
 					const remaining = prev.filter((node) => !subtreeIds.has(node.id));
 					return remaining.map((node) => {
 						if (node.id !== parentId) return node;
-						if (branch === "else") return { ...node, elseNodeId: undefined };
-						if (branch === "body") return { ...node, bodyStartNodeId: undefined };
-						if (branch === "merge") return { ...node, mergeNodeId: undefined };
-						return { ...node, nextNodeId: undefined };
+						if (branch === "else") return { ...node, elseNodeId: continuationId };
+						if (branch === "body")
+							return { ...node, bodyStartNodeId: continuationId };
+						if (branch === "merge") return { ...node, mergeNodeId: continuationId };
+						return { ...node, nextNodeId: continuationId };
 					});
 				});
 

--- a/apps/web/src/app/(workspace)/automations/hooks/use-automation-editor.ts
+++ b/apps/web/src/app/(workspace)/automations/hooks/use-automation-editor.ts
@@ -22,7 +22,10 @@ import {
 	TRIGGER_NODE_ID,
 	TRIGGER_PLACEHOLDER_ID,
 	automationToReactFlow,
+	isGhostId,
+	isMergeId,
 	isTerminalId,
+	MERGE_PREFIX,
 	serializeEditorNodes,
 	type EditorNode,
 	type PlaceholderEntry,
@@ -518,12 +521,20 @@ export function useAutomationEditor(automationId: string | null) {
 			const targetId = edge.target;
 			const branchType = (edge.data?.branchType as string) || "next";
 			// "no" (condition) -> elseNodeId; "each" (loop body entry) -> bodyStartNodeId;
+			// "merge" (a condition's merge dot) -> mergeNodeId on the OWNING
+			// condition (the dot is synthetic — resolve it to its condition);
 			// everything else (incl. loop's "after") is a plain nextNodeId continuation.
 			const isElseBranch = branchType === "no";
 			const isBodyBranch = branchType === "each";
-			const isTerminalTarget = isTerminalId(targetId);
+			const isMergeBranch = branchType === "merge" && isMergeId(sourceId);
+			const pointerOwnerId = isMergeBranch
+				? sourceId.slice(MERGE_PREFIX.length)
+				: sourceId;
+			// Terminal stubs and ghost cards are synthetic — inserting on their
+			// edge means "append", never "point at the synthetic node".
+			const isSyntheticTarget = isTerminalId(targetId) || isGhostId(targetId);
 			const realTargetId =
-				!isTerminalTarget &&
+				!isSyntheticTarget &&
 				targetId !== TRIGGER_NODE_ID &&
 				targetId !== TRIGGER_PLACEHOLDER_ID
 					? targetId
@@ -541,10 +552,12 @@ export function useAutomationEditor(automationId: string | null) {
 					const condNode = buildConditionNode(newId);
 					condNode.nextNodeId = yesPlaceholderId;
 					condNode.elseNodeId = noPlaceholderId;
+					// Downstream steps run after EITHER branch — they continue
+					// at the merge, not inside the Yes branch.
+					condNode.mergeNodeId = downstreamId;
 					const yesPlaceholder: PlaceholderEntry = {
 						id: yesPlaceholderId,
 						type: "placeholder",
-						nextNodeId: downstreamId,
 					};
 					const noPlaceholder: PlaceholderEntry = {
 						id: noPlaceholderId,
@@ -604,8 +617,11 @@ export function useAutomationEditor(automationId: string | null) {
 					if (sourceId === TRIGGER_NODE_ID || sourceId === TRIGGER_PLACEHOLDER_ID) {
 						return node;
 					}
-					if (node.id !== sourceId) {
+					if (node.id !== pointerOwnerId) {
 						return node;
+					}
+					if (isMergeBranch) {
+						return { ...node, mergeNodeId: newId };
 					}
 					if (isBodyBranch) {
 						return { ...node, bodyStartNodeId: newId };
@@ -643,8 +659,11 @@ export function useAutomationEditor(automationId: string | null) {
 							const condNode = buildConditionNode(nodeId);
 							condNode.nextNodeId = yesPlaceholderId;
 							condNode.elseNodeId = noPlaceholderId;
+							// Downstream steps run after EITHER branch — they
+							// continue at the merge, not inside the Yes branch.
+							condNode.mergeNodeId = downstreamId;
 							extraNodes.push(
-								{ id: yesPlaceholderId, type: "placeholder", nextNodeId: downstreamId },
+								{ id: yesPlaceholderId, type: "placeholder" },
 								{ id: noPlaceholderId, type: "placeholder" }
 							);
 							return condNode;
@@ -749,6 +768,7 @@ export function useAutomationEditor(automationId: string | null) {
 						if (node.id !== parentId) return node;
 						if (branch === "else") return { ...node, elseNodeId: undefined };
 						if (branch === "body") return { ...node, bodyStartNodeId: undefined };
+						if (branch === "merge") return { ...node, mergeNodeId: undefined };
 						return { ...node, nextNodeId: undefined };
 					});
 				});
@@ -771,6 +791,7 @@ export function useAutomationEditor(automationId: string | null) {
 						if (node.id !== parentId) return node;
 						if (branch === "else") return { ...node, elseNodeId: afterLastChildId };
 						if (branch === "body") return { ...node, bodyStartNodeId: afterLastChildId };
+						if (branch === "merge") return { ...node, mergeNodeId: afterLastChildId };
 						return { ...node, nextNodeId: afterLastChildId };
 					});
 				});
@@ -790,6 +811,7 @@ export function useAutomationEditor(automationId: string | null) {
 					if (node.id !== parentId) return node;
 					if (branch === "else") return { ...node, elseNodeId: childNodeId };
 					if (branch === "body") return { ...node, bodyStartNodeId: childNodeId };
+					if (branch === "merge") return { ...node, mergeNodeId: childNodeId };
 					return { ...node, nextNodeId: childNodeId };
 				});
 			});

--- a/apps/web/src/app/(workspace)/automations/lib/derived-layout.test.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/derived-layout.test.ts
@@ -309,7 +309,7 @@ describe("computeDerivedLayout", () => {
 		);
 	});
 
-	it("keeps yes and no branches ordered — yes on the spine, no strictly to its right", () => {
+	it("fans yes and no branches out symmetrically around the condition's spine", () => {
 		const nodes = [
 			N("__trigger__", "triggerNode"),
 			N("cond", "conditionNode"),
@@ -327,8 +327,46 @@ describe("computeDerivedLayout", () => {
 		const cond = rectOf("cond", nodes, positions);
 		const y = rectOf("y", nodes, positions);
 		const n = rectOf("n", nodes, positions);
-		// Yes inherits the condition's spine; No is strictly to the right.
-		expect(y.x + y.width / 2).toBeCloseTo(cond.x + cond.width / 2);
-		expect(n.x).toBeGreaterThan(y.x + y.width);
+		const condCx = cond.x + cond.width / 2;
+		// Yes lane left of the spine, No lane right, BRANCH_H_GAP centered on it.
+		expect(y.x + y.width / 2).toBeLessThan(condCx);
+		expect(n.x + n.width / 2).toBeGreaterThan(condCx);
+		expect(n.x - (y.x + y.width)).toBeCloseTo(BRANCH_H_GAP);
+		expect(condCx - (y.x + y.width)).toBeCloseTo(BRANCH_H_GAP / 2);
+	});
+
+	it("places a condition's merge dot on the spine below the taller lane", () => {
+		const nodes = [
+			N("__trigger__", "triggerNode"),
+			N("loop", "loopNode"),
+			N("cond", "conditionNode"),
+			N("a"),
+			N("__merge__cond", "mergeNode"),
+		];
+		const edges = [
+			edge("__trigger__", "loop"),
+			edge("loop", "cond", "each"),
+			edge("cond", "a", "yes"),
+			edge("a", "__terminal__a"),
+			edge("cond", "__terminal__cond-no", "no"),
+			edge("__terminal__a", "__merge__cond", "merge_in"),
+			edge("__terminal__cond-no", "__merge__cond", "merge_in"),
+			edge("loop", "__terminal__loop-after", "after"),
+		];
+		const { positions, containers } = computeDerivedLayout(
+			nodes,
+			edges,
+			"__trigger__",
+			defaultSizes
+		);
+		const cond = rectOf("cond", nodes, positions);
+		const merge = rectOf("__merge__cond", nodes, positions);
+		const a = rectOf("a", nodes, positions);
+		// Centered on the condition's spine, below the taller (yes) lane.
+		expect(merge.x + merge.width / 2).toBeCloseTo(cond.x + cond.width / 2);
+		expect(merge.y).toBeGreaterThan(a.y + a.height + TERMINAL_DROP);
+		// The merge dot stays inside the loop container.
+		const container = containers.get("loop")!;
+		expect(merge.y + merge.height).toBeLessThan(container.y + container.height);
 	});
 });

--- a/apps/web/src/app/(workspace)/automations/lib/derived-layout.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/derived-layout.ts
@@ -20,6 +20,8 @@
 export const V_GAP = 80;
 /** Minimum horizontal gap between a yes-subtree's right extent and the no-subtree's left extent. */
 export const BRANCH_H_GAP = 80;
+/** Drop from the taller branch lane's bottom to a condition's merge dot. */
+export const MERGE_DROP = 40;
 /** Terminal "+" stub: edge is a fixed 50px drop, button is a 28px circle. */
 export const TERMINAL_DROP = 50;
 /** Half-width reserved for a terminal stub ("+" button plus an optional "↩ Next item" marker). */
@@ -66,6 +68,8 @@ const DEFAULT_SIZES: Record<string, NodeSize> = {
 	nextItemNode: { width: 280, height: 46 },
 	placeholderNode: { width: 280, height: 56 },
 	terminalNode: { width: 1, height: 1 },
+	mergeNode: { width: 1, height: 1 },
+	branchGhostNode: { width: 280, height: 56 },
 };
 
 export function getDefaultNodeSize(rfType: string | undefined): NodeSize {
@@ -148,7 +152,9 @@ function buildChildMap(edges: LayoutEdgeInput[]): Map<string, ChildMap> {
 	const children = new Map<string, ChildMap>();
 	for (const edge of edges) {
 		const branchType = edge.data?.branchType;
-		if (branchType === "loop_back") continue;
+		// Loop-back and merge connectors would re-converge the tree (their
+		// targets already have a parent); both are placed by other means.
+		if (branchType === "loop_back" || branchType === "merge_in") continue;
 		const entry = children.get(edge.source) ?? {};
 		const ref: ChildRef = { id: edge.target, isTerminal: isTerminalRef(edge) };
 		switch (branchType) {
@@ -204,8 +210,11 @@ export function computeDerivedLayout(
 		string,
 		{ containerLeft: number; containerRight: number; containerBottom: number }
 	>();
-	// Per-condition horizontal offset of the no-branch spine from the condition spine.
-	const noSpineDx = new Map<string, number>();
+	// Per-condition metadata captured during measurement, consumed at place time.
+	const condMeta = new Map<
+		string,
+		{ yesDx: number; noDx: number; branchesBottom: number; mergeId?: string }
+	>();
 	const measuring = new Set<string>(); // cycle guard (defensive; graph is a tree)
 
 	function measureChild(ref: ChildRef | undefined): Extent | null {
@@ -235,29 +244,49 @@ export function computeDerivedLayout(
 		let extent: Extent;
 
 		if (kids.yes || kids.no) {
-			// Condition: yes-subtree continues on the spine, no-subtree sits to
-			// the right of everything the yes side occupies.
+			// Condition: symmetric fan-out — yes lane left of the spine, no lane
+			// right, gap centered. A lone branch stays on the spine.
 			const yesE = measureChild(kids.yes);
 			const noE = measureChild(kids.no);
 			const yesGap = kids.yes ? gapAbove(kids.yes) : 0;
 			const noGap = kids.no ? gapAbove(kids.no) : 0;
 
-			const spineRight = Math.max(half, yesE?.right ?? 0);
-			let right = spineRight;
-			if (noE && kids.no) {
-				const dx = spineRight + BRANCH_H_GAP + noE.left;
-				noSpineDx.set(nodeId, dx);
-				right = Math.max(right, dx + noE.right);
-			}
+			const bothLanes = !!(yesE && noE);
+			const yesDx = bothLanes && yesE ? -(BRANCH_H_GAP / 2 + yesE.right) : 0;
+			const noDx = bothLanes && noE ? BRANCH_H_GAP / 2 + noE.left : 0;
+			const branchesBottom = Math.max(
+				yesE ? yesGap + yesE.height : 0,
+				noE ? noGap + noE.height : 0
+			);
+
+			// A merge dot exists when the adapter synthesized one for this
+			// condition; it sits on the spine below the taller lane, and its
+			// continuation chain (or "+" stub) hangs below it as a regular
+			// subtree.
+			const mergeId = `__merge__${nodeId}`;
+			const mergeE = nodeTypes.has(mergeId) ? measure(mergeId) : null;
+			condMeta.set(nodeId, {
+				yesDx,
+				noDx,
+				branchesBottom,
+				mergeId: mergeE ? mergeId : undefined,
+			});
+
 			extent = {
-				left: Math.max(half, yesE?.left ?? 0),
-				right,
+				left: Math.max(
+					half,
+					yesE ? -yesDx + yesE.left : 0,
+					mergeE?.left ?? 0
+				),
+				right: Math.max(
+					half,
+					noE ? noDx + noE.right : 0,
+					mergeE?.right ?? 0
+				),
 				height:
 					size.height +
-					Math.max(
-						yesE ? yesGap + yesE.height : 0,
-						noE ? noGap + noE.height : 0
-					),
+					branchesBottom +
+					(mergeE ? MERGE_DROP + mergeE.height : 0),
 			};
 		} else if (kids.each || kids.after) {
 			// Loop: body nested in a container on the spine; After-Last target
@@ -323,10 +352,15 @@ export function computeDerivedLayout(
 		const kids = children.get(nodeId) ?? {};
 
 		if (kids.yes || kids.no) {
-			if (kids.yes) placeChild(kids.yes, spineX, bottom + gapAbove(kids.yes));
-			if (kids.no) {
-				const dx = noSpineDx.get(nodeId) ?? BRANCH_H_GAP;
-				placeChild(kids.no, spineX + dx, bottom + gapAbove(kids.no));
+			const meta = condMeta.get(nodeId);
+			const yesDx = meta?.yesDx ?? 0;
+			const noDx = meta?.noDx ?? BRANCH_H_GAP;
+			if (kids.yes)
+				placeChild(kids.yes, spineX + yesDx, bottom + gapAbove(kids.yes));
+			if (kids.no) placeChild(kids.no, spineX + noDx, bottom + gapAbove(kids.no));
+			if (meta?.mergeId) {
+				// place() recurses into the dot's continuation chain/stub.
+				place(meta.mergeId, spineX, bottom + meta.branchesBottom + MERGE_DROP);
 			}
 			return;
 		}

--- a/apps/web/src/app/(workspace)/automations/lib/flow-adapter.test.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/flow-adapter.test.ts
@@ -640,8 +640,8 @@ describe("flow-adapter", () => {
 		const mergeIns = rf.edges.filter((e) => e.data?.branchType === "merge_in");
 		expect(mergeIns.map((e) => e.source)).toEqual(["__ghost__cond1-no"]);
 
-		// Both branches stop → no merge at all; loop-back falls back to the
-		// yes terminal.
+		// Both branches stop → no merge at all, and no loop-back: nothing falls
+		// out of the condition, so there is no tail to return from.
 		const rf2 = automationToReactFlow(makeTrigger(), [
 			{ ...base[0] },
 			{ ...base[1], elseNodeId: "end2" } as EditorNode,
@@ -649,8 +649,17 @@ describe("flow-adapter", () => {
 			{ id: "end2", type: "end", config: { kind: "end" } },
 		]);
 		expect(rf2.nodes.find((n) => n.id.startsWith("__merge__"))).toBeUndefined();
-		const loopBack2 = rf2.edges.find((e) => e.data?.branchType === "loop_back");
-		expect(loopBack2?.source).toBe("__terminal__cond1-yes");
+		expect(
+			rf2.edges.find((e) => e.data?.branchType === "loop_back")
+		).toBeUndefined();
+
+		// Every emitted edge must resolve to a real node — React Flow silently
+		// drops edges whose endpoints don't exist.
+		const nodeIds = new Set(rf2.nodes.map((n) => n.id));
+		for (const e of rf2.edges) {
+			expect(nodeIds.has(e.source)).toBe(true);
+			expect(nodeIds.has(e.target)).toBe(true);
+		}
 	});
 
 	it("chains nested condition merges into the outer merge", () => {

--- a/apps/web/src/app/(workspace)/automations/lib/flow-adapter.test.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/flow-adapter.test.ts
@@ -367,26 +367,33 @@ describe("flow-adapter", () => {
 		expect(triggerEdge!.type).toBe(RF_EDGE_TYPES.straight);
 	});
 
-	it("terminal stub edges inherit branchType", () => {
+	it("empty branch ghost edges inherit branchType and sourceHandle", () => {
 		const trigger = makeTrigger();
 		const nodes: EditorNode[] = [
 			{
 				id: "c1",
 				type: "condition",
 				config: statusEqualsCondition("active"),
-				// No nextNodeId or elseNodeId - both are terminal stubs
+				// No nextNodeId or elseNodeId — both branches render ghost cards
 			},
 		];
 
 		const result = automationToReactFlow(trigger, nodes);
-		const terminalEdges = result.edges.filter((e) => e.data?.isTerminal === true && e.source === "c1");
-		expect(terminalEdges).toHaveLength(2);
+		const ghostEdges = result.edges.filter(
+			(e) => e.data?.ghostTarget === true && e.source === "c1"
+		);
+		expect(ghostEdges).toHaveLength(2);
 
-		const yesTerminal = terminalEdges.find((e) => e.sourceHandle === "yes");
-		const noTerminal = terminalEdges.find((e) => e.sourceHandle === "no");
+		const yesGhost = ghostEdges.find((e) => e.sourceHandle === "yes");
+		const noGhost = ghostEdges.find((e) => e.sourceHandle === "no");
 
-		expect(yesTerminal!.data?.branchType).toBe("yes");
-		expect(noTerminal!.data?.branchType).toBe("no");
+		expect(yesGhost!.data?.branchType).toBe("yes");
+		expect(yesGhost!.target).toBe("__ghost__c1-yes");
+		expect(noGhost!.data?.branchType).toBe("no");
+		expect(noGhost!.target).toBe("__ghost__c1-no");
+
+		// Ghost cards render as nodes but never serialize.
+		expect(result.nodes.filter((n) => n.id.startsWith("__ghost__"))).toHaveLength(2);
 	});
 
 	it("edge IDs include sourceHandle for condition branches", () => {
@@ -483,7 +490,7 @@ describe("flow-adapter", () => {
 		expect(after1).toBeDefined();
 	});
 
-	it("routes loop-back from a condition's yes terminal when the loop body ends at a condition", () => {
+	it("routes loop-back from the condition's merge dot when the loop body ends at a condition", () => {
 		const trigger = makeTrigger();
 		const nodes: EditorNode[] = [
 			{
@@ -499,18 +506,217 @@ describe("flow-adapter", () => {
 		];
 
 		const result = automationToReactFlow(trigger, nodes);
-		const loopBackEdge = result.edges.find((e) => e.data?.branchType === "loop_back");
 
+		// Both empty branch ghost cards reconverge at the condition's merge dot…
+		const mergeNode = result.nodes.find((n) => n.id === "__merge__cond1");
+		expect(mergeNode?.type).toBe("mergeNode");
+		const mergeIns = result.edges.filter(
+			(e) => e.data?.branchType === "merge_in"
+		);
+		expect(mergeIns.map((e) => e.source).sort()).toEqual([
+			"__ghost__cond1-no",
+			"__ghost__cond1-yes",
+		]);
+		expect(mergeIns.every((e) => e.target === "__merge__cond1")).toBe(true);
+
+		// …and the loop-back departs from the merge, not a branch terminal.
+		const loopBackEdge = result.edges.find((e) => e.data?.branchType === "loop_back");
 		expect(loopBackEdge).toBeDefined();
-		expect(loopBackEdge!.source).toBe("__terminal__cond1-yes");
+		expect(loopBackEdge!.source).toBe("__merge__cond1");
 		expect(loopBackEdge!.target).toBe("loop1");
 	});
 
-	it("RF_EDGE_TYPES has straight, branchLabel, loopBack, and afterLast", () => {
+	it("tags every edge sourced inside a loop body with inLoop (accent styling)", () => {
+		const trigger = makeTrigger();
+		const nodes: EditorNode[] = [
+			{
+				id: "loop1",
+				type: "loop",
+				config: { kind: "loop", sourceNodeId: "loop1" },
+				bodyStartNodeId: "cond1",
+				nextNodeId: "after1",
+			},
+			{
+				id: "cond1",
+				type: "condition",
+				config: statusEqualsCondition("active"),
+				nextNodeId: "act1",
+				mergeNodeId: "chain1",
+			},
+			{ id: "act1", type: "action", config: updateStatusAction("done") },
+			{ id: "chain1", type: "action", config: updateStatusAction("done") },
+			{ id: "after1", type: "action", config: updateClientStatusAction("active") },
+		];
+
+		const rf = automationToReactFlow(trigger, nodes);
+
+		// Everything owned by a body node is tagged — including edges from
+		// synthetic sources (act1's terminal stub, the empty-No ghost, the
+		// merge point itself).
+		const bodySources = [
+			"cond1",
+			"act1",
+			"__terminal__act1",
+			"__ghost__cond1-no",
+			"__merge__cond1",
+			"chain1",
+		];
+		for (const source of bodySources) {
+			const sourced = rf.edges.filter((e) => e.source === source);
+			expect(sourced.length).toBeGreaterThan(0);
+			for (const e of sourced) expect(e.data?.inLoop).toBe(true);
+		}
+
+		// Edges outside the body (trigger spine, loop header lanes, after-loop
+		// chain) stay untagged — loop lanes get their accent from the edge type.
+		for (const source of ["__trigger__", "loop1", "after1"]) {
+			for (const e of rf.edges.filter((x) => x.source === source)) {
+				expect(e.data?.inLoop).toBeUndefined();
+			}
+		}
+	});
+
+	it("gives a top-level condition a merge dot with an insertable continuation stub", () => {
+		const rf = automationToReactFlow(makeTrigger(), [
+			{ id: "condTop", type: "condition", config: statusEqualsCondition("active") },
+		]);
+		// Merges are universal: every condition converges, and with no
+		// mergeNodeId chain the dot carries an insertable "+" stub whose
+		// insert writes the condition's continuation.
+		expect(rf.nodes.find((n) => n.id === "__merge__condTop")).toBeDefined();
+		expect(
+			rf.edges.filter((e) => e.data?.branchType === "merge_in")
+		).toHaveLength(2);
+		const stubEdge = rf.edges.find(
+			(e) =>
+				e.source === "__merge__condTop" &&
+				e.data?.isTerminal &&
+				e.data?.branchType === "merge"
+		);
+		expect(stubEdge).toBeDefined();
+	});
+
+	it("renders a configured merge continuation chain below the dot and round-trips it", () => {
+		const nodes: EditorNode[] = [
+			{
+				id: "cond1",
+				type: "condition",
+				config: statusEqualsCondition("active"),
+				mergeNodeId: "after1",
+			},
+			{ id: "after1", type: "action", config: updateStatusAction("done") },
+		];
+		const rf = automationToReactFlow(makeTrigger(), nodes);
+
+		// Dot → chain head is a real, insertable edge (branchType "merge").
+		const mergeOut = rf.edges.find(
+			(e) => e.source === "__merge__cond1" && e.target === "after1"
+		);
+		expect(mergeOut?.data?.branchType).toBe("merge");
+		// The chain head is NOT the root (it's referenced via mergeNodeId).
+		const triggerEdge = rf.edges.find((e) => e.source === "__trigger__");
+		expect(triggerEdge?.target).toBe("cond1");
+
+		// Round-trip reconstructs mergeNodeId from the dot's outgoing edge.
+		const result = reactFlowToFlatArray(rf.nodes, rf.edges);
+		const cond = result.nodes.find((n) => n.id === "cond1");
+		expect(cond!.mergeNodeId).toBe("after1");
+	});
+
+	it("excludes end/next_item branch tails from the merge; drops the merge when both stop", () => {
+		const base: EditorNode[] = [
+			{ id: "loop1", type: "loop", bodyStartNodeId: "cond1" },
+			{
+				id: "cond1",
+				type: "condition",
+				config: statusEqualsCondition("active"),
+				nextNodeId: "end1",
+			},
+			{ id: "end1", type: "end", config: { kind: "end" } },
+		];
+
+		// yes → end (stops), no → dangling ghost: the merge has exactly one input.
+		const rf = automationToReactFlow(makeTrigger(), base);
+		const mergeIns = rf.edges.filter((e) => e.data?.branchType === "merge_in");
+		expect(mergeIns.map((e) => e.source)).toEqual(["__ghost__cond1-no"]);
+
+		// Both branches stop → no merge at all; loop-back falls back to the
+		// yes terminal.
+		const rf2 = automationToReactFlow(makeTrigger(), [
+			{ ...base[0] },
+			{ ...base[1], elseNodeId: "end2" } as EditorNode,
+			{ ...base[2] },
+			{ id: "end2", type: "end", config: { kind: "end" } },
+		]);
+		expect(rf2.nodes.find((n) => n.id.startsWith("__merge__"))).toBeUndefined();
+		const loopBack2 = rf2.edges.find((e) => e.data?.branchType === "loop_back");
+		expect(loopBack2?.source).toBe("__terminal__cond1-yes");
+	});
+
+	it("chains nested condition merges into the outer merge", () => {
+		const nodes: EditorNode[] = [
+			{ id: "loop1", type: "loop", bodyStartNodeId: "cond1" },
+			{
+				id: "cond1",
+				type: "condition",
+				config: statusEqualsCondition("active"),
+				nextNodeId: "cond2",
+			},
+			{
+				id: "cond2",
+				type: "condition",
+				config: statusEqualsCondition("draft"),
+			},
+		];
+		const rf = automationToReactFlow(makeTrigger(), nodes);
+
+		const mergeIns = rf.edges.filter((e) => e.data?.branchType === "merge_in");
+		// Inner merge collects cond2's two empty-branch ghosts; the outer merge
+		// collects the inner merge's "+" stub (every dot carries an insertable
+		// continuation stub) plus cond1's no-ghost.
+		const bySource = new Map(mergeIns.map((e) => [e.source, e.target]));
+		expect(bySource.get("__ghost__cond2-yes")).toBe("__merge__cond2");
+		expect(bySource.get("__ghost__cond2-no")).toBe("__merge__cond2");
+		expect(bySource.get("__terminal____merge__cond2")).toBe("__merge__cond1");
+		expect(bySource.get("__ghost__cond1-no")).toBe("__merge__cond1");
+
+		const loopBack = rf.edges.find((e) => e.data?.branchType === "loop_back");
+		expect(loopBack?.source).toBe("__merge__cond1");
+	});
+
+	it("filters merge dots and their connectors from the save path", () => {
+		const nodes: EditorNode[] = [
+			{ id: "loop1", type: "loop", bodyStartNodeId: "cond1", nextNodeId: "after1" },
+			{
+				id: "cond1",
+				type: "condition",
+				config: statusEqualsCondition("active"),
+				nextNodeId: "a1",
+			},
+			{ id: "a1", type: "action", config: updateStatusAction("done") },
+			{ id: "after1", type: "action", config: updateClientStatusAction("active") },
+		];
+		const rf = automationToReactFlow(makeTrigger(), nodes);
+		const result = reactFlowToFlatArray(rf.nodes, rf.edges);
+
+		expect(result.nodes.find((n) => n.id.startsWith("__merge__"))).toBeUndefined();
+		expect(result.nodes.find((n) => n.id.startsWith("__ghost__"))).toBeUndefined();
+		expect(result.nodes).toHaveLength(4);
+		const cond = result.nodes.find((n) => n.id === "cond1");
+		expect(cond!.nextNodeId).toBe("a1");
+		// The empty no-branch renders a ghost card, which must never leak into
+		// elseNodeId on save.
+		expect(cond!.elseNodeId).toBeUndefined();
+		const a1 = result.nodes.find((n) => n.id === "a1");
+		expect(a1!.nextNodeId).toBeUndefined();
+	});
+
+	it("RF_EDGE_TYPES has straight, branchLabel, loopBack, afterLast, and mergeIn", () => {
 		expect(RF_EDGE_TYPES.straight).toBe("straightEdge");
 		expect(RF_EDGE_TYPES.branchLabel).toBe("branchLabelEdge");
 		expect(RF_EDGE_TYPES.loopBack).toBe("loopBackEdge");
 		expect(RF_EDGE_TYPES.afterLast).toBe("afterLastEdge");
+		expect(RF_EDGE_TYPES.mergeIn).toBe("mergeInEdge");
 		// plusButton should not exist
 		expect((RF_EDGE_TYPES as Record<string, string>).plusButton).toBeUndefined();
 	});
@@ -661,7 +867,7 @@ describe("derived layout integration", () => {
 		expect(result.nodes[0].position).toBeUndefined();
 	});
 
-	it("marks dangling condition branches inside a loop with impliedNextItem", () => {
+	it("suppresses next-item markers on condition branches inside a loop — the merge shows the return", () => {
 		const nodes: EditorNode[] = [
 			{
 				id: "loop1",
@@ -673,31 +879,38 @@ describe("derived layout integration", () => {
 		];
 		const rf = automationToReactFlow(makeTrigger(), nodes);
 
-		// The yes-terminal carries the loop-back edge (return already visible);
-		// the no-terminal is the invisible dead-end that gets the marker.
+		// Both empty branches render ghost "Choose a step" cards that flow
+		// onward into the merge dot — no "↩ Next item" marker needed on either.
 		const yesEdge = rf.edges.find(
-			(e) => e.data?.branchType === "yes" && e.data?.isTerminal
+			(e) => e.data?.branchType === "yes" && e.data?.ghostTarget
 		);
 		const noEdge = rf.edges.find(
-			(e) => e.data?.branchType === "no" && e.data?.isTerminal
+			(e) => e.data?.branchType === "no" && e.data?.ghostTarget
 		);
+		expect(yesEdge?.target).toBe("__ghost__cond1-yes");
+		expect(noEdge?.target).toBe("__ghost__cond1-no");
 		expect(yesEdge?.data?.impliedNextItem).toBeUndefined();
-		expect(noEdge?.data?.impliedNextItem).toBe(true);
+		expect(noEdge?.data?.impliedNextItem).toBeUndefined();
+		expect(
+			rf.edges.filter((e) => e.data?.branchType === "merge_in")
+		).toHaveLength(2);
 
-		// Outside a loop, a dangling branch just ends the run — no marker.
+		// Outside a loop, a dangling branch just ends the run — ghost card,
+		// no merge, no marker.
 		const rf2 = automationToReactFlow(makeTrigger(), [
 			{ id: "condTop", type: "condition", config: statusEqualsCondition("active") },
 		]);
 		const topNo = rf2.edges.find(
-			(e) => e.data?.branchType === "no" && e.data?.isTerminal
+			(e) => e.data?.branchType === "no" && e.data?.ghostTarget
 		);
+		expect(topNo).toBeDefined();
 		expect(topNo?.data?.impliedNextItem).toBeUndefined();
 	});
 
-	it("marks dangling LEAF stubs inside a loop (e.g. steps under a branched condition)", () => {
+	it("routes branch leaf stubs into the merge instead of marking them (steps under a branched condition)", () => {
 		// The realistic shape: condition in a body with a step on each branch.
-		// a1 carries the loop-back edge (return visible); b1 dead-ends silently
-		// and must get the marker on its plain next-stub.
+		// Both leaves reconverge at the condition's merge, which carries the
+		// loop-back — neither stub gets a marker.
 		const nodes: EditorNode[] = [
 			{
 				id: "loop1",
@@ -720,7 +933,14 @@ describe("derived layout integration", () => {
 		const stubFor = (sourceId: string) =>
 			rf.edges.find((e) => e.source === sourceId && e.data?.isTerminal);
 		expect(stubFor("a1")?.data?.impliedNextItem).toBeUndefined();
-		expect(stubFor("b1")?.data?.impliedNextItem).toBe(true);
+		expect(stubFor("b1")?.data?.impliedNextItem).toBeUndefined();
+		const mergeIns = rf.edges.filter((e) => e.data?.branchType === "merge_in");
+		expect(mergeIns.map((e) => e.source).sort()).toEqual([
+			"__terminal__a1",
+			"__terminal__b1",
+		]);
+		const loopBack = rf.edges.find((e) => e.data?.branchType === "loop_back");
+		expect(loopBack?.source).toBe("__merge__cond1");
 
 		// A top-level (non-nested) loop's dangling After-Last gets no marker.
 		const afterStub = rf.edges.find(

--- a/apps/web/src/app/(workspace)/automations/lib/flow-adapter.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/flow-adapter.ts
@@ -246,7 +246,9 @@ function resolveLoopBackSourceId(
 			if (mergeConditionIds?.has(bodyNode.id)) {
 				return mergeIdForCondition(bodyNode.id);
 			}
-			return `${TERMINAL_PREFIX}${bodyNode.id}-yes`;
+			// No merge: both branches stop (end/next_item), so nothing falls out
+			// of the condition — there is no tail to return from.
+			return "";
 		}
 		if (!bodyNode?.nextNodeId || visited.has(bodyNode.nextNodeId)) {
 			return loopBackSourceId;
@@ -603,12 +605,14 @@ export function automationToReactFlow(
 				});
 			}
 
-			// Loop-back edge: from last body node (or empty terminal) back to loop header
-			{
-				const loopBackSourceId = node.bodyStartNodeId
-					? resolveLoopBackSourceId(node.bodyStartNodeId, nodes, mergeConditionIds)
-					: ghostIdFor(node.id, "each");
-
+			// Loop-back edge: from last body node (or empty terminal) back to loop
+			// header. Omitted when the body has no live tail (every path ends in
+			// end/next_item) — an edge from a node that doesn't exist would be
+			// silently dropped by React Flow anyway.
+			const loopBackSourceId = node.bodyStartNodeId
+				? resolveLoopBackSourceId(node.bodyStartNodeId, nodes, mergeConditionIds)
+				: ghostIdFor(node.id, "each");
+			if (loopBackSourceId) {
 				rfEdges.push({
 					id: `e-loopback-${node.id}`,
 					source: loopBackSourceId,

--- a/apps/web/src/app/(workspace)/automations/lib/flow-adapter.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/flow-adapter.ts
@@ -27,6 +27,8 @@ export const TRIGGER_NODE_ID = "__trigger__";
 export const TRIGGER_PLACEHOLDER_ID = "__trigger_placeholder__";
 export const TERMINAL_PREFIX = "__terminal__";
 export const CONTAINER_PREFIX = "__container__";
+export const MERGE_PREFIX = "__merge__";
+export const GHOST_PREFIX = "__ghost__";
 
 /** React Flow node type names (must match nodeTypes object keys) */
 export const RF_NODE_TYPES = {
@@ -44,6 +46,8 @@ export const RF_NODE_TYPES = {
 	next_item: "nextItemNode",
 	placeholder: "placeholderNode",
 	terminal: "terminalNode",
+	merge: "mergeNode",
+	branchGhost: "branchGhostNode",
 } as const;
 
 /** React Flow edge type names (must match edgeTypes object keys) */
@@ -52,6 +56,7 @@ export const RF_EDGE_TYPES = {
 	branchLabel: "branchLabelEdge",
 	loopBack: "loopBackEdge",
 	afterLast: "afterLastEdge",
+	mergeIn: "mergeInEdge",
 } as const;
 
 /**
@@ -66,6 +71,8 @@ export type PlaceholderEntry = {
 	elseNodeId?: string;
 	/** Never set on placeholders (only loop nodes have a body); present for GraphNode-shape compatibility. */
 	bodyStartNodeId?: string;
+	/** Never set on placeholders (only conditions merge); present for GraphNode-shape compatibility. */
+	mergeNodeId?: string;
 	position?: { x: number; y: number };
 };
 
@@ -84,6 +91,24 @@ export function isTerminalId(id: string): boolean {
 /** Check if a node ID is a loop-container frame (not a real workflow node) */
 export function isContainerId(id: string): boolean {
 	return id.startsWith(CONTAINER_PREFIX);
+}
+
+/** Check if a node ID is a synthetic branch-merge dot (not a real workflow node) */
+export function isMergeId(id: string): boolean {
+	return id.startsWith(MERGE_PREFIX);
+}
+
+export function mergeIdForCondition(conditionId: string): string {
+	return `${MERGE_PREFIX}${conditionId}`;
+}
+
+/** Check if a node ID is a ghost "Choose a step" card (not a real workflow node) */
+export function isGhostId(id: string): boolean {
+	return id.startsWith(GHOST_PREFIX);
+}
+
+export function ghostIdFor(sourceId: string, handle: string): string {
+	return `${GHOST_PREFIX}${sourceId}-${handle}`;
 }
 
 export function containerIdForLoop(loopId: string): string {
@@ -162,9 +187,43 @@ function addTerminalStub(
 	} as AppEdge);
 }
 
+/**
+ * Ghost "Choose a step" card + branch edge for an EMPTY condition branch or
+ * loop body — the lane shows the same card a transient placeholder would,
+ * instead of a bare "+" stub.
+ */
+function addBranchGhost(
+	rfNodes: AppNode[],
+	rfEdges: AppEdge[],
+	sourceId: string,
+	sourceHandle: string,
+	edgeData: Record<string, unknown>
+) {
+	const ghostId = ghostIdFor(sourceId, sourceHandle);
+	const edgeId = `e-${sourceId}-${sourceHandle}-${ghostId}`;
+
+	rfNodes.push({
+		id: ghostId,
+		type: RF_NODE_TYPES.branchGhost,
+		data: { nodeType: "branchGhost", edgeId },
+		position: { x: 0, y: 0 },
+		draggable: false,
+	} as AppNode);
+
+	rfEdges.push({
+		id: edgeId,
+		source: sourceId,
+		target: ghostId,
+		sourceHandle,
+		type: RF_EDGE_TYPES.branchLabel,
+		data: { ...edgeData, ghostTarget: true },
+	} as AppEdge);
+}
+
 function resolveLoopBackSourceId(
 	startNodeId: string | undefined,
-	nodes: EditorNode[]
+	nodes: EditorNode[],
+	mergeConditionIds?: Set<string>
 ): string {
 	if (!startNodeId) {
 		return "";
@@ -176,14 +235,98 @@ function resolveLoopBackSourceId(
 	while (true) {
 		visited.add(loopBackSourceId);
 		const bodyNode = nodes.find((n) => n.id === loopBackSourceId);
-		if (!bodyNode?.nextNodeId || visited.has(bodyNode.nextNodeId)) {
-			if (bodyNode?.type === "condition") {
-				return `${TERMINAL_PREFIX}${bodyNode.id}-yes`;
+		// A condition's nextNodeId is the YES BRANCH, not a continuation.
+		// Branch lanes reconverge at its merge dot; if a merge chain exists
+		// the walk continues along it, otherwise the dot is the tail.
+		if (bodyNode?.type === "condition") {
+			if (bodyNode.mergeNodeId && !visited.has(bodyNode.mergeNodeId)) {
+				loopBackSourceId = bodyNode.mergeNodeId;
+				continue;
 			}
+			if (mergeConditionIds?.has(bodyNode.id)) {
+				return mergeIdForCondition(bodyNode.id);
+			}
+			return `${TERMINAL_PREFIX}${bodyNode.id}-yes`;
+		}
+		if (!bodyNode?.nextNodeId || visited.has(bodyNode.nextNodeId)) {
 			return loopBackSourceId;
 		}
 		loopBackSourceId = bodyNode.nextNodeId;
 	}
+}
+
+/** Where a branch-tail's outgoing merge connector starts. */
+type MergeExit = { sourceId: string; fromTerminalStub: boolean };
+
+/**
+ * Plan a merge dot per condition (Salesforce-style): both branch lanes
+ * reconverge below the condition, and flow continues at the condition's
+ * mergeNodeId chain when one is configured. A branch exits via its dangling
+ * tail's terminal "+" stub, a nested condition's merge SUBTREE exit (its
+ * chain tail when a continuation exists, else its dot's "+" stub), a tail
+ * loop's After-Last stub, or an empty branch's ghost card; explicit
+ * end/next_item tails stop the flow and feed nothing. A condition whose
+ * branches both stop gets no merge dot unless a continuation is configured.
+ */
+function planConditionMerges(nodes: EditorNode[]): Map<string, MergeExit[]> {
+	const byId = new Map(nodes.map((n) => [n.id, n]));
+	const merges = new Map<string, MergeExit[]>();
+	const planned = new Set<string>();
+
+	function chainExit(startId: string): MergeExit | null {
+		let currentId = startId;
+		const visited = new Set<string>();
+		while (true) {
+			visited.add(currentId);
+			const node = byId.get(currentId);
+			if (!node) return null;
+			if (node.type === "end" || node.type === "next_item") return null;
+			if (node.type === "condition") return conditionExit(node);
+			if (!node.nextNodeId || visited.has(node.nextNodeId)) {
+				const suffix = node.type === "loop" ? "-after" : "";
+				return {
+					sourceId: `${TERMINAL_PREFIX}${node.id}${suffix}`,
+					fromTerminalStub: true,
+				};
+			}
+			currentId = node.nextNodeId;
+		}
+	}
+
+	function conditionExit(cond: EditorNode): MergeExit | null {
+		if (cond.type !== "condition") return null;
+		if (!planned.has(cond.id)) {
+			planned.add(cond.id);
+			const inputs: MergeExit[] = [];
+			// An empty branch renders a ghost "Choose a step" card; the merge
+			// connector departs from the ghost's bottom.
+			const yes = cond.nextNodeId
+				? chainExit(cond.nextNodeId)
+				: { sourceId: ghostIdFor(cond.id, "yes"), fromTerminalStub: false };
+			const no = cond.elseNodeId
+				? chainExit(cond.elseNodeId)
+				: { sourceId: ghostIdFor(cond.id, "no"), fromTerminalStub: false };
+			if (yes) inputs.push(yes);
+			if (no) inputs.push(no);
+			// A configured continuation keeps the dot even with no live inputs
+			// (both branches stop) — the chain must stay visible/editable.
+			if (inputs.length > 0 || cond.mergeNodeId) merges.set(cond.id, inputs);
+		}
+		if (!merges.has(cond.id)) return null;
+		// The condition subtree's exit: the merge chain's tail when a
+		// continuation exists, else the dot's own "+" stub.
+		const mergeNodeId = (cond as WorkflowNode).mergeNodeId;
+		if (mergeNodeId) return chainExit(mergeNodeId);
+		return {
+			sourceId: `${TERMINAL_PREFIX}${mergeIdForCondition(cond.id)}`,
+			fromTerminalStub: true,
+		};
+	}
+
+	for (const node of nodes) {
+		if (node.type === "condition") conditionExit(node);
+	}
+	return merges;
 }
 
 function buildNodeData(node: EditorNode, trigger: TriggerConfig) {
@@ -306,7 +449,6 @@ export function automationToReactFlow(
 	// the canvas says so, except where the loop-back edge already makes the
 	// return visible.
 	const bodyNodeIds = new Set<string>();
-	const loopBackSourceIds = new Set<string>();
 	for (const node of nodes) {
 		if (node.type === "loop" && node.bodyStartNodeId) {
 			for (const id of collectLoopBody(node.id, nodes)) {
@@ -314,22 +456,42 @@ export function automationToReactFlow(
 				// outer loop's body count (a top-level loop's After-Last just ends).
 				if (id !== node.id) bodyNodeIds.add(id);
 			}
-			loopBackSourceIds.add(resolveLoopBackSourceId(node.bodyStartNodeId, nodes));
+		}
+	}
+
+	// Every condition gets a merge dot where its branch lanes reconverge;
+	// flow continues at the condition's mergeNodeId chain when configured.
+	const merges = planConditionMerges(nodes);
+	const mergeConditionIds = new Set(merges.keys());
+	const mergeFedIds = new Set<string>();
+	for (const inputs of merges.values()) {
+		for (const input of inputs) mergeFedIds.add(input.sourceId);
+	}
+
+	const loopBackSourceIds = new Set<string>();
+	for (const node of nodes) {
+		if (node.type === "loop" && node.bodyStartNodeId) {
+			loopBackSourceIds.add(
+				resolveLoopBackSourceId(node.bodyStartNodeId, nodes, mergeConditionIds)
+			);
 		}
 	}
 	const impliedNextItemData = (sourceId: string, terminalId: string) =>
 		bodyNodeIds.has(sourceId) &&
 		!loopBackSourceIds.has(sourceId) &&
-		!loopBackSourceIds.has(terminalId)
+		!loopBackSourceIds.has(terminalId) &&
+		// A stub that flows onward into a merge dot already shows its return path.
+		!mergeFedIds.has(terminalId)
 			? { impliedNextItem: true }
 			: {};
 
-	// 2. Find root node (not referenced by any other node's nextNodeId or elseNodeId)
+	// 2. Find root node (not referenced by any other node's pointers)
 	const referencedIds = new Set<string>();
 	for (const node of nodes) {
 		if (node.nextNodeId) referencedIds.add(node.nextNodeId);
 		if (node.elseNodeId) referencedIds.add(node.elseNodeId);
 		if (node.bodyStartNodeId) referencedIds.add(node.bodyStartNodeId);
+		if (node.mergeNodeId) referencedIds.add(node.mergeNodeId);
 	}
 	const rootNode = nodes.find((n) => !referencedIds.has(n.id));
 
@@ -375,11 +537,10 @@ export function automationToReactFlow(
 					data: { label: "Yes", variant: "yes", branchType: "yes" as const },
 				} as AppEdge);
 			} else {
-				addTerminalStub(rfNodes, rfEdges, node.id, "yes", RF_EDGE_TYPES.branchLabel, {
+				addBranchGhost(rfNodes, rfEdges, node.id, "yes", {
 					label: "Yes",
 					variant: "yes",
 					branchType: "yes" as const,
-					...impliedNextItemData(node.id, `${TERMINAL_PREFIX}${node.id}-yes`),
 				});
 			}
 
@@ -394,11 +555,10 @@ export function automationToReactFlow(
 					data: { label: "No", variant: "no", branchType: "no" as const },
 				} as AppEdge);
 			} else {
-				addTerminalStub(rfNodes, rfEdges, node.id, "no", RF_EDGE_TYPES.branchLabel, {
+				addBranchGhost(rfNodes, rfEdges, node.id, "no", {
 					label: "No",
 					variant: "no",
 					branchType: "no" as const,
-					...impliedNextItemData(node.id, `${TERMINAL_PREFIX}${node.id}-no`),
 				});
 			}
 
@@ -415,7 +575,7 @@ export function automationToReactFlow(
 					data: { label: "For Each", variant: "yes", branchType: "each" as const },
 				} as AppEdge);
 			} else {
-				addTerminalStub(rfNodes, rfEdges, node.id, "each", RF_EDGE_TYPES.branchLabel, {
+				addBranchGhost(rfNodes, rfEdges, node.id, "each", {
 					label: "For Each",
 					variant: "yes",
 					branchType: "each" as const,
@@ -446,8 +606,8 @@ export function automationToReactFlow(
 			// Loop-back edge: from last body node (or empty terminal) back to loop header
 			{
 				const loopBackSourceId = node.bodyStartNodeId
-					? resolveLoopBackSourceId(node.bodyStartNodeId, nodes)
-					: `${TERMINAL_PREFIX}${node.id}-each`;
+					? resolveLoopBackSourceId(node.bodyStartNodeId, nodes, mergeConditionIds)
+					: ghostIdFor(node.id, "each");
 
 				rfEdges.push({
 					id: `e-loopback-${node.id}`,
@@ -484,6 +644,74 @@ export function automationToReactFlow(
 					...impliedNextItemData(node.id, `${TERMINAL_PREFIX}${node.id}`),
 				});
 			}
+		}
+	}
+
+	// Merge dots + their incoming connectors. The dot itself is display-only
+	// (never serialized), but its OUTGOING edge is real: the condition's
+	// mergeNodeId continuation chain, or an insertable "+" stub to start one.
+	for (const [conditionId, inputs] of merges) {
+		const mergeId = mergeIdForCondition(conditionId);
+		rfNodes.push({
+			id: mergeId,
+			type: RF_NODE_TYPES.merge,
+			data: { nodeType: "merge", conditionId },
+			position: { x: 0, y: 0 },
+			draggable: false,
+			selectable: false,
+			focusable: false,
+		} as AppNode);
+		for (const input of inputs) {
+			rfEdges.push({
+				id: `e-mergein-${input.sourceId}-${mergeId}`,
+				source: input.sourceId,
+				target: mergeId,
+				type: RF_EDGE_TYPES.mergeIn,
+				data: {
+					branchType: "merge_in" as const,
+					fromTerminalStub: input.fromTerminalStub,
+				},
+			} as AppEdge);
+		}
+
+		const condition = nodes.find((n) => n.id === conditionId);
+		const mergeTargetId =
+			condition && !isPlaceholderEntry(condition)
+				? condition.mergeNodeId
+				: undefined;
+		if (mergeTargetId) {
+			rfEdges.push({
+				id: `e-${mergeId}-merge-${mergeTargetId}`,
+				source: mergeId,
+				target: mergeTargetId,
+				type: RF_EDGE_TYPES.straight,
+				data: { branchType: "merge" as const },
+			} as AppEdge);
+		} else {
+			addTerminalStub(rfNodes, rfEdges, mergeId, undefined, RF_EDGE_TYPES.straight, {
+				branchType: "merge" as const,
+			});
+		}
+	}
+
+	// Edges sourced inside a loop body render in the loop's accent color.
+	// Synthetic sources (terminal stubs, ghosts, merge points — possibly
+	// stacked, e.g. a merge point's terminal stub) resolve to the real node
+	// that owns them.
+	const syntheticOwnerId = (sourceId: string): string => {
+		let id = sourceId;
+		if (id.startsWith(TERMINAL_PREFIX)) {
+			id = id.slice(TERMINAL_PREFIX.length).replace(/-(after|yes|no)$/, "");
+		}
+		if (id.startsWith(GHOST_PREFIX)) {
+			id = id.slice(GHOST_PREFIX.length).replace(/-(each|yes|no)$/, "");
+		}
+		if (id.startsWith(MERGE_PREFIX)) id = id.slice(MERGE_PREFIX.length);
+		return id;
+	};
+	for (const e of rfEdges) {
+		if (bodyNodeIds.has(syntheticOwnerId(e.source))) {
+			e.data = { ...e.data, inLoop: true };
 		}
 	}
 
@@ -537,6 +765,7 @@ export function serializeEditorNodes(nodes: EditorNode[]): WorkflowNode[] {
 				nextNodeId: node.nextNodeId,
 				elseNodeId: node.elseNodeId,
 				bodyStartNodeId: node.bodyStartNodeId,
+				mergeNodeId: node.mergeNodeId,
 			};
 		});
 }
@@ -566,6 +795,8 @@ export function reactFlowToFlatArray(
 		if (rfNode.id === TRIGGER_PLACEHOLDER_ID) continue;
 		if (isTerminalId(rfNode.id)) continue;
 		if (isContainerId(rfNode.id)) continue;
+		if (isMergeId(rfNode.id)) continue;
+		if (isGhostId(rfNode.id)) continue;
 		// Filter out placeholder nodes -- they are frontend-only transient state
 		if ((rfNode.data as { nodeType?: string })?.nodeType === "placeholder")
 			continue;
@@ -580,10 +811,26 @@ export function reactFlowToFlatArray(
 		let nextNodeId: string | undefined;
 		let elseNodeId: string | undefined;
 		let bodyStartNodeId: string | undefined;
+		let mergeNodeId: string | undefined;
+
+		// The condition's continuation edge hangs off its synthetic merge dot,
+		// not the condition node itself.
+		if (dbType === "condition") {
+			const mergeOut = rfEdges.find(
+				(e) =>
+					e.source === mergeIdForCondition(rfNode.id) &&
+					e.data?.branchType === "merge" &&
+					!isTerminalId(e.target)
+			);
+			if (mergeOut) mergeNodeId = mergeOut.target;
+		}
 
 		for (const edge of outEdges) {
 			if (isTerminalId(edge.target)) continue;
+			if (isMergeId(edge.target)) continue;
+			if (isGhostId(edge.target)) continue;
 			if (edge.data?.branchType === "loop_back") continue;
+			if (edge.data?.branchType === "merge_in") continue;
 
 			const branchType = edge.data?.branchType as string | undefined;
 
@@ -617,6 +864,7 @@ export function reactFlowToFlatArray(
 			nextNodeId,
 			elseNodeId,
 			bodyStartNodeId,
+			mergeNodeId,
 		});
 	}
 

--- a/apps/web/src/app/(workspace)/automations/lib/graph-utils.test.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/graph-utils.test.ts
@@ -56,6 +56,43 @@ describe("graph-utils", () => {
 			expect(result).toEqual(new Set(["c1", "a1", "a2", "a3"]));
 		});
 
+		// Regression: deleting a condition must not take its merge continuation
+		// with it — those steps run after the branches converge, so they belong
+		// to the parent chain (same rule as a loop's After-Last path).
+		it("excludeRootMerge keeps the root's continuation but still collects nested merges", () => {
+			const nodes: WorkflowNode[] = [
+				{
+					id: "c1",
+					type: "condition",
+					config: condition("active"),
+					nextNodeId: "c2",
+					elseNodeId: "a2",
+					mergeNodeId: "keep1",
+				},
+				{
+					id: "c2",
+					type: "condition",
+					config: condition("done"),
+					nextNodeId: "a1",
+					// A nested condition's continuation IS inside c1's true branch.
+					mergeNodeId: "nested1",
+				},
+				{ id: "a1", type: "action", config: action("done") },
+				{ id: "a2", type: "action", config: action("inactive") },
+				{ id: "nested1", type: "action", config: action("active") },
+				{ id: "keep1", type: "action", config: action("active"), nextNodeId: "keep2" },
+				{ id: "keep2", type: "action", config: action("done") },
+			];
+
+			expect(collectSubtree("c1", nodes, { excludeRootMerge: true })).toEqual(
+				new Set(["c1", "c2", "a1", "a2", "nested1"])
+			);
+			// Without the flag the continuation chain is part of the subtree.
+			expect(collectSubtree("c1", nodes)).toEqual(
+				new Set(["c1", "c2", "a1", "a2", "nested1", "keep1", "keep2"])
+			);
+		});
+
 		it("returns only the node itself for a leaf node", () => {
 			const nodes: WorkflowNode[] = [
 				{

--- a/apps/web/src/app/(workspace)/automations/lib/graph-utils.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/graph-utils.ts
@@ -15,12 +15,18 @@ export type GraphNode = {
 
 /**
  * Collect all node IDs in the subtree rooted at startNodeId.
- * Follows both nextNodeId and elseNodeId pointers via BFS.
+ * Follows nextNodeId, elseNodeId, and mergeNodeId pointers via BFS.
  * Always includes startNodeId itself, even if not found in the nodes array.
+ *
+ * `excludeRootMerge` stops at the ROOT's merge continuation — the steps after
+ * its branches converge are downstream of the condition, not part of it (the
+ * same reason collectLoopBody never walks a loop's own After-Last path).
+ * Descendants' merge chains still belong to the subtree and are collected.
  */
 export function collectSubtree(
 	startNodeId: string,
-	nodes: GraphNode[]
+	nodes: GraphNode[],
+	options?: { excludeRootMerge?: boolean }
 ): Set<string> {
 	const nodeMap = new Map<string, GraphNode>();
 	for (const node of nodes) {
@@ -44,7 +50,11 @@ export function collectSubtree(
 		if (node.elseNodeId && !visited.has(node.elseNodeId)) {
 			queue.push(node.elseNodeId);
 		}
-		if (node.mergeNodeId && !visited.has(node.mergeNodeId)) {
+		if (
+			node.mergeNodeId &&
+			!visited.has(node.mergeNodeId) &&
+			!(options?.excludeRootMerge && current === startNodeId)
+		) {
 			queue.push(node.mergeNodeId);
 		}
 	}

--- a/apps/web/src/app/(workspace)/automations/lib/graph-utils.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/graph-utils.ts
@@ -9,6 +9,8 @@ export type GraphNode = {
 	elseNodeId?: string;
 	/** Loop body entry point. */
 	bodyStartNodeId?: string;
+	/** Condition continuation ("after the branches converge"). */
+	mergeNodeId?: string;
 };
 
 /**
@@ -42,6 +44,9 @@ export function collectSubtree(
 		if (node.elseNodeId && !visited.has(node.elseNodeId)) {
 			queue.push(node.elseNodeId);
 		}
+		if (node.mergeNodeId && !visited.has(node.mergeNodeId)) {
+			queue.push(node.mergeNodeId);
+		}
 	}
 
 	return visited;
@@ -71,8 +76,9 @@ export function collectLoopBody(
 		return visited;
 	}
 
-	// BFS following nextNodeId and elseNodeId from body nodes (the loop
-	// node's own nextNodeId -- the "After Last" path -- is never queued).
+	// BFS following nextNodeId, elseNodeId, and mergeNodeId from body nodes
+	// (the loop node's own nextNodeId -- the "After Last" path -- is never
+	// queued).
 	const queue: string[] = [loopNode.bodyStartNodeId];
 
 	while (queue.length > 0) {
@@ -89,6 +95,9 @@ export function collectLoopBody(
 		if (node.elseNodeId && !visited.has(node.elseNodeId)) {
 			queue.push(node.elseNodeId);
 		}
+		if (node.mergeNodeId && !visited.has(node.mergeNodeId)) {
+			queue.push(node.mergeNodeId);
+		}
 	}
 
 	return visited;
@@ -103,7 +112,10 @@ export function collectLoopBody(
 export function findParent(
 	nodeId: string,
 	nodes: GraphNode[]
-): { parentId: string | null; branch: "next" | "else" | "body" | null } {
+): {
+	parentId: string | null;
+	branch: "next" | "else" | "body" | "merge" | null;
+} {
 	for (const node of nodes) {
 		if (node.nextNodeId === nodeId) {
 			return { parentId: node.id, branch: "next" };
@@ -113,6 +125,9 @@ export function findParent(
 		}
 		if (node.bodyStartNodeId === nodeId) {
 			return { parentId: node.id, branch: "body" };
+		}
+		if (node.mergeNodeId === nodeId) {
+			return { parentId: node.id, branch: "merge" };
 		}
 	}
 

--- a/apps/web/src/app/(workspace)/automations/lib/legacy-load.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/legacy-load.ts
@@ -23,6 +23,7 @@ export type DbWorkflowNode = {
 	nextNodeId?: string;
 	elseNodeId?: string;
 	bodyStartNodeId?: string;
+	mergeNodeId?: string;
 	position?: { x: number; y: number };
 };
 
@@ -58,6 +59,7 @@ export function legacyNodeToV2(node: DbWorkflowNode): WorkflowNode {
 		nextNodeId: node.nextNodeId,
 		elseNodeId: node.elseNodeId,
 		bodyStartNodeId: node.bodyStartNodeId,
+		mergeNodeId: node.mergeNodeId,
 		position: node.position,
 	};
 }

--- a/apps/web/src/app/(workspace)/automations/lib/node-types.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/node-types.ts
@@ -188,6 +188,8 @@ export interface WorkflowNode {
 	elseNodeId?: string;
 	/** Loop body entry point. */
 	bodyStartNodeId?: string;
+	/** Condition continuation: where flow resumes after either branch completes. */
+	mergeNodeId?: string;
 	/** Persisted UI position from manual drag. */
 	position?: { x: number; y: number };
 }
@@ -398,6 +400,29 @@ export type TerminalNodeData = {
 	nodeType: "terminal";
 };
 
+/**
+ * Ghost "Choose a step" card rendered in an empty condition branch or empty
+ * loop body — the same affordance a transient placeholder shows, so lanes
+ * look identical whether or not an insert has started. Clicking it inserts
+ * a placeholder via its incoming edge. Display-only — never serialized.
+ */
+export type BranchGhostNodeData = {
+	nodeType: "branchGhost";
+	/** The incoming branch edge id, used to route the insert. */
+	edgeId: string;
+	onInsertNode?: (edgeId: string, nodeType: string, actionType?: string) => void;
+};
+
+/**
+ * Synthetic join point rendered below a condition inside a loop body: both
+ * branch tails reconverge here before the loop-back edge returns to the loop
+ * header. Display-only — never serialized.
+ */
+export type MergeNodeData = {
+	nodeType: "merge";
+	conditionId: string;
+};
+
 /** Non-interactive dotted frame rendered behind a loop's body (derived layout). */
 export type LoopContainerNodeData = {
 	nodeType: "loopContainer";
@@ -427,6 +452,8 @@ export type EndRFNode = Node<EndNodeData, "endNode">;
 export type NextItemRFNode = Node<NextItemNodeData, "nextItemNode">;
 export type PlaceholderRFNode = Node<PlaceholderNodeData, "placeholderNode">;
 export type TerminalRFNode = Node<TerminalNodeData, "terminalNode">;
+export type MergeRFNode = Node<MergeNodeData, "mergeNode">;
+export type BranchGhostRFNode = Node<BranchGhostNodeData, "branchGhostNode">;
 export type LoopContainerRFNode = Node<LoopContainerNodeData, "loopContainerNode">;
 
 export type AppNode =
@@ -444,13 +471,23 @@ export type AppNode =
 	| NextItemRFNode
 	| PlaceholderRFNode
 	| TerminalRFNode
+	| MergeRFNode
+	| BranchGhostRFNode
 	| LoopContainerRFNode;
 
 // ---------------------------------------------------------------------------
 // 9. AppEdge type
 // ---------------------------------------------------------------------------
 
-export type BranchType = "next" | "yes" | "no" | "each" | "after" | "loop_back";
+export type BranchType =
+	| "next"
+	| "yes"
+	| "no"
+	| "each"
+	| "after"
+	| "loop_back"
+	| "merge_in"
+	| "merge";
 
 export type EdgeData = {
 	branchType?: BranchType;
@@ -467,6 +504,12 @@ export type EdgeData = {
 	routeRightX?: number;
 	/** X of the loop-back edge's vertical run (derived layout, loop edges only). */
 	routeLeftX?: number;
+	/** Merge-in edge starts at a terminal stub — offset below its "+" button. */
+	fromTerminalStub?: boolean;
+	/** Edge targets a ghost "Choose a step" card — the card is the insert affordance, hide the edge "+". */
+	ghostTarget?: boolean;
+	/** Edge lives inside a loop body — renders in the loop's accent color. */
+	inLoop?: boolean;
 	/** actionType selects the action variant when nodeType is "action". */
 	onInsertNode?: (edgeId: string, nodeType: string, actionType?: string) => void;
 };

--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -933,6 +933,92 @@ describe("automationExecutor (v2 engine)", () => {
 			]);
 		});
 
+		// The delay path resolves its own continuation (delayNextNodeId) before
+		// parking, so a branch tail that ends in a delay must checkpoint AT the
+		// merge and resume there an hour later.
+		it("a branch tail ending in a delay parks at the merge and resumes into it", async () => {
+			const { orgId, asUser } = await setupUser();
+
+			const automationId = await asUser.mutation(api.automations.create, {
+				name: "Delay on the true branch",
+				trigger: { type: "record_created", objectType: "client" },
+				nodes: [
+					conditionNode("cond-1", "companyName", "contains", "Acme", {
+						nextNodeId: "delay-1",
+						mergeNodeId: "merge-1",
+					}),
+					{
+						id: "delay-1",
+						type: "delay" as const,
+						config: {
+							kind: "delay" as const,
+							amount: 1,
+							unit: "hours" as const,
+						},
+						// No nextNodeId: the branch dangles, so the delay's
+						// continuation is the condition's merge.
+					},
+					updateFieldActionNode("merge-1", "companyDescription", "Merge ran"),
+				],
+				isActive: true,
+			});
+
+			const clientId = await asUser.mutation(api.clients.create, {
+				portalAccessId: crypto.randomUUID(),
+				companyName: "Acme Corp",
+				status: "lead",
+			});
+
+			// Drive executeAutomation directly so the parked state is observable
+			// (see the delay checkpoint suite for why draining won't stop here).
+			const executionId = await t.run(async (ctx) =>
+				ctx.db.insert("workflowExecutions", {
+					orgId,
+					automationId,
+					triggeredBy: clientId,
+					triggeredAt: Date.now(),
+					status: "running",
+					nodesExecuted: [],
+					executionChain: [automationId],
+					recursionDepth: 0,
+				})
+			);
+
+			await t.mutation(internal.automationExecutor.executeAutomation, {
+				orgId,
+				executionId,
+				automationId,
+				objectType: "client",
+				objectId: clientId,
+				executionChain: [automationId],
+				recursionDepth: 1,
+			});
+
+			const midExecution = await t.run(async (ctx) => ctx.db.get(executionId));
+			expect(midExecution?.status).toBe("running");
+			expect(midExecution?.resumeState?.resumeNodeId).toBe("merge-1");
+			expect(midExecution?.nodesExecuted.map((n) => n.nodeId)).toEqual([
+				"cond-1",
+				"delay-1",
+			]);
+
+			await t.mutation(internal.automationExecutor.resumeExecution, {
+				orgId,
+				executionId,
+				automationId,
+			});
+
+			const client = await t.run(async (ctx) => ctx.db.get(clientId));
+			expect(client?.companyDescription).toBe("Merge ran");
+			const finalExecution = await t.run(async (ctx) => ctx.db.get(executionId));
+			expect(finalExecution?.status).toBe("completed");
+			expect(finalExecution?.nodesExecuted.map((n) => n.nodeId)).toEqual([
+				"cond-1",
+				"delay-1",
+				"merge-1",
+			]);
+		});
+
 		it("a false branch with no elseNodeId continues directly into the merge chain", async () => {
 			const { asUser } = await setupUser();
 

--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -63,7 +63,7 @@ function conditionNode(
 	field: string,
 	operator: string,
 	value: string | number | boolean,
-	opts: { nextNodeId?: string; elseNodeId?: string } = {}
+	opts: { nextNodeId?: string; elseNodeId?: string; mergeNodeId?: string } = {}
 ) {
 	return {
 		id,
@@ -87,6 +87,7 @@ function conditionNode(
 		},
 		nextNodeId: opts.nextNodeId,
 		elseNodeId: opts.elseNodeId,
+		mergeNodeId: opts.mergeNodeId,
 	};
 }
 
@@ -885,6 +886,127 @@ describe("automationExecutor (v2 engine)", () => {
 			await drainEvents();
 			const falseClient = await t.run(async (ctx) => ctx.db.get(falseId));
 			expect(falseClient?.notes).toBe("No match");
+		});
+	});
+
+	describe("condition mergeNodeId (branch convergence)", () => {
+		function endNode(id: string) {
+			return { id, type: "end" as const, config: { kind: "end" as const } };
+		}
+
+		it("a dangling true-branch action continues into the merge chain", async () => {
+			const { asUser } = await setupUser();
+
+			await asUser.mutation(api.automations.create, {
+				name: "Merge after true branch",
+				trigger: { type: "record_created", objectType: "client" },
+				nodes: [
+					conditionNode("cond-1", "companyName", "contains", "Acme", {
+						nextNodeId: "act-true",
+						mergeNodeId: "merge-1",
+					}),
+					updateFieldActionNode("act-true", "notes", "Branch ran"),
+					updateFieldActionNode("merge-1", "companyDescription", "Merge ran"),
+				],
+				isActive: true,
+			});
+
+			const clientId = await asUser.mutation(api.clients.create, {
+				portalAccessId: crypto.randomUUID(),
+				companyName: "Acme Corp",
+				status: "lead",
+			});
+			await drainEvents();
+
+			const client = await t.run(async (ctx) => ctx.db.get(clientId));
+			expect(client?.notes).toBe("Branch ran");
+			expect(client?.companyDescription).toBe("Merge ran");
+
+			const executions = await t.run(async (ctx) =>
+				ctx.db.query("workflowExecutions").collect()
+			);
+			expect(executions).toHaveLength(1);
+			expect(executions[0].nodesExecuted.map((n) => n.nodeId)).toEqual([
+				"cond-1",
+				"act-true",
+				"merge-1",
+			]);
+		});
+
+		it("a false branch with no elseNodeId continues directly into the merge chain", async () => {
+			const { asUser } = await setupUser();
+
+			await asUser.mutation(api.automations.create, {
+				name: "Merge after empty false branch",
+				trigger: { type: "record_created", objectType: "client" },
+				nodes: [
+					conditionNode("cond-1", "companyName", "contains", "Acme", {
+						nextNodeId: "act-true",
+						// No elseNodeId: the false path has no branch of its own.
+						mergeNodeId: "merge-1",
+					}),
+					updateFieldActionNode("act-true", "notes", "Branch ran"),
+					updateFieldActionNode("merge-1", "companyDescription", "Merge ran"),
+				],
+				isActive: true,
+			});
+
+			const clientId = await asUser.mutation(api.clients.create, {
+				portalAccessId: crypto.randomUUID(),
+				companyName: "Other Co",
+				status: "lead",
+			});
+			await drainEvents();
+
+			const client = await t.run(async (ctx) => ctx.db.get(clientId));
+			expect(client?.notes).toBeUndefined();
+			expect(client?.companyDescription).toBe("Merge ran");
+
+			const executions = await t.run(async (ctx) =>
+				ctx.db.query("workflowExecutions").collect()
+			);
+			expect(executions).toHaveLength(1);
+			expect(executions[0].nodesExecuted.map((n) => n.nodeId)).toEqual([
+				"cond-1",
+				"merge-1",
+			]);
+		});
+
+		it("a branch ending in an explicit end node does not continue to the merge chain", async () => {
+			const { asUser } = await setupUser();
+
+			await asUser.mutation(api.automations.create, {
+				name: "End node short-circuits the merge",
+				trigger: { type: "record_created", objectType: "client" },
+				nodes: [
+					conditionNode("cond-1", "companyName", "contains", "Acme", {
+						nextNodeId: "end-1",
+						mergeNodeId: "merge-1",
+					}),
+					endNode("end-1"),
+					updateFieldActionNode("merge-1", "companyDescription", "Merge ran"),
+				],
+				isActive: true,
+			});
+
+			const clientId = await asUser.mutation(api.clients.create, {
+				portalAccessId: crypto.randomUUID(),
+				companyName: "Acme Corp",
+				status: "lead",
+			});
+			await drainEvents();
+
+			const client = await t.run(async (ctx) => ctx.db.get(clientId));
+			expect(client?.companyDescription).toBeUndefined();
+
+			const executions = await t.run(async (ctx) =>
+				ctx.db.query("workflowExecutions").collect()
+			);
+			expect(executions).toHaveLength(1);
+			expect(executions[0].status).toBe("completed");
+			const nodeIds = executions[0].nodesExecuted.map((n) => n.nodeId);
+			expect(nodeIds).toEqual(["cond-1", "end-1"]);
+			expect(nodeIds).not.toContain("merge-1");
 		});
 	});
 
@@ -1866,7 +1988,11 @@ describe("automationExecutor (v2 engine)", () => {
 			field: string,
 			operator: string,
 			value: string | number | boolean,
-			opts: { nextNodeId?: string; elseNodeId?: string } = {}
+			opts: {
+				nextNodeId?: string;
+				elseNodeId?: string;
+				mergeNodeId?: string;
+			} = {}
 		) {
 			return {
 				id,
@@ -1879,6 +2005,7 @@ describe("automationExecutor (v2 engine)", () => {
 				},
 				nextNodeId: opts.nextNodeId,
 				elseNodeId: opts.elseNodeId,
+				mergeNodeId: opts.mergeNodeId,
 			};
 		}
 
@@ -2142,6 +2269,109 @@ describe("automationExecutor (v2 engine)", () => {
 				(n) => n.nodeId === "loop-1"
 			);
 			expect(loopEntry?.recordsProcessed).toBe(2);
+		});
+
+		it("loop-scoped condition mergeNodeId: the merge action runs once per item, both branches converge, and the loop advances past the dangling merge chain", async () => {
+			const { asUser, orgId } = await setupUser();
+			await makeOrgPremium(orgId);
+
+			const clientId = await asUser.mutation(api.clients.create, {
+				portalAccessId: crypto.randomUUID(),
+				companyName: "Acme Co",
+				status: "active",
+			});
+			const keep1Id = await asUser.mutation(api.projects.create, {
+				clientId,
+				title: "Keep A",
+				status: "planned",
+				projectType: "one-off",
+			});
+			const keep2Id = await asUser.mutation(api.projects.create, {
+				clientId,
+				title: "Keep B",
+				status: "planned",
+				projectType: "one-off",
+			});
+			const skipId = await asUser.mutation(api.projects.create, {
+				clientId,
+				title: "Skip me",
+				status: "planned",
+				projectType: "one-off",
+			});
+
+			const automationId = await asUser.mutation(api.automations.create, {
+				name: "Merge convergence inside loop body",
+				trigger: {
+					type: "scheduled",
+					schedule: { frequency: "daily", timezone: "UTC", time: "09:00" },
+				},
+				nodes: [
+					fetchNode(
+						"fetch-1",
+						"project",
+						[filterGroup("status", "equals", "planned")],
+						{ nextNodeId: "loop-1" }
+					),
+					loopNode("loop-1", "fetch-1", {
+						bodyStartNodeId: "cond-1",
+						nextNodeId: "end-1",
+					}),
+					// No elseNodeId: the false path converges straight into mergeNodeId,
+					// same as the true branch once body-act dangles.
+					loopConditionNode("cond-1", "loop-1", "title", "contains", "Keep", {
+						nextNodeId: "body-act",
+						mergeNodeId: "merge-act",
+					}),
+					updateFieldActionNode("body-act", "status", "in-progress", {
+						target: "self",
+					}),
+					updateFieldActionNode("merge-act", "description", "merged", {
+						target: "self",
+					}),
+					endNode("end-1"),
+				],
+				isActive: true,
+			});
+
+			await runScheduledOnce(automationId);
+
+			const [keep1, keep2, skip] = await t.run(async (ctx) =>
+				Promise.all([
+					ctx.db.get(keep1Id),
+					ctx.db.get(keep2Id),
+					ctx.db.get(skipId),
+				])
+			);
+			// body-act only ran for the matching items.
+			expect(keep1?.status).toBe("in-progress");
+			expect(keep2?.status).toBe("in-progress");
+			expect(skip?.status).toBe("planned");
+			// merge-act converges both branches: every item gets it.
+			expect(keep1?.description).toBe("merged");
+			expect(keep2?.description).toBe("merged");
+			expect(skip?.description).toBe("merged");
+
+			const executions = await t.run(async (ctx) =>
+				ctx.db.query("workflowExecutions").collect()
+			);
+			expect(executions).toHaveLength(1);
+			const execution = executions[0];
+			expect(execution.status).toBe("completed");
+			const loopEntry = execution.nodesExecuted.find(
+				(n) => n.nodeId === "loop-1"
+			);
+			expect(loopEntry?.recordsProcessed).toBe(3);
+			expect(
+				execution.nodesExecuted.filter((n) => n.nodeId === "body-act")
+			).toHaveLength(2);
+			expect(
+				execution.nodesExecuted.filter((n) => n.nodeId === "merge-act")
+			).toHaveLength(3);
+			// The dangling merge chain never escapes the loop body: the run still
+			// reaches the post-loop end node exactly once.
+			expect(
+				execution.nodesExecuted.filter((n) => n.nodeId === "end-1")
+			).toHaveLength(1);
 		});
 
 		it("var-kind fetch filter: cancel client cascades to only its own tasks", async () => {

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -1536,41 +1536,64 @@ async function finishWalk(
  * means "next item"), and a dangle inside a condition's own merge chain
  * continues at the ANCESTORS' merges, not back at that condition.
  */
+type ParentLink = {
+	parent: AutomationNode;
+	via: "branch" | "merge" | "body" | "next";
+};
+
+/**
+ * Reverse parent index (child id -> parent + the pointer that reaches it),
+ * cached per node map. A definition's nodesById is built once per execution
+ * and never mutated, so the index stays valid for the whole walk; without it
+ * every ancestor hop rescans all nodes.
+ */
+const parentIndexCache = new WeakMap<
+	Map<string, AutomationNode>,
+	Map<string, ParentLink>
+>();
+
+function parentIndexFor(
+	nodesById: Map<string, AutomationNode>
+): Map<string, ParentLink> {
+	const cached = parentIndexCache.get(nodesById);
+	if (cached) return cached;
+
+	const index = new Map<string, ParentLink>();
+	// First writer wins, matching the linear scan this replaces: a malformed
+	// stored graph with a multi-parented node resolves to the same parent it
+	// did before (writes reject those, but legacy rows may predate the check).
+	const link = (childId: string | undefined, parent: AutomationNode, via: ParentLink["via"]) => {
+		if (childId && !index.has(childId)) index.set(childId, { parent, via });
+	};
+	for (const candidate of nodesById.values()) {
+		link(candidate.bodyStartNodeId, candidate, "body");
+		link(candidate.mergeNodeId, candidate, "merge");
+		link(candidate.elseNodeId, candidate, "branch");
+		// A condition's nextNodeId IS its true branch; every other node's
+		// nextNodeId is a plain chain link.
+		link(
+			candidate.nextNodeId,
+			candidate,
+			candidate.type === "condition" ? "branch" : "next"
+		);
+	}
+
+	parentIndexCache.set(nodesById, index);
+	return index;
+}
+
 function mergeContinuationFor(
 	nodesById: Map<string, AutomationNode>,
 	nodeId: string
 ): string | undefined {
+	const parents = parentIndexFor(nodesById);
 	let currentId = nodeId;
 	const seen = new Set<string>();
 	while (!seen.has(currentId)) {
 		seen.add(currentId);
-		let parent: AutomationNode | undefined;
-		let via: "branch" | "merge" | "body" | "next" | undefined;
-		for (const candidate of nodesById.values()) {
-			if (candidate.bodyStartNodeId === currentId) {
-				parent = candidate;
-				via = "body";
-				break;
-			}
-			if (candidate.mergeNodeId === currentId) {
-				parent = candidate;
-				via = "merge";
-				break;
-			}
-			if (candidate.elseNodeId === currentId) {
-				parent = candidate;
-				via = "branch";
-				break;
-			}
-			if (candidate.nextNodeId === currentId) {
-				parent = candidate;
-				// A condition's nextNodeId IS its true branch; every other
-				// node's nextNodeId is a plain chain link.
-				via = candidate.type === "condition" ? "branch" : "next";
-				break;
-			}
-		}
-		if (!parent) return undefined;
+		const link = parents.get(currentId);
+		if (!link) return undefined;
+		const { parent, via } = link;
 		if (via === "body") return undefined;
 		if (via === "branch" && parent.type === "condition" && parent.mergeNodeId) {
 			return parent.mergeNodeId;

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -1423,7 +1423,13 @@ export const resumeExecution = systemMutation({
 					remainingItemIds: resume.loop.remainingItemIds,
 				});
 				if (outcome.kind === "chain_done") {
-					outcome = await runWalk(ctx, env, loopNode.nextNodeId, scopeRecord);
+					outcome = await runWalk(
+						ctx,
+						env,
+						loopNode.nextNodeId ??
+							mergeContinuationFor(env.nodesById, loopNode.id),
+						scopeRecord
+					);
 				}
 			} else {
 				outcome = await runWalk(ctx, env, resume.resumeNodeId, scopeRecord);
@@ -1524,6 +1530,57 @@ async function finishWalk(
 }
 
 /**
+ * Continuation for a dangling chain tail: the nearest enclosing condition's
+ * mergeNodeId ("after the branches converge"). Ascends the static parent
+ * tree. Boundaries: never escapes a loop body (a dangling body leaf still
+ * means "next item"), and a dangle inside a condition's own merge chain
+ * continues at the ANCESTORS' merges, not back at that condition.
+ */
+function mergeContinuationFor(
+	nodesById: Map<string, AutomationNode>,
+	nodeId: string
+): string | undefined {
+	let currentId = nodeId;
+	const seen = new Set<string>();
+	while (!seen.has(currentId)) {
+		seen.add(currentId);
+		let parent: AutomationNode | undefined;
+		let via: "branch" | "merge" | "body" | "next" | undefined;
+		for (const candidate of nodesById.values()) {
+			if (candidate.bodyStartNodeId === currentId) {
+				parent = candidate;
+				via = "body";
+				break;
+			}
+			if (candidate.mergeNodeId === currentId) {
+				parent = candidate;
+				via = "merge";
+				break;
+			}
+			if (candidate.elseNodeId === currentId) {
+				parent = candidate;
+				via = "branch";
+				break;
+			}
+			if (candidate.nextNodeId === currentId) {
+				parent = candidate;
+				// A condition's nextNodeId IS its true branch; every other
+				// node's nextNodeId is a plain chain link.
+				via = candidate.type === "condition" ? "branch" : "next";
+				break;
+			}
+		}
+		if (!parent) return undefined;
+		if (via === "body") return undefined;
+		if (via === "branch" && parent.type === "condition" && parent.mergeNodeId) {
+			return parent.mergeNodeId;
+		}
+		currentId = parent.id;
+	}
+	return undefined;
+}
+
+/**
  * Walk a node chain from startNodeId. Loop bodies recurse with the loop item
  * as the scope record; delays checkpoint and return "waiting".
  */
@@ -1577,7 +1634,8 @@ async function runWalk(
 				recordsProcessed: fetched.output.count,
 				truncated: fetched.output.truncated,
 			});
-			currentNodeId = node.nextNodeId;
+			currentNodeId =
+				node.nextNodeId ?? mergeContinuationFor(env.nodesById, node.id);
 			continue;
 		}
 
@@ -1598,7 +1656,8 @@ async function runWalk(
 				output: { result: result.value },
 				truncated: result.truncated,
 			});
-			currentNodeId = node.nextNodeId;
+			currentNodeId =
+				node.nextNodeId ?? mergeContinuationFor(env.nodesById, node.id);
 			continue;
 		}
 
@@ -1617,7 +1676,8 @@ async function runWalk(
 				result: "success",
 				output: { result: result.value },
 			});
-			currentNodeId = node.nextNodeId;
+			currentNodeId =
+				node.nextNodeId ?? mergeContinuationFor(env.nodesById, node.id);
 			continue;
 		}
 
@@ -1629,7 +1689,8 @@ async function runWalk(
 			}
 			const outcome = await runLoopNode(ctx, env, node, config);
 			if (outcome.kind !== "chain_done") return outcome;
-			currentNodeId = node.nextNodeId;
+			currentNodeId =
+				node.nextNodeId ?? mergeContinuationFor(env.nodesById, node.id);
 			continue;
 		}
 
@@ -1653,18 +1714,20 @@ async function runWalk(
 				result: "success",
 				output: { resumeAt: resume.resumeAt },
 			});
+			const delayNextNodeId =
+				node.nextNodeId ?? mergeContinuationFor(env.nodesById, node.id);
 			// Nothing to wait for: already due, or no downstream steps.
-			if (resume.resumeAt <= Date.now() || !node.nextNodeId) {
-				currentNodeId = node.nextNodeId;
+			if (resume.resumeAt <= Date.now() || !delayNextNodeId) {
+				currentNodeId = delayNextNodeId;
 				continue;
 			}
 			await ctx.db.patch(env.executionId, {
 				nodesExecuted: env.nodesExecuted,
 				dataTruncated: env.dataTruncated,
 				loopSummary: loopSummaryPatch(env),
-				currentNodeId: node.nextNodeId,
+				currentNodeId: delayNextNodeId,
 				resumeState: {
-					resumeNodeId: node.nextNodeId,
+					resumeNodeId: delayNextNodeId,
 					resumeAt: resume.resumeAt,
 					// Parked-at timestamp; resume adds (now - checkpointAt) to pausedMs.
 					checkpointAt: Date.now(),
@@ -1735,10 +1798,10 @@ async function runWalk(
 
 		currentNodeId =
 			node.type === "condition"
-				? result.conditionMet
-					? node.nextNodeId
-					: node.elseNodeId
-				: node.nextNodeId;
+				? ((result.conditionMet ? node.nextNodeId : node.elseNodeId) ??
+					node.mergeNodeId ??
+					mergeContinuationFor(env.nodesById, node.id))
+				: (node.nextNodeId ?? mergeContinuationFor(env.nodesById, node.id));
 	}
 
 	return { kind: "chain_done" };
@@ -4863,7 +4926,8 @@ async function dryRunWalk(
 				},
 				output: { count: fetched.output.count },
 			});
-			currentNodeId = node.nextNodeId;
+			currentNodeId =
+				node.nextNodeId ?? mergeContinuationFor(env.nodesById, node.id);
 			continue;
 		}
 
@@ -4890,7 +4954,8 @@ async function dryRunWalk(
 				},
 				output: { result: result.value },
 			});
-			currentNodeId = node.nextNodeId;
+			currentNodeId =
+				node.nextNodeId ?? mergeContinuationFor(env.nodesById, node.id);
 			continue;
 		}
 
@@ -4915,7 +4980,8 @@ async function dryRunWalk(
 				},
 				output: { result: result.value },
 			});
-			currentNodeId = node.nextNodeId;
+			currentNodeId =
+				node.nextNodeId ?? mergeContinuationFor(env.nodesById, node.id);
 			continue;
 		}
 
@@ -4927,7 +4993,8 @@ async function dryRunWalk(
 			}
 			const outcome = await dryRunLoopNode(ctx, env, node, config);
 			if (outcome !== "chain_done") return outcome;
-			currentNodeId = node.nextNodeId;
+			currentNodeId =
+				node.nextNodeId ?? mergeContinuationFor(env.nodesById, node.id);
 			continue;
 		}
 
@@ -4952,7 +5019,8 @@ async function dryRunWalk(
 						: { until: config.until },
 				output: { wouldWaitUntil: resume.resumeAt, dryRunSkipped: true },
 			});
-			currentNodeId = node.nextNodeId;
+			currentNodeId =
+				node.nextNodeId ?? mergeContinuationFor(env.nodesById, node.id);
 			continue;
 		}
 
@@ -4987,10 +5055,10 @@ async function dryRunWalk(
 
 		currentNodeId =
 			node.type === "condition"
-				? result.conditionMet
-					? node.nextNodeId
-					: node.elseNodeId
-				: node.nextNodeId;
+				? ((result.conditionMet ? node.nextNodeId : node.elseNodeId) ??
+					node.mergeNodeId ??
+					mergeContinuationFor(env.nodesById, node.id))
+				: (node.nextNodeId ?? mergeContinuationFor(env.nodesById, node.id));
 	}
 
 	return "chain_done";

--- a/packages/backend/convex/automationRuns.test.ts
+++ b/packages/backend/convex/automationRuns.test.ts
@@ -63,7 +63,7 @@ function conditionNode(
 	field: string,
 	operator: string,
 	value: string,
-	opts: { nextNodeId?: string; elseNodeId?: string } = {}
+	opts: { nextNodeId?: string; elseNodeId?: string; mergeNodeId?: string } = {}
 ) {
 	return {
 		id,
@@ -87,6 +87,7 @@ function conditionNode(
 		},
 		nextNodeId: opts.nextNodeId,
 		elseNodeId: opts.elseNodeId,
+		mergeNodeId: opts.mergeNodeId,
 	};
 }
 
@@ -227,6 +228,49 @@ describe("automation runs (test + manual)", () => {
 			// Dry run must not have touched the client.
 			const client = await t.run(async (ctx) => ctx.db.get(clientId));
 			expect(client?.status).toBe("lead");
+		});
+
+		// The dry-run walk duplicates the production walk, so merge routing has
+		// to be asserted on both sides or the two silently drift.
+		it("routes a dangling branch tail into the merge chain, same as production", async () => {
+			const { asUser } = await setupUser();
+			const clientId = await makeClient(asUser);
+
+			const automationId = await asUser.mutation(api.automations.create, {
+				name: "Dry-run merge convergence",
+				trigger: clientCreatedTrigger,
+				nodes: [
+					// True branch dangles into the merge; the false branch has no
+					// elseNodeId, so it converges straight onto it.
+					conditionNode("cond-1", "companyName", "contains", "Acme", {
+						nextNodeId: "act-true",
+						mergeNodeId: "merge-1",
+					}),
+					notesActionNode("act-true", "branch ran"),
+					statusActionNode("merge-1", "inactive"),
+				],
+			});
+
+			const executionId = await asUser.mutation(
+				api.automationExecutor.startTestRun,
+				{ automationId, record: { entityType: "client", entityId: clientId } }
+			);
+			await drainScheduled();
+
+			const done = await asUser.query(api.automationExecutor.getExecution, {
+				executionId,
+			});
+			expect(done?.status).toBe("completed");
+			expect(done?.nodesExecuted.map((n) => n.nodeId)).toEqual([
+				"cond-1",
+				"act-true",
+				"merge-1",
+			]);
+
+			// Still a dry run: nothing written.
+			const client = await t.run(async (ctx) => ctx.db.get(clientId));
+			expect(client?.status).toBe("lead");
+			expect(client?.notes).toBeUndefined();
 		});
 
 		it("simulates create_task without creating a task", async () => {

--- a/packages/backend/convex/automations.test.ts
+++ b/packages/backend/convex/automations.test.ts
@@ -11,7 +11,11 @@ const clientTrigger = {
 	toStatus: "active",
 } as const;
 
-function conditionNode(id: string, nextNodeId?: string) {
+function conditionNode(
+	id: string,
+	nextNodeId?: string,
+	opts: { elseNodeId?: string; mergeNodeId?: string } = {}
+) {
 	return {
 		id,
 		type: "condition" as const,
@@ -32,6 +36,8 @@ function conditionNode(id: string, nextNodeId?: string) {
 			],
 		},
 		nextNodeId,
+		elseNodeId: opts.elseNodeId,
+		mergeNodeId: opts.mergeNodeId,
 	};
 }
 
@@ -641,6 +647,71 @@ describe("Automations", () => {
 					],
 				})
 			).rejects.toThrow(/cycle/i);
+		});
+
+		describe("mergeNodeId (branch convergence)", () => {
+			it("rejects mergeNodeId on a non-condition node", async () => {
+				const { asUser } = await setupUser();
+
+				await expect(
+					asUser.mutation(api.automations.create, {
+						name: "Merge on an action",
+						trigger: clientTrigger,
+						nodes: [
+							{ ...actionNode("act-1"), mergeNodeId: "act-2" },
+							actionNode("act-2"),
+						],
+					})
+				).rejects.toThrow(/only conditions can have a merge continuation/i);
+			});
+
+			it("rejects a mergeNodeId referencing a missing node", async () => {
+				const { asUser } = await setupUser();
+
+				await expect(
+					asUser.mutation(api.automations.create, {
+						name: "Merge to nowhere",
+						trigger: clientTrigger,
+						nodes: [
+							conditionNode("cond-1", "act-1", { mergeNodeId: "ghost" }),
+							actionNode("act-1"),
+						],
+					})
+				).rejects.toThrow(/references missing node/i);
+			});
+
+			it("rejects a merge target that is also reachable via another node's nextNodeId", async () => {
+				const { asUser } = await setupUser();
+
+				await expect(
+					asUser.mutation(api.automations.create, {
+						name: "Double-parented merge target",
+						trigger: clientTrigger,
+						nodes: [
+							conditionNode("cond-1", "act-1", { mergeNodeId: "merge-1" }),
+							actionNode("act-1"),
+							{ ...actionNode("other-1"), nextNodeId: "merge-1" },
+							actionNode("merge-1"),
+						],
+					})
+				).rejects.toThrow(/already reachable from another step/i);
+			});
+
+			it("rejects a cycle formed through a mergeNodeId pointing back to the condition", async () => {
+				const { asUser } = await setupUser();
+
+				await expect(
+					asUser.mutation(api.automations.create, {
+						name: "Merge cycle",
+						trigger: clientTrigger,
+						nodes: [
+							conditionNode("cond-1", "act-1", { mergeNodeId: "merge-1" }),
+							actionNode("act-1"),
+							{ ...actionNode("merge-1"), nextNodeId: "cond-1" },
+						],
+					})
+				).rejects.toThrow(/cycle/i);
+			});
 		});
 
 		it("rejects activating with zero nodes but allows a zero-node draft", async () => {

--- a/packages/backend/convex/automations.ts
+++ b/packages/backend/convex/automations.ts
@@ -76,6 +76,7 @@ const nodeArgValidator = v.object({
 	nextNodeId: v.optional(v.string()),
 	elseNodeId: v.optional(v.string()),
 	bodyStartNodeId: v.optional(v.string()),
+	mergeNodeId: v.optional(v.string()),
 	position: v.optional(v.object({ x: v.number(), y: v.number() })),
 });
 
@@ -86,6 +87,7 @@ type NodeArg = {
 	nextNodeId?: string;
 	elseNodeId?: string;
 	bodyStartNodeId?: string;
+	mergeNodeId?: string;
 	position?: { x: number; y: number };
 };
 
@@ -672,6 +674,7 @@ function computeLoopBodyScopeTypes(
 			const member = byId.get(id);
 			if (member?.nextNodeId !== undefined) stack.push(member.nextNodeId);
 			if (member?.elseNodeId !== undefined) stack.push(member.elseNodeId);
+			if (member?.mergeNodeId !== undefined) stack.push(member.mergeNodeId);
 		}
 	}
 	return bodyScopeType;
@@ -710,6 +713,7 @@ function validateWorkflowDefinition(
 			node.nextNodeId,
 			node.elseNodeId,
 			node.bodyStartNodeId,
+			node.mergeNodeId,
 		]) {
 			if (ref !== undefined) {
 				if (!nodeIds.has(ref)) {
@@ -720,6 +724,33 @@ function validateWorkflowDefinition(
 				if (ref === node.id) {
 					throw new Error(`Node ${node.id}: references itself`);
 				}
+			}
+		}
+
+		if (node.mergeNodeId !== undefined) {
+			if (node.type !== "condition") {
+				throw new Error(
+					`Node ${node.id}: only conditions can have a merge continuation`
+				);
+			}
+			// The merge chain must be single-parented — a target also reachable
+			// via another pointer would execute twice (and breaks the canvas
+			// tree). Cycles through mergeNodeId are caught by the DFS below.
+			let referenceCount = 0;
+			for (const other of nodes) {
+				for (const ref of [
+					other.nextNodeId,
+					other.elseNodeId,
+					other.bodyStartNodeId,
+					other.mergeNodeId,
+				]) {
+					if (ref === node.mergeNodeId) referenceCount++;
+				}
+			}
+			if (referenceCount > 1) {
+				throw new Error(
+					`Node ${node.id}: merge continuation target "${node.mergeNodeId}" is already reachable from another step`
+				);
 			}
 		}
 
@@ -966,7 +997,7 @@ function validateWorkflowDefinition(
 		}
 	}
 
-	// Reject cycles across nextNodeId/elseNodeId/bodyStartNodeId — the
+	// Reject cycles across nextNodeId/elseNodeId/bodyStartNodeId/mergeNodeId — the
 	// executor walks these links and must terminate. (The builder UI cannot
 	// produce cycles; this guards direct API writes.)
 	const byId = new Map(nodes.map((n) => [n.id, n]));
@@ -983,6 +1014,7 @@ function validateWorkflowDefinition(
 			node?.nextNodeId,
 			node?.elseNodeId,
 			node?.bodyStartNodeId,
+			node?.mergeNodeId,
 		]) {
 			if (ref !== undefined) visit(ref);
 		}
@@ -995,7 +1027,7 @@ function validateWorkflowDefinition(
 
 /**
  * Structural rules for loop bodies (walked from bodyStartNodeId via
- * nextNodeId/elseNodeId):
+ * nextNodeId/elseNodeId/mergeNodeId):
  * - no nested loops and no delay steps inside a body (the walk engine can't
  *   checkpoint mid-loop);
  * - a node can belong to at most one loop body and must not also be
@@ -1019,6 +1051,7 @@ function validateLoopBodies(
 			// is per-loop, and nested loops are rejected below anyway.
 			if (node.nextNodeId !== undefined) stack.push(node.nextNodeId);
 			if (node.elseNodeId !== undefined) stack.push(node.elseNodeId);
+			if (node.mergeNodeId !== undefined) stack.push(node.mergeNodeId);
 		}
 		return found;
 	};

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -22,6 +22,9 @@ const workflowNodeValidator = v.object({
 	elseNodeId: v.optional(v.string()),
 	// Loop body entry point (v2)
 	bodyStartNodeId: v.optional(v.string()),
+	// Condition continuation: where flow resumes after either branch chain
+	// completes ("after the branches converge"). Conditions only.
+	mergeNodeId: v.optional(v.string()),
 	// UI position (persisted for manual drag positioning)
 	position: v.optional(
 		v.object({


### PR DESCRIPTION
This pull request introduces significant improvements to the automation editor's flowchart rendering, focusing on more accurate and flexible handling of conditional branches, merges, and insertion points. The main changes include the addition of explicit merge nodes and edges, improved handling of "ghost" (empty) branch cards, and visual and interaction refinements for flow edges and nodes. These updates improve both the user experience and the maintainability of the flow editor.

**Branch and Merge Node Handling:**
- Added explicit `mergeNode` and `branchGhostNode` React Flow node types, with corresponding components (`MergeNodeRF`, `BranchGhostNodeRF`) for more accurate routing and interaction at branch convergence points and empty branches. [[1]](diffhunk://#diff-8a05f3afa5dc71917c09d55987363289a8b1406d45c40a4f44a56f0ebeacac78R49-R55) [[2]](diffhunk://#diff-8a05f3afa5dc71917c09d55987363289a8b1406d45c40a4f44a56f0ebeacac78R74-R83) [[3]](diffhunk://#diff-5e8d18108d6b3d699ac161b4091545cec56819f656f070e7308de4708cbad41eR1-R39) [[4]](diffhunk://#diff-9a591b81bfacdcfa31fed444f082b7f454c5de6f481e10c519f0305511dfbc24R1-R27)
- Introduced the `MergeInEdge` edge type/component to visually connect branch tails to merge points, handling layout and styling for these connections. [[1]](diffhunk://#diff-8a05f3afa5dc71917c09d55987363289a8b1406d45c40a4f44a56f0ebeacac78R49-R55) [[2]](diffhunk://#diff-8a05f3afa5dc71917c09d55987363289a8b1406d45c40a4f44a56f0ebeacac78R74-R83) [[3]](diffhunk://#diff-9ffa61b4784c31bd199a435bd388200cb8f2370275405123dd17ab2057d96e08R1-R54)

**Flow Node and Edge Interaction Improvements:**
- Updated event handlers to prevent clicks and context menus on synthetic nodes (merge, ghost, container, terminal), ensuring only meaningful nodes are interactive. [[1]](diffhunk://#diff-8a05f3afa5dc71917c09d55987363289a8b1406d45c40a4f44a56f0ebeacac78L294-R304) [[2]](diffhunk://#diff-8a05f3afa5dc71917c09d55987363289a8b1406d45c40a4f44a56f0ebeacac78L316-R333)
- Ghost nodes ("Choose a step" cards) now handle their own insertion logic via their incoming edge, matching the "+" button flow. [[1]](diffhunk://#diff-3392f4a7564b6621673229c2ae9f2e68322f8bf03a525a42072d968150fbfb0bL83-R98) [[2]](diffhunk://#diff-5e8d18108d6b3d699ac161b4091545cec56819f656f070e7308de4708cbad41eR1-R39)

**Edge and Visual Styling:**
- Refined the styling and pathing of branch label edges to use smooth curves, improved label placement, and conditional rendering of "+" buttons only when appropriate (e.g., not on ghost cards). [[1]](diffhunk://#diff-870a8e93663d275928b3f36549d1608a785ecebc5e2b0221bb1c118a3c1a0dcfL6-R17) [[2]](diffhunk://#diff-870a8e93663d275928b3f36549d1608a785ecebc5e2b0221bb1c118a3c1a0dcfR27-R78) [[3]](diffhunk://#diff-870a8e93663d275928b3f36549d1608a785ecebc5e2b0221bb1c118a3c1a0dcfL74-R92) [[4]](diffhunk://#diff-870a8e93663d275928b3f36549d1608a785ecebc5e2b0221bb1c118a3c1a0dcfR116-L136)
- Standardized edge styles, including dashed lines for normal and loop edges, and ensured correct color and dash patterns. [[1]](diffhunk://#diff-6451abed90091ddab70aec6e48d3c14b8e4128cce80fb174dd2bc2904d0bda46R13) [[2]](diffhunk://#diff-b528f39e58a7d6a754c8be698b50bddeab6a263ff48e9f4474159b1ed0dae12cL13-R13) [[3]](diffhunk://#diff-b528f39e58a7d6a754c8be698b50bddeab6a263ff48e9f4474159b1ed0dae12cR27) [[4]](diffhunk://#diff-b528f39e58a7d6a754c8be698b50bddeab6a263ff48e9f4474159b1ed0dae12cL46-R47) [[5]](diffhunk://#diff-b528f39e58a7d6a754c8be698b50bddeab6a263ff48e9f4474159b1ed0dae12cL76-R77)
- Improved invisible node/handle sizing for terminal and merge nodes to ensure correct edge attachment and layout without visual artifacts. [[1]](diffhunk://#diff-58efbb9b6f4a3eb95648969d949668055baac2ef9257ea8cda340dcc766110d4L17-R22) [[2]](diffhunk://#diff-9a591b81bfacdcfa31fed444f082b7f454c5de6f481e10c519f0305511dfbc24R1-R27)

**Editor Logic Enhancements:**
- Updated automation editor logic to recognize and correctly resolve synthetic node IDs (ghost, merge) when inserting nodes, ensuring that new steps are appended in the correct place and that synthetic nodes are not targeted directly. [[1]](diffhunk://#diff-e3ab58d202efc7863fbaec52908884bf53e4a4170c325fca046f2765c5b6abdfR25-R28) [[2]](diffhunk://#diff-e3ab58d202efc7863fbaec52908884bf53e4a4170c325fca046f2765c5b6abdfR524-R537)

---

**Most Important Changes:**

**Branch and Merge Flow Improvements**
- Added explicit `mergeNode` and `branchGhostNode` types and components (`MergeNodeRF`, `BranchGhostNodeRF`) for accurate branch convergence and empty branch handling in the flow editor. [[1]](diffhunk://#diff-8a05f3afa5dc71917c09d55987363289a8b1406d45c40a4f44a56f0ebeacac78R49-R55) [[2]](diffhunk://#diff-8a05f3afa5dc71917c09d55987363289a8b1406d45c40a4f44a56f0ebeacac78R74-R83) [[3]](diffhunk://#diff-5e8d18108d6b3d699ac161b4091545cec56819f656f070e7308de4708cbad41eR1-R39) [[4]](diffhunk://#diff-9a591b81bfacdcfa31fed444f082b7f454c5de6f481e10c519f0305511dfbc24R1-R27)
- Introduced `MergeInEdge` for visually connecting branch tails to merge points, with correct styling and layout. [[1]](diffhunk://#diff-8a05f3afa5dc71917c09d55987363289a8b1406d45c40a4f44a56f0ebeacac78R49-R55) [[2]](diffhunk://#diff-8a05f3afa5dc71917c09d55987363289a8b1406d45c40a4f44a56f0ebeacac78R74-R83) [[3]](diffhunk://#diff-9ffa61b4784c31bd199a435bd388200cb8f2370275405123dd17ab2057d96e08R1-R54)

**Node and Edge Interaction**
- Updated event handlers to prevent interaction with synthetic nodes (merge, ghost, container, terminal), ensuring only actionable nodes respond to clicks and context menus. [[1]](diffhunk://#diff-8a05f3afa5dc71917c09d55987363289a8b1406d45c40a4f44a56f0ebeacac78L294-R304) [[2]](diffhunk://#diff-8a05f3afa5dc71917c09d55987363289a8b1406d45c40a4f44a56f0ebeacac78L316-R333)
- Ghost nodes now handle their own "insert node" logic, aligning the user experience for adding steps in empty branches with other insert affordances. [[1]](diffhunk://#diff-3392f4a7564b6621673229c2ae9f2e68322f8bf03a525a42072d968150fbfb0bL83-R98) [[2]](diffhunk://#diff-5e8d18108d6b3d699ac161b4091545cec56819f656f070e7308de4708cbad41eR1-R39)

**Visual and Styling Updates**
- Improved edge pathing and label rendering for branch label edges, using smooth curves, better label placement, and conditional "+" button display. [[1]](diffhunk://#diff-870a8e93663d275928b3f36549d1608a785ecebc5e2b0221bb1c118a3c1a0dcfL6-R17) [[2]](diffhunk://#diff-870a8e93663d275928b3f36549d1608a785ecebc5e2b0221bb1c118a3c1a0dcfR27-R78) [[3]](diffhunk://#diff-870a8e93663d275928b3f36549d1608a785ecebc5e2b0221bb1c118a3c1a0dcfL74-R92) [[4]](diffhunk://#diff-870a8e93663d275928b3f36549d1608a785ecebc5e2b0221bb1c118a3c1a0dcfR116-L136)
- Standardized edge and handle styling for both normal and loop edges, including dashed lines and improved invisible handle sizing for correct edge attachment. [[1]](diffhunk://#diff-6451abed90091ddab70aec6e48d3c14b8e4128cce80fb174dd2bc2904d0bda46R13) [[2]](diffhunk://#diff-b528f39e58a7d6a754c8be698b50bddeab6a263ff48e9f4474159b1ed0dae12cL13-R13) [[3]](diffhunk://#diff-b528f39e58a7d6a754c8be698b50bddeab6a263ff48e9f4474159b1ed0dae12cR27) [[4]](diffhunk://#diff-b528f39e58a7d6a754c8be698b50bddeab6a263ff48e9f4474159b1ed0dae12cL46-R47) [[5]](diffhunk://#diff-b528f39e58a7d6a754c8be698b50bddeab6a263ff48e9f4474159b1ed0dae12cL76-R77) [[6]](diffhunk://#diff-58efbb9b6f4a3eb95648969d949668055baac2ef9257ea8cda340dcc766110d4L17-R22) [[7]](diffhunk://#diff-9a591b81bfacdcfa31fed444f082b7f454c5de6f481e10c519f0305511dfbc24R1-R27)

**Editor Logic**
- Enhanced editor logic to resolve synthetic node IDs correctly when inserting nodes, ensuring new steps are appended to the correct logical parent rather than targeting synthetic nodes. [[1]](diffhunk://#diff-e3ab58d202efc7863fbaec52908884bf53e4a4170c325fca046f2765c5b6abdfR25-R28) [[2]](diffhunk://#diff-e3ab58d202efc7863fbaec52908884bf53e4a4170c325fca046f2765c5b6abdfR524-R537)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added condition branch merge points so both paths can converge into a shared sequence.
  * Added interactive “Choose a step” placeholder cards for empty condition and loop branches.
  * Added support for saving/loading/editing/continuing merge-linked workflows via merge continuation.
* **Bug Fixes**
  * Fixed execution to correctly follow merge continuations and resume after delays in branching/looping scenarios.
  * Prevented synthetic merge/ghost UI elements from opening clicks or context menus.
* **Improvements**
  * Updated branch/merge visuals and connector styling (including dashed sequential connectors).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a Salesforce-Flow-style merge continuation model for condition nodes: both branch lanes now reconverge at an explicit merge dot, and flow resumes at a configurable `mergeNodeId` chain after either branch completes. It also replaces bare "+" terminal stubs on empty branches with visible "Choose a step" ghost cards, unifies branch-edge rendering to use smooth-step curves with symmetric fan-out, and adds a global `inLoop` accent-color pass for edges inside loop bodies.

- **Backend**: `mergeNodeId` is added to the schema and Convex node validator; `validateWorkflowDefinition` enforces type-restriction (conditions only), single-parent uniqueness, and DFS cycle detection; `mergeContinuationFor` in the executor threads the merge continuation as the fallback `nextNodeId` for every node type in both `runWalk` and `dryRunWalk`, with loop-body boundary enforcement.
- **Canvas**: New `MergeNodeRF`, `BranchGhostNodeRF`, and `MergeInEdge` components are registered; `planConditionMerges` plans all merge dots and their inputs before the main render pass; `derivedLayout` places merge dots symmetrically on the condition spine below the taller branch lane.
- **`EDGE_STYLE` now includes `strokeDasharray: \"6 3\"`**, making all non-loop edges globally dashed — a visible change to every existing automation canvas.

<h3>Confidence Score: 3/5</h3>

Safe to merge for new automations; one execution path in `mergeContinuationFor` may silently propagate a merge continuation through a loop-node `nextNodeId` boundary in a way that doesn't match what the canvas shows.

The `mergeContinuationFor` function ascends the parent tree via `nextNodeId` pointers without stopping at loop-node boundaries the way it stops for `bodyStartNodeId`. In a topology where a loop's after-last action is inside a condition branch, the function could return an outer condition's `mergeNodeId` for a node that should simply end the run. This topology isn't covered by the existing tests. All other moving parts (validation, canvas rendering, round-trip serialization) look correct and are well-covered.

`packages/backend/convex/automationExecutor.ts` — specifically `mergeContinuationFor` and its interaction with loop `nextNodeId` pointer traversal. `apps/web/src/app/(workspace)/automations/components/flow/edge-style.ts` — the new global dashed style deserves a deliberate visual sign-off.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/backend/convex/automationExecutor.ts | Adds `mergeContinuationFor` helper and wires it as the fallback `nextNodeId` for every node type in both `runWalk` and `dryRunWalk`. Two concerns: the function does a linear parent scan per level (O(N²) for deep chains), and a subtle case where a non-condition node reached via `nextNodeId` could cause the function to ascend past a loop boundary into an outer condition's merge chain. |
| apps/web/src/app/(workspace)/automations/lib/flow-adapter.ts | Large rewrite introducing merge dots, ghost branch cards, and inLoop edge tagging. `planConditionMerges` correctly handles nested conditions, end-node short-circuits, and the single-parent constraint. Minor: in-place mutation of `rfEdges` entries during the inLoop-tagging pass. |
| packages/backend/convex/automations.ts | Adds `mergeNodeId` to the node validator, the `NodeArg` type, and three validation passes: existence check, single-parent check, and the DFS cycle guard. All four new validation cases are correctly covered. |
| packages/backend/convex/schema.ts | Adds optional `mergeNodeId` field to `workflowNodeValidator`. Backward-compatible — existing stored records without the field remain valid. |
| apps/web/src/app/(workspace)/automations/lib/derived-layout.ts | Replaces the asymmetric yes-on-spine/no-to-right layout with symmetric fan-out around the condition's spine, and adds merge-dot placement below the taller branch. The `condMeta` map correctly threads layout metadata from the measure pass into the place pass. |
| apps/web/src/app/(workspace)/automations/components/flow/branch-label-edge.tsx | Unifies terminal and non-terminal branch edge rendering into a single `getSmoothStepPath` path, hides the "+" button for ghost-target edges, and moves the label pill to the fan-out corner. |
| apps/web/src/app/(workspace)/automations/hooks/use-automation-editor.ts | Correctly resolves merge-branch edges by stripping the `__merge__` prefix to find the owning condition, then updating its `mergeNodeId`. Ghost targets are treated as synthetic, preserving insertion-appends-to-parent semantics. |
| apps/web/src/app/(workspace)/automations/components/flow/edge-style.ts | Adds `strokeDasharray: "6 3"` to the shared `EDGE_STYLE` constant, making all normal (non-loop) edges dashed globally — affects every existing automation canvas. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant E as automationToReactFlow
    participant P as planConditionMerges
    participant D as derivedLayout
    participant X as runWalk / dryRunWalk

    E->>P: nodes (EditorNode[])
    P-->>E: merges Map condId MergeExit
    E->>E: emit MergeNodeRF + MergeInEdge per condition
    E->>E: ghost cards for empty branches (addBranchGhost)
    E->>E: tag inLoop on all edges (syntheticOwnerId resolve)
    E->>D: nodes + edges (incl. merge/ghost)
    D-->>E: positioned nodes (symmetric fan-out, merge dot below taller lane)

    Note over X: At runtime (per record)
    X->>X: "conditionMet? -> nextNodeId / elseNodeId"
    X->>X: "branch result undefined? -> node.mergeNodeId"
    X->>X: "still undefined? -> mergeContinuationFor(nodesById, nodeId)"
    Note over X: ascends parent tree, stops at loop body boundary
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant E as automationToReactFlow
    participant P as planConditionMerges
    participant D as derivedLayout
    participant X as runWalk / dryRunWalk

    E->>P: nodes (EditorNode[])
    P-->>E: merges Map condId MergeExit
    E->>E: emit MergeNodeRF + MergeInEdge per condition
    E->>E: ghost cards for empty branches (addBranchGhost)
    E->>E: tag inLoop on all edges (syntheticOwnerId resolve)
    E->>D: nodes + edges (incl. merge/ghost)
    D-->>E: positioned nodes (symmetric fan-out, merge dot below taller lane)

    Note over X: At runtime (per record)
    X->>X: "conditionMet? -> nextNodeId / elseNodeId"
    X->>X: "branch result undefined? -> node.mergeNodeId"
    X->>X: "still undefined? -> mergeContinuationFor(nodesById, nodeId)"
    Note over X: ascends parent tree, stops at loop body boundary
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `packages/backend/convex/automationExecutor.ts`, line 2093-2132 ([link](https://github.com/xcarter93/onetool/blob/2891c70f2d18bfa6fc175414a2304a76782e6786/packages/backend/convex/automationExecutor.ts#L2093-L2132)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`mergeContinuationFor` does an O(N) linear scan per level**

   The inner `for...of nodesById.values()` scan runs once per ancestor level, making the overall complexity O(N²) for chains that traverse the full depth. For typical automation sizes (tens of nodes) this is harmless, but the function is called at every node transition in `runWalk` and `dryRunWalk`, so deep merge chains under heavy loop execution could accumulate noticeable overhead. Building a single reverse-parent `Map<id, {parent, via}>` once before the walk (or lazily at execution start) would reduce per-call cost to O(1).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/backend/convex/automationExecutor.ts
   Line: 2093-2132

   Comment:
   **`mergeContinuationFor` does an O(N) linear scan per level**

   The inner `for...of nodesById.values()` scan runs once per ancestor level, making the overall complexity O(N²) for chains that traverse the full depth. For typical automation sizes (tens of nodes) this is harmless, but the function is called at every node transition in `runWalk` and `dryRunWalk`, so deep merge chains under heavy loop execution could accumulate noticeable overhead. Building a single reverse-parent `Map<id, {parent, via}>` once before the walk (or lazily at execution start) would reduce per-call cost to O(1).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


2. `packages/backend/convex/automationExecutor.ts`, line 2126-2131 ([link](https://github.com/xcarter93/onetool/blob/2891c70f2d18bfa6fc175414a2304a76782e6786/packages/backend/convex/automationExecutor.ts#L2126-L2131)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Unhandled `via === "next"` cases can silently skip the merge continuation**

   When `via === "merge"` (the node sits inside a condition's merge chain) and the parent is found, the code falls through to `currentId = parent.id` — this is intentional to continue ascending. However, for `via === "next"` where the parent is a **non-condition** node that itself has no `nextNodeId` (e.g., a loop node), the function also falls through rather than returning `undefined` immediately. This means a node that is the continuation of a loop node (via `nextNodeId`) will keep ascending the parent tree, potentially finding and returning an ancestor condition's `mergeNodeId` that should not apply. Concretely: if an action's parent is a loop node reachable via `nextNodeId` (the loop's after-last chain), the function would ascend to the loop's parent and could incorrectly return an outer condition's merge continuation rather than `undefined`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/backend/convex/automationExecutor.ts
   Line: 2126-2131

   Comment:
   **Unhandled `via === "next"` cases can silently skip the merge continuation**

   When `via === "merge"` (the node sits inside a condition's merge chain) and the parent is found, the code falls through to `currentId = parent.id` — this is intentional to continue ascending. However, for `via === "next"` where the parent is a **non-condition** node that itself has no `nextNodeId` (e.g., a loop node), the function also falls through rather than returning `undefined` immediately. This means a node that is the continuation of a loop node (via `nextNodeId`) will keep ascending the parent tree, potentially finding and returning an ancestor condition's `mergeNodeId` that should not apply. Concretely: if an action's parent is a loop node reachable via `nextNodeId` (the loop's after-last chain), the function would ascend to the loop's parent and could incorrectly return an outer condition's merge continuation rather than `undefined`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `apps/web/src/app/(workspace)/automations/components/flow/branch-ghost-node-rf.tsx`, line 155 ([link](https://github.com/xcarter93/onetool/blob/2891c70f2d18bfa6fc175414a2304a76782e6786/apps/web/src/app/(workspace)/automations/components/flow/branch-ghost-node-rf.tsx#L155)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`aria-label` uses an ASCII double-dash instead of standard punctuation**

   `"Empty branch -- click to add a step"` contains `--`, which screen readers typically announce as "dash dash". Using an em dash (`—`) or a comma/colon would produce cleaner output: `"Empty branch — click to add a step"` or `"Empty branch: click to add a step"`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/app/(workspace)/automations/components/flow/branch-ghost-node-rf.tsx
   Line: 155

   Comment:
   **`aria-label` uses an ASCII double-dash instead of standard punctuation**

   `"Empty branch -- click to add a step"` contains `--`, which screen readers typically announce as "dash dash". Using an em dash (`—`) or a comma/colon would produce cleaner output: `"Empty branch — click to add a step"` or `"Empty branch: click to add a step"`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


4. `apps/web/src/app/(workspace)/automations/lib/flow-adapter.ts`, line 1531-1546 ([link](https://github.com/xcarter93/onetool/blob/2891c70f2d18bfa6fc175414a2304a76782e6786/apps/web/src/app/(workspace)/automations/lib/flow-adapter.ts#L1531-L1546)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`syntheticOwnerId` strips terminal suffixes with regex `/(after|yes|no)$/` but mutates `rfEdges` in-place**

   The `for (const e of rfEdges) { e.data = { ...e.data, inLoop: true }; }` loop mutates edge objects directly. While the objects are freshly allocated within `automationToReactFlow`, this is an unusual pattern — a spread of `e.data` produces a new object but the assignment back to `e.data` mutates the outer array element. If `rfEdges` elements are ever aliased elsewhere before this loop runs (e.g., by a shallow reference captured in a closure), the mutation would silently apply `inLoop` to a shared reference.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/app/(workspace)/automations/lib/flow-adapter.ts
   Line: 1531-1546

   Comment:
   **`syntheticOwnerId` strips terminal suffixes with regex `/(after|yes|no)$/` but mutates `rfEdges` in-place**

   The `for (const e of rfEdges) { e.data = { ...e.data, inLoop: true }; }` loop mutates edge objects directly. While the objects are freshly allocated within `automationToReactFlow`, this is an unusual pattern — a spread of `e.data` produces a new object but the assignment back to `e.data` mutates the outer array element. If `rfEdges` elements are ever aliased elsewhere before this loop runs (e.g., by a shallow reference captured in a closure), the mutation would silently apply `inLoop` to a shared reference.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 5 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 5
packages/backend/convex/automationExecutor.ts:2093-2132
**`mergeContinuationFor` does an O(N) linear scan per level**

The inner `for...of nodesById.values()` scan runs once per ancestor level, making the overall complexity O(N²) for chains that traverse the full depth. For typical automation sizes (tens of nodes) this is harmless, but the function is called at every node transition in `runWalk` and `dryRunWalk`, so deep merge chains under heavy loop execution could accumulate noticeable overhead. Building a single reverse-parent `Map<id, {parent, via}>` once before the walk (or lazily at execution start) would reduce per-call cost to O(1).

### Issue 2 of 5
packages/backend/convex/automationExecutor.ts:2126-2131
**Unhandled `via === "next"` cases can silently skip the merge continuation**

When `via === "merge"` (the node sits inside a condition's merge chain) and the parent is found, the code falls through to `currentId = parent.id` — this is intentional to continue ascending. However, for `via === "next"` where the parent is a **non-condition** node that itself has no `nextNodeId` (e.g., a loop node), the function also falls through rather than returning `undefined` immediately. This means a node that is the continuation of a loop node (via `nextNodeId`) will keep ascending the parent tree, potentially finding and returning an ancestor condition's `mergeNodeId` that should not apply. Concretely: if an action's parent is a loop node reachable via `nextNodeId` (the loop's after-last chain), the function would ascend to the loop's parent and could incorrectly return an outer condition's merge continuation rather than `undefined`.

### Issue 3 of 5
apps/web/src/app/(workspace)/automations/components/flow/branch-ghost-node-rf.tsx:155
**`aria-label` uses an ASCII double-dash instead of standard punctuation**

`"Empty branch -- click to add a step"` contains `--`, which screen readers typically announce as "dash dash". Using an em dash (`—`) or a comma/colon would produce cleaner output: `"Empty branch — click to add a step"` or `"Empty branch: click to add a step"`.

### Issue 4 of 5
apps/web/src/app/(workspace)/automations/components/flow/edge-style.ts:10-13
**Adding `strokeDasharray` to `EDGE_STYLE` makes all "straight" (non-loop) edges dashed globally**

`EDGE_STYLE` is shared by `PlusButtonEdge`, `BranchLabelEdge`, `MergeInEdge`, and the generic straight edge used for the merge-dot outgoing edge. Every existing automation flow edge that was previously solid will now render as dashed. If this is intentional (matching the PR description's "Standardized edge styles"), the change is correct, but it's a visual-breaking change for all existing automations in production and is worth a deliberate sign-off.

### Issue 5 of 5
apps/web/src/app/(workspace)/automations/lib/flow-adapter.ts:1531-1546
**`syntheticOwnerId` strips terminal suffixes with regex `/(after|yes|no)$/` but mutates `rfEdges` in-place**

The `for (const e of rfEdges) { e.data = { ...e.data, inLoop: true }; }` loop mutates edge objects directly. While the objects are freshly allocated within `automationToReactFlow`, this is an unusual pattern — a spread of `e.data` produces a new object but the assignment back to `e.data` mutates the outer array element. If `rfEdges` elements are ever aliased elsewhere before this loop runs (e.g., by a shallow reference captured in a closure), the mutation would silently apply `inLoop` to a shared reference.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(automations): Salesforce-style canv..."](https://github.com/xcarter93/onetool/commit/2891c70f2d18bfa6fc175414a2304a76782e6786) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44905171)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->