### PR TITLE
Fix automation task assignment and enhance line item handling

### DIFF
--- a/apps/web/src/app/(workspace)/automations/components/editor/debug-panel.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/editor/debug-panel.tsx
@@ -27,9 +27,10 @@ import { cn } from "@/lib/utils";
 import type { RunRecordRef } from "../../hooks/use-automation-editor";
 import { DebugTimeline } from "./debug-timeline";
 import { summarizeLoopFailures, type RunStatus } from "../../lib/run-format";
+import type { TriggerableObjectType } from "../../lib/node-types";
 
 type SampleRecord = {
-	entityType: "client" | "project" | "quote" | "invoice" | "task";
+	entityType: TriggerableObjectType;
 	entityId: string;
 	label: string;
 };

--- a/apps/web/src/app/(workspace)/automations/components/editor/formula-editor-modal.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/editor/formula-editor-modal.tsx
@@ -29,7 +29,7 @@ import {
 import { cn } from "@/lib/utils";
 import {
 	FORMULA_RETURN_TYPES,
-	type AutomationObjectType,
+	type TriggerableObjectType,
 	type AutomationTrigger,
 	type FormulaResource,
 	type FormulaReturnType,
@@ -40,7 +40,7 @@ import { getAllVariableOptions } from "../../lib/variables";
 
 /** A record the formula preview can resolve trigger.record.<field> against. */
 export type SampleRecord = {
-	entityType: AutomationObjectType;
+	entityType: TriggerableObjectType;
 	entityId: string;
 	label: string;
 };

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/action-config.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/action-config.tsx
@@ -31,6 +31,7 @@ import {
 	getWritableFields,
 	type ActionNodeConfig,
 	type AutomationObjectType,
+	type TriggerableObjectType,
 	type AutomationTrigger,
 	type CreateRecordAction,
 	type CreateTaskAction,
@@ -117,7 +118,7 @@ function UpdateFieldsFields({
 	formulas,
 	commit,
 }: ActionFieldsProps<UpdateFieldsAction> & {
-	triggerObjectType: AutomationObjectType | null;
+	triggerObjectType: TriggerableObjectType | null;
 }) {
 	// Inside a loop body, `target: "self"` (and its related FKs) resolve against
 	// the loop's fetched item, not the trigger record — mirror the engine.
@@ -344,7 +345,7 @@ function CreateRecordFields({
 	formulas,
 	commit,
 }: ActionFieldsProps<CreateRecordAction> & {
-	triggerObjectType: AutomationObjectType | null;
+	triggerObjectType: TriggerableObjectType | null;
 }) {
 	const objectType = action.objectType;
 	const scope = getScopeObjectType(nodes, nodeId, triggerObjectType);
@@ -709,7 +710,7 @@ function SendNotificationFields({
 	formulas,
 	commit,
 }: ActionFieldsProps<SendNotificationAction> & {
-	triggerObjectType: AutomationObjectType | null;
+	triggerObjectType: TriggerableObjectType | null;
 }) {
 	const members = useQuery(api.users.listByOrg);
 	const update = (patch: Partial<SendNotificationAction>) => {
@@ -990,7 +991,7 @@ function SendTeamMessageFields({
 	formulas,
 	commit,
 }: ActionFieldsProps<SendTeamMessageAction> & {
-	triggerObjectType: AutomationObjectType | null;
+	triggerObjectType: TriggerableObjectType | null;
 }) {
 	const members = useQuery(api.users.listByOrg);
 

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/filter-groups-editor.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/filter-groups-editor.tsx
@@ -320,6 +320,7 @@ export function FilterGroupsEditor({
 											trigger={trigger}
 											targetNodeId={targetNodeId}
 											formulas={formulas}
+											arrayResolution="any"
 										/>
 									)}
 								</div>

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/filter-groups-editor.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/filter-groups-editor.tsx
@@ -320,7 +320,12 @@ export function FilterGroupsEditor({
 											trigger={trigger}
 											targetNodeId={targetNodeId}
 											formulas={formulas}
-											arrayResolution="any"
+											arrayResolution={
+												rule.operator === "equals" ||
+												rule.operator === "not_equals"
+													? "any"
+													: "none"
+											}
 										/>
 									)}
 								</div>

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/trigger-config.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/trigger-config.tsx
@@ -15,14 +15,14 @@ import { Input } from "@/components/ui/input";
 import ComboBox from "@/components/ui/combo-box";
 import {
 	DEFAULT_SCHEDULE_TIME,
-	OBJECT_TYPE_OPTIONS,
+	TRIGGERABLE_OBJECT_TYPE_OPTIONS,
 	TRIGGER_TYPE_OPTIONS,
 	describeSchedule,
 	getFilterableFields,
 	getStatusOptions,
 	triggerScopeObjectType,
 	validateSchedule,
-	type AutomationObjectType,
+	type TriggerableObjectType,
 	type AutomationSchedule,
 	type TriggerConfig,
 	type TriggerType,
@@ -143,7 +143,7 @@ export function TriggerConfigPanel({
 	};
 
 	const handleObjectTypeChange = (value: string) => {
-		const newObjType = value as AutomationObjectType;
+		const newObjType = value as TriggerableObjectType;
 		const newStatusOptions = getStatusOptions(newObjType);
 		if (currentTrigger.type === "scheduled") return;
 		onTriggerChange({
@@ -220,7 +220,7 @@ export function TriggerConfigPanel({
 									<SelectValue />
 								</SelectTrigger>
 								<SelectContent>
-									{OBJECT_TYPE_OPTIONS.map((type) => (
+									{TRIGGERABLE_OBJECT_TYPE_OPTIONS.map((type) => (
 										<SelectItem key={type.value} value={type.value}>
 											{type.label}
 										</SelectItem>

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/value-input.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/value-input.tsx
@@ -568,6 +568,11 @@ export function ValueInput({
 													field.refType,
 													option.refType
 												);
+												// An array feeding this single-valued field resolves to
+												// its first element — say so rather than let the author
+												// assume all of them land.
+												const usesFirstMember =
+													!!option.isArray && !needsConversion;
 												return (
 													<CommandItem
 														key={option.path}
@@ -589,6 +594,11 @@ export function ValueInput({
 														{needsConversion && (
 															<span className="ml-2 shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">
 																needs conversion
+															</span>
+														)}
+														{usesFirstMember && (
+															<span className="ml-2 shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">
+																uses first
 															</span>
 														)}
 													</CommandItem>

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/value-input.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/value-input.tsx
@@ -148,6 +148,7 @@ const REF_PLACEHOLDER: Record<NonNullable<FieldDefinition["refType"]>, string> =
 	client: "Select a client",
 	project: "Select a project",
 	user: "Select a member",
+	invoice: "Select an invoice",
 	quote: "Select a quote",
 };
 
@@ -175,6 +176,10 @@ function IdValueControl({
 	const projects = useQuery(api.projects.list, refType === "project" ? {} : "skip");
 	const users = useQuery(api.users.listByOrg, refType === "user" ? {} : "skip");
 	const quotes = useQuery(api.quotes.list, refType === "quote" ? {} : "skip");
+	const invoices = useQuery(
+		api.invoices.list,
+		refType === "invoice" ? {} : "skip"
+	);
 
 	const options = useMemo<{ id: string; label: string }[]>(() => {
 		switch (refType) {
@@ -192,16 +197,22 @@ function IdValueControl({
 					id: q._id,
 					label: q.title || `Quote #${q.quoteNumber}`,
 				}));
+			case "invoice":
+				return (invoices ?? []).map((i) => ({
+					id: i._id,
+					label: `Invoice #${i.invoiceNumber}`,
+				}));
 			default:
 				return [];
 		}
-	}, [refType, clients, projects, users, quotes]);
+	}, [refType, clients, projects, users, quotes, invoices]);
 
 	const loading =
 		(refType === "client" && clients === undefined) ||
 		(refType === "project" && projects === undefined) ||
 		(refType === "user" && users === undefined) ||
-		(refType === "quote" && quotes === undefined);
+		(refType === "quote" && quotes === undefined) ||
+		(refType === "invoice" && invoices === undefined);
 
 	const selected = value ? options.find((o) => o.id === value) : undefined;
 	const triggerLabel = selected

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/value-input.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/value-input.tsx
@@ -457,9 +457,10 @@ export interface ValueInputProps {
 	/**
 	 * How an array variable feeding this single-valued field resolves — action
 	 * writes coerce to the first element ("first"); condition/filter compares
-	 * match on membership ("any"). Drives the picker hint only.
+	 * match on membership ("any"); operators with neither behavior ("none")
+	 * show no hint. Drives the picker hint only.
 	 */
-	arrayResolution?: "first" | "any";
+	arrayResolution?: "first" | "any" | "none";
 }
 
 /**
@@ -590,7 +591,9 @@ export function ValueInput({
 												// per arrayResolution — say so rather than let the
 												// author assume all of them land.
 												const arrayHint =
-													option.isArray && !needsConversion
+													option.isArray &&
+													!needsConversion &&
+													arrayResolution !== "none"
 														? arrayResolution === "first"
 															? "uses first"
 															: "matches any"

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/value-input.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/value-input.tsx
@@ -454,6 +454,12 @@ export interface ValueInputProps {
 	className?: string;
 	/** Inline error shown beneath the control (per-rule save feedback). */
 	error?: string;
+	/**
+	 * How an array variable feeding this single-valued field resolves — action
+	 * writes coerce to the first element ("first"); condition/filter compares
+	 * match on membership ("any"). Drives the picker hint only.
+	 */
+	arrayResolution?: "first" | "any";
 }
 
 /**
@@ -473,6 +479,7 @@ export function ValueInput({
 	placeholder,
 	className,
 	error,
+	arrayResolution = "first",
 }: ValueInputProps) {
 	const [open, setOpen] = useState(false);
 	const { variables, groups } = useGroupedVariables(nodes, trigger, targetNodeId, formulas);
@@ -579,11 +586,15 @@ export function ValueInput({
 													field.refType,
 													option.refType
 												);
-												// An array feeding this single-valued field resolves to
-												// its first element — say so rather than let the author
-												// assume all of them land.
-												const usesFirstMember =
-													!!option.isArray && !needsConversion;
+												// An array feeding this single-valued field resolves
+												// per arrayResolution — say so rather than let the
+												// author assume all of them land.
+												const arrayHint =
+													option.isArray && !needsConversion
+														? arrayResolution === "first"
+															? "uses first"
+															: "matches any"
+														: null;
 												return (
 													<CommandItem
 														key={option.path}
@@ -607,9 +618,9 @@ export function ValueInput({
 																needs conversion
 															</span>
 														)}
-														{usesFirstMember && (
+														{arrayHint && (
 															<span className="ml-2 shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">
-																uses first
+																{arrayHint}
 															</span>
 														)}
 													</CommandItem>

--- a/apps/web/src/app/(workspace)/automations/lib/node-types.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/node-types.ts
@@ -13,11 +13,15 @@ import type { Node, Edge } from "@xyflow/react";
 import type {
 	AutomationAction,
 	AutomationObjectType,
+	TriggerableObjectType,
 	WorkflowNodeConfig,
 	WorkflowNodeType,
 	ConditionGroup,
 } from "@onetool/backend/convex/lib/workflowTypes";
-import { AUTOMATION_OBJECT_TYPES } from "@onetool/backend/convex/lib/workflowTypes";
+import {
+	AUTOMATION_OBJECT_TYPES,
+	TRIGGERABLE_OBJECT_TYPES,
+} from "@onetool/backend/convex/lib/workflowTypes";
 import {
 	RELATED_OBJECTS,
 	CREATABLE_OBJECT_TYPES,
@@ -29,6 +33,9 @@ import {
 
 export {
 	AUTOMATION_OBJECT_TYPES,
+	TRIGGERABLE_OBJECT_TYPES,
+	isFetchOnlyObjectType,
+	LOOP_FETCH_ONLY_ERROR,
 	CONDITION_OPERATORS,
 	VALUELESS_OPERATORS,
 	NODE_TYPES,
@@ -49,6 +56,7 @@ export {
 
 export type {
 	AutomationObjectType,
+	TriggerableObjectType,
 	AutomationTrigger,
 	AutomationTriggerV2,
 	AutomationStatus,
@@ -107,12 +115,28 @@ export const OBJECT_TYPE_LABELS: Record<AutomationObjectType, string> = {
 	quote: "Quote",
 	invoice: "Invoice",
 	task: "Task",
+	quote_line_item: "Quote line item",
+	invoice_line_item: "Invoice line item",
 };
 
+/** Everything selectable as a "Find records" source — line items included. */
 export const OBJECT_TYPE_OPTIONS: {
 	value: AutomationObjectType;
 	label: string;
 }[] = AUTOMATION_OBJECT_TYPES.map((value) => ({
+	value,
+	label: OBJECT_TYPE_LABELS[value],
+}));
+
+/**
+ * Object types an automation can trigger on. Distinct from OBJECT_TYPE_OPTIONS:
+ * line items are fetch+aggregate only, so they must never reach the trigger
+ * picker (the backend validator rejects them, but the option shouldn't exist).
+ */
+export const TRIGGERABLE_OBJECT_TYPE_OPTIONS: {
+	value: TriggerableObjectType;
+	label: string;
+}[] = TRIGGERABLE_OBJECT_TYPES.map((value) => ({
 	value,
 	label: OBJECT_TYPE_LABELS[value],
 }));
@@ -265,7 +289,7 @@ type TriggerConfigBase = {
 export type TriggerConfig =
 	| (TriggerConfigBase & {
 			type?: "status_changed" | "record_created" | "record_updated";
-			objectType?: AutomationObjectType;
+			objectType?: TriggerableObjectType;
 	  })
 	| (TriggerConfigBase & { type: "scheduled" });
 
@@ -288,7 +312,7 @@ export const VARIABLE_LEFT_OPERATORS = [
 /** The object type bound to `trigger.record`, or null when there is none. */
 export function triggerScopeObjectType(
 	trigger: TriggerConfig | null | undefined
-): AutomationObjectType | null {
+): TriggerableObjectType | null {
 	if (!trigger || trigger.type === "scheduled") return null;
 	return trigger.objectType ?? null;
 }
@@ -299,14 +323,14 @@ export function triggerScopeObjectType(
 
 export type ActionTargetOption = {
 	/** "self" or the related object type. */
-	value: "self" | AutomationObjectType;
+	value: "self" | TriggerableObjectType;
 	label: string;
 	/** The object type the target resolves to (drives field pickers). */
-	objectType: AutomationObjectType;
+	objectType: TriggerableObjectType;
 };
 
 export function getTargetOptions(
-	objectType: AutomationObjectType
+	objectType: TriggerableObjectType
 ): ActionTargetOption[] {
 	return [
 		{
@@ -329,7 +353,7 @@ export function getTargetOptions(
 export type TriggerNodeData = {
 	nodeType: "trigger";
 	trigger: TriggerConfig;
-	triggerObjectType: AutomationObjectType | null;
+	triggerObjectType: TriggerableObjectType | null;
 };
 
 export type TriggerPlaceholderNodeData = {
@@ -339,49 +363,49 @@ export type TriggerPlaceholderNodeData = {
 export type ConditionNodeData = {
 	nodeType: "condition";
 	config?: ConditionNodeConfig;
-	triggerObjectType: AutomationObjectType | null;
+	triggerObjectType: TriggerableObjectType | null;
 };
 
 export type ActionNodeData = {
 	nodeType: "action";
 	config?: ActionNodeConfig;
-	triggerObjectType: AutomationObjectType | null;
+	triggerObjectType: TriggerableObjectType | null;
 };
 
 export type FetchNodeData = {
 	nodeType: "fetch_records";
 	config?: FetchNodeConfig;
-	triggerObjectType: AutomationObjectType | null;
+	triggerObjectType: TriggerableObjectType | null;
 };
 
 export type LoopNodeData = {
 	nodeType: "loop";
 	config?: LoopNodeConfig;
-	triggerObjectType: AutomationObjectType | null;
+	triggerObjectType: TriggerableObjectType | null;
 };
 
 export type AggregateNodeData = {
 	nodeType: "aggregate";
 	config?: AggregateNodeConfig;
-	triggerObjectType: AutomationObjectType | null;
+	triggerObjectType: TriggerableObjectType | null;
 };
 
 export type AdjustTimeNodeData = {
 	nodeType: "adjust_time";
 	config?: AdjustTimeNodeConfig;
-	triggerObjectType: AutomationObjectType | null;
+	triggerObjectType: TriggerableObjectType | null;
 };
 
 export type DelayNodeData = {
 	nodeType: "delay";
 	config?: DelayNodeConfig;
-	triggerObjectType: AutomationObjectType | null;
+	triggerObjectType: TriggerableObjectType | null;
 };
 
 export type DelayUntilNodeData = {
 	nodeType: "delay_until";
 	config?: DelayUntilNodeConfig;
-	triggerObjectType: AutomationObjectType | null;
+	triggerObjectType: TriggerableObjectType | null;
 };
 
 export type EndNodeData = {

--- a/apps/web/src/app/(workspace)/automations/lib/validation.test.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/validation.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { validateWorkflowForSave } from "./validation";
+import { LOOP_FETCH_ONLY_ERROR } from "./node-types";
 import type {
 	AggregateNodeConfig,
+	AutomationObjectType,
 	ConditionNodeConfig,
 	FetchNodeConfig,
 	LoopNodeConfig,
@@ -288,6 +290,67 @@ describe("validateWorkflowForSave — condition node loop scope", () => {
 				(e) => e.nodeId === "cond1" && e.message === "Finish configuring the condition"
 			)
 		).toBe(true);
+	});
+});
+
+describe("validateWorkflowForSave — loops over fetch-only types (B7)", () => {
+	// Line items are fetch+aggregate only. A loop hands each item to actions as
+	// the record in scope, which a line item can never be — so the loop itself
+	// is rejected. Parity with the backend publish validator, which throws the
+	// same shared LOOP_FETCH_ONLY_ERROR string.
+	const scheduledTrigger: TriggerConfig = {
+		type: "scheduled",
+		schedule: { frequency: "daily", timezone: "UTC", time: "09:00" },
+	};
+
+	function loopOverNodes(objectType: AutomationObjectType): WorkflowNode[] {
+		return [
+			{
+				id: "fetch1",
+				type: "fetch_records",
+				config: { kind: "fetch_records", objectType, filters: [] },
+			},
+			{
+				id: "loop1",
+				type: "loop",
+				config: { kind: "loop", sourceNodeId: "fetch1" } satisfies LoopNodeConfig,
+				bodyStartNodeId: "act1",
+			},
+			{
+				id: "act1",
+				type: "action",
+				config: {
+					kind: "action",
+					action: {
+						type: "send_notification",
+						recipient: { allMembers: true },
+						message: "hi",
+					},
+				},
+			},
+		] as WorkflowNode[];
+	}
+
+	it.each(["quote_line_item", "invoice_line_item"] as const)(
+		"rejects a loop whose source fetches %s",
+		(objectType) => {
+			const result = validateWorkflowForSave(
+				scheduledTrigger,
+				loopOverNodes(objectType)
+			);
+			expect(
+				result.errors.some(
+					(e) => e.nodeId === "loop1" && e.message === LOOP_FETCH_ONLY_ERROR
+				)
+			).toBe(true);
+		}
+	);
+
+	it("still allows a loop over a normal fetched type", () => {
+		const result = validateWorkflowForSave(scheduledTrigger, loopOverNodes("task"));
+		expect(
+			result.errors.some((e) => e.message === LOOP_FETCH_ONLY_ERROR)
+		).toBe(false);
 	});
 });
 

--- a/apps/web/src/app/(workspace)/automations/lib/validation.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/validation.ts
@@ -38,6 +38,8 @@ import {
 	type ConditionRule,
 	type DelayNodeConfig,
 	type DelayUntilNodeConfig,
+	isFetchOnlyObjectType,
+	LOOP_FETCH_ONLY_ERROR,
 	type FetchNodeConfig,
 	type FieldType,
 	type LoopNodeConfig,
@@ -721,6 +723,22 @@ function validateLoopNode(
 		errors.push({
 			type: "missing_required_config",
 			message: 'Loops need a "Find records" step to run earlier in the workflow',
+			nodeId,
+		});
+		return;
+	}
+
+	// Parity with the backend publish validator: a loop hands each item to
+	// actions as the record in scope, which a line item can never be.
+	const sourceObjectType = (
+		workflowNodes.find((n) => n.id === config.sourceNodeId)?.config as
+			| FetchNodeConfig
+			| undefined
+	)?.objectType;
+	if (sourceObjectType && isFetchOnlyObjectType(sourceObjectType)) {
+		errors.push({
+			type: "missing_required_config",
+			message: LOOP_FETCH_ONLY_ERROR,
 			nodeId,
 		});
 		return;

--- a/apps/web/src/app/(workspace)/automations/lib/variables.test.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/variables.test.ts
@@ -174,6 +174,32 @@ describe("getAvailableVariables", () => {
 		expect(atLoopItself.some((o) => o.path.startsWith("loop.loop1."))).toBe(false);
 	});
 
+	// B8: the picker half of "create a task per project, assigned to the
+	// project's assignee" — the option has to be offered at all, and carry
+	// isArray so the value input can say it resolves to the first member.
+	it("offers a project's assigned team as a loop-item variable, flagged as an array", () => {
+		const nodes = [
+			fetchNode("f1", "project"),
+			loopNode("loop1", "f1", { bodyStartNodeId: "body1" }),
+			actionNode("body1"),
+		];
+
+		const option = getAvailableVariables(
+			nodes,
+			statusChangedTrigger,
+			"body1"
+		).find((o) => o.path === "loop.loop1.item.assignedUserIds");
+
+		expect(option).toEqual({
+			path: "loop.loop1.item.assignedUserIds",
+			label: "Loop item → Assigned team ID",
+			group: "Loop item",
+			fieldType: "id",
+			refType: "user",
+			isArray: true,
+		});
+	});
+
 	it("caveats user.* globals as empty on scheduled runs (populated on manual + user-caused event runs since Phase 1.4)", () => {
 		const target = actionNode("a1");
 		const options = getAvailableVariables([target], statusChangedTrigger, "a1");

--- a/apps/web/src/app/(workspace)/automations/lib/variables.test.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/variables.test.ts
@@ -192,7 +192,7 @@ describe("getAvailableVariables", () => {
 
 		expect(option).toEqual({
 			path: "loop.loop1.item.assignedUserIds",
-			label: "Loop item → Assigned team ID",
+			label: "Loop item → Assigned team IDs",
 			group: "Loop item",
 			fieldType: "id",
 			refType: "user",
@@ -336,6 +336,32 @@ describe("getScopeObjectType", () => {
 			inLoop: false,
 			loopNodeId: null,
 		});
+	});
+
+	it("reports no scope (not the trigger type) for a fetch-only loop source", () => {
+		const lineItemFetch = fetchNode("f2", "quote_line_item");
+		const lineItemLoop = loopNode("loop3", "f2", { bodyStartNodeId: "b1" });
+		const body = actionNode("b1");
+		expect(
+			getScopeObjectType([lineItemFetch, lineItemLoop, body], "b1", "client")
+		).toEqual({
+			objectType: null,
+			inLoop: true,
+			loopNodeId: "loop3",
+		});
+	});
+
+	it("offers no loop-item variables for a fetch-only loop source", () => {
+		const lineItemFetch = fetchNode("f2", "quote_line_item");
+		const lineItemLoop = loopNode("loop3", "f2", { bodyStartNodeId: "b1" });
+		const body = actionNode("b1");
+		const nodes = [lineItemFetch, lineItemLoop, body];
+
+		const scoped = getAvailableVariables(nodes, statusChangedTrigger, "b1");
+		expect(scoped.some((o) => o.path.startsWith("loop.loop3."))).toBe(false);
+
+		const all = getAllVariableOptions(nodes, statusChangedTrigger);
+		expect(all.some((o) => o.path.startsWith("loop.loop3."))).toBe(false);
 	});
 
 	it("stays in-loop but falls back to the trigger type when the fetch source is unresolved", () => {

--- a/apps/web/src/app/(workspace)/automations/lib/variables.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/variables.ts
@@ -132,10 +132,11 @@ export function getScopeObjectType(
 		// A fetch-only source (line items) can't be a scope record — publish
 		// validation rejects the loop; report no scope rather than a type
 		// actions can't act on.
-		const scopeType: TriggerableObjectType | null =
-			sourceType && !isFetchOnlyObjectType(sourceType) ? sourceType : null;
+		if (sourceType && isFetchOnlyObjectType(sourceType)) {
+			return { objectType: null, inLoop: true, loopNodeId: node.id };
+		}
 		return {
-			objectType: scopeType ?? triggerObjectType,
+			objectType: sourceType ?? triggerObjectType,
 			inLoop: true,
 			loopNodeId: node.id,
 		};
@@ -201,8 +202,12 @@ const GLOBAL_VARIABLE_OPTIONS: VariableOption[] = [
 ];
 
 /** " ID" suffix for id-type fields (e.g. "Client" -> "Client ID") disambiguates FK references. */
-function fieldOptionLabel(prefix: string, field: { label: string; type: FieldType }): string {
-	return `${prefix} → ${field.label}${field.type === "id" ? " ID" : ""}`;
+function fieldOptionLabel(
+	prefix: string,
+	field: { label: string; type: FieldType; isArray?: boolean }
+): string {
+	const suffix = field.type === "id" ? (field.isArray ? " IDs" : " ID") : "";
+	return `${prefix} → ${field.label}${suffix}`;
 }
 
 /**
@@ -372,7 +377,9 @@ export function getAvailableVariables(
 		const sourceNode = byId.get(config.sourceNodeId);
 		const sourceObjectType = (sourceNode?.config as FetchNodeConfig | undefined)
 			?.objectType;
-		if (!sourceObjectType) continue;
+		// A fetch-only source (line items) can't drive a loop — publish rejects
+		// it, so don't offer item variables that could never resolve.
+		if (!sourceObjectType || isFetchOnlyObjectType(sourceObjectType)) continue;
 
 		// Runtime resolves _id by raw property lookup on the loop item; offer it explicitly.
 		options.push({
@@ -489,7 +496,9 @@ export function getAllVariableOptions(
 		const sourceNode = nodes.find((n) => n.id === config.sourceNodeId);
 		const sourceObjectType = (sourceNode?.config as FetchNodeConfig | undefined)
 			?.objectType;
-		if (!sourceObjectType) continue;
+		// A fetch-only source (line items) can't drive a loop — publish rejects
+		// it, so don't offer item variables that could never resolve.
+		if (!sourceObjectType || isFetchOnlyObjectType(sourceObjectType)) continue;
 
 		options.push({
 			path: `loop.${node.id}.item._id`,

--- a/apps/web/src/app/(workspace)/automations/lib/variables.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/variables.ts
@@ -6,7 +6,9 @@ import { collectLoopBody } from "./graph-utils";
 import {
 	OBJECT_TYPE_LABELS,
 	getFilterableFields,
+	isFetchOnlyObjectType,
 	type AutomationObjectType,
+	type TriggerableObjectType,
 	type AutomationTrigger,
 	type FetchNodeConfig,
 	type FieldDefinition,
@@ -107,9 +109,9 @@ export function getUpstreamFetchNodes(
 export function getScopeObjectType(
 	nodes: WorkflowNode[],
 	targetNodeId: string,
-	triggerObjectType: AutomationObjectType | null
+	triggerObjectType: TriggerableObjectType | null
 ): {
-	objectType: AutomationObjectType | null;
+	objectType: TriggerableObjectType | null;
 	inLoop: boolean;
 	loopNodeId: string | null;
 } {
@@ -127,7 +129,16 @@ export function getScopeObjectType(
 		const sourceType = (sourceNode?.config as FetchNodeConfig | undefined)
 			?.objectType;
 		// Nested loops are rejected, so a node belongs to at most one body.
-		return { objectType: sourceType ?? triggerObjectType, inLoop: true, loopNodeId: node.id };
+		// A fetch-only source (line items) can't be a scope record — publish
+		// validation rejects the loop; report no scope rather than a type
+		// actions can't act on.
+		const scopeType: TriggerableObjectType | null =
+			sourceType && !isFetchOnlyObjectType(sourceType) ? sourceType : null;
+		return {
+			objectType: scopeType ?? triggerObjectType,
+			inLoop: true,
+			loopNodeId: node.id,
+		};
 	}
 	return { objectType: triggerObjectType, inLoop: false, loopNodeId: null };
 }
@@ -196,16 +207,22 @@ function fieldOptionLabel(prefix: string, field: { label: string; type: FieldTyp
 
 /**
  * A record's own `_id` option is refType-compatible with a destination `id`
- * field pointing at the same object type — but task/invoice aren't valid
- * `refType` values (no id field ever points at one), so those fall back to
- * undefined, same as any other unknown ref type: never flagged.
+ * field pointing at the same object type — but `task` and the line-item types
+ * aren't valid `refType` values (no id field ever points at one), so those fall
+ * back to undefined, same as any other unknown ref type: never flagged.
  */
 function asRefType(
 	objectType: AutomationObjectType
 ): FieldDefinition["refType"] {
-	return objectType === "task" || objectType === "invoice"
-		? undefined
-		: objectType;
+	switch (objectType) {
+		case "client":
+		case "project":
+		case "quote":
+		case "invoice":
+			return objectType;
+		default:
+			return undefined;
+	}
 }
 
 /** trigger.record.<field> + trigger.event.oldValue/newValue — shared by both functions. */

--- a/apps/web/src/app/(workspace)/automations/lib/variables.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/variables.ts
@@ -35,6 +35,8 @@ export type VariableOption = {
 	fieldType?: FieldType;
 	/** For an `id`-typed option, the entity it points at — lets the picker flag e.g. a client id fed into a user id field. */
 	refType?: FieldDefinition["refType"];
+	/** The option holds an array — feeding it a single-valued field uses the first element. */
+	isArray?: boolean;
 };
 
 function childrenOf(node: WorkflowNode): string[] {
@@ -236,6 +238,7 @@ function triggerVariableOptions(
 				group: "Trigger",
 				fieldType: field.type,
 				refType: field.refType,
+				isArray: field.isArray,
 			});
 		}
 	}
@@ -369,6 +372,7 @@ export function getAvailableVariables(
 				group: "Loop item",
 				fieldType: field.type,
 				refType: field.refType,
+				isArray: field.isArray,
 			});
 		}
 		options.push({
@@ -484,6 +488,7 @@ export function getAllVariableOptions(
 				group: "Loop item",
 				fieldType: field.type,
 				refType: field.refType,
+				isArray: field.isArray,
 			});
 		}
 		options.push({

--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -4,6 +4,7 @@ import { createTestOrg, createTestIdentity, addMemberToOrg } from "./test.helper
 import { api, internal } from "./_generated/api";
 import { isFatalExecutionError, scanOrgRows } from "./automationExecutor";
 import { projectCountsAggregate } from "./aggregates";
+import { LOOP_FETCH_ONLY_ERROR } from "./lib/workflowTypes";
 import type { Id } from "./_generated/dataModel";
 
 /**
@@ -2779,6 +2780,344 @@ describe("automationExecutor (v2 engine)", () => {
 			expect(result("avg")).toBeNull();
 			expect(result("min")).toBeNull();
 			expect(result("max")).toBeNull();
+		});
+
+		describe("line items — fetch + aggregate only (B7)", () => {
+			/** fetchNode above is typed to the 5 triggerable object types; line items need their own. */
+			function lineItemFetchNode(
+				id: string,
+				objectType: "quote_line_item" | "invoice_line_item",
+				filters: ReturnType<typeof filterGroup>[] = [],
+				opts: { nextNodeId?: string } = {}
+			) {
+				return {
+					id,
+					type: "fetch_records" as const,
+					config: {
+						kind: "fetch_records" as const,
+						objectType,
+						filters,
+					},
+					nextNodeId: opts.nextNodeId,
+				};
+			}
+
+			function lineItemAggNode(
+				id: string,
+				sourceNodeId: string,
+				field: string,
+				op: "sum" | "avg" | "min" | "max",
+				next?: string
+			) {
+				return {
+					id,
+					type: "aggregate" as const,
+					config: {
+						kind: "aggregate" as const,
+						sourceNodeId,
+						field,
+						op,
+					},
+					nextNodeId: next,
+				};
+			}
+
+			it("fetch quote_line_item filtered to a parent quote, then sum(amount) is cent-exact and excludes other quotes", async () => {
+				const { asUser, orgId } = await setupUser();
+				await makeOrgPremium(orgId);
+
+				const clientId = await asUser.mutation(api.clients.create, {
+					portalAccessId: crypto.randomUUID(),
+					companyName: "Acme Co",
+					status: "active",
+				});
+				const targetQuoteId = await asUser.mutation(api.quotes.create, {
+					clientId,
+					status: "draft",
+					subtotal: 0,
+					total: 0,
+				});
+				const otherQuoteId = await asUser.mutation(api.quotes.create, {
+					clientId,
+					status: "draft",
+					subtotal: 0,
+					total: 0,
+				});
+
+				// Totals 0.10, 0.20, 100 -> sum 100.30 exactly (same cent-rounding
+				// case the invoice aggregate test above exercises).
+				await t.run(async (ctx) => {
+					const amounts = [0.1, 0.2, 100];
+					for (let i = 0; i < amounts.length; i++) {
+						await ctx.db.insert("quoteLineItems", {
+							quoteId: targetQuoteId,
+							orgId,
+							description: `Item ${i}`,
+							quantity: 1,
+							unit: "item",
+							rate: amounts[i],
+							amount: amounts[i],
+							sortOrder: i,
+						});
+					}
+					// Belongs to a different quote — must not leak into the filtered sum.
+					await ctx.db.insert("quoteLineItems", {
+						quoteId: otherQuoteId,
+						orgId,
+						description: "Other quote's item",
+						quantity: 1,
+						unit: "item",
+						rate: 9999,
+						amount: 9999,
+						sortOrder: 0,
+					});
+				});
+
+				const automationId = await asUser.mutation(api.automations.create, {
+					name: "Quote line item total",
+					trigger: {
+						type: "scheduled",
+						schedule: { frequency: "daily", timezone: "UTC", time: "09:00" },
+					},
+					nodes: [
+						lineItemFetchNode(
+							"fetch-1",
+							"quote_line_item",
+							[filterGroup("quoteId", "equals", targetQuoteId)],
+							{ nextNodeId: "sum" }
+						),
+						lineItemAggNode("sum", "fetch-1", "amount", "sum", "end-1"),
+						endNode("end-1"),
+					],
+					isActive: true,
+				});
+
+				await runScheduledOnce(automationId);
+
+				const executions = await t.run(async (ctx) =>
+					ctx.db.query("workflowExecutions").collect()
+				);
+				expect(executions).toHaveLength(1);
+				expect(executions[0].status).toBe("completed");
+				const fetchEntry = executions[0].nodesExecuted.find(
+					(n) => n.nodeId === "fetch-1"
+				);
+				expect(fetchEntry?.recordsProcessed).toBe(3);
+				const sumOutput = executions[0].nodesExecuted.find(
+					(n) => n.nodeId === "sum"
+				)?.output as { result: number } | undefined;
+				expect(sumOutput?.result).toBe(100.3);
+			});
+
+			it("fetch invoice_line_item filtered to a parent invoice, then sum(total) is cent-exact", async () => {
+				const { asUser, orgId } = await setupUser();
+				await makeOrgPremium(orgId);
+
+				const clientId = await asUser.mutation(api.clients.create, {
+					portalAccessId: crypto.randomUUID(),
+					companyName: "Acme Co",
+					status: "active",
+				});
+				const invoiceId = await t.run(async (ctx) =>
+					ctx.db.insert("invoices", {
+						orgId,
+						clientId,
+						invoiceNumber: "INV-100",
+						status: "sent" as const,
+						subtotal: 0,
+						total: 0,
+						issuedDate: Date.now(),
+						dueDate: Date.now(),
+						publicToken: crypto.randomUUID(),
+					})
+				);
+
+				await t.run(async (ctx) => {
+					const totals = [0.1, 0.2, 100];
+					for (let i = 0; i < totals.length; i++) {
+						await ctx.db.insert("invoiceLineItems", {
+							invoiceId,
+							orgId,
+							description: `Item ${i}`,
+							quantity: 1,
+							unitPrice: totals[i],
+							total: totals[i],
+							sortOrder: i,
+						});
+					}
+				});
+
+				const automationId = await asUser.mutation(api.automations.create, {
+					name: "Invoice line item total",
+					trigger: {
+						type: "scheduled",
+						schedule: { frequency: "daily", timezone: "UTC", time: "09:00" },
+					},
+					nodes: [
+						lineItemFetchNode(
+							"fetch-1",
+							"invoice_line_item",
+							[filterGroup("invoiceId", "equals", invoiceId)],
+							{ nextNodeId: "sum" }
+						),
+						lineItemAggNode("sum", "fetch-1", "total", "sum", "end-1"),
+						endNode("end-1"),
+					],
+					isActive: true,
+				});
+
+				await runScheduledOnce(automationId);
+
+				const executions = await t.run(async (ctx) =>
+					ctx.db.query("workflowExecutions").collect()
+				);
+				expect(executions).toHaveLength(1);
+				expect(executions[0].status).toBe("completed");
+				const sumOutput = executions[0].nodesExecuted.find(
+					(n) => n.nodeId === "sum"
+				)?.output as { result: number } | undefined;
+				expect(sumOutput?.result).toBe(100.3);
+			});
+
+			it("org isolation: a fetch never returns another org's line items", async () => {
+				const orgA = await setupUser({
+					clerkUserId: "user_orgA_lineitems",
+					clerkOrgId: "org_orgA_lineitems",
+				});
+				await makeOrgPremium(orgA.orgId);
+				const orgB = await setupUser({
+					clerkUserId: "user_orgB_lineitems",
+					clerkOrgId: "org_orgB_lineitems",
+				});
+
+				const clientA = await orgA.asUser.mutation(api.clients.create, {
+					portalAccessId: crypto.randomUUID(),
+					companyName: "Org A Client",
+					status: "active",
+				});
+				const quoteA = await orgA.asUser.mutation(api.quotes.create, {
+					clientId: clientA,
+					status: "draft",
+					subtotal: 0,
+					total: 0,
+				});
+				const clientB = await orgB.asUser.mutation(api.clients.create, {
+					portalAccessId: crypto.randomUUID(),
+					companyName: "Org B Client",
+					status: "active",
+				});
+				const quoteB = await orgB.asUser.mutation(api.quotes.create, {
+					clientId: clientB,
+					status: "draft",
+					subtotal: 0,
+					total: 0,
+				});
+
+				await t.run(async (ctx) => {
+					await ctx.db.insert("quoteLineItems", {
+						quoteId: quoteA,
+						orgId: orgA.orgId,
+						description: "Org A item",
+						quantity: 1,
+						unit: "item",
+						rate: 10,
+						amount: 10,
+						sortOrder: 0,
+					});
+					await ctx.db.insert("quoteLineItems", {
+						quoteId: quoteA,
+						orgId: orgA.orgId,
+						description: "Org A item 2",
+						quantity: 1,
+						unit: "item",
+						rate: 20,
+						amount: 20,
+						sortOrder: 1,
+					});
+					// Org B's line item must never surface in org A's fetch/aggregate.
+					await ctx.db.insert("quoteLineItems", {
+						quoteId: quoteB,
+						orgId: orgB.orgId,
+						description: "Org B item",
+						quantity: 1,
+						unit: "item",
+						rate: 999,
+						amount: 999,
+						sortOrder: 0,
+					});
+				});
+
+				// No filter — every quote_line_item in the caller's org, unscoped by quote.
+				const automationId = await orgA.asUser.mutation(api.automations.create, {
+					name: "Org A line item total",
+					trigger: {
+						type: "scheduled",
+						schedule: { frequency: "daily", timezone: "UTC", time: "09:00" },
+					},
+					nodes: [
+						lineItemFetchNode("fetch-1", "quote_line_item", [], {
+							nextNodeId: "sum",
+						}),
+						lineItemAggNode("sum", "fetch-1", "amount", "sum", "end-1"),
+						endNode("end-1"),
+					],
+					isActive: true,
+				});
+
+				await t.run(async (ctx) =>
+					ctx.db.patch(automationId, { nextRunAt: Date.now() - 1000 })
+				);
+				await t.mutation(internal.automationExecutor.dispatchScheduledAutomations, {});
+				await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+				const executions = await t.run(async (ctx) =>
+					ctx.db.query("workflowExecutions").collect()
+				);
+				expect(executions).toHaveLength(1);
+				expect(executions[0].status).toBe("completed");
+				const fetchEntry = executions[0].nodesExecuted.find(
+					(n) => n.nodeId === "fetch-1"
+				);
+				// Only org A's 2 items — org B's 999-amount item is excluded.
+				expect(fetchEntry?.recordsProcessed).toBe(2);
+				const sumOutput = executions[0].nodesExecuted.find(
+					(n) => n.nodeId === "sum"
+				)?.output as { result: number } | undefined;
+				expect(sumOutput?.result).toBe(30);
+			});
+
+			it("rejects at publish: looping over a quote_line_item fetch source", async () => {
+				const { asUser } = await setupUser();
+
+				await expect(
+					asUser.mutation(api.automations.create, {
+						name: "Loop over line items",
+						trigger: {
+							type: "scheduled",
+							schedule: { frequency: "daily", timezone: "UTC", time: "09:00" },
+						},
+						nodes: [
+							lineItemFetchNode("fetch-1", "quote_line_item", [], {
+								nextNodeId: "loop-1",
+							}),
+							{
+								id: "loop-1",
+								type: "loop" as const,
+								config: { kind: "loop" as const, sourceNodeId: "fetch-1" },
+								bodyStartNodeId: "body-end",
+								nextNodeId: "end-1",
+							},
+							{
+								id: "body-end",
+								type: "next_item" as const,
+								config: { kind: "next_item" as const },
+							},
+							endNode("end-1"),
+						],
+						isActive: false,
+					})
+				).rejects.toThrow(LOOP_FETCH_ONLY_ERROR);
+			});
 		});
 
 		describe("scheduled triggers have no record (A1)", () => {

--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -2844,10 +2844,10 @@ describe("automationExecutor (v2 engine)", () => {
 					total: 0,
 				});
 
-				// Totals 0.10, 0.20, 100 -> sum 100.30 exactly (same cent-rounding
-				// case the invoice aggregate test above exercises).
+				// 0.1 + 0.2 float-sums to 0.30000000000000004, so an exact 0.3
+				// only comes out of the integer-cents sum path.
 				await t.run(async (ctx) => {
-					const amounts = [0.1, 0.2, 100];
+					const amounts = [0.1, 0.2, 0];
 					for (let i = 0; i < amounts.length; i++) {
 						await ctx.db.insert("quoteLineItems", {
 							quoteId: targetQuoteId,
@@ -2906,7 +2906,7 @@ describe("automationExecutor (v2 engine)", () => {
 				const sumOutput = executions[0].nodesExecuted.find(
 					(n) => n.nodeId === "sum"
 				)?.output as { result: number } | undefined;
-				expect(sumOutput?.result).toBe(100.3);
+				expect(sumOutput?.result).toBe(0.3);
 			});
 
 			it("fetch invoice_line_item filtered to a parent invoice, then sum(total) is cent-exact", async () => {
@@ -2933,7 +2933,8 @@ describe("automationExecutor (v2 engine)", () => {
 				);
 
 				await t.run(async (ctx) => {
-					const totals = [0.1, 0.2, 100];
+					// Same float trap as the quote test: 0.1 + 0.2 !== 0.3 in doubles.
+					const totals = [0.1, 0.2, 0];
 					for (let i = 0; i < totals.length; i++) {
 						await ctx.db.insert("invoiceLineItems", {
 							invoiceId,
@@ -2976,7 +2977,7 @@ describe("automationExecutor (v2 engine)", () => {
 				const sumOutput = executions[0].nodesExecuted.find(
 					(n) => n.nodeId === "sum"
 				)?.output as { result: number } | undefined;
-				expect(sumOutput?.result).toBe(100.3);
+				expect(sumOutput?.result).toBe(0.3);
 			});
 
 			it("org isolation: a fetch never returns another org's line items", async () => {

--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -5553,6 +5553,90 @@ describe("automationExecutor (v2 engine)", () => {
 				})
 			).rejects.toThrow(/not a valid value/i);
 		});
+
+		it("regression: an array-valued loop item field (project.assignedUserIds) feeding a single-id create_record field (task.assigneeUserId) takes the first element", async () => {
+			const { asUser, orgId } = await setupUser();
+			await makeOrgPremium(orgId);
+
+			const member1 = await t.run(async (ctx) =>
+				addMemberToOrg(ctx, orgId, { userName: "Alice" })
+			);
+			const member2 = await t.run(async (ctx) =>
+				addMemberToOrg(ctx, orgId, { userName: "Bob" })
+			);
+
+			const clientId = await asUser.mutation(api.clients.create, {
+				portalAccessId: crypto.randomUUID(),
+				companyName: "Acme Co",
+				status: "active",
+			});
+			await asUser.mutation(api.projects.create, {
+				clientId,
+				title: "Kitchen remodel",
+				status: "planned",
+				projectType: "one-off",
+				assignedUserIds: [member1.userId, member2.userId],
+			});
+
+			const automationId = await asUser.mutation(api.automations.create, {
+				name: "Assign follow-up task to project assignee",
+				trigger: {
+					type: "scheduled",
+					schedule: { frequency: "daily", timezone: "UTC", time: "09:00" },
+				},
+				nodes: [
+					{
+						id: "fetch-1",
+						type: "fetch_records" as const,
+						config: {
+							kind: "fetch_records" as const,
+							objectType: "project" as const,
+							filters: [],
+						},
+						nextNodeId: "loop-1",
+					},
+					{
+						id: "loop-1",
+						type: "loop" as const,
+						config: {
+							kind: "loop" as const,
+							sourceNodeId: "fetch-1",
+						},
+						bodyStartNodeId: "act-1",
+						nextNodeId: "end-1",
+					},
+					createRecordActionNode("act-1", {
+						objectType: "task",
+						fields: [
+							{ field: "title", value: { kind: "static", value: "Follow up" } },
+							{
+								field: "assigneeUserId",
+								value: {
+									kind: "var",
+									path: "loop.loop-1.item.assignedUserIds",
+								},
+							},
+						],
+					}),
+					{ id: "end-1", type: "end" as const, config: { kind: "end" as const } },
+				],
+				isActive: true,
+			});
+
+			await runScheduledOnce(automationId);
+
+			const tasks = await t.run(async (ctx) => ctx.db.query("tasks").collect());
+			expect(tasks).toHaveLength(1);
+			expect(tasks[0].title).toBe("Follow up");
+			// String(["m1","m2"]) => "m1,m2" would fail FK resolution; the fix
+			// takes the array's first element instead.
+			expect(tasks[0].assigneeUserId).toBe(member1.userId);
+
+			const executions = await t.run(async (ctx) =>
+				ctx.db.query("workflowExecutions").collect()
+			);
+			expect(executions[0].status).toBe("completed");
+		});
 	});
 
 	describe("action fallback type validation (server-side var-fallback check)", () => {

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -2793,8 +2793,21 @@ function coerceFieldValue(
 			// instant from then on.
 			return { ok: true, value: calendarDayEpoch(n, tz) };
 		}
-		case "id":
+		case "id": {
+			// An array-valued source (project.assignedUserIds) feeding a
+			// single-id destination (task.assigneeUserId) takes the first
+			// element; empty means "not supplied", not the string "".
+			// Without this, String(raw) yields "u1,u2" and FK resolution fails.
+			if (Array.isArray(raw)) {
+				if (raw.length === 0) return { ok: true, value: null };
+				const [first] = raw;
+				if (first === undefined || first === null) {
+					return { ok: true, value: null };
+				}
+				return { ok: true, value: String(first) };
+			}
 			return { ok: true, value: String(raw) };
+		}
 		default: {
 			const _exhaustive: never = fieldDef.type;
 			return _exhaustive;

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -50,13 +50,17 @@ import {
 	MAX_FETCH_LIMIT,
 	MAX_LOOP_ITEM_ERRORS,
 	MAX_LOOP_ITERATIONS,
+	isFetchOnlyObjectType,
+	LOOP_FETCH_ONLY_ERROR,
 	objectTypeValidator,
+	triggerableObjectTypeValidator,
 	triggerRecordObjectType,
 	type ActionTarget,
 	type AutomationAction,
 	type TeamMessageMention,
 	type ValueRef,
 	type AutomationObjectType,
+	type TriggerableObjectType,
 	type AutomationTrigger,
 	type ExecutedNode,
 	type FormulaResource,
@@ -79,7 +83,12 @@ import {
  */
 
 // Type definitions
-type ObjectType = AutomationObjectType;
+/**
+ * A record type the engine can act on: trigger, target, emit events about,
+ * link a notification to. Excludes fetch-only line items by construction — the
+ * fetch/aggregate surfaces below say AutomationObjectType explicitly.
+ */
+type ObjectType = TriggerableObjectType;
 type AutomationNode = Doc<"workflowAutomations">["nodes"][number];
 type AutomationDoc = Doc<"workflowAutomations">;
 
@@ -541,13 +550,7 @@ async function matchAndScheduleAutomations(
 export const handleStatusChangeEvent = systemMutation({
 	args: {
 		eventId: v.id("domainEvents"),
-		entityType: v.union(
-			v.literal("client"),
-			v.literal("project"),
-			v.literal("quote"),
-			v.literal("invoice"),
-			v.literal("task")
-		),
+		entityType: triggerableObjectTypeValidator,
 		entityId: v.string(),
 		fromStatus: v.string(),
 		toStatus: v.string(),
@@ -797,13 +800,13 @@ export const dispatchScheduledAutomations = internalMutation({
 
 /** The record a node operates on: the trigger record, or a loop item. */
 type ScopeRecord = {
-	type: ObjectType;
+	type: TriggerableObjectType;
 	id: string;
 	record: Record<string, unknown>;
 };
 
 type FetchOutput = {
-	objectType: ObjectType;
+	objectType: AutomationObjectType;
 	records: Record<string, unknown>[];
 	count: number;
 	/** True when the scan stopped at its cap with org rows still unscanned. */
@@ -1869,6 +1872,14 @@ async function runLoopNode(
 		pushEntry(env, { nodeId: node.id, result: "failed", error });
 		return { kind: "failed", error };
 	}
+	// Line items are fetch+aggregate only: they can't be a scope record, so a
+	// loop can't hand one to an action. Publish validation rejects this too;
+	// this is the runtime backstop for already-published snapshots.
+	if (isFetchOnlyObjectType(source.objectType)) {
+		const error = LOOP_FETCH_ONLY_ERROR;
+		pushEntry(env, { nodeId: node.id, result: "failed", error });
+		return { kind: "failed", error };
+	}
 
 	const summary = loopSummaryFor(env, node.id);
 
@@ -2129,7 +2140,7 @@ type OrgRow = Record<string, unknown> & { _creationTime: number };
  */
 async function takeOrgPage(
 	ctx: { db: QueryCtx["db"] },
-	objectType: ObjectType,
+	objectType: AutomationObjectType,
 	orgId: Id<"organizations">,
 	before: number | undefined,
 	count: number
@@ -2180,6 +2191,24 @@ async function takeOrgPage(
 				})
 				.order("desc")
 				.take(count);
+		case "quote_line_item":
+			return await ctx.db
+				.query("quoteLineItems")
+				.withIndex("by_org", (q) => {
+					const r = q.eq("orgId", orgId);
+					return before === undefined ? r : r.lt("_creationTime", before);
+				})
+				.order("desc")
+				.take(count);
+		case "invoice_line_item":
+			return await ctx.db
+				.query("invoiceLineItems")
+				.withIndex("by_org", (q) => {
+					const r = q.eq("orgId", orgId);
+					return before === undefined ? r : r.lt("_creationTime", before);
+				})
+				.order("desc")
+				.take(count);
 		default: {
 			const _exhaustive: never = objectType;
 			return _exhaustive;
@@ -2199,7 +2228,7 @@ async function takeOrgPage(
  */
 export async function scanOrgRows(
 	ctx: { db: QueryCtx["db"] },
-	objectType: ObjectType,
+	objectType: AutomationObjectType,
 	orgId: Id<"organizations">,
 	opts: {
 		predicate?: (row: Record<string, unknown>) => boolean;
@@ -2437,7 +2466,7 @@ function computeDelayResume(
  */
 async function getObject(
 	ctx: { db: QueryCtx["db"] },
-	objectType: ObjectType,
+	objectType: AutomationObjectType,
 	objectId: string,
 	orgId: Id<"organizations">
 ): Promise<
@@ -2446,6 +2475,8 @@ async function getObject(
 	| Doc<"quotes">
 	| Doc<"invoices">
 	| Doc<"tasks">
+	| Doc<"quoteLineItems">
+	| Doc<"invoiceLineItems">
 	| null
 > {
 	let doc:
@@ -2454,6 +2485,8 @@ async function getObject(
 		| Doc<"quotes">
 		| Doc<"invoices">
 		| Doc<"tasks">
+		| Doc<"quoteLineItems">
+		| Doc<"invoiceLineItems">
 		| null;
 	switch (objectType) {
 		case "client":
@@ -2471,8 +2504,16 @@ async function getObject(
 		case "task":
 			doc = await ctx.db.get(objectId as Id<"tasks">);
 			break;
-		default:
-			return null;
+		case "quote_line_item":
+			doc = await ctx.db.get(objectId as Id<"quoteLineItems">);
+			break;
+		case "invoice_line_item":
+			doc = await ctx.db.get(objectId as Id<"invoiceLineItems">);
+			break;
+		default: {
+			const _exhaustive: never = objectType;
+			return _exhaustive;
+		}
 	}
 	if (doc && doc.orgId !== orgId) {
 		console.warn(
@@ -3346,7 +3387,8 @@ async function resolveCreateFk(
 		client: "clients",
 		project: "projects",
 		quote: "quotes",
-	}[refType] as "users" | "clients" | "projects" | "quotes";
+		invoice: "invoices",
+	}[refType] as "users" | "clients" | "projects" | "quotes" | "invoices";
 	const normalized = ctx.db.normalizeId(table, raw);
 	if (!normalized) {
 		return { ok: false, error: `Referenced ${refType} is not a valid id` };
@@ -4354,7 +4396,7 @@ function pushDry(env: DryEnv, entry: ExecutedNode): void {
 
 /** Human label for a record, used in the run's triggerRecord + sample picker. */
 function sampleRecordLabel(
-	objectType: ObjectType,
+	objectType: AutomationObjectType,
 	record: Record<string, unknown>
 ): string {
 	switch (objectType) {
@@ -4372,6 +4414,9 @@ function sampleRecordLabel(
 				: "Invoice";
 		case "task":
 			return String(record.title ?? "Task");
+		case "quote_line_item":
+		case "invoice_line_item":
+			return String(record.description ?? "Line item");
 		default: {
 			const _exhaustive: never = objectType;
 			return _exhaustive;
@@ -4822,6 +4867,14 @@ async function dryRunLoopNode(
 		pushDry(env, { nodeId: node.id, result: "failed", error });
 		return "failed";
 	}
+	// Line items are fetch+aggregate only: they can't be a scope record, so a
+	// loop can't hand one to an action. Publish validation rejects this too;
+	// this is the runtime backstop for already-published snapshots.
+	if (isFetchOnlyObjectType(source.objectType)) {
+		const error = LOOP_FETCH_ONLY_ERROR;
+		pushDry(env, { nodeId: node.id, result: "failed", error });
+		return "failed";
+	}
 
 	const total = Math.min(
 		source.records.length,
@@ -5171,7 +5224,10 @@ export const startTestRun = userMutation({
 	args: {
 		automationId: v.id("workflowAutomations"),
 		record: v.optional(
-			v.object({ entityType: objectTypeValidator, entityId: v.string() })
+			v.object({
+				entityType: triggerableObjectTypeValidator,
+				entityId: v.string(),
+			})
 		),
 	},
 	handler: async (ctx, args): Promise<Id<"workflowExecutions">> => {
@@ -5403,7 +5459,10 @@ export const startManualRun = userMutation({
 	args: {
 		automationId: v.id("workflowAutomations"),
 		record: v.optional(
-			v.object({ entityType: objectTypeValidator, entityId: v.string() })
+			v.object({
+				entityType: triggerableObjectTypeValidator,
+				entityId: v.string(),
+			})
 		),
 	},
 	handler: async (ctx, args): Promise<Id<"workflowExecutions">> => {
@@ -5526,7 +5585,7 @@ export const getExecution = userQuery({
 export const getSampleRecords = userQuery({
 	args: {
 		automationId: v.optional(v.id("workflowAutomations")),
-		objectType: v.optional(objectTypeValidator),
+		objectType: v.optional(triggerableObjectTypeValidator),
 	},
 	handler: async (
 		ctx,

--- a/packages/backend/convex/automations.ts
+++ b/packages/backend/convex/automations.ts
@@ -8,6 +8,8 @@ import { userMutation, userQuery } from "./lib/factories";
 import {
 	AUTOMATION_OBJECT_TYPES,
 	DELAY_UNIT_MS,
+	LOOP_FETCH_ONLY_ERROR,
+	isFetchOnlyObjectType,
 	MAX_CONDITION_GROUPS,
 	MAX_DELAY_MS,
 	MAX_DUE_IN_DAYS,
@@ -905,6 +907,12 @@ function validateWorkflowDefinition(
 					throw new Error(
 						`Node ${node.id}: loops must reference a "Find records" node`
 					);
+				}
+				// A loop hands each item to actions as the record in scope, and a
+				// line item can't be one (fetch+aggregate only). The executor has
+				// the same guard for already-published snapshots.
+				if (isFetchOnlyObjectType(source.config.objectType)) {
+					throw new Error(`Node ${node.id}: ${LOOP_FETCH_ONLY_ERROR}`);
 				}
 				break;
 			}

--- a/packages/backend/convex/eventBus.ts
+++ b/packages/backend/convex/eventBus.ts
@@ -7,6 +7,10 @@ import { v } from "convex/values";
 import { Doc, Id } from "./_generated/dataModel";
 import { internal } from "./_generated/api";
 import { systemMutation } from "./lib/factories";
+import {
+	triggerableObjectTypeValidator,
+	type TriggerableObjectType,
+} from "./lib/workflowTypes";
 
 /**
  * Emitters accept any MutationCtx; when called from a userMutation the
@@ -45,7 +49,14 @@ const MAX_RETRY_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 5000; // 5 seconds
 const BATCH_SIZE = 50; // Events to process per batch
 
-type EntityType = "client" | "project" | "quote" | "invoice" | "task";
+/**
+ * The entity types that emit domain events. Derived from AutomationObjectType
+ * so the two enums can't drift — but fetch-only line items are excluded rather
+ * than aliased in: they never emit events (their parent quote/invoice does),
+ * and a bare alias would silently make emitStatusChangeEvent(…, "quote_line_item")
+ * type-check.
+ */
+type EntityType = TriggerableObjectType;
 
 /**
  * Publish an event to the event bus
@@ -56,13 +67,7 @@ export const publishEvent = systemMutation({
 		eventType: v.string(),
 		eventSource: v.string(),
 		payload: v.object({
-			entityType: v.union(
-				v.literal("client"),
-				v.literal("project"),
-				v.literal("quote"),
-				v.literal("invoice"),
-				v.literal("task")
-			),
+			entityType: triggerableObjectTypeValidator,
 			entityId: v.string(),
 			field: v.optional(v.string()),
 			oldValue: v.optional(v.any()),

--- a/packages/backend/convex/lib/conditionEval.test.ts
+++ b/packages/backend/convex/lib/conditionEval.test.ts
@@ -460,6 +460,66 @@ describe("evaluateRule", () => {
 				).toBe(false);
 			});
 		});
+
+		describe("array compare values match on membership (B8 symmetric)", () => {
+			// The array can sit on the value side too: "task.assigneeUserId
+			// equals {{loop.x.item.assignedUserIds}}" means "assignee is one of
+			// the team", not strict equality against the array.
+			const teamScope: VariableScope = {
+				trigger: { record: { assignedUserIds: ["u1", "u2"], noTeam: [] } },
+			};
+			const teamRef: ValueRef = {
+				kind: "var",
+				path: "trigger.record.assignedUserIds",
+			};
+
+			it("equals is true for a member field, false for a non-member", () => {
+				expect(
+					evaluateRule(
+						rule("assigneeUserId", "equals", teamRef),
+						{ assigneeUserId: "u2" },
+						teamScope
+					)
+				).toBe(true);
+				expect(
+					evaluateRule(
+						rule("assigneeUserId", "equals", teamRef),
+						{ assigneeUserId: "u3" },
+						teamScope
+					)
+				).toBe(false);
+			});
+
+			it("not_equals negates membership", () => {
+				expect(
+					evaluateRule(
+						rule("assigneeUserId", "not_equals", teamRef),
+						{ assigneeUserId: "u3" },
+						teamScope
+					)
+				).toBe(true);
+				expect(
+					evaluateRule(
+						rule("assigneeUserId", "not_equals", teamRef),
+						{ assigneeUserId: "u1" },
+						teamScope
+					)
+				).toBe(false);
+			});
+
+			it("an empty array value matches nothing", () => {
+				expect(
+					evaluateRule(
+						rule("assigneeUserId", "equals", {
+							kind: "var",
+							path: "trigger.record.noTeam",
+						}),
+						{ assigneeUserId: "u1" },
+						teamScope
+					)
+				).toBe(false);
+			});
+		});
 	});
 
 	describe("contains / not_contains", () => {

--- a/packages/backend/convex/lib/conditionEval.test.ts
+++ b/packages/backend/convex/lib/conditionEval.test.ts
@@ -401,6 +401,65 @@ describe("evaluateRule", () => {
 				evaluateRule(rule("amount", "not_equals", staticRef("100")), record, emptyScope)
 			).toBe(false);
 		});
+
+		describe("array-valued fields match on membership (B8)", () => {
+			// project.assignedUserIds is an array; "Assigned team equals Alice"
+			// has to mean "Alice is on the team", not "the array IS Alice".
+			const team = { assignedUserIds: ["u1", "u2"], empty: [] as string[] };
+
+			it("equals is true for any member, false for a non-member", () => {
+				expect(
+					evaluateRule(
+						rule("assignedUserIds", "equals", staticRef("u1")),
+						team,
+						emptyScope
+					)
+				).toBe(true);
+				expect(
+					evaluateRule(
+						rule("assignedUserIds", "equals", staticRef("u2")),
+						team,
+						emptyScope
+					)
+				).toBe(true);
+				expect(
+					evaluateRule(
+						rule("assignedUserIds", "equals", staticRef("u3")),
+						team,
+						emptyScope
+					)
+				).toBe(false);
+			});
+
+			it("not_equals negates membership", () => {
+				expect(
+					evaluateRule(
+						rule("assignedUserIds", "not_equals", staticRef("u3")),
+						team,
+						emptyScope
+					)
+				).toBe(true);
+				expect(
+					evaluateRule(
+						rule("assignedUserIds", "not_equals", staticRef("u1")),
+						team,
+						emptyScope
+					)
+				).toBe(false);
+			});
+
+			it("an empty array matches nothing and reads as empty", () => {
+				expect(
+					evaluateRule(rule("empty", "equals", staticRef("u1")), team, emptyScope)
+				).toBe(false);
+				expect(evaluateRule(rule("empty", "is_empty"), team, emptyScope)).toBe(
+					true
+				);
+				expect(
+					evaluateRule(rule("assignedUserIds", "is_empty"), team, emptyScope)
+				).toBe(false);
+			});
+		});
 	});
 
 	describe("contains / not_contains", () => {

--- a/packages/backend/convex/lib/conditionEval.test.ts
+++ b/packages/backend/convex/lib/conditionEval.test.ts
@@ -507,6 +507,30 @@ describe("evaluateRule", () => {
 				).toBe(false);
 			});
 
+			it("two arrays match when they share at least one member", () => {
+				expect(
+					evaluateRule(
+						rule("assignedUserIds", "equals", teamRef),
+						{ assignedUserIds: ["u2", "u9"] },
+						teamScope
+					)
+				).toBe(true);
+				expect(
+					evaluateRule(
+						rule("assignedUserIds", "equals", teamRef),
+						{ assignedUserIds: ["u8", "u9"] },
+						teamScope
+					)
+				).toBe(false);
+				expect(
+					evaluateRule(
+						rule("assignedUserIds", "equals", teamRef),
+						{ assignedUserIds: [] },
+						teamScope
+					)
+				).toBe(false);
+			});
+
 			it("an empty array value matches nothing", () => {
 				expect(
 					evaluateRule(

--- a/packages/backend/convex/lib/conditionEval.ts
+++ b/packages/backend/convex/lib/conditionEval.ts
@@ -308,6 +308,11 @@ function looseEquals(a: unknown, b: unknown): boolean {
 	if (Array.isArray(a) && !Array.isArray(b)) {
 		return a.some((element) => looseEquals(element, b));
 	}
+	// Symmetric: an array compare value ({{loop.x.item.assignedUserIds}})
+	// matches a scalar field on membership too — "assignee is one of them".
+	if (Array.isArray(b) && !Array.isArray(a)) {
+		return b.some((element) => looseEquals(a, element));
+	}
 	if (typeof a === "number" && typeof b === "string") {
 		return numericStringToNumber(b) === a;
 	}

--- a/packages/backend/convex/lib/conditionEval.ts
+++ b/packages/backend/convex/lib/conditionEval.ts
@@ -302,6 +302,12 @@ export function interpolateTemplate(
 /** Strict equality, except a number compares equal to its numeric string. */
 function looseEquals(a: unknown, b: unknown): boolean {
 	if (a === b) return true;
+	// An array-valued field (project.assignedUserIds) matches on membership:
+	// "Assigned team equals Alice" means Alice is on the team. Without this a
+	// rule on an array field silently never matches.
+	if (Array.isArray(a) && !Array.isArray(b)) {
+		return a.some((element) => looseEquals(element, b));
+	}
 	if (typeof a === "number" && typeof b === "string") {
 		return numericStringToNumber(b) === a;
 	}

--- a/packages/backend/convex/lib/conditionEval.ts
+++ b/packages/backend/convex/lib/conditionEval.ts
@@ -313,6 +313,11 @@ function looseEquals(a: unknown, b: unknown): boolean {
 	if (Array.isArray(b) && !Array.isArray(a)) {
 		return b.some((element) => looseEquals(a, element));
 	}
+	// Both arrays ("Assigned team equals {{trigger.record.assignedUserIds}}"):
+	// match when the two share at least one member.
+	if (Array.isArray(a) && Array.isArray(b)) {
+		return a.some((element) => b.some((other) => looseEquals(element, other)));
+	}
 	if (typeof a === "number" && typeof b === "string") {
 		return numericStringToNumber(b) === a;
 	}

--- a/packages/backend/convex/lib/fieldRegistry.test.ts
+++ b/packages/backend/convex/lib/fieldRegistry.test.ts
@@ -6,11 +6,18 @@ import {
 	RELATION_FIELD,
 	getFieldDefinition,
 	getWritableFields,
+	getCreatableFields,
 	getFilterableFields,
+	isCreatableObjectType,
 	operatorsForField,
 	getStatusOptions,
 } from "./fieldRegistry";
-import { AUTOMATION_OBJECT_TYPES } from "./workflowTypes";
+import {
+	AUTOMATION_OBJECT_TYPES,
+	FETCH_ONLY_OBJECT_TYPES,
+	TRIGGERABLE_OBJECT_TYPES,
+	isFetchOnlyObjectType,
+} from "./workflowTypes";
 
 /**
  * Expected field keys hardcoded from schema.ts table validators. If the schema
@@ -106,6 +113,26 @@ const SCHEMA_KEYS = {
 		"repeatUntil",
 		"parentTaskId",
 	],
+	quote_line_item: [
+		"quoteId",
+		"orgId",
+		"description",
+		"quantity",
+		"unit",
+		"rate",
+		"amount",
+		"cost",
+		"sortOrder",
+	],
+	invoice_line_item: [
+		"invoiceId",
+		"orgId",
+		"description",
+		"quantity",
+		"unitPrice",
+		"total",
+		"sortOrder",
+	],
 } as const;
 
 /** Exact status enum values from schema.ts, in declaration order. */
@@ -115,6 +142,9 @@ const SCHEMA_STATUS_VALUES = {
 	quote: ["draft", "sent", "approved", "declined", "expired"],
 	invoice: ["draft", "sent", "paid", "overdue", "cancelled"],
 	task: ["pending", "in-progress", "completed", "cancelled"],
+	// Line items have no status — nothing to transition, nothing to trigger on.
+	quote_line_item: [],
+	invoice_line_item: [],
 } as const;
 
 describe("FIELD_REGISTRY", () => {
@@ -307,5 +337,44 @@ describe("relations", () => {
 				).toContain(fkField);
 			}
 		}
+	});
+});
+
+describe("line items are fetch+aggregate only (B7)", () => {
+	it.each(FETCH_ONLY_OBJECT_TYPES)(
+		"%s has no writable or creatable fields",
+		(objectType) => {
+			expect(getWritableFields(objectType)).toEqual([]);
+			expect(getCreatableFields(objectType)).toEqual([]);
+			expect(isCreatableObjectType(objectType)).toBe(false);
+		}
+	);
+
+	it("TRIGGERABLE_OBJECT_TYPES excludes both line-item types", () => {
+		expect(TRIGGERABLE_OBJECT_TYPES).not.toContain("quote_line_item");
+		expect(TRIGGERABLE_OBJECT_TYPES).not.toContain("invoice_line_item");
+		expect(TRIGGERABLE_OBJECT_TYPES).toEqual([
+			"client",
+			"project",
+			"quote",
+			"invoice",
+			"task",
+		]);
+	});
+
+	it("isFetchOnlyObjectType is true only for line-item types", () => {
+		for (const objectType of AUTOMATION_OBJECT_TYPES) {
+			const expected = (FETCH_ONLY_OBJECT_TYPES as readonly string[]).includes(
+				objectType
+			);
+			expect(isFetchOnlyObjectType(objectType)).toBe(expected);
+		}
+		expect(isFetchOnlyObjectType("quote_line_item")).toBe(true);
+		expect(isFetchOnlyObjectType("invoice_line_item")).toBe(true);
+		expect(isFetchOnlyObjectType("client")).toBe(false);
+		expect(isFetchOnlyObjectType("project")).toBe(false);
+		expect(isFetchOnlyObjectType("quote")).toBe(false);
+		expect(isFetchOnlyObjectType("invoice")).toBe(false);
+		expect(isFetchOnlyObjectType("task")).toBe(false);
 	});
 });

--- a/packages/backend/convex/lib/fieldRegistry.ts
+++ b/packages/backend/convex/lib/fieldRegistry.ts
@@ -1,4 +1,8 @@
-import type { AutomationObjectType, ConditionOperator } from "./workflowTypes";
+import type {
+	AutomationObjectType,
+	ConditionOperator,
+	TriggerableObjectType,
+} from "./workflowTypes";
 
 /**
  * Shared entity field registry for workflow automations.
@@ -55,7 +59,7 @@ export interface FieldDefinition {
 	 * On read-only FKs it lets the builder render a record picker instead of a
 	 * raw-id text box in condition/filter rules.
 	 */
-	refType?: "client" | "project" | "user" | "quote";
+	refType?: "client" | "project" | "user" | "quote" | "invoice";
 	/**
 	 * The field holds an array of `type` values, not one. Filters match on
 	 * membership (`equals` = "is one of them"), and feeding one into a
@@ -412,6 +416,117 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 		},
 	],
 
+	/**
+	 * Line items are FETCH+AGGREGATE only: every field is writable:false and none
+	 * is creatable, so getWritableFields()/CREATABLE_OBJECT_TYPES exclude them
+	 * with no type-level guard needed. Aggregating over amount/total — the
+	 * headline use case — needs no engine change beyond the fetch switch.
+	 * Field names differ per table: quotes use rate/amount, invoices unitPrice/total.
+	 */
+	quote_line_item: [
+		{
+			key: "description",
+			label: "Description",
+			type: "text",
+			writable: false,
+			writeExclusionReason: "Line items can be read and aggregated; editing them from automations isn't supported yet",
+			filterable: true,
+		},
+		{
+			key: "quantity",
+			label: "Quantity",
+			type: "number",
+			writable: false,
+			writeExclusionReason: "Line items can be read and aggregated; editing them from automations isn't supported yet",
+			filterable: true,
+		},
+		{
+			key: "unit",
+			label: "Unit",
+			type: "text",
+			writable: false,
+			writeExclusionReason: "Line items can be read and aggregated; editing them from automations isn't supported yet",
+			filterable: true,
+		},
+		{
+			key: "rate",
+			label: "Rate",
+			type: "currency",
+			writable: false,
+			writeExclusionReason: "Line items can be read and aggregated; editing them from automations isn't supported yet",
+			filterable: true,
+		},
+		{
+			key: "amount",
+			label: "Amount",
+			type: "currency",
+			writable: false,
+			writeExclusionReason: "Line items can be read and aggregated; editing them from automations isn't supported yet",
+			filterable: true,
+		},
+		{
+			key: "cost",
+			label: "Cost",
+			type: "currency",
+			writable: false,
+			writeExclusionReason: "Line items can be read and aggregated; editing them from automations isn't supported yet",
+			filterable: true,
+		},
+		{
+			key: "quoteId",
+			label: "Quote",
+			type: "id",
+			refType: "quote",
+			writable: false,
+			writeExclusionReason: "Line items can be read and aggregated; editing them from automations isn't supported yet",
+			filterable: true,
+		},
+	],
+
+	invoice_line_item: [
+		{
+			key: "description",
+			label: "Description",
+			type: "text",
+			writable: false,
+			writeExclusionReason: "Line items can be read and aggregated; editing them from automations isn't supported yet",
+			filterable: true,
+		},
+		{
+			key: "quantity",
+			label: "Quantity",
+			type: "number",
+			writable: false,
+			writeExclusionReason: "Line items can be read and aggregated; editing them from automations isn't supported yet",
+			filterable: true,
+		},
+		{
+			key: "unitPrice",
+			label: "Unit Price",
+			type: "currency",
+			writable: false,
+			writeExclusionReason: "Line items can be read and aggregated; editing them from automations isn't supported yet",
+			filterable: true,
+		},
+		{
+			key: "total",
+			label: "Total",
+			type: "currency",
+			writable: false,
+			writeExclusionReason: "Line items can be read and aggregated; editing them from automations isn't supported yet",
+			filterable: true,
+		},
+		{
+			key: "invoiceId",
+			label: "Invoice",
+			type: "id",
+			refType: "invoice",
+			writable: false,
+			writeExclusionReason: "Line items can be read and aggregated; editing them from automations isn't supported yet",
+			filterable: true,
+		},
+	],
+
 	task: [
 		{ key: "title", label: "Title", type: "text", writable: true, filterable: true, creatable: true, requiredOnCreate: true },
 		{ key: "description", label: "Description", type: "text", writable: true, filterable: true, creatable: true },
@@ -595,13 +710,16 @@ export function getStatusOptions(
  */
 export const RELATED_OBJECTS: Record<
 	AutomationObjectType,
-	AutomationObjectType[]
+	TriggerableObjectType[]
 > = {
 	client: [],
 	project: ["client"],
 	quote: ["client", "project"],
 	invoice: ["client", "project", "quote"],
 	task: ["project", "client"],
+	// Direct FK only — item -> parent -> client is two-hop traversal (Item 13).
+	quote_line_item: ["quote"],
+	invoice_line_item: ["invoice"],
 };
 
 /**
@@ -627,6 +745,8 @@ export const USER_REF_RECIPIENT_FIELDS: Record<
 	],
 	client: [{ key: "createdByUserId", label: "Creator", isArray: false }],
 	invoice: [{ key: "createdByUserId", label: "Creator", isArray: false }],
+	quote_line_item: [],
+	invoice_line_item: [],
 };
 
 /** FK field on the source record used to resolve each relation. */
@@ -639,4 +759,6 @@ export const RELATION_FIELD: Record<
 	quote: { client: "clientId", project: "projectId" },
 	invoice: { client: "clientId", project: "projectId", quote: "quoteId" },
 	task: { project: "projectId", client: "clientId" },
+	quote_line_item: { quote: "quoteId" },
+	invoice_line_item: { invoice: "invoiceId" },
 };

--- a/packages/backend/convex/lib/fieldRegistry.ts
+++ b/packages/backend/convex/lib/fieldRegistry.ts
@@ -56,6 +56,12 @@ export interface FieldDefinition {
 	 * raw-id text box in condition/filter rules.
 	 */
 	refType?: "client" | "project" | "user" | "quote";
+	/**
+	 * The field holds an array of `type` values, not one. Filters match on
+	 * membership (`equals` = "is one of them"), and feeding one into a
+	 * single-valued destination takes the first element.
+	 */
+	isArray?: boolean;
 }
 
 const opt = (value: string, label: string) => ({ value, label });
@@ -172,6 +178,16 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 			creatable: true,
 			requiredOnCreate: true,
 			refType: "client",
+		},
+		{
+			key: "assignedUserIds",
+			label: "Assigned team",
+			type: "id",
+			writable: false,
+			writeExclusionReason: "References user records; assign from the project",
+			filterable: true,
+			refType: "user",
+			isArray: true,
 		},
 	],
 

--- a/packages/backend/convex/lib/workflowTypes.ts
+++ b/packages/backend/convex/lib/workflowTypes.ts
@@ -33,11 +33,68 @@ export const AUTOMATION_OBJECT_TYPES = [
 	"quote",
 	"invoice",
 	"task",
+	"quote_line_item",
+	"invoice_line_item",
 ] as const;
 
 export type AutomationObjectType = (typeof AUTOMATION_OBJECT_TYPES)[number];
 
+/**
+ * Types that can only be read (fetched + aggregated), never triggered on,
+ * created, or written. Line items are financial rows whose `amount`/`total`
+ * and whose parent's subtotal/total are recomputed by dedicated domain
+ * mutations; a raw automation write would skip both and silently drift an
+ * invoice. Every read-only surface derives from this list.
+ */
+export const FETCH_ONLY_OBJECT_TYPES = [
+	"quote_line_item",
+	"invoice_line_item",
+] as const;
+
+export type FetchOnlyObjectType = (typeof FETCH_ONLY_OBJECT_TYPES)[number];
+
+/** An object type an automation can trigger on / target a record of. */
+export type TriggerableObjectType = Exclude<
+	AutomationObjectType,
+	FetchOnlyObjectType
+>;
+
+export const TRIGGERABLE_OBJECT_TYPES = AUTOMATION_OBJECT_TYPES.filter(
+	(t): t is TriggerableObjectType =>
+		!(FETCH_ONLY_OBJECT_TYPES as readonly string[]).includes(t)
+);
+
+/**
+ * Rejecting a loop over a fetch-only type. Shared by publish validation
+ * (backend + web) and the executor's runtime backstop so they can't drift.
+ */
+export const LOOP_FETCH_ONLY_ERROR =
+	"Line items can be read and aggregated, but looping over them isn't supported";
+
+export function isFetchOnlyObjectType(
+	objectType: AutomationObjectType
+): objectType is FetchOnlyObjectType {
+	return (FETCH_ONLY_OBJECT_TYPES as readonly string[]).includes(objectType);
+}
+
+/** Every object type — fetch/aggregate sources included. */
 export const objectTypeValidator = v.union(
+	v.literal("client"),
+	v.literal("project"),
+	v.literal("quote"),
+	v.literal("invoice"),
+	v.literal("task"),
+	v.literal("quote_line_item"),
+	v.literal("invoice_line_item")
+);
+
+/**
+ * Triggerable types only. Triggers use this rather than the wide validator so
+ * a line-item trigger is unrepresentable rather than merely rejected — the
+ * executor's getObject() has a silent `default: return null`, so a bad stored
+ * trigger would no-op instead of erroring.
+ */
+export const triggerableObjectTypeValidator = v.union(
 	v.literal("client"),
 	v.literal("project"),
 	v.literal("quote"),
@@ -157,7 +214,7 @@ export const actionTargetValidator = v.union(
 	v.literal("self"),
 	// A record related to the one in scope (resolved via the field registry
 	// relations map, e.g. a task's project, a quote's client).
-	v.object({ related: objectTypeValidator })
+	v.object({ related: triggerableObjectTypeValidator })
 );
 
 export type ActionTarget = Infer<typeof actionTargetValidator>;
@@ -507,7 +564,7 @@ export const entryCriteriaValidator = v.object({
 
 export const statusChangedTriggerValidator = v.object({
 	type: v.literal("status_changed"),
-	objectType: objectTypeValidator,
+	objectType: triggerableObjectTypeValidator,
 	fromStatus: v.optional(v.string()),
 	toStatus: v.string(),
 	entryCriteria: v.optional(entryCriteriaValidator),
@@ -515,13 +572,13 @@ export const statusChangedTriggerValidator = v.object({
 
 export const recordCreatedTriggerValidator = v.object({
 	type: v.literal("record_created"),
-	objectType: objectTypeValidator,
+	objectType: triggerableObjectTypeValidator,
 	entryCriteria: v.optional(entryCriteriaValidator),
 });
 
 export const recordUpdatedTriggerValidator = v.object({
 	type: v.literal("record_updated"),
-	objectType: objectTypeValidator,
+	objectType: triggerableObjectTypeValidator,
 	/** Fire only when one of these fields changed; any field if omitted/empty. */
 	fields: v.optional(v.array(v.string())),
 	entryCriteria: v.optional(entryCriteriaValidator),
@@ -537,7 +594,7 @@ export const scheduledTriggerValidator = v.object({
 	 * stored rows parse; `triggerRecordObjectType()` returns undefined for
 	 * scheduled, and writes strip it.
 	 */
-	objectType: v.optional(objectTypeValidator),
+	objectType: v.optional(triggerableObjectTypeValidator),
 });
 
 export const triggerValidator = v.union(

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -7,6 +7,7 @@ import {
 	formulaResourceValidator,
 	nodeConfigValidator,
 	nodeTypeValidator,
+	objectTypeValidator,
 	triggerValidator,
 } from "./lib/workflowTypes";
 
@@ -1476,13 +1477,7 @@ export default defineSchema({
 				fetchOutputs: v.array(
 					v.object({
 						nodeId: v.string(),
-						objectType: v.union(
-							v.literal("client"),
-							v.literal("project"),
-							v.literal("quote"),
-							v.literal("invoice"),
-							v.literal("task")
-						),
+						objectType: objectTypeValidator,
 						recordIds: v.array(v.string()),
 						count: v.number(),
 					})

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -9,6 +9,7 @@ import {
 	nodeTypeValidator,
 	objectTypeValidator,
 	triggerValidator,
+	triggerableObjectTypeValidator,
 } from "./lib/workflowTypes";
 
 // v2 workflow node shape: each node carries the unified `config` union
@@ -1464,15 +1465,7 @@ export default defineSchema({
 				checkpointAt: v.optional(v.number()),
 				eventOldValue: v.optional(v.string()),
 				eventNewValue: v.optional(v.string()),
-				objectType: v.optional(
-					v.union(
-						v.literal("client"),
-						v.literal("project"),
-						v.literal("quote"),
-						v.literal("invoice"),
-						v.literal("task")
-					)
-				),
+				objectType: v.optional(triggerableObjectTypeValidator),
 				objectId: v.optional(v.string()),
 				fetchOutputs: v.array(
 					v.object({


### PR DESCRIPTION
This pull request refactors the automations UI code to distinguish between all automation object types and those that are valid as trigger sources. It introduces the `TriggerableObjectType` type and related constants, ensuring that only valid object types can be selected for triggers (e.g., line items are excluded). The changes also improve type safety across the codebase and enhance the user experience with clearer hints for array variable resolution and better support for invoices in value pickers.

**Type and Option Refactoring:**

* Replaced usage of `AutomationObjectType` with `TriggerableObjectType` for trigger-related types and props throughout the codebase, ensuring only valid trigger sources are selectable and improving type safety. [[1]](diffhunk://#diff-c3f393b17424aa2c2f361e08b7813177b189fadc3cb6f290960d920ffd8fb048R30-R33) [[2]](diffhunk://#diff-d7bbb6dbc6a767dc9d487a12bdcf2da9877e299d3681af8f12756f5c525525f1L32-R32) [[3]](diffhunk://#diff-d7bbb6dbc6a767dc9d487a12bdcf2da9877e299d3681af8f12756f5c525525f1L43-R43) [[4]](diffhunk://#diff-0c11235fe4a1577606a406820c8f8b3460bfce979f8e4eae08d8794666f1571bR34) [[5]](diffhunk://#diff-0c11235fe4a1577606a406820c8f8b3460bfce979f8e4eae08d8794666f1571bL120-R121) [[6]](diffhunk://#diff-0c11235fe4a1577606a406820c8f8b3460bfce979f8e4eae08d8794666f1571bL347-R348) [[7]](diffhunk://#diff-0c11235fe4a1577606a406820c8f8b3460bfce979f8e4eae08d8794666f1571bL712-R713) [[8]](diffhunk://#diff-0c11235fe4a1577606a406820c8f8b3460bfce979f8e4eae08d8794666f1571bL993-R994) [[9]](diffhunk://#diff-59dd78270c6ed87bcec63f4d06d3df9e1a4d4d379556d4a11751967e031cec32L18-R25) [[10]](diffhunk://#diff-59dd78270c6ed87bcec63f4d06d3df9e1a4d4d379556d4a11751967e031cec32L146-R146) [[11]](diffhunk://#diff-59dd78270c6ed87bcec63f4d06d3df9e1a4d4d379556d4a11751967e031cec32L223-R223) [[12]](diffhunk://#diff-0f753071641ca98373d2d153eb30abe04e10fd5bfdf79b2044d57d6daf159228R16-R24) [[13]](diffhunk://#diff-0f753071641ca98373d2d153eb30abe04e10fd5bfdf79b2044d57d6daf159228R36-R38) [[14]](diffhunk://#diff-0f753071641ca98373d2d153eb30abe04e10fd5bfdf79b2044d57d6daf159228R59) [[15]](diffhunk://#diff-0f753071641ca98373d2d153eb30abe04e10fd5bfdf79b2044d57d6daf159228L268-R292) [[16]](diffhunk://#diff-0f753071641ca98373d2d153eb30abe04e10fd5bfdf79b2044d57d6daf159228L291-R315) [[17]](diffhunk://#diff-0f753071641ca98373d2d153eb30abe04e10fd5bfdf79b2044d57d6daf159228L302-R333) [[18]](diffhunk://#diff-0f753071641ca98373d2d153eb30abe04e10fd5bfdf79b2044d57d6daf159228L332-R356) [[19]](diffhunk://#diff-0f753071641ca98373d2d153eb30abe04e10fd5bfdf79b2044d57d6daf159228L342-R408)
* Added `TRIGGERABLE_OBJECT_TYPES` and `TRIGGERABLE_OBJECT_TYPE_OPTIONS` constants, and updated trigger object type pickers to use these, preventing selection of fetch-only types like line items. [[1]](diffhunk://#diff-0f753071641ca98373d2d153eb30abe04e10fd5bfdf79b2044d57d6daf159228R16-R24) [[2]](diffhunk://#diff-0f753071641ca98373d2d153eb30abe04e10fd5bfdf79b2044d57d6daf159228R131-R143)

**UI and Usability Improvements:**

* Updated value pickers to support invoices, including fetching invoice options and displaying appropriate placeholder text. [[1]](diffhunk://#diff-edfd75d695e692af8c582bcb0d85fa7b95c9d0d1a0e263d492d275d986936ce2R151) [[2]](diffhunk://#diff-edfd75d695e692af8c582bcb0d85fa7b95c9d0d1a0e263d492d275d986936ce2R179-R182) [[3]](diffhunk://#diff-edfd75d695e692af8c582bcb0d85fa7b95c9d0d1a0e263d492d275d986936ce2R200-R215)
* Enhanced the variable picker UI with hints for how array variables resolve in single-valued fields (e.g., "uses first" or "matches any"), clarifying automation behavior for users. [[1]](diffhunk://#diff-edfd75d695e692af8c582bcb0d85fa7b95c9d0d1a0e263d492d275d986936ce2R457-R462) [[2]](diffhunk://#diff-edfd75d695e692af8c582bcb0d85fa7b95c9d0d1a0e263d492d275d986936ce2R482) [[3]](diffhunk://#diff-edfd75d695e692af8c582bcb0d85fa7b95c9d0d1a0e263d492d275d986936ce2R589-R597) [[4]](diffhunk://#diff-edfd75d695e692af8c582bcb0d85fa7b95c9d0d1a0e263d492d275d986936ce2R621-R625)
* Added support for passing an `arrayResolution` prop to `ValueInput`, allowing context-specific hints in filter editors and other panels. [[1]](diffhunk://#diff-f646d49d19a0c1599de715e23d0b560e5dc4624b97900fdac1f386451ad05fd7R323) [[2]](diffhunk://#diff-edfd75d695e692af8c582bcb0d85fa7b95c9d0d1a0e263d492d275d986936ce2R457-R462) [[3]](diffhunk://#diff-edfd75d695e692af8c582bcb0d85fa7b95c9d0d1a0e263d492d275d986936ce2R482)

**Test and Validation Updates:**

* Updated type imports and error references in validation tests to align with the new triggerable object type logic.

These changes collectively improve type safety, user experience, and maintainability in the automations editor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for fetching and aggregating quote and invoice line items.
  * Added invoice record selection for ID fields.
  * Enhanced array-aware variable handling and value resolution (including “uses first” / “matches any” hints).
* **Bug Fixes**
  * Improved condition evaluation for array comparisons (membership semantics for equals/not_equals).
  * Prevented unsupported loops over fetch-only line-item sources with clear publish-time errors, and added execution-time safeguards.
  * Improved coercion when array inputs are mapped to single-value foreign keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `TriggerableObjectType` (the subset of `AutomationObjectType` that excludes fetch-only line items) and wires it throughout the automations UI and backend. It also adds `quote_line_item` / `invoice_line_item` as first-class fetch-and-aggregate sources, fixes array-valued fields feeding single-valued action fields (takes first element), and adds symmetric array-membership logic to `looseEquals` for filter evaluation.

- **Type refactoring**: `TriggerableObjectType`, `TRIGGERABLE_OBJECT_TYPES`, `isFetchOnlyObjectType`, and `LOOP_FETCH_ONLY_ERROR` are introduced centrally in `workflowTypes.ts` and propagated consistently across the backend executor, publish validator, and UI panels.
- **Line item support**: `quote_line_item` and `invoice_line_item` are added to `FIELD_REGISTRY`, `takeOrgPage`, and `getObject` to enable fetch/aggregate workflows; a runtime and publish-time guard blocks them from being used as loop scope records.
- **Array coercion + hints**: `coerceFieldValue` now takes the first element when an array feeds a single-id field; `ValueInput` shows \"uses first\" / \"matches any\" hints; `looseEquals` is extended to check array membership on either side of an `equals` comparison.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core type refactoring, line-item fetch/aggregate, and array coercion changes are well-guarded at both publish time and runtime.

The looseEquals array-vs-array gap could silently cause a filter comparing two array-typed fields to never match, and resumeState.objectType in the schema remains a manually-maintained five-literal union rather than the new shared validator — both are forward-compatibility concerns rather than current breakage.

packages/backend/convex/lib/conditionEval.ts (array-vs-array equality gap) and packages/backend/convex/schema.ts (resumeState.objectType drift risk).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/backend/convex/lib/workflowTypes.ts | Central definition of TriggerableObjectType, FETCH_ONLY_OBJECT_TYPES, isFetchOnlyObjectType, triggerableObjectTypeValidator, and LOOP_FETCH_ONLY_ERROR. Well-structured; trigger validators correctly narrowed. |
| packages/backend/convex/lib/conditionEval.ts | looseEquals extended to handle array-vs-scalar membership correctly; silent gap when both sides are arrays (falls to reference equality). |
| packages/backend/convex/automationExecutor.ts | Line item fetch/aggregate support added (takeOrgPage, getObject, sampleRecordLabel); runtime loop guard added; coerceFieldValue takes first element of array for id fields; resolveCreateFk now handles invoice refType. |
| packages/backend/convex/schema.ts | fetchOutputs.objectType updated to objectTypeValidator (includes line items); resumeState.objectType and domainEvents.payload.entityType remain as hardcoded 5-type literal unions. |
| packages/backend/convex/lib/fieldRegistry.ts | quote_line_item and invoice_line_item entries added as read-only; project.assignedUserIds registered with isArray:true; refType expanded to include invoice; RELATED_OBJECTS updated. |
| apps/web/src/app/(workspace)/automations/components/sidebar/panels/value-input.tsx | Invoice option added to IdValueControl; arrayResolution prop wired to show uses first / matches any hints on array variables in picker. |
| apps/web/src/app/(workspace)/automations/lib/validation.ts | validateLoopNode now rejects loops whose fetch source is a fetch-only type; mirrors publish validator in automations.ts. |
| apps/web/src/app/(workspace)/automations/lib/variables.ts | getAvailableVariables and getAllVariableOptions skip loop item variables for fetch-only sources; asRefType corrected to return invoice; isArray propagated to variable options. |
| packages/backend/convex/eventBus.ts | Inline union of 5 entity type literals replaced with triggerableObjectTypeValidator; EntityType alias updated to TriggerableObjectType. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/backend/convex/schema.ts`, line 1467-1475 ([link](https://github.com/xcarter93/onetool/blob/1c5b1b5fa1c794639ed6478e2a45742b4dd349eb/packages/backend/convex/schema.ts#L1467-L1475)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`resumeState.objectType` not using shared validator**

   `resumeState.objectType` is still a hardcoded five-literal union rather than `triggerableObjectTypeValidator`. If a new triggerable type is added later and `triggerableObjectTypeValidator` is updated, saved delay-checkpoint rows for automations using that type would fail Convex schema validation on read — making those runs permanently unresumable. The adjacent `fetchOutputs.objectType` was already updated to use the shared `objectTypeValidator` in this PR; `resumeState.objectType` should follow the same pattern using `triggerableObjectTypeValidator`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/backend/convex/schema.ts
   Line: 1467-1475

   Comment:
   **`resumeState.objectType` not using shared validator**

   `resumeState.objectType` is still a hardcoded five-literal union rather than `triggerableObjectTypeValidator`. If a new triggerable type is added later and `triggerableObjectTypeValidator` is updated, saved delay-checkpoint rows for automations using that type would fail Convex schema validation on read — making those runs permanently unresumable. The adjacent `fetchOutputs.objectType` was already updated to use the shared `objectTypeValidator` in this PR; `resumeState.objectType` should follow the same pattern using `triggerableObjectTypeValidator`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/backend/convex/lib/conditionEval.ts:308-315
Array-vs-array case silently falls through to reference equality. If a user builds a filter like "project's assigned team equals {{trigger.record.assignedUserIds}}", both sides resolve to arrays, neither array branch fires, and the rule always returns `false` — the filter never matches. A natural interpretation would be "the two teams share at least one member". Consider a set-intersection check when both sides are arrays.

```suggestion
	if (Array.isArray(a) && !Array.isArray(b)) {
		return a.some((element) => looseEquals(element, b));
	}
	// Symmetric: an array compare value ({{loop.x.item.assignedUserIds}})
	// matches a scalar field on membership too — "assignee is one of them".
	if (Array.isArray(b) && !Array.isArray(a)) {
		return b.some((element) => looseEquals(a, element));
	}
	// Both sides are arrays: match when any element of a appears in b.
	if (Array.isArray(a) && Array.isArray(b)) {
		return a.some((element) => b.some((bEl) => looseEquals(element, bEl)));
	}
```

### Issue 2 of 2
packages/backend/convex/schema.ts:1467-1475
**`resumeState.objectType` not using shared validator**

`resumeState.objectType` is still a hardcoded five-literal union rather than `triggerableObjectTypeValidator`. If a new triggerable type is added later and `triggerableObjectTypeValidator` is updated, saved delay-checkpoint rows for automations using that type would fail Convex schema validation on read — making those runs permanently unresumable. The adjacent `fetchOutputs.objectType` was already updated to use the shared `objectTypeValidator` in this PR; `resumeState.objectType` should follow the same pattern using `triggerableObjectTypeValidator`.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(automations): B7/B8 self-review swee..."](https://github.com/xcarter93/onetool/commit/1c5b1b5fa1c794639ed6478e2a45742b4dd349eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45208071)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->