### PR TITLE
fix(automations): B0 — sync Clerk premium override to Convex docs so …

### DIFF
--- a/apps/web/src/app/(workspace)/automations/components/runs-table.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/runs-table.tsx
@@ -93,9 +93,24 @@ export function RunsTable() {
 						status === "completed_with_errors"
 							? summarizeLoopFailures(row.original.loopSummary).failed
 							: 0;
+					// A skip records WHY in `error`, but the badge alone reads like an
+					// engine fault — surface the stored reason on hover.
+					const skipReason =
+						status === "skipped" ? row.original.error : undefined;
 					return (
 						<div className="flex flex-wrap items-center gap-1.5">
-							<RunStatusBadge status={status} />
+							{skipReason ? (
+								<Tooltip>
+									<TooltipTrigger render={<span tabIndex={0} />}>
+										<RunStatusBadge status={status} />
+									</TooltipTrigger>
+									<TooltipContent side="top" className="max-w-xs">
+										{skipReason}
+									</TooltipContent>
+								</Tooltip>
+							) : (
+								<RunStatusBadge status={status} />
+							)}
 							{row.original.dataTruncated && (
 								<Tooltip>
 									<TooltipTrigger render={<Badge variant="warning" className="gap-1" />}>

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -91,6 +91,7 @@ import type * as migrations_addReceivingAddresses from "../migrations/addReceivi
 import type * as migrations_backfillCreatedByFromOrgOwner from "../migrations/backfillCreatedByFromOrgOwner.js";
 import type * as migrations_backfillEmailThreads from "../migrations/backfillEmailThreads.js";
 import type * as migrations_backfillMemberPermissions from "../migrations/backfillMemberPermissions.js";
+import type * as migrations_backfillPremiumOverrides from "../migrations/backfillPremiumOverrides.js";
 import type * as migrations_backfillTeamMessagesFromNotifications from "../migrations/backfillTeamMessagesFromNotifications.js";
 import type * as migrations_fixInvoiceTotals from "../migrations/fixInvoiceTotals.js";
 import type * as migrations_geocodeAddresses from "../migrations/geocodeAddresses.js";
@@ -227,6 +228,7 @@ declare const fullApi: ApiFromModules<{
   "migrations/backfillCreatedByFromOrgOwner": typeof migrations_backfillCreatedByFromOrgOwner;
   "migrations/backfillEmailThreads": typeof migrations_backfillEmailThreads;
   "migrations/backfillMemberPermissions": typeof migrations_backfillMemberPermissions;
+  "migrations/backfillPremiumOverrides": typeof migrations_backfillPremiumOverrides;
   "migrations/backfillTeamMessagesFromNotifications": typeof migrations_backfillTeamMessagesFromNotifications;
   "migrations/fixInvoiceTotals": typeof migrations_fixInvoiceTotals;
   "migrations/geocodeAddresses": typeof migrations_geocodeAddresses;

--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -1824,6 +1824,56 @@ describe("automationExecutor (v2 engine)", () => {
 			expect(executions[0].error).toMatch(/premium/i);
 		});
 
+		it("dispatches for an org premium via the metadata override, not a paid plan", async () => {
+			// Regression (B0): the override lives in Clerk public_metadata and reaches
+			// identity-scoped code via the JWT, which cron has no access to. Before the
+			// doc mirror, every scheduled run for an override-premium org was silently
+			// skipped while the UI showed the user as fully premium.
+			const { asUser, orgId } = await setupUser();
+			await t.run(async (ctx) =>
+				ctx.db.patch(orgId, { hasPremiumFeatureAccess: true })
+			);
+
+			const id = await asUser.mutation(
+				api.automations.create,
+				scheduledAutomation({ isActive: true })
+			);
+			await t.run(async (ctx) => ctx.db.patch(id, { nextRunAt: Date.now() - 1000 }));
+
+			await t.mutation(internal.automationExecutor.dispatchScheduledAutomations, {});
+			await drainScheduled();
+
+			const executions = await t.run(async (ctx) =>
+				ctx.db.query("workflowExecutions").collect()
+			);
+			expect(executions).toHaveLength(1);
+			expect(executions[0].status).toBe("completed");
+		});
+
+		it("dispatches when only the automation's creator holds a user-level override", async () => {
+			// A user-level override follows the automations that user built; the org
+			// itself stays non-premium.
+			const { asUser, userId } = await setupUser();
+			await t.run(async (ctx) =>
+				ctx.db.patch(userId, { hasPremiumFeatureAccess: true })
+			);
+
+			const id = await asUser.mutation(
+				api.automations.create,
+				scheduledAutomation({ isActive: true })
+			);
+			await t.run(async (ctx) => ctx.db.patch(id, { nextRunAt: Date.now() - 1000 }));
+
+			await t.mutation(internal.automationExecutor.dispatchScheduledAutomations, {});
+			await drainScheduled();
+
+			const executions = await t.run(async (ctx) =>
+				ctx.db.query("workflowExecutions").collect()
+			);
+			expect(executions).toHaveLength(1);
+			expect(executions[0].status).toBe("completed");
+		});
+
 		it("clears a stale nextRunAt pointer when the trigger is no longer scheduled, with no execution", async () => {
 			const { asUser } = await setupUser();
 

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -13,7 +13,11 @@ import { ActivityHelpers } from "./lib/activities";
 import { ENTITY_PERMISSION_OBJECT } from "./activities";
 import { systemMutation, userMutation, userQuery } from "./lib/factories";
 import { computeNextRunAt } from "./lib/schedule";
-import { isAdminRole, orgHasPremiumPlan } from "./lib/permissions";
+import {
+	isAdminRole,
+	orgHasPremiumPlan,
+	userHasPremiumOverride,
+} from "./lib/permissions";
 import { getMembership, listMembershipsByOrg } from "./lib/memberships";
 import { enqueuePush } from "./push";
 import { insertTeamMessage } from "./teamMessages";
@@ -680,8 +684,14 @@ export const dispatchScheduledAutomations = internalMutation({
 
 				// Plan gate: the automations UI is premium-gated, but a downgraded
 				// org's schedules keep coming due — skip visibly instead of running.
+				// Cron has no identity, so both premium overrides are read from the
+				// webhook-synced doc mirrors: the org's, else the creator's (a user-level
+				// override follows the automations that user built).
 				const org = await ctx.db.get(automation.orgId);
-				if (!orgHasPremiumPlan(org)) {
+				const premium =
+					orgHasPremiumPlan(org) ||
+					userHasPremiumOverride(await ctx.db.get(automation.createdBy));
+				if (!premium) {
 					await ctx.db.insert("workflowExecutions", {
 						orgId: automation.orgId,
 						automationId: automation._id,

--- a/packages/backend/convex/http.ts
+++ b/packages/backend/convex/http.ts
@@ -16,6 +16,7 @@ import {
 	secondsToMilliseconds,
 } from "./lib/webhooks";
 import { resend } from "./email/durableResend";
+import { readPremiumOverride } from "./lib/permissions";
 
 const http = httpRouter();
 
@@ -94,6 +95,9 @@ http.route({
 						name: orgData.name,
 						ownerClerkUserId: orgData.created_by,
 						logoUrl: orgData.image_url || undefined,
+						hasPremiumFeatureAccess: readPremiumOverride(
+							orgData.public_metadata
+						),
 					});
 					logWebhookSuccess("Clerk", "organization.created", orgData.id);
 				} catch (error) {
@@ -120,6 +124,9 @@ http.route({
 						clerkOrganizationId: orgData.id,
 						name: orgData.name,
 						logoUrl: orgData.image_url || undefined,
+						hasPremiumFeatureAccess: readPremiumOverride(
+							orgData.public_metadata
+						),
 					});
 					logWebhookSuccess("Clerk", "organization.updated", orgData.id);
 				} catch (error) {

--- a/packages/backend/convex/lib/permissions.test.ts
+++ b/packages/backend/convex/lib/permissions.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { isAdminRole } from "./permissions";
+import {
+	PREMIUM_PLAN_SLUG,
+	isAdminRole,
+	orgHasPremiumPlan,
+	readPremiumOverride,
+	userHasPremiumOverride,
+} from "./permissions";
 import { isPermissionObject } from "./permissionKeys";
 
 describe("isAdminRole", () => {
@@ -30,6 +36,78 @@ describe("isAdminRole", () => {
 		expect(isAdminRole(undefined)).toBe(false);
 		expect(isAdminRole(null)).toBe(false);
 		expect(isAdminRole("")).toBe(false);
+	});
+});
+
+describe("readPremiumOverride", () => {
+	it("reads the granted flag out of Clerk public_metadata", () => {
+		expect(readPremiumOverride({ has_premium_feature_access: true })).toBe(true);
+	});
+
+	it("treats a revoke (key set to null) as not premium", () => {
+		// The admin console revokes by writing the key back as null rather than
+		// deleting it, so anything but `true` MUST read false or the revoke would
+		// never propagate to the doc mirror.
+		expect(readPremiumOverride({ has_premium_feature_access: null })).toBe(
+			false
+		);
+		expect(readPremiumOverride({ has_premium_feature_access: false })).toBe(
+			false
+		);
+		expect(readPremiumOverride({ has_premium_feature_access: "true" })).toBe(
+			false
+		);
+		expect(readPremiumOverride({ has_premium_feature_access: 1 })).toBe(false);
+	});
+
+	it("is secure-by-default on missing or non-object metadata", () => {
+		expect(readPremiumOverride({})).toBe(false);
+		expect(readPremiumOverride(undefined)).toBe(false);
+		expect(readPremiumOverride(null)).toBe(false);
+		expect(readPremiumOverride("nonsense")).toBe(false);
+	});
+});
+
+describe("orgHasPremiumPlan", () => {
+	it("honors the webhook-synced org-level override without a paid plan", () => {
+		// The whole point of the doc mirror: cron has no JWT to read the override
+		// from, so an override-premium org must pass on the doc alone.
+		expect(orgHasPremiumPlan({ hasPremiumFeatureAccess: true })).toBe(true);
+	});
+
+	it("still passes a genuinely subscribed org with no override", () => {
+		expect(
+			orgHasPremiumPlan({
+				clerkPlanSlug: PREMIUM_PLAN_SLUG,
+				subscriptionStatus: "active",
+			})
+		).toBe(true);
+	});
+
+	it("rejects an org with neither an override nor an active paid plan", () => {
+		expect(orgHasPremiumPlan({ hasPremiumFeatureAccess: false })).toBe(false);
+		expect(
+			orgHasPremiumPlan({
+				clerkPlanSlug: PREMIUM_PLAN_SLUG,
+				subscriptionStatus: "canceled",
+			})
+		).toBe(false);
+		expect(orgHasPremiumPlan({})).toBe(false);
+		expect(orgHasPremiumPlan(null)).toBe(false);
+	});
+});
+
+describe("userHasPremiumOverride", () => {
+	it("reads the user-level mirror", () => {
+		expect(userHasPremiumOverride({ hasPremiumFeatureAccess: true })).toBe(true);
+	});
+
+	it("is secure-by-default when unset or absent", () => {
+		expect(userHasPremiumOverride({ hasPremiumFeatureAccess: false })).toBe(
+			false
+		);
+		expect(userHasPremiumOverride({})).toBe(false);
+		expect(userHasPremiumOverride(null)).toBe(false);
 	});
 });
 

--- a/packages/backend/convex/lib/permissions.ts
+++ b/packages/backend/convex/lib/permissions.ts
@@ -79,25 +79,65 @@ export const debugAuthToken = query({
 
 export const PREMIUM_PLAN_SLUG = "onetool_business_plan_org";
 
+/** The Clerk public_metadata key carrying the manual premium override. */
+export const PREMIUM_OVERRIDE_METADATA_KEY = "has_premium_feature_access";
+
+/**
+ * Read the premium override out of a Clerk public_metadata bag. Strict `=== true`
+ * is load-bearing: the admin console revokes by writing the key back as `null`
+ * (not by deleting it), so anything other than `true` must read as false or a
+ * revoke would never propagate.
+ */
+export function readPremiumOverride(
+	publicMetadata: unknown
+): boolean {
+	if (typeof publicMetadata !== "object" || publicMetadata === null) {
+		return false;
+	}
+	return (
+		(publicMetadata as Record<string, unknown>)[
+			PREMIUM_OVERRIDE_METADATA_KEY
+		] === true
+	);
+}
+
 // Statuses under which a subscription grants access (free trials arrive as
 // "active" with is_free_trial on the item, so "trialing" rarely appears).
 const PREMIUM_SUBSCRIPTION_STATUSES = new Set(["active", "trialing"]);
 
 /**
  * Plan check from the org doc alone, for system/cron contexts with no request
- * identity. Cannot see the has_premium_feature_access metadata overrides
- * (those live in the JWT) — identity-scoped callers use hasPremiumAccess.
+ * identity. Honors the ORG-level has_premium_feature_access override via the
+ * webhook-synced `hasPremiumFeatureAccess` mirror. A USER-level override is not
+ * visible here: callers that hold a specific user (e.g. cron dispatch, which has
+ * the automation's creator) OR this with userHasPremiumOverride. Identity-scoped
+ * callers should use hasPremiumAccess instead, which reads the live JWT.
  */
 export function orgHasPremiumPlan(
 	org: {
 		clerkPlanSlug?: string;
 		subscriptionStatus?: string;
+		hasPremiumFeatureAccess?: boolean;
 	} | null
 ): boolean {
+	if (org?.hasPremiumFeatureAccess === true) {
+		return true;
+	}
 	return (
 		org?.clerkPlanSlug === PREMIUM_PLAN_SLUG &&
 		PREMIUM_SUBSCRIPTION_STATUSES.has(org.subscriptionStatus ?? "")
 	);
+}
+
+/**
+ * User-level premium override, from the webhook-synced mirror. For identity-less
+ * contexts that have a specific user in hand (e.g. a scheduled automation's
+ * creator). Grants premium to that user only, never to the whole org.
+ */
+export function userHasPremiumOverride(
+	user: { hasPremiumFeatureAccess?: boolean } | null
+): boolean {
+	return user?.hasPremiumFeatureAccess === true;
 }
 
 /**

--- a/packages/backend/convex/migrations/backfillPremiumOverrides.ts
+++ b/packages/backend/convex/migrations/backfillPremiumOverrides.ts
@@ -1,0 +1,105 @@
+import { internalMutation } from "../_generated/server";
+import { v } from "convex/values";
+
+/**
+ * One-shot backfill: stamps `hasPremiumFeatureAccess = true` on the users and
+ * organizations named in the passed Clerk ID lists.
+ *
+ * Context: the manual premium override lives in Clerk `public_metadata` and
+ * previously reached us ONLY through the JWT, so identity-less contexts (the
+ * scheduled-automation cron) could not see it and skipped every run for
+ * override-premium orgs. The webhook sync now mirrors the flag onto the docs,
+ * but only fires on future user.updated / organization.updated events — this
+ * backfill seeds the orgs and users that were already overridden.
+ *
+ * Takes an EXPLICIT ID list rather than enumerating Clerk (which would need a
+ * CLERK_SECRET_KEY in the Convex environment). Source the ids from the admin
+ * console, which already lists override-premium users and orgs.
+ *
+ * Only ever sets the flag TRUE. Revocation is not backfilled: nothing has the
+ * field set before this runs, so there is nothing stale to clear, and every
+ * later change (grant or revoke) arrives via the webhook.
+ *
+ * Idempotent — a doc already stamped is reported as `alreadySet`, so re-runs
+ * are safe. Unknown ids are reported in `notFound` rather than throwing, so one
+ * typo doesn't abort the batch.
+ *
+ * Operator workflow (post-deploy of the schema change):
+ *   1. Dry run first — confirm the resolved counts match the admin console:
+ *      `npx convex run migrations/backfillPremiumOverrides:backfillPremiumOverrides \
+ *        '{"clerkUserIds":["user_abc"],"clerkOrganizationIds":["org_xyz"],"dryRun":true}'`
+ *      -> { users: {...}, organizations: {...}, dryRun: true }
+ *   2. Re-run without `dryRun` to write.
+ *   3. Verify: the target org's next scheduled run should execute rather than
+ *      record `Skipped`.
+ */
+export const backfillPremiumOverrides = internalMutation({
+	args: {
+		clerkUserIds: v.optional(v.array(v.string())),
+		clerkOrganizationIds: v.optional(v.array(v.string())),
+		dryRun: v.optional(v.boolean()),
+	},
+	handler: async (
+		ctx,
+		{ clerkUserIds = [], clerkOrganizationIds = [], dryRun = false }
+	) => {
+		const users = {
+			updated: 0,
+			alreadySet: 0,
+			notFound: [] as string[],
+		};
+
+		// Deduped: a repeated id would otherwise be counted twice under dryRun (no
+		// write lands, so the second pass counts it as `updated` again) — and dryRun
+		// counts are what the operator reconciles against the admin console.
+		for (const externalId of new Set(clerkUserIds)) {
+			const user = await ctx.db
+				.query("users")
+				.withIndex("by_external_id", (q) => q.eq("externalId", externalId))
+				.first();
+
+			if (!user) {
+				users.notFound.push(externalId);
+				continue;
+			}
+			if (user.hasPremiumFeatureAccess === true) {
+				users.alreadySet++;
+				continue;
+			}
+			if (!dryRun) {
+				await ctx.db.patch(user._id, { hasPremiumFeatureAccess: true });
+			}
+			users.updated++;
+		}
+
+		const organizations = {
+			updated: 0,
+			alreadySet: 0,
+			notFound: [] as string[],
+		};
+
+		for (const clerkOrganizationId of new Set(clerkOrganizationIds)) {
+			const org = await ctx.db
+				.query("organizations")
+				.withIndex("by_clerk_org", (q) =>
+					q.eq("clerkOrganizationId", clerkOrganizationId)
+				)
+				.first();
+
+			if (!org) {
+				organizations.notFound.push(clerkOrganizationId);
+				continue;
+			}
+			if (org.hasPremiumFeatureAccess === true) {
+				organizations.alreadySet++;
+				continue;
+			}
+			if (!dryRun) {
+				await ctx.db.patch(org._id, { hasPremiumFeatureAccess: true });
+			}
+			organizations.updated++;
+		}
+
+		return { users, organizations, dryRun };
+	},
+});

--- a/packages/backend/convex/organizations.test.ts
+++ b/packages/backend/convex/organizations.test.ts
@@ -1384,6 +1384,44 @@ describe("Organizations", () => {
 
 				// Test passes if no error is thrown
 			});
+
+			it("syncs the premium override on, then back off when revoked (B0)", async () => {
+				// The doc mirror is what identity-less contexts (the scheduled-automation
+				// cron) read, so a revoke that failed to propagate would leave an org
+				// premium forever.
+				const { orgId } = await t.run(async (ctx) => {
+					const userId = await ctx.db.insert("users", {
+						name: "Owner User",
+						email: "owner@example.com",
+						image: "https://example.com/owner.jpg",
+						externalId: "user_override",
+					});
+					const orgId = await ctx.db.insert("organizations", {
+						clerkOrganizationId: "org_override",
+						name: "Override Org",
+						ownerUserId: userId,
+					});
+					return { orgId };
+				});
+
+				await t.mutation(internal.organizations.updateFromClerk, {
+					clerkOrganizationId: "org_override",
+					name: "Override Org",
+					hasPremiumFeatureAccess: true,
+				});
+				expect(
+					(await t.run(async (ctx) => ctx.db.get(orgId)))?.hasPremiumFeatureAccess
+				).toBe(true);
+
+				await t.mutation(internal.organizations.updateFromClerk, {
+					clerkOrganizationId: "org_override",
+					name: "Override Org",
+					hasPremiumFeatureAccess: false,
+				});
+				expect(
+					(await t.run(async (ctx) => ctx.db.get(orgId)))?.hasPremiumFeatureAccess
+				).toBe(false);
+			});
 		});
 
 		describe("deleteFromClerk", () => {

--- a/packages/backend/convex/organizations.ts
+++ b/packages/backend/convex/organizations.ts
@@ -81,6 +81,7 @@ export const createFromClerk = internalMutation({
 		name: v.string(),
 		ownerClerkUserId: v.string(),
 		logoUrl: v.optional(v.string()),
+		hasPremiumFeatureAccess: v.optional(v.boolean()),
 	},
 	handler: async (ctx, args) => {
 		// Find the owner user by Clerk ID
@@ -117,6 +118,7 @@ export const createFromClerk = internalMutation({
 			name: args.name,
 			ownerUserId: ownerUser._id,
 			logoUrl: args.logoUrl,
+			hasPremiumFeatureAccess: args.hasPremiumFeatureAccess ?? false,
 			isMetadataComplete: false, // User needs to complete additional setup
 			// Generate unique receiving address for this organization
 			receivingAddress: `org-${crypto
@@ -231,6 +233,7 @@ export const updateFromClerk = internalMutation({
 		clerkOrganizationId: v.string(),
 		name: v.string(),
 		logoUrl: v.optional(v.string()),
+		hasPremiumFeatureAccess: v.optional(v.boolean()),
 	},
 	handler: async (ctx, args) => {
 		const organization = await ctx.db
@@ -248,13 +251,23 @@ export const updateFromClerk = internalMutation({
 		}
 
 		// Update the organization name and logo URL
-		const updates: { name: string; logoUrl?: string } = {
+		const updates: {
+			name: string;
+			logoUrl?: string;
+			hasPremiumFeatureAccess?: boolean;
+		} = {
 			name: args.name,
 		};
 
 		// Only update logoUrl if provided (Clerk might not always include it)
 		if (args.logoUrl !== undefined && args.logoUrl !== null) {
 			updates.logoUrl = args.logoUrl;
+		}
+
+		// The webhook always resolves this to a concrete boolean, so a revoke lands
+		// as false. Skipped only for legacy callers that omit it entirely.
+		if (args.hasPremiumFeatureAccess !== undefined) {
+			updates.hasPremiumFeatureAccess = args.hasPremiumFeatureAccess;
 		}
 
 		await ctx.db.patch(organization._id, updates);

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -46,6 +46,11 @@ export default defineSchema({
 		// Onboarding
 		hasSeenTour: v.optional(v.boolean()), // Track if user has completed the product tour
 
+		// Mirror of Clerk public_metadata.has_premium_feature_access, synced by the
+		// user.created/user.updated webhook. Exists so identity-less contexts (cron)
+		// can honor the override, which otherwise only reaches us via the JWT.
+		hasPremiumFeatureAccess: v.optional(v.boolean()),
+
 		// Subscription (user-level status only, billing handled at org level)
 		subscriptionStatus: v.optional(
 			v.union(
@@ -98,6 +103,12 @@ export default defineSchema({
 		clerkSubscriptionId: v.optional(v.string()), // Clerk subscription ID
 		clerkPlanId: v.optional(v.string()), // Clerk plan identifier
 		clerkPlanSlug: v.optional(v.string()), // Active paid plan slug from webhook items[] (plan gate source of truth)
+
+		// Mirror of Clerk public_metadata.has_premium_feature_access, synced by the
+		// organization.created/organization.updated webhook. Grants premium to every
+		// member; see the user-level twin for single-user overrides.
+		hasPremiumFeatureAccess: v.optional(v.boolean()),
+
 		subscriptionStatus: v.optional(
 			v.union(
 				v.literal("active"),

--- a/packages/backend/convex/users.test.ts
+++ b/packages/backend/convex/users.test.ts
@@ -241,6 +241,45 @@ describe("Users", () => {
 
 	describe("Internal Mutations", () => {
 		describe("upsertFromClerk", () => {
+			it("mirrors the premium override, and clears it on the null-shaped revoke (B0)", async () => {
+				// The admin console revokes by writing the key back as null rather than
+				// deleting it. If that didn't clear the doc mirror, a revoked user would
+				// keep premium in every identity-less context (the automation cron).
+				await t.mutation(internal.users.upsertFromClerk, {
+					data: {
+						id: "clerk_user_override",
+						first_name: "Over",
+						last_name: "Ride",
+						email_addresses: [{ email_address: "over@example.com" }],
+						image_url: "https://example.com/o.jpg",
+						public_metadata: { has_premium_feature_access: true },
+					} as any,
+				});
+
+				const readUser = async () =>
+					await t.run(async (ctx) =>
+						ctx.db
+							.query("users")
+							.filter((q) => q.eq(q.field("externalId"), "clerk_user_override"))
+							.first()
+					);
+
+				expect((await readUser())?.hasPremiumFeatureAccess).toBe(true);
+
+				await t.mutation(internal.users.upsertFromClerk, {
+					data: {
+						id: "clerk_user_override",
+						first_name: "Over",
+						last_name: "Ride",
+						email_addresses: [{ email_address: "over@example.com" }],
+						image_url: "https://example.com/o.jpg",
+						public_metadata: { has_premium_feature_access: null },
+					} as any,
+				});
+
+				expect((await readUser())?.hasPremiumFeatureAccess).toBe(false);
+			});
+
 			it("should create a new user from Clerk webhook data", async () => {
 				await t.mutation(internal.users.upsertFromClerk, {
 					data: {

--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -16,6 +16,7 @@ import {
 	removeMembership,
 } from "./lib/memberships";
 import { optionalUserQuery, userMutation } from "./lib/factories";
+import { readPremiumOverride } from "./lib/permissions";
 
 export const current = optionalUserQuery({
 	args: {},
@@ -77,6 +78,8 @@ export const upsertFromClerk = internalMutation({
 			image: data.image_url || "",
 			lastSignedInDate: Date.now(),
 			externalId: data.id,
+			// Always written, so a revoke (metadata key set back to null) clears it.
+			hasPremiumFeatureAccess: readPremiumOverride(data.public_metadata),
 		};
 
 		const user = await userByExternalId(ctx, data.id);


### PR DESCRIPTION
…cron can see it

Scheduled runs recorded `Skipped / 0ms / 0 steps` for orgs that are premium via the manual metadata override. The override lives in Clerk public_metadata and reached the backend only through the JWT, so `hasPremiumAccess` saw it (and the UI showed the user fully premium) while `dispatchScheduledAutomations`' org-doc-only `orgHasPremiumPlan` gate could not — every scheduled dispatch was silently skipped, mimicking a scheduler bug.

Persist the override onto the docs so identity-less contexts can honor it:

- schema: `hasPremiumFeatureAccess` on `users` and `organizations`
- sync it through the already-subscribed user.created/updated and organization.created/updated webhooks (they were dropping public_metadata)
- `orgHasPremiumPlan` ORs the org mirror; new `userHasPremiumOverride` reads the user mirror; the dispatch gate falls back to the automation's creator, so a user-level override follows the automations that user built
- `backfillPremiumOverrides` seeds already-overridden orgs/users from an explicit Clerk id list (sourced from the admin console; no CLERK_SECRET_KEY needed)

Revocation is the subtle part: the admin console revokes by writing the key back as `null` rather than deleting it, so shared `readPremiumOverride` coerces strict `=== true` and the sync always writes the resolved boolean — otherwise grants would propagate but revokes never would.

Also surfaces the stored skip reason on the Runs table's Skipped badge, which is why this read as an engine fault for so long.

Note: `orgHasPremiumPlan` also gates the free-plan caps in create_record, so override-premium orgs no longer hit them inside automations.

Deploy backend BEFORE web, then run the backfill (dryRun first).

Backend 1230 tests (+12, incl. 2 dispatch regression tests verified to fail against the pre-fix gate), web 549, pnpm build green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Premium feature access can now be granted through account or workspace overrides.
  - Scheduled automations can run when an eligible premium override is active.
  - Skip reasons are displayed when hovering over skipped run statuses.
  - Premium access settings are synchronized and preserved across account and workspace updates.
  - Added a safe backfill option for applying premium access overrides to existing records.

- **Bug Fixes**
  - Revoking a premium override now correctly removes premium access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent scheduler bug where orgs granted premium access via a manual Clerk `public_metadata` override were having all their scheduled automations skipped. The override previously reached Convex only through the JWT (unavailable to the identity-less cron), so `dispatchScheduledAutomations` never saw it.

- Adds a `hasPremiumFeatureAccess` doc mirror to both `users` and `organizations`, synced by the already-subscribed Clerk webhooks via a new `readPremiumOverride` helper that uses strict `=== true` so null-shaped revokes propagate correctly.
- Updates `orgHasPremiumPlan` to OR in the org doc mirror, and adds `userHasPremiumOverride` for per-user grants; the dispatch gate now falls back to the automation's creator when the org itself isn't premium.
- Adds a `backfillPremiumOverrides` migration for already-overridden entities (dry-run-first workflow), and surfaces the stored skip reason on the Runs table's Skipped badge as a tooltip.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge. The core fix is well-encapsulated behind strict equality checks and covered by regression tests that verify both grant and revoke paths. The schema change is backward-compatible, webhook sync is idempotent, and the backfill is a dry-run-first internal mutation.

The dispatch gate change is targeted and well-tested with two new regression tests that reproduce the exact pre-fix failure. readPremiumOverride uses === true so null-shaped revokes and type coercions are explicitly handled. The || short-circuit avoids an unnecessary DB lookup for already-premium orgs. The migration is idempotent with dryRun support, and the UI change surfaces backend-controlled strings with no new data trust boundaries.

No files require special attention. The backfill migration should be run after backend deploy per the documented workflow.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/lib/permissions.ts | Adds readPremiumOverride (strict === true), userHasPremiumOverride, and updates orgHasPremiumPlan to OR in the doc mirror. Logic is sound and well-guarded for null/missing inputs. |
| packages/backend/convex/automationExecutor.ts | dispatchScheduledAutomations now ORs orgHasPremiumPlan with userHasPremiumOverride(createdBy). The right-hand DB lookup is only evaluated when the org check fails (|| short-circuits), so no unnecessary reads for paid orgs. |
| packages/backend/convex/http.ts | organization.created and organization.updated webhook handlers now pass readPremiumOverride(orgData.public_metadata) to the internal mutations; user webhooks already delegated to upsertFromClerk which was updated separately. |
| packages/backend/convex/users.ts | upsertFromClerk always writes hasPremiumFeatureAccess via readPremiumOverride, so a null-shaped revoke in public_metadata correctly clears the doc mirror. |
| packages/backend/convex/organizations.ts | createFromClerk defaults the new field to false (via ?? false) ensuring all new org docs carry an explicit value; updateFromClerk guards the write behind !== undefined for backward-compatible callers. |
| packages/backend/convex/migrations/backfillPremiumOverrides.ts | Idempotent internalMutation backfill with dryRun support, deduplication via Set, and alreadySet/notFound accounting. Supports both user and org IDs. |
| packages/backend/convex/schema.ts | Adds v.optional(v.boolean()) hasPremiumFeatureAccess to both users and organizations tables; schema change is backward-compatible. |
| apps/web/src/app/(workspace)/automations/components/runs-table.tsx | Surfaces the stored skip reason on the Skipped badge as a hover/focus tooltip using a span wrapper for focusability; uses the existing Tooltip/TooltipTrigger pattern consistent with the file. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Admin as Clerk Admin Console
    participant Clerk as Clerk
    participant HTTP as http.ts (webhook handler)
    participant DB as Convex DB
    participant Cron as dispatchScheduledAutomations

    Admin->>Clerk: "Set public_metadata.has_premium_feature_access = true"
    Clerk->>HTTP: organization.updated webhook (Svix-verified)
    HTTP->>DB: "updateFromClerk({ hasPremiumFeatureAccess: true })"
    Note over Cron,DB: Cron fires (no identity/JWT)
    Cron->>DB: get org doc
    DB-->>Cron: "org { hasPremiumFeatureAccess: true }"
    Cron->>Cron: orgHasPremiumPlan(org) true via doc mirror
    Cron->>DB: insert workflowExecution running
    Admin->>Clerk: Revoke - set key to null
    Clerk->>HTTP: organization.updated webhook (Svix-verified)
    HTTP->>DB: "updateFromClerk({ hasPremiumFeatureAccess: false })"
    Note over Cron,DB: Next cron fires
    Cron->>DB: get org doc
    DB-->>Cron: "org { hasPremiumFeatureAccess: false }"
    Cron->>DB: insert workflowExecution skipped
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Admin as Clerk Admin Console
    participant Clerk as Clerk
    participant HTTP as http.ts (webhook handler)
    participant DB as Convex DB
    participant Cron as dispatchScheduledAutomations

    Admin->>Clerk: "Set public_metadata.has_premium_feature_access = true"
    Clerk->>HTTP: organization.updated webhook (Svix-verified)
    HTTP->>DB: "updateFromClerk({ hasPremiumFeatureAccess: true })"
    Note over Cron,DB: Cron fires (no identity/JWT)
    Cron->>DB: get org doc
    DB-->>Cron: "org { hasPremiumFeatureAccess: true }"
    Cron->>Cron: orgHasPremiumPlan(org) true via doc mirror
    Cron->>DB: insert workflowExecution running
    Admin->>Clerk: Revoke - set key to null
    Clerk->>HTTP: organization.updated webhook (Svix-verified)
    HTTP->>DB: "updateFromClerk({ hasPremiumFeatureAccess: false })"
    Note over Cron,DB: Next cron fires
    Cron->>DB: get org doc
    DB-->>Cron: "org { hasPremiumFeatureAccess: false }"
    Cron->>DB: insert workflowExecution skipped
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(automations): B0 — sync Clerk premiu..."](https://github.com/xcarter93/onetool/commit/4f896b5efe67645ae4dbd834dd28c5ede589975a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44970262)</sub>

<!-- /greptile_comment -->