### PR TITLE
feat(community): ReUI redesign of community status page and editor

### DIFF
--- a/apps/web/src/app/(workspace)/community/components/nodes-illustration.tsx
+++ b/apps/web/src/app/(workspace)/community/components/nodes-illustration.tsx
@@ -1,0 +1,170 @@
+import { cn } from "@/lib/utils";
+
+// Vendored from a ReUI empty-state pattern: a hub-and-spoke node diagram.
+// Scales via className (viewBox preserved); colors resolve from theme tokens.
+export function NodesIllustration({ className }: { className?: string }) {
+	return (
+		<svg
+			viewBox="0 0 200 120"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			className={cn("h-[120px] w-[200px]", className)}
+		>
+			{/* Connection lines */}
+			<line
+				x1="100"
+				y1="60"
+				x2="44"
+				y2="30"
+				className="stroke-border"
+				strokeWidth="1.5"
+				strokeDasharray="4 3"
+			/>
+			<line
+				x1="100"
+				y1="60"
+				x2="44"
+				y2="90"
+				className="stroke-border"
+				strokeWidth="1.5"
+				strokeDasharray="4 3"
+			/>
+			<line
+				x1="100"
+				y1="60"
+				x2="156"
+				y2="30"
+				className="stroke-border"
+				strokeWidth="1.5"
+				strokeDasharray="4 3"
+			/>
+			<line
+				x1="100"
+				y1="60"
+				x2="156"
+				y2="90"
+				className="stroke-border"
+				strokeWidth="1.5"
+				strokeDasharray="4 3"
+			/>
+
+			{/* Center node */}
+			<circle
+				cx="100"
+				cy="60"
+				r="18"
+				className="fill-primary/10 dark:fill-primary/15 stroke-primary/40"
+				strokeWidth="1.5"
+			/>
+			<circle cx="100" cy="60" r="6" className="fill-primary/30" />
+			<circle cx="100" cy="60" r="2.5" className="fill-primary" />
+
+			{/* Top-left node */}
+			<circle
+				cx="44"
+				cy="30"
+				r="14"
+				className="fill-muted dark:fill-muted/60 stroke-border"
+				strokeWidth="1.5"
+			/>
+			<rect
+				x="37"
+				y="26"
+				width="14"
+				height="3"
+				rx="1.5"
+				className="fill-muted-foreground/20"
+			/>
+			<rect
+				x="40"
+				y="32"
+				width="8"
+				height="2"
+				rx="1"
+				className="fill-muted-foreground/12"
+			/>
+
+			{/* Bottom-left node */}
+			<circle
+				cx="44"
+				cy="90"
+				r="14"
+				className="fill-muted dark:fill-muted/60 stroke-border"
+				strokeWidth="1.5"
+			/>
+			<rect
+				x="37"
+				y="86"
+				width="14"
+				height="3"
+				rx="1.5"
+				className="fill-muted-foreground/20"
+			/>
+			<rect
+				x="40"
+				y="92"
+				width="8"
+				height="2"
+				rx="1"
+				className="fill-muted-foreground/12"
+			/>
+
+			{/* Top-right node */}
+			<circle
+				cx="156"
+				cy="30"
+				r="14"
+				className="fill-muted dark:fill-muted/60 stroke-border"
+				strokeWidth="1.5"
+			/>
+			<rect
+				x="149"
+				y="26"
+				width="14"
+				height="3"
+				rx="1.5"
+				className="fill-muted-foreground/20"
+			/>
+			<rect
+				x="152"
+				y="32"
+				width="8"
+				height="2"
+				rx="1"
+				className="fill-muted-foreground/12"
+			/>
+
+			{/* Bottom-right node */}
+			<circle
+				cx="156"
+				cy="90"
+				r="14"
+				className="fill-muted dark:fill-muted/60 stroke-border"
+				strokeWidth="1.5"
+			/>
+			<rect
+				x="149"
+				y="86"
+				width="14"
+				height="3"
+				rx="1.5"
+				className="fill-muted-foreground/20"
+			/>
+			<rect
+				x="152"
+				y="92"
+				width="8"
+				height="2"
+				rx="1"
+				className="fill-muted-foreground/12"
+			/>
+
+			{/* Small floating dots */}
+			<circle cx="72" cy="40" r="2" className="fill-primary/15" />
+			<circle cx="128" cy="80" r="2" className="fill-primary/15" />
+			<circle cx="72" cy="80" r="1.5" className="fill-muted-foreground/10" />
+			<circle cx="128" cy="40" r="1.5" className="fill-muted-foreground/10" />
+		</svg>
+	);
+}

--- a/apps/web/src/app/(workspace)/community/edit/community-edit-content.tsx
+++ b/apps/web/src/app/(workspace)/community/edit/community-edit-content.tsx
@@ -118,6 +118,7 @@ export default function CommunityEditContent() {
 		actions.isPublishing ||
 		!!actions.slugError ||
 		actions.isSlugAvailable === false ||
+		actions.isCheckingSlug ||
 		actions.hasInvalidSocialUrls ||
 		(!actions.hasUnsavedChanges && !mainSettings.isPublic);
 
@@ -231,6 +232,7 @@ export default function CommunityEditContent() {
 										!actions.hasPublishableContent ||
 										!!actions.slugError ||
 										actions.isSlugAvailable === false ||
+										actions.isCheckingSlug ||
 										actions.hasInvalidSocialUrls
 									}
 								>

--- a/apps/web/src/app/(workspace)/community/edit/community-edit-content.tsx
+++ b/apps/web/src/app/(workspace)/community/edit/community-edit-content.tsx
@@ -2,11 +2,31 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, Save, Send, Loader2, Globe, GlobeLock, Copy, Check, ExternalLink, Eye } from "lucide-react";
+import {
+	ArrowLeft,
+	Save,
+	Send,
+	Loader2,
+	GlobeLock,
+	Copy,
+	Check,
+	ExternalLink,
+	Eye,
+	Sparkles,
+	Palette,
+	BadgeCheck,
+	FileText,
+	Images,
+	Wrench,
+	Tags,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/reui/badge";
+import { Frame, FramePanel } from "@/components/reui/frame";
+import { Scrollspy } from "@/components/reui/scrollspy";
 import { cn } from "@/lib/utils";
 import { useCommunityPageForm, SECTION_LIST } from "./use-community-page-form";
+import type { SectionId } from "./use-community-page-form";
 import { MainSettingsSection } from "./sections/main-settings-section";
 import { BioSection } from "./sections/bio-section";
 import { GallerySection } from "./sections/gallery-section";
@@ -16,48 +36,72 @@ import { BusinessInfoSection } from "./sections/business-info-section";
 import { DesignSection } from "./sections/design-section";
 import { PreviewModal } from "./preview-modal";
 
+/** Sticky chrome is ~150px tall; scrollspy targets land just below it. */
+const SCROLLSPY_OFFSET = 160;
+
+const SECTION_ICONS: Record<
+	SectionId,
+	React.ComponentType<{ className?: string }>
+> = {
+	mainSettings: Sparkles,
+	design: Palette,
+	businessInfo: BadgeCheck,
+	bio: FileText,
+	imageGallery: Images,
+	services: Wrench,
+	pricing: Tags,
+};
+
 export default function CommunityEditContent() {
 	const router = useRouter();
-	const { mainSettings, design, businessInfo, bio, gallery, services, pricing, actions, activeSection, setActiveSection, sectionRefs, sectionRefSetters, dirtyBySection, isLoading, isRedirecting } = useCommunityPageForm();
+	const {
+		mainSettings,
+		design,
+		businessInfo,
+		bio,
+		gallery,
+		services,
+		pricing,
+		actions,
+		sectionRefSetters,
+		dirtyBySection,
+		isLoading,
+		isRedirecting,
+	} = useCommunityPageForm();
 	const isPageLoaded = !isLoading && !isRedirecting;
 	const [previewOpen, setPreviewOpen] = useState(false);
+
+	// The workspace card interior (.workspace-canvas) is the real scroller on
+	// desktop; the window scrolls on mobile. Point Scrollspy at whichever is live.
+	const scrollTargetRef = useRef<HTMLElement | Document | null>(null);
+	useEffect(() => {
+		const canvas = document.querySelector<HTMLElement>(".workspace-canvas");
+		const mq = window.matchMedia("(min-width: 768px)");
+		const update = () => {
+			scrollTargetRef.current = mq.matches && canvas ? canvas : document;
+		};
+		update();
+		mq.addEventListener("change", update);
+		return () => mq.removeEventListener("change", update);
+	}, []);
 
 	// Sentinel-based sticky header detection
 	const sentinelRef = useRef<HTMLDivElement>(null);
 	const [isSticky, setIsSticky] = useState(false);
 
 	useEffect(() => {
+		if (!isPageLoaded) return;
 		const sentinel = sentinelRef.current;
 		if (!sentinel) return;
 		const observer = new IntersectionObserver(
-			([entry]) => { setIsSticky(!entry.isIntersecting); },
+			([entry]) => {
+				setIsSticky(!entry.isIntersecting);
+			},
 			{ threshold: 0, rootMargin: "-72px 0px 0px 0px" },
 		);
 		observer.observe(sentinel);
 		return () => observer.disconnect();
-	}, []);
-
-	useEffect(() => {
-		if (!isPageLoaded) return;
-		const visibleSections = new Set<string>();
-		const observer = new IntersectionObserver(
-			(entries) => {
-				for (const entry of entries) {
-					if (entry.isIntersecting) visibleSections.add(entry.target.id);
-					else visibleSections.delete(entry.target.id);
-				}
-				for (const section of SECTION_LIST) {
-					if (visibleSections.has(section.id)) { setActiveSection(section.id); break; }
-				}
-			},
-			{ root: null, rootMargin: "-180px 0px -35% 0px", threshold: [0, 0.15] },
-		);
-		for (const section of SECTION_LIST) {
-			const element = sectionRefs.current[section.id];
-			if (element) observer.observe(element);
-		}
-		return () => observer.disconnect();
-	}, [isPageLoaded, setActiveSection, sectionRefs]);
+	}, [isPageLoaded]);
 
 	if (isLoading || isRedirecting) {
 		return (
@@ -69,8 +113,21 @@ export default function CommunityEditContent() {
 
 	const publicUrl = `${typeof window !== "undefined" ? window.location.origin : ""}/communities/${mainSettings.slug}`;
 
+	const saveDisabled =
+		actions.isSaving ||
+		actions.isPublishing ||
+		!!actions.slugError ||
+		actions.isSlugAvailable === false ||
+		actions.hasInvalidSocialUrls ||
+		(!actions.hasUnsavedChanges && !mainSettings.isPublic);
+
 	return (
-		<div className="relative min-h-screen bg-background">
+		// No background here — the workspace canvas dot texture stays visible
+		// across the whole page; content sits on opaque panels.
+		// shrink-0 (and no min-h override) keeps this flex item at full content
+		// height inside the fixed-height canvas; a shrunken root would end the
+		// sticky header's containing block after ~one viewport.
+		<div className="shrink-0">
 			{/* Sentinel for sticky detection */}
 			<div ref={sentinelRef} className="h-0 w-full" />
 
@@ -78,53 +135,83 @@ export default function CommunityEditContent() {
 			    pt-12 pushes visible content below main nav's notched items on desktop. */}
 			<div
 				className={cn(
-					"sticky top-0 z-20 bg-background transition-shadow duration-200 pt-10 md:pt-12",
-					isSticky
-						? "shadow-[0_4px_6px_-1px_rgba(0,0,0,0.1)] border-b border-border/60"
-						: "border-b border-border/60",
+					"sticky top-0 z-20 bg-background transition-shadow duration-200 pt-10 md:pt-12 border-b border-border/60",
+					isSticky && "shadow-[0_4px_6px_-1px_rgba(0,0,0,0.1)]",
 				)}
 			>
 				<div className="mx-auto px-4 sm:px-6 lg:px-8 py-4">
 					<div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-						<div className="flex items-center gap-4">
-							<Button variant="outline" size="icon-sm" onClick={() => router.push("/community")} aria-label="Back to Community">
+						<div className="flex items-center gap-4 min-w-0">
+							<Button
+								variant="outline"
+								size="icon-sm"
+								onClick={() => router.push("/community")}
+								aria-label="Back to Community"
+							>
 								<ArrowLeft className="size-4" />
 							</Button>
-							<div>
+							<div className="min-w-0">
 								<div className="flex items-center gap-3">
-									<h1 className="text-xl font-bold text-fg">Edit Page</h1>
+									<h1 className="text-xl font-bold text-fg truncate">
+										{mainSettings.pageTitle || "Edit Page"}
+									</h1>
 									{mainSettings.isPublic ? (
-										<Badge variant="success" className="transition-all duration-200"><Globe className="size-3" />Live</Badge>
+										<Badge variant="success" className="shrink-0">
+											<span className="relative flex size-2" aria-hidden>
+												<span className="absolute inline-flex size-full animate-ping rounded-full bg-emerald-400 opacity-75 motion-reduce:animate-none" />
+												<span className="relative inline-flex size-2 rounded-full bg-emerald-500" />
+											</span>
+											Live
+										</Badge>
 									) : (
-										<Badge variant="warning" className="transition-all duration-200"><GlobeLock className="size-3" />Private</Badge>
+										<Badge variant="warning" className="shrink-0">
+											<GlobeLock className="size-3" />
+											Private
+										</Badge>
+									)}
+									{actions.hasUnsavedChanges && (
+										<span
+											className="size-2 shrink-0 rounded-full bg-amber-500"
+											title="Unsaved changes"
+										/>
 									)}
 								</div>
 								{mainSettings.isPublic && (
 									<div className="flex items-center gap-2 mt-1">
-										<a href={publicUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-muted-fg hover:text-fg font-mono flex items-center gap-1 transition-colors">
-											{publicUrl}<ExternalLink className="size-3" />
+										<a
+											href={publicUrl}
+											target="_blank"
+											rel="noopener noreferrer"
+											className="text-xs text-muted-fg hover:text-fg font-mono flex items-center gap-1 transition-colors truncate"
+										>
+											{publicUrl}
+											<ExternalLink className="size-3 shrink-0" />
 										</a>
-										<button onClick={mainSettings.handleCopyUrl} className="text-xs text-muted-fg hover:text-fg transition-colors">
-											{mainSettings.copied ? <Check className="size-3 text-emerald-500" /> : <Copy className="size-3" />}
+										<button
+											onClick={mainSettings.handleCopyUrl}
+											className="text-xs text-muted-fg hover:text-fg transition-colors"
+											aria-label="Copy public URL"
+										>
+											{mainSettings.copied ? (
+												<Check className="size-3 text-emerald-500" />
+											) : (
+												<Copy className="size-3" />
+											)}
 										</button>
 									</div>
 								)}
 							</div>
 						</div>
-						<div className="flex items-center gap-3">
+						<div className="flex items-center gap-2.5 shrink-0">
 							<Button
 								variant="outline"
 								size="sm"
 								onClick={() => setPreviewOpen(true)}
 							>
 								<Eye className="size-4 mr-2" />
-								Preview Page
+								Preview
 							</Button>
-							{actions.hasUnsavedChanges && (
-								<span className="text-sm font-medium text-amber-600 dark:text-amber-500 animate-pulse hidden sm:inline-block pr-2">Unsaved changes</span>
-							)}
-							{mainSettings.isPublic && (
-								// TODO(reui-rebuild): warning button intent mapped to outline
+							{mainSettings.isPublic ? (
 								<Button
 									variant="outline"
 									size="sm"
@@ -133,62 +220,137 @@ export default function CommunityEditContent() {
 									<GlobeLock className="size-4 mr-2" />
 									Make Private
 								</Button>
-							)}
-							{!mainSettings.isPublic && (
-								// TODO(reui-rebuild): success button intent mapped to default
+							) : (
 								<Button
 									variant="default"
+									size="sm"
 									onClick={actions.handlePublish}
-									disabled={actions.isSaving || actions.isPublishing || !actions.hasPublishableContent || !!actions.slugError || actions.isSlugAvailable === false || actions.hasInvalidSocialUrls}
+									disabled={
+										actions.isSaving ||
+										actions.isPublishing ||
+										!actions.hasPublishableContent ||
+										!!actions.slugError ||
+										actions.isSlugAvailable === false ||
+										actions.hasInvalidSocialUrls
+									}
 								>
-									{actions.isPublishing ? <Loader2 className="size-4 mr-2 animate-spin" /> : <Send className="size-4 mr-2" />}
+									{actions.isPublishing ? (
+										<Loader2 className="size-4 mr-2 animate-spin" />
+									) : (
+										<Send className="size-4 mr-2" />
+									)}
 									Publish
 								</Button>
 							)}
 							<Button
 								variant={actions.hasUnsavedChanges ? "default" : "secondary"}
+								size="sm"
 								onClick={actions.handleSave}
-								disabled={actions.isSaving || actions.isPublishing || !!actions.slugError || actions.isSlugAvailable === false || actions.hasInvalidSocialUrls || (!actions.hasUnsavedChanges && !mainSettings.isPublic)}
+								disabled={saveDisabled}
 							>
-								{actions.isSaving ? <Loader2 className="size-4 mr-2 animate-spin" /> : <Save className="size-4 mr-2" />}
+								{actions.isSaving ? (
+									<Loader2 className="size-4 mr-2 animate-spin" />
+								) : (
+									<Save className="size-4 mr-2" />
+								)}
 								{mainSettings.isPublic ? "Save Changes" : "Save Draft"}
 							</Button>
 						</div>
 					</div>
 				</div>
 			</div>
-			{/* Content area — pt-6 gives breathing room below sticky header */}
-			<div className="mx-auto px-4 sm:px-6 lg:px-8 pt-6 pb-8">
-				<div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_260px]">
-					<div className="space-y-12 pb-[40vh]">
-						<MainSettingsSection {...mainSettings} sectionRef={sectionRefSetters.mainSettings} />
-						<DesignSection {...design} sectionRef={sectionRefSetters.design} />
-						<BusinessInfoSection {...businessInfo} sectionRef={sectionRefSetters.businessInfo} />
-						<BioSection {...bio} sectionRef={sectionRefSetters.bio} />
-						<GallerySection {...gallery} sectionRef={sectionRefSetters.imageGallery} />
-						<ServicesSection {...services} sectionRef={sectionRefSetters.services} />
-						<PricingSection {...pricing} sectionRef={sectionRefSetters.pricing} />
-					</div>
-					<aside className="hidden lg:block">
-						<div className="sticky top-40 rounded-xl border border-border/60 bg-background p-3">
-							<nav className="space-y-1">
-								{SECTION_LIST.map((section) => (
-									<button key={section.id} type="button"
-										onClick={() => sectionRefs.current[section.id]?.scrollIntoView({ behavior: "smooth", block: "start" })}
-										className={cn(
-											"w-full text-left px-3 py-2 rounded-lg text-sm transition-all duration-200 flex items-center justify-between",
-											activeSection === section.id ? "bg-primary/10 text-primary font-medium ring-1 ring-primary/20 shadow-sm" : "text-muted-fg hover:bg-muted/40 hover:text-fg",
-										)}
-									>
-										<span>{section.label}</span>
-										{dirtyBySection[section.id] && <span className="size-2 rounded-full bg-amber-500" />}
-									</button>
-								))}
-							</nav>
+
+			{/* Content area — scrollspy rail + stacked sections */}
+			<Scrollspy targetRef={scrollTargetRef} offset={SCROLLSPY_OFFSET}>
+				<div className="mx-auto px-4 sm:px-6 lg:px-8 pt-6 pb-8">
+					{/* Mobile section chips */}
+					<div className="lg:hidden -mx-4 px-4 mb-6 overflow-x-auto">
+						<div className="flex w-max gap-2 pb-1">
+							{SECTION_LIST.map((section) => (
+								<button
+									key={section.id}
+									type="button"
+									data-scrollspy-anchor={section.id}
+									className="flex shrink-0 items-center gap-1.5 rounded-full border border-border/60 bg-card px-3 py-1.5 text-xs font-medium text-muted-fg transition-colors cursor-pointer data-[active=true]:border-primary/40 data-[active=true]:text-primary"
+								>
+									{section.label}
+									{dirtyBySection[section.id] && (
+										<span className="size-1.5 rounded-full bg-amber-500" />
+									)}
+								</button>
+							))}
 						</div>
-					</aside>
+					</div>
+
+					<div className="grid gap-10 lg:grid-cols-[240px_minmax(0,1fr)]">
+						{/* Desktop rail */}
+						<aside className="hidden lg:block">
+							<nav
+								aria-label="Page sections"
+								className="sticky top-40 space-y-0.5 rounded-xl border border-border/60 bg-card p-3 shadow-xs"
+							>
+								<p className="px-3 pb-2 text-[11px] font-semibold uppercase tracking-wider text-muted-fg">
+									Sections
+								</p>
+								{SECTION_LIST.map((section) => {
+									const Icon = SECTION_ICONS[section.id];
+									return (
+										<button
+											key={section.id}
+											type="button"
+											data-scrollspy-anchor={section.id}
+											className={cn(
+												"group flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-sm text-muted-fg transition-colors cursor-pointer",
+												"hover:bg-muted/40 hover:text-fg",
+												"data-[active=true]:bg-primary/10 data-[active=true]:text-primary data-[active=true]:font-medium",
+											)}
+										>
+											<Icon className="size-4 shrink-0 opacity-70 group-data-[active=true]:opacity-100" />
+											<span className="flex-1 truncate">{section.label}</span>
+											{dirtyBySection[section.id] && (
+												<span
+													className="size-2 shrink-0 rounded-full bg-amber-500"
+													title="Unsaved changes in this section"
+												/>
+											)}
+										</button>
+									);
+								})}
+							</nav>
+						</aside>
+
+						{/* Sections */}
+						<div className="min-w-0 pb-[40vh]">
+							<Frame>
+								<FramePanel className="space-y-12 px-6 py-8 sm:px-8">
+							<MainSettingsSection
+								{...mainSettings}
+								sectionRef={sectionRefSetters.mainSettings}
+							/>
+							<DesignSection {...design} sectionRef={sectionRefSetters.design} />
+							<BusinessInfoSection
+								{...businessInfo}
+								sectionRef={sectionRefSetters.businessInfo}
+							/>
+							<BioSection {...bio} sectionRef={sectionRefSetters.bio} />
+							<GallerySection
+								{...gallery}
+								sectionRef={sectionRefSetters.imageGallery}
+							/>
+							<ServicesSection
+								{...services}
+								sectionRef={sectionRefSetters.services}
+							/>
+							<PricingSection
+								{...pricing}
+								sectionRef={sectionRefSetters.pricing}
+							/>
+								</FramePanel>
+							</Frame>
+						</div>
+					</div>
 				</div>
-			</div>
+			</Scrollspy>
 
 			<PreviewModal
 				open={previewOpen}
@@ -196,31 +358,66 @@ export default function CommunityEditContent() {
 				pageTitle={mainSettings.pageTitle}
 				bannerUrl={mainSettings.bannerUrl}
 				avatarUrl={mainSettings.avatarUrl}
-				organization={mainSettings.organization ? { name: mainSettings.organization.name, email: mainSettings.organization.email, phone: mainSettings.organization.phone, website: mainSettings.organization.website } : null}
+				organization={
+					mainSettings.organization
+						? {
+								name: mainSettings.organization.name,
+								email: mainSettings.organization.email,
+								phone: mainSettings.organization.phone,
+								website: mainSettings.organization.website,
+							}
+						: null
+				}
 				bioContent={bio.bioContent}
 				servicesContent={services.servicesContent}
 				pricingMode={pricing.pricingMode}
 				pricingContent={pricing.pricingContent}
 				pricingTiers={pricing.pricingTiers}
-				galleryImages={gallery.galleryItems.filter(item => item.url).map(item => ({ url: item.url!, storageId: String(item.storageId), sortOrder: item.sortOrder }))}
+				galleryImages={gallery.galleryItems
+					.filter((item) => item.url)
+					.map((item) => ({
+						url: item.url!,
+						storageId: String(item.storageId),
+						sortOrder: item.sortOrder,
+					}))}
 				theme={design.theme}
-				ownerInfo={businessInfo.ownerName || businessInfo.ownerTitle ? { name: businessInfo.ownerName || undefined, title: businessInfo.ownerTitle || undefined } : undefined}
+				ownerInfo={
+					businessInfo.ownerName || businessInfo.ownerTitle
+						? {
+								name: businessInfo.ownerName || undefined,
+								title: businessInfo.ownerTitle || undefined,
+							}
+						: undefined
+				}
 				credentials={
-					businessInfo.isLicensed || businessInfo.isBonded || businessInfo.isInsured || businessInfo.yearEstablished || businessInfo.certifications.length > 0
+					businessInfo.isLicensed ||
+					businessInfo.isBonded ||
+					businessInfo.isInsured ||
+					businessInfo.yearEstablished ||
+					businessInfo.certifications.length > 0
 						? {
 								isLicensed: businessInfo.isLicensed || undefined,
 								isBonded: businessInfo.isBonded || undefined,
 								isInsured: businessInfo.isInsured || undefined,
 								yearEstablished: businessInfo.yearEstablished,
-								certifications: businessInfo.certifications.length > 0 ? businessInfo.certifications : undefined,
+								certifications:
+									businessInfo.certifications.length > 0
+										? businessInfo.certifications
+										: undefined,
 							}
 						: undefined
 				}
 				businessHours={{
 					byAppointmentOnly: businessInfo.byAppointmentOnly,
-					schedule: businessInfo.byAppointmentOnly ? undefined : businessInfo.businessSchedule,
+					schedule: businessInfo.byAppointmentOnly
+						? undefined
+						: businessInfo.businessSchedule,
 				}}
-				socialLinks={Object.values(businessInfo.socialLinks).some(Boolean) ? businessInfo.socialLinks : undefined}
+				socialLinks={
+					Object.values(businessInfo.socialLinks).some(Boolean)
+						? businessInfo.socialLinks
+						: undefined
+				}
 			/>
 		</div>
 	);

--- a/apps/web/src/app/(workspace)/community/edit/components/theme-card.tsx
+++ b/apps/web/src/app/(workspace)/community/edit/components/theme-card.tsx
@@ -60,7 +60,7 @@ export function ThemeCard({
 			type="button"
 			onClick={onSelect}
 			className={cn(
-				"relative w-full text-left rounded-xl border-2 p-4 transition-all duration-200 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+				"relative w-full text-left rounded-xl border-2 p-4 cursor-pointer transition-colors duration-200 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
 				isSelected
 					? "border-primary ring-2 ring-primary/20 shadow-sm"
 					: "border-border hover:border-border/80",

--- a/apps/web/src/app/(workspace)/community/edit/components/theme-card.tsx
+++ b/apps/web/src/app/(workspace)/community/edit/components/theme-card.tsx
@@ -58,6 +58,7 @@ export function ThemeCard({
 	return (
 		<button
 			type="button"
+			aria-pressed={isSelected}
 			onClick={onSelect}
 			className={cn(
 				"relative w-full text-left rounded-xl border-2 p-4 cursor-pointer transition-colors duration-200 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",

--- a/apps/web/src/app/(workspace)/community/edit/sections/bio-section.tsx
+++ b/apps/web/src/app/(workspace)/community/edit/sections/bio-section.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import React from "react";
+import { FileText } from "lucide-react";
 import type { JSONContent } from "@tiptap/react";
 import { CommunityEditor } from "@/components/tiptap/community-editor";
+import { SectionShell } from "./section-shell";
 
 interface BioSectionProps {
 	bioContent: JSONContent | undefined;
@@ -16,22 +18,18 @@ export const BioSection = React.memo(function BioSection({
 	sectionRef,
 }: BioSectionProps) {
 	return (
-		<section
+		<SectionShell
 			id="bio"
-			ref={sectionRef}
-			className="scroll-mt-44"
+			sectionRef={sectionRef}
+			icon={FileText}
+			title="Bio"
+			description="Tell visitors who you are and what makes your business unique."
 		>
-			<div className="mb-4">
-				<h2 className="text-lg font-semibold text-fg">Bio</h2>
-				<p className="text-sm text-muted-fg">
-					Tell visitors who you are and what makes your business unique.
-				</p>
-			</div>
 			<CommunityEditor
 				content={bioContent}
 				onChange={setBioContent}
 				placeholder="Share your story, background, and core values..."
 			/>
-		</section>
+		</SectionShell>
 	);
 });

--- a/apps/web/src/app/(workspace)/community/edit/sections/business-info-section.tsx
+++ b/apps/web/src/app/(workspace)/community/edit/sections/business-info-section.tsx
@@ -246,6 +246,7 @@ export const BusinessInfoSection = React.memo(function BusinessInfoSection({
 						<button
 							key={cred.label}
 							type="button"
+							aria-pressed={cred.checked}
 							onClick={() => cred.toggle(!cred.checked)}
 							className={`group relative flex flex-col items-center justify-center w-28 sm:w-32 p-4 rounded-xl border cursor-pointer select-none transition-colors duration-200 ${
 								cred.checked

--- a/apps/web/src/app/(workspace)/community/edit/sections/business-info-section.tsx
+++ b/apps/web/src/app/(workspace)/community/edit/sections/business-info-section.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { Field, FieldLabel } from "@/components/ui/field";
 import { TagsInput } from "@/components/shared/tags-input";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -24,6 +25,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import { SectionShell } from "./section-shell";
 import type { DaySchedule, SocialLinks } from "../use-community-page-form";
 import { isValidUrl } from "@/lib/validators";
 
@@ -141,9 +143,7 @@ const SocialLinkInput = React.memo(function SocialLinkInput({
 			<div className="flex-1">
 				<div
 					className={
-						invalid
-							? "rounded-md ring-2 ring-red-500 ring-offset-0"
-							: undefined
+						invalid ? "rounded-md ring-2 ring-danger ring-offset-0" : undefined
 					}
 				>
 					<Input
@@ -153,7 +153,7 @@ const SocialLinkInput = React.memo(function SocialLinkInput({
 					/>
 				</div>
 				{invalid && (
-					<p className="text-xs text-red-600 dark:text-red-400 mt-1">
+					<p className="text-xs text-danger mt-1">
 						Please enter a valid URL (e.g. https://example.com)
 					</p>
 				)}
@@ -198,43 +198,46 @@ export const BusinessInfoSection = React.memo(function BusinessInfoSection({
 		);
 	};
 
-	return (
-		<section id="businessInfo" ref={sectionRef} className="scroll-mt-48">
-			<h2 className="text-lg font-semibold text-fg mb-6">Business Info</h2>
+	const sublabelClass =
+		"text-[11px] font-semibold uppercase tracking-wider text-muted-fg";
 
+	return (
+		<SectionShell
+			id="businessInfo"
+			sectionRef={sectionRef}
+			icon={BadgeCheck}
+			title="Business Info"
+			description="Tell clients who they'll be working with."
+		>
 			{/* Owner Info */}
-			<div className="space-y-4 mb-8">
-				<h3 className="text-sm font-medium text-muted-fg uppercase tracking-wider">
-					Owner Info
-				</h3>
+			<div className="space-y-4">
+				<h3 className={sublabelClass}>Owner Info</h3>
 				<div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-					<div className="space-y-1.5">
-						<Label htmlFor="ownerName">Your Name</Label>
+					<Field>
+						<FieldLabel htmlFor="ownerName">Your Name</FieldLabel>
 						<Input
 							id="ownerName"
 							placeholder="e.g., Jane Doe"
 							value={ownerName}
 							onChange={(e) => setOwnerName(e.target.value)}
 						/>
-					</div>
-					<div className="space-y-1.5">
-						<Label htmlFor="ownerTitle">Your Title</Label>
+					</Field>
+					<Field>
+						<FieldLabel htmlFor="ownerTitle">Your Title</FieldLabel>
 						<Input
 							id="ownerTitle"
 							placeholder="e.g., Owner & Operator"
 							value={ownerTitle}
 							onChange={(e) => setOwnerTitle(e.target.value)}
 						/>
-					</div>
+					</Field>
 				</div>
 			</div>
 
 			{/* Credentials */}
-			<div className="space-y-4 mb-8">
-				<h3 className="text-sm font-medium text-muted-fg uppercase tracking-wider">
-					Credentials
-				</h3>
-				<div className="flex flex-wrap gap-4">
+			<div className="space-y-4 border-t border-border/40 pt-6">
+				<h3 className={sublabelClass}>Credentials</h3>
+				<div className="flex flex-wrap gap-3">
 					{([
 						{ label: "Licensed", icon: ShieldCheck, checked: isLicensed, toggle: setIsLicensed },
 						{ label: "Bonded", icon: Handshake, checked: isBonded, toggle: setIsBonded },
@@ -244,19 +247,19 @@ export const BusinessInfoSection = React.memo(function BusinessInfoSection({
 							key={cred.label}
 							type="button"
 							onClick={() => cred.toggle(!cred.checked)}
-							className={`group relative flex flex-col items-center justify-center w-28 sm:w-32 p-5 rounded-2xl border transition-all duration-300 ease-in-out transform hover:scale-105 hover:z-10 shadow-sm hover:shadow-md cursor-pointer select-none ${
+							className={`group relative flex flex-col items-center justify-center w-28 sm:w-32 p-4 rounded-xl border cursor-pointer select-none transition-colors duration-200 ${
 								cred.checked
-									? "bg-gradient-to-br from-primary/15 to-primary/25 border-primary/50 ring-2 ring-primary/30 shadow-primary/10"
-									: "bg-card/80 border-border/60 hover:border-primary/30 hover:bg-card/90"
+									? "border-primary/40 bg-primary/10"
+									: "border-border/60 bg-card/60 hover:border-primary/30 hover:bg-card/90"
 							}`}
 						>
 							{cred.checked && (
-								<div className="absolute -top-2 -right-2 w-6 h-6 bg-gradient-to-br from-primary to-primary/80 rounded-full flex items-center justify-center shadow-md ring-2 ring-background">
-									<Check className="w-3.5 h-3.5 text-primary-foreground" />
+								<div className="absolute -top-2 -right-2 size-5 bg-primary rounded-full flex items-center justify-center ring-2 ring-background">
+									<Check className="size-3 text-primary-foreground" />
 								</div>
 							)}
 							<cred.icon
-								className={`w-8 h-8 mb-2 transition-all duration-300 ${
+								className={`size-7 mb-2 transition-colors duration-200 ${
 									cred.checked
 										? "text-primary"
 										: "text-muted-fg group-hover:text-primary"
@@ -275,8 +278,8 @@ export const BusinessInfoSection = React.memo(function BusinessInfoSection({
 					))}
 				</div>
 				<div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-					<div className="space-y-1.5">
-						<Label htmlFor="yearEstablished">Year Established</Label>
+					<Field>
+						<FieldLabel htmlFor="yearEstablished">Year Established</FieldLabel>
 						<Input
 							id="yearEstablished"
 							type="number"
@@ -294,33 +297,31 @@ export const BusinessInfoSection = React.memo(function BusinessInfoSection({
 								}
 							}}
 						/>
-					</div>
-					<div className="space-y-1.5">
-						<Label htmlFor="licenseNumber">License Number</Label>
+					</Field>
+					<Field>
+						<FieldLabel htmlFor="licenseNumber">License Number</FieldLabel>
 						<Input
 							id="licenseNumber"
 							placeholder="e.g., ABC-123456"
 							value={licenseNumber}
 							onChange={(e) => setLicenseNumber(e.target.value)}
 						/>
-					</div>
+					</Field>
 				</div>
-				<div className="space-y-1.5">
-					<Label>Additional Certifications</Label>
+				<Field>
+					<FieldLabel>Additional Certifications</FieldLabel>
 					<TagsInput
 						tags={certifications}
 						setTags={setCertifications}
 						placeholder="Type a certification and press Enter"
 					/>
-				</div>
+				</Field>
 			</div>
 
 			{/* Business Hours */}
-			<div className="space-y-4 mb-8">
-				<h3 className="text-sm font-medium text-muted-fg uppercase tracking-wider">
-					Business Hours
-				</h3>
-				<div className="flex items-center gap-3 mb-4">
+			<div className="space-y-4 border-t border-border/40 pt-6">
+				<h3 className={sublabelClass}>Business Hours</h3>
+				<div className="flex items-center gap-3">
 					<Switch
 						checked={byAppointmentOnly}
 						onCheckedChange={setByAppointmentOnly}
@@ -390,10 +391,8 @@ export const BusinessInfoSection = React.memo(function BusinessInfoSection({
 			</div>
 
 			{/* Social Links */}
-			<div className="space-y-4">
-				<h3 className="text-sm font-medium text-muted-fg uppercase tracking-wider">
-					Social Links
-				</h3>
+			<div className="space-y-4 border-t border-border/40 pt-6">
+				<h3 className={sublabelClass}>Social Links</h3>
 				<div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
 					{SOCIAL_PLATFORMS.map((platform) => (
 						<SocialLinkInput
@@ -411,6 +410,6 @@ export const BusinessInfoSection = React.memo(function BusinessInfoSection({
 					))}
 				</div>
 			</div>
-		</section>
+		</SectionShell>
 	);
 });

--- a/apps/web/src/app/(workspace)/community/edit/sections/design-section.tsx
+++ b/apps/web/src/app/(workspace)/community/edit/sections/design-section.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { Palette } from "lucide-react";
+
+import { SectionShell } from "./section-shell";
 import { ThemeCard } from "../components/theme-card";
 
 interface DesignSectionProps {
@@ -32,18 +35,13 @@ export function DesignSection({
 	sectionRef,
 }: DesignSectionProps) {
 	return (
-		<section
+		<SectionShell
 			id="design"
-			ref={sectionRef}
-			className="border-t border-border/40 pt-12 space-y-6"
+			sectionRef={sectionRef}
+			icon={Palette}
+			title="Design"
+			description="Choose a visual style for your public page."
 		>
-			<div>
-				<h2 className="text-lg font-semibold text-fg">Page Design</h2>
-				<p className="text-sm text-muted-fg mt-1">
-					Choose a visual style for your public page.
-				</p>
-			</div>
-
 			<div className="grid grid-cols-1 md:grid-cols-3 gap-4">
 				{THEMES.map((t) => (
 					<ThemeCard
@@ -56,6 +54,6 @@ export function DesignSection({
 					/>
 				))}
 			</div>
-		</section>
+		</SectionShell>
 	);
 }

--- a/apps/web/src/app/(workspace)/community/edit/sections/gallery-section.tsx
+++ b/apps/web/src/app/(workspace)/community/edit/sections/gallery-section.tsx
@@ -6,6 +6,7 @@ import {
 	Trash2,
 	Loader2,
 	ImageIcon,
+	Images,
 	ChevronUp,
 	ChevronDown,
 	Plus,
@@ -13,6 +14,7 @@ import {
 
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/reui/badge";
+import { SectionShell } from "./section-shell";
 import type { Id } from "@onetool/backend/convex/_generated/dataModel";
 import { MAX_GALLERY_IMAGES, type GalleryItem } from "../use-community-page-form";
 
@@ -36,39 +38,38 @@ export const GallerySection = React.memo(function GallerySection({
 	sectionRef,
 }: GallerySectionProps) {
 	return (
-		<section
+		<SectionShell
 			id="imageGallery"
-			ref={sectionRef}
-			className="scroll-mt-44"
-		>
-			<div className="mb-4 flex items-start justify-between gap-4">
+			sectionRef={sectionRef}
+			icon={Images}
+			title="Image Gallery"
+			description="Show off recent work with photos."
+			headerAccessory={
 				<div className="flex items-center gap-3">
-					<h2 className="text-lg font-semibold text-fg">
-						Image Gallery
-					</h2>
 					<Badge
 						variant={galleryItems.length >= MAX_GALLERY_IMAGES ? "warning" : "default"}
 						className="transition-all duration-200"
 					>
 						{galleryItems.length}/{MAX_GALLERY_IMAGES}
 					</Badge>
+					{galleryItems.length > 0 && galleryItems.length < MAX_GALLERY_IMAGES && (
+						<Button
+							variant="secondary"
+							size="sm"
+							onClick={() => galleryInputRef.current?.click()}
+							disabled={isUploadingGallery}
+						>
+							{isUploadingGallery ? (
+								<Loader2 className="size-4 mr-2 animate-spin" />
+							) : (
+								<Plus className="size-4 mr-2" />
+							)}
+							Add Image
+						</Button>
+					)}
 				</div>
-				{galleryItems.length > 0 && galleryItems.length < MAX_GALLERY_IMAGES && (
-					<Button
-						variant="secondary"
-						size="sm"
-						onClick={() => galleryInputRef.current?.click()}
-						disabled={isUploadingGallery}
-					>
-						{isUploadingGallery ? (
-							<Loader2 className="size-4 mr-2 animate-spin" />
-						) : (
-							<Plus className="size-4 mr-2" />
-						)}
-						Add Image
-					</Button>
-				)}
-			</div>
+			}
+		>
 			<input
 				ref={galleryInputRef}
 				type="file"
@@ -114,8 +115,8 @@ export const GallerySection = React.memo(function GallerySection({
 										<Loader2 className="size-5 animate-spin" />
 									</div>
 								)}
-								<div className="absolute inset-0 bg-linear-to-t from-black/60 via-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
-								<div className="absolute bottom-0 inset-x-0 p-3 flex items-end justify-between opacity-0 group-hover:opacity-100 transition-opacity">
+								<div className="absolute inset-0 bg-linear-to-t from-black/60 via-black/20 to-transparent opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-200" />
+								<div className="absolute bottom-0 inset-x-0 p-3 flex items-end justify-between opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-200">
 									<span className="text-xs font-medium text-white/90 bg-black/30 backdrop-blur-sm rounded-md px-2 py-1">
 										{index + 1} of {galleryItems.length}
 									</span>
@@ -124,7 +125,8 @@ export const GallerySection = React.memo(function GallerySection({
 											type="button"
 											onClick={() => moveGalleryItem(index, -1)}
 											disabled={index === 0}
-											className="size-8 rounded-lg bg-white/20 backdrop-blur-sm text-white flex items-center justify-center hover:bg-white/30 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+											aria-label="Move image earlier"
+											className="size-8 rounded-lg bg-white/20 backdrop-blur-sm text-white flex items-center justify-center hover:bg-white/30 transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed"
 										>
 											<ChevronUp className="size-4" />
 										</button>
@@ -132,14 +134,16 @@ export const GallerySection = React.memo(function GallerySection({
 											type="button"
 											onClick={() => moveGalleryItem(index, 1)}
 											disabled={index === galleryItems.length - 1}
-											className="size-8 rounded-lg bg-white/20 backdrop-blur-sm text-white flex items-center justify-center hover:bg-white/30 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+											aria-label="Move image later"
+											className="size-8 rounded-lg bg-white/20 backdrop-blur-sm text-white flex items-center justify-center hover:bg-white/30 transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed"
 										>
 											<ChevronDown className="size-4" />
 										</button>
 										<button
 											type="button"
 											onClick={() => removeGalleryItem(item.storageId)}
-											className="size-8 rounded-lg bg-red-500/80 backdrop-blur-sm text-white flex items-center justify-center hover:bg-red-500 transition-colors"
+											aria-label="Remove image"
+											className="size-8 rounded-lg bg-danger/80 backdrop-blur-sm text-white flex items-center justify-center hover:bg-danger transition-colors cursor-pointer"
 										>
 											<Trash2 className="size-4" />
 										</button>
@@ -165,6 +169,6 @@ export const GallerySection = React.memo(function GallerySection({
 					)}
 				</div>
 			)}
-		</section>
+		</SectionShell>
 	);
 });

--- a/apps/web/src/app/(workspace)/community/edit/sections/gallery-section.tsx
+++ b/apps/web/src/app/(workspace)/community/edit/sections/gallery-section.tsx
@@ -83,9 +83,11 @@ export const GallerySection = React.memo(function GallerySection({
 			/>
 
 			{galleryItems.length === 0 ? (
-				<div
-					className="rounded-xl border-2 border-dashed border-border/70 bg-muted/10 p-12 text-center cursor-pointer hover:border-primary/50 hover:bg-primary/5 transition-all group"
+				<button
+					type="button"
+					className="w-full rounded-xl border-2 border-dashed border-border/70 bg-muted/10 p-12 text-center cursor-pointer hover:border-primary/50 hover:bg-primary/5 transition-all group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
 					onClick={() => galleryInputRef.current?.click()}
+					disabled={isUploadingGallery}
 				>
 					{isUploadingGallery ? (
 						<Loader2 className="size-10 mx-auto animate-spin text-muted-fg mb-3" />
@@ -94,7 +96,7 @@ export const GallerySection = React.memo(function GallerySection({
 					)}
 					<p className="text-sm font-medium text-fg">Add photos of your work</p>
 					<p className="text-xs text-muted-fg mt-1">Up to {MAX_GALLERY_IMAGES} images, 5MB each</p>
-				</div>
+				</button>
 			) : (
 				<div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
 					{galleryItems.map((item, index) => (

--- a/apps/web/src/app/(workspace)/community/edit/sections/main-settings-section.tsx
+++ b/apps/web/src/app/(workspace)/community/edit/sections/main-settings-section.tsx
@@ -100,9 +100,23 @@ export const MainSettingsSection = React.memo(function MainSettingsSection({
 					className={cn(
 						"relative w-full aspect-[4.8/1] rounded-xl overflow-hidden border border-dashed border-border bg-muted/20",
 						"hover:border-primary/50 hover:bg-muted/30 transition-colors duration-200 cursor-pointer group",
+						"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
 						isUploadingBanner && "opacity-50 pointer-events-none",
 					)}
 					onClick={() => bannerInputRef.current?.click()}
+					// Keyboard-operable only when empty; with an image, the focusable
+					// Replace/Remove overlay buttons take over (no nested interactives).
+					{...(!bannerUrl && {
+						role: "button",
+						tabIndex: 0,
+						"aria-label": "Upload banner image",
+						onKeyDown: (e: React.KeyboardEvent) => {
+							if (e.key === "Enter" || e.key === " ") {
+								e.preventDefault();
+								bannerInputRef.current?.click();
+							}
+						},
+					})}
 				>
 					{bannerUrl ? (
 						<>
@@ -113,7 +127,7 @@ export const MainSettingsSection = React.memo(function MainSettingsSection({
 								className="object-cover"
 							/>
 							<div
-								className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex items-center justify-center gap-4"
+								className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-200 flex items-center justify-center gap-4"
 								onClick={(e) => e.stopPropagation()}
 							>
 								<Button
@@ -172,9 +186,21 @@ export const MainSettingsSection = React.memo(function MainSettingsSection({
 						className={cn(
 							"relative size-24 rounded-xl overflow-hidden border border-dashed border-border bg-muted/20",
 							"hover:border-primary/50 hover:bg-muted/30 transition-colors duration-200 cursor-pointer group",
+							"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
 							isUploadingAvatar && "opacity-50 pointer-events-none",
 						)}
 						onClick={() => avatarInputRef.current?.click()}
+						role="button"
+						tabIndex={0}
+						aria-label={
+							avatarUrl ? "Replace avatar image" : "Upload avatar image"
+						}
+						onKeyDown={(e) => {
+							if (e.key === "Enter" || e.key === " ") {
+								e.preventDefault();
+								avatarInputRef.current?.click();
+							}
+						}}
 					>
 						{avatarUrl ? (
 							<>
@@ -184,7 +210,7 @@ export const MainSettingsSection = React.memo(function MainSettingsSection({
 									fill
 									className="object-cover"
 								/>
-								<div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex items-center justify-center">
+								<div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-200 flex items-center justify-center">
 									<Upload className="size-5 text-white" />
 								</div>
 							</>

--- a/apps/web/src/app/(workspace)/community/edit/sections/main-settings-section.tsx
+++ b/apps/web/src/app/(workspace)/community/edit/sections/main-settings-section.tsx
@@ -5,21 +5,23 @@ import Image from "next/image";
 import {
 	Upload,
 	Trash2,
-	Globe,
-	GlobeLock,
-	Copy,
-	Check,
-	ExternalLink,
 	Loader2,
 	ImageIcon,
+	Sparkles,
 } from "lucide-react";
-import type { JSONContent } from "@tiptap/react";
 
-import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Field, FieldLabel, FieldDescription } from "@/components/ui/field";
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupText,
+	InputGroupInput,
+} from "@/components/ui/input-group";
 import { cn } from "@/lib/utils";
 import type { Id } from "@onetool/backend/convex/_generated/dataModel";
+import { SectionShell } from "./section-shell";
 
 interface MainSettingsSectionProps {
 	pageTitle: string;
@@ -55,7 +57,6 @@ export const MainSettingsSection = React.memo(function MainSettingsSection({
 	slug,
 	metaDescription,
 	setMetaDescription,
-	bannerStorageId,
 	avatarStorageId,
 	bannerUrl,
 	avatarUrl,
@@ -69,40 +70,36 @@ export const MainSettingsSection = React.memo(function MainSettingsSection({
 	slugError,
 	debouncedSlug,
 	isSlugAvailable,
-	copied,
-	handleCopyUrl,
 	organization,
 	bannerInputRef,
 	avatarInputRef,
 	sectionRef,
 }: MainSettingsSectionProps) {
-	const publicUrl = `${
-		typeof window !== "undefined" ? window.location.origin : ""
-	}/communities/${slug}`;
+	// still checking (debounce hasn't settled or query in flight)
+	const isChecking =
+		slug.length >= 3 &&
+		(debouncedSlug !== slug || isSlugAvailable === undefined);
+	// debounce settled and query returned
+	const hasAvailability =
+		slug.length >= 3 &&
+		debouncedSlug === slug &&
+		isSlugAvailable !== undefined;
 
 	return (
-		<section
+		<SectionShell
 			id="mainSettings"
-			ref={sectionRef}
-			className="scroll-mt-44 space-y-10"
+			sectionRef={sectionRef}
+			icon={Sparkles}
+			title="Main Page Settings"
+			description="Configure branding, URL, and SEO information."
+			first
 		>
-			<div>
-				<h2 className="text-lg font-semibold text-fg">
-					Main Page Settings
-				</h2>
-				<p className="text-sm text-muted-fg">
-					Configure branding, URL, and SEO information.
-				</p>
-			</div>
-
 			<div className="space-y-4">
-				<h3 className="text-base font-semibold text-fg">
-					Banner Image
-				</h3>
+				<h3 className="text-base font-semibold text-fg">Banner Image</h3>
 				<div
 					className={cn(
-						"relative w-full aspect-[4.8/1] rounded-2xl overflow-hidden border border-border/60 bg-muted/20",
-						"hover:border-primary/50 transition-colors cursor-pointer group",
+						"relative w-full aspect-[4.8/1] rounded-xl overflow-hidden border border-dashed border-border bg-muted/20",
+						"hover:border-primary/50 hover:bg-muted/30 transition-colors duration-200 cursor-pointer group",
 						isUploadingBanner && "opacity-50 pointer-events-none",
 					)}
 					onClick={() => bannerInputRef.current?.click()}
@@ -116,7 +113,7 @@ export const MainSettingsSection = React.memo(function MainSettingsSection({
 								className="object-cover"
 							/>
 							<div
-								className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-4"
+								className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex items-center justify-center gap-4"
 								onClick={(e) => e.stopPropagation()}
 							>
 								<Button
@@ -138,12 +135,14 @@ export const MainSettingsSection = React.memo(function MainSettingsSection({
 							</div>
 						</>
 					) : (
-						<div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-muted-fg group-hover:text-fg transition-colors">
+						<div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-muted-fg group-hover:text-fg transition-colors duration-200">
 							{isUploadingBanner ? (
 								<Loader2 className="size-8 animate-spin" />
 							) : (
 								<>
-									<ImageIcon className="size-10 mb-2 opacity-50 group-hover:opacity-100 transition-opacity" />
+									<div className="flex size-10 items-center justify-center rounded-lg bg-muted/60 mb-1">
+										<ImageIcon className="size-5 opacity-70 group-hover:opacity-100 transition-opacity duration-200" />
+									</div>
 									<span className="text-sm font-medium">
 										Click to upload banner image
 									</span>
@@ -167,14 +166,12 @@ export const MainSettingsSection = React.memo(function MainSettingsSection({
 			</div>
 
 			<div className="space-y-4">
-				<h3 className="text-base font-semibold text-fg">
-					Avatar / Logo
-				</h3>
+				<h3 className="text-base font-semibold text-fg">Avatar / Logo</h3>
 				<div className="flex items-center gap-6">
 					<div
 						className={cn(
-							"relative size-24 rounded-2xl overflow-hidden border border-border/60 bg-muted/20",
-							"hover:border-primary/50 transition-colors cursor-pointer group",
+							"relative size-24 rounded-xl overflow-hidden border border-dashed border-border bg-muted/20",
+							"hover:border-primary/50 hover:bg-muted/30 transition-colors duration-200 cursor-pointer group",
 							isUploadingAvatar && "opacity-50 pointer-events-none",
 						)}
 						onClick={() => avatarInputRef.current?.click()}
@@ -187,7 +184,7 @@ export const MainSettingsSection = React.memo(function MainSettingsSection({
 									fill
 									className="object-cover"
 								/>
-								<div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+								<div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex items-center justify-center">
 									<Upload className="size-5 text-white" />
 								</div>
 							</>
@@ -196,7 +193,9 @@ export const MainSettingsSection = React.memo(function MainSettingsSection({
 								{isUploadingAvatar ? (
 									<Loader2 className="size-6 animate-spin" />
 								) : (
-									<ImageIcon className="size-8 opacity-50" />
+									<div className="flex size-8 items-center justify-center rounded-lg bg-muted/60">
+										<ImageIcon className="size-4 opacity-70" />
+									</div>
 								)}
 							</div>
 						)}
@@ -212,11 +211,7 @@ export const MainSettingsSection = React.memo(function MainSettingsSection({
 							Upload Avatar
 						</Button>
 						{avatarStorageId && (
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={handleDeleteAvatar}
-							>
+							<Button variant="ghost" size="sm" onClick={handleDeleteAvatar}>
 								<Trash2 className="size-4 mr-2" />
 								Use Organization Logo
 							</Button>
@@ -237,83 +232,80 @@ export const MainSettingsSection = React.memo(function MainSettingsSection({
 			</div>
 
 			<div className="grid gap-8 lg:grid-cols-2">
-				<div className="space-y-3">
-					<Label htmlFor="pageTitle">Page Title</Label>
+				<Field>
+					<FieldLabel htmlFor="pageTitle">Page Title</FieldLabel>
 					<Input
 						id="pageTitle"
 						value={pageTitle}
 						onChange={(e) => setPageTitle(e.target.value)}
 						placeholder={organization?.name || "Your Business Name"}
 					/>
-				</div>
+				</Field>
 
-				<div className="space-y-3">
-					<Label htmlFor="slug">Page URL</Label>
-					<div className="flex items-center gap-3">
-						<div className="flex">
-							<div className="flex shrink-0 items-center rounded-l-md bg-muted/50 px-3 py-2 text-sm text-muted-fg border border-r-0 border-border">
+				<Field>
+					<FieldLabel htmlFor="slug">Page URL</FieldLabel>
+					<InputGroup>
+						<InputGroupAddon align="inline-start">
+							<InputGroupText className="font-mono text-xs">
 								onetool.biz/communities/
-							</div>
-							<input
-								id="slug"
-								type="text"
-								value={slug}
-								onChange={handleSlugChange}
-								placeholder="your-business-name"
-								className={cn(
-									"block w-full sm:w-48 rounded-r-md border border-border bg-background px-3 py-2 text-sm text-fg placeholder:text-muted-fg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent",
-									slugError && "border-danger focus:ring-danger",
-									!slugError &&
-										isSlugAvailable === false &&
-										"border-danger focus:ring-danger",
-								)}
-							/>
-						</div>
-						{slugError ? (
-							<span className="text-sm text-danger">{slugError}</span>
-						) : slug.length >= 3 &&
-						  (debouncedSlug !== slug ||
-								isSlugAvailable === undefined) ? (
-							<Loader2 className="size-4 animate-spin text-muted-fg" />
-						) : slug.length >= 3 &&
-						  debouncedSlug === slug &&
-						  isSlugAvailable !== undefined ? (
-							<div className="flex items-center gap-1.5">
-								<span
-									className={cn(
-										"size-2 rounded-full",
-										isSlugAvailable ? "bg-emerald-500" : "bg-red-500",
-									)}
-								/>
-								<span
-									className={cn(
-										"text-sm font-medium",
-										isSlugAvailable
-											? "text-emerald-600 dark:text-emerald-400"
-											: "text-red-600 dark:text-red-400",
-									)}
-								>
-									{isSlugAvailable ? "Available" : "Taken"}
-								</span>
-							</div>
-						) : null}
-					</div>
-				</div>
+							</InputGroupText>
+						</InputGroupAddon>
+						<InputGroupInput
+							id="slug"
+							value={slug}
+							onChange={handleSlugChange}
+							placeholder="your-business-name"
+							aria-invalid={
+								!!slugError || (!slugError && isSlugAvailable === false)
+							}
+						/>
+						<InputGroupAddon align="inline-end">
+							{isChecking ? (
+								<Loader2 className="size-4 animate-spin text-muted-fg" />
+							) : hasAvailability ? (
+								<InputGroupText className="gap-1.5">
+									<span
+										className={cn(
+											"size-2 rounded-full",
+											isSlugAvailable ? "bg-emerald-500" : "bg-red-500",
+										)}
+									/>
+									<span
+										className={cn(
+											"text-xs font-medium",
+											isSlugAvailable
+												? "text-emerald-600 dark:text-emerald-400"
+												: "text-red-600 dark:text-red-400",
+										)}
+									>
+										{isSlugAvailable ? "Available" : "Taken"}
+									</span>
+								</InputGroupText>
+							) : null}
+						</InputGroupAddon>
+					</InputGroup>
+					{slugError && (
+						<FieldDescription className="text-danger">
+							{slugError}
+						</FieldDescription>
+					)}
+				</Field>
 
-				<div className="space-y-3 lg:col-span-2">
-					<Label htmlFor="metaDescription">SEO Description</Label>
+				<Field className="lg:col-span-2">
+					<FieldLabel htmlFor="metaDescription">
+						SEO Description
+					</FieldLabel>
 					<Input
 						id="metaDescription"
 						value={metaDescription}
 						onChange={(e) => setMetaDescription(e.target.value)}
 						placeholder="A brief description for search engines (optional)"
 					/>
-					<p className="text-xs text-muted-fg">
+					<FieldDescription>
 						{metaDescription.length}/160 characters recommended
-					</p>
-				</div>
+					</FieldDescription>
+				</Field>
 			</div>
-
-		</section>
+		</SectionShell>
 	);
 });

--- a/apps/web/src/app/(workspace)/community/edit/sections/pricing-section.tsx
+++ b/apps/web/src/app/(workspace)/community/edit/sections/pricing-section.tsx
@@ -93,8 +93,9 @@ export const PricingSection = React.memo(function PricingSection({
 							<div className="p-4 space-y-3">
 								<div className="grid gap-3 sm:grid-cols-2">
 									<Field>
-										<FieldLabel className="text-xs uppercase tracking-wider text-muted-fg">Tier Name</FieldLabel>
+										<FieldLabel htmlFor={`pricing-tier-${index}-name`} className="text-xs uppercase tracking-wider text-muted-fg">Tier Name</FieldLabel>
 										<Input
+											id={`pricing-tier-${index}-name`}
 											value={tier.name}
 											onChange={(e) =>
 												setPricingTiers((prev) =>
@@ -109,8 +110,9 @@ export const PricingSection = React.memo(function PricingSection({
 										/>
 									</Field>
 									<Field>
-										<FieldLabel className="text-xs uppercase tracking-wider text-muted-fg">Price</FieldLabel>
+										<FieldLabel htmlFor={`pricing-tier-${index}-price`} className="text-xs uppercase tracking-wider text-muted-fg">Price</FieldLabel>
 										<Input
+											id={`pricing-tier-${index}-price`}
 											value={tier.price}
 											onChange={(e) =>
 												setPricingTiers((prev) =>
@@ -126,8 +128,9 @@ export const PricingSection = React.memo(function PricingSection({
 									</Field>
 								</div>
 								<Field>
-									<FieldLabel className="text-xs uppercase tracking-wider text-muted-fg">Description</FieldLabel>
+									<FieldLabel htmlFor={`pricing-tier-${index}-description`} className="text-xs uppercase tracking-wider text-muted-fg">Description</FieldLabel>
 									<Input
+										id={`pricing-tier-${index}-description`}
 										value={tier.description}
 										onChange={(e) =>
 											setPricingTiers((prev) =>

--- a/apps/web/src/app/(workspace)/community/edit/sections/pricing-section.tsx
+++ b/apps/web/src/app/(workspace)/community/edit/sections/pricing-section.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import React from "react";
-import { Trash2, Plus } from "lucide-react";
+import { Trash2, Plus, Tags } from "lucide-react";
 import type { JSONContent } from "@tiptap/react";
 
-import { Label } from "@/components/ui/label";
+import { Field, FieldLabel } from "@/components/ui/field";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -13,6 +13,7 @@ import {
 	PillTabsTrigger,
 } from "@/components/shared/pill-tabs";
 import { CommunityEditor } from "@/components/tiptap/community-editor";
+import { SectionShell } from "./section-shell";
 import type { PricingMode, PricingTier } from "../use-community-page-form";
 
 interface PricingSectionProps {
@@ -35,17 +36,14 @@ export const PricingSection = React.memo(function PricingSection({
 	sectionRef,
 }: PricingSectionProps) {
 	return (
-		<section
+		<SectionShell
 			id="pricing"
-			ref={sectionRef}
-			className="scroll-mt-44 pb-12"
+			sectionRef={sectionRef}
+			icon={Tags}
+			title="Pricing"
+			description="Choose structured tiers or a rich-text pricing section."
+			contentClassName="space-y-6 pb-12"
 		>
-			<div className="mb-4">
-				<h2 className="text-lg font-semibold text-fg">Pricing</h2>
-				<p className="text-sm text-muted-fg">
-					Choose structured tiers or a rich-text pricing section.
-				</p>
-			</div>
 			<PillTabs
 				value={pricingMode}
 				onValueChange={(v) =>
@@ -68,7 +66,7 @@ export const PricingSection = React.memo(function PricingSection({
 					{pricingTiers.map((tier, index) => (
 						<div
 							key={index}
-							className="rounded-xl border border-border/60 overflow-hidden bg-background"
+							className="rounded-xl border border-border/60 overflow-hidden bg-background transition-colors hover:border-border"
 						>
 							<div className="flex items-center justify-between px-4 py-3 bg-muted/30 border-b border-border/40">
 								<div className="flex items-center gap-3">
@@ -79,23 +77,23 @@ export const PricingSection = React.memo(function PricingSection({
 										{tier.name || "Untitled Tier"}
 									</span>
 								</div>
-								<Button
-									variant="destructive"
-									size="sm"
+								<button
+									type="button"
+									aria-label="Remove tier"
 									onClick={() =>
 										setPricingTiers((prev) =>
 											prev.filter((_, i) => i !== index),
 										)
 									}
+									className="size-8 rounded-lg flex items-center justify-center text-muted-fg cursor-pointer transition-colors hover:bg-danger/10 hover:text-danger"
 								>
-									<Trash2 className="size-3.5 mr-1.5" />
-									Remove
-								</Button>
+									<Trash2 className="size-4" />
+								</button>
 							</div>
 							<div className="p-4 space-y-3">
 								<div className="grid gap-3 sm:grid-cols-2">
-									<div className="space-y-2">
-										<Label className="text-xs uppercase tracking-wider text-muted-fg">Tier Name</Label>
+									<Field>
+										<FieldLabel className="text-xs uppercase tracking-wider text-muted-fg">Tier Name</FieldLabel>
 										<Input
 											value={tier.name}
 											onChange={(e) =>
@@ -109,9 +107,9 @@ export const PricingSection = React.memo(function PricingSection({
 											}
 											placeholder="e.g. Starter Package"
 										/>
-									</div>
-									<div className="space-y-2">
-										<Label className="text-xs uppercase tracking-wider text-muted-fg">Price</Label>
+									</Field>
+									<Field>
+										<FieldLabel className="text-xs uppercase tracking-wider text-muted-fg">Price</FieldLabel>
 										<Input
 											value={tier.price}
 											onChange={(e) =>
@@ -125,10 +123,10 @@ export const PricingSection = React.memo(function PricingSection({
 											}
 											placeholder="$199 / month"
 										/>
-									</div>
+									</Field>
 								</div>
-								<div className="space-y-2">
-									<Label className="text-xs uppercase tracking-wider text-muted-fg">Description</Label>
+								<Field>
+									<FieldLabel className="text-xs uppercase tracking-wider text-muted-fg">Description</FieldLabel>
 									<Input
 										value={tier.description}
 										onChange={(e) =>
@@ -142,7 +140,7 @@ export const PricingSection = React.memo(function PricingSection({
 										}
 										placeholder="Brief description of what's included"
 									/>
-								</div>
+								</Field>
 							</div>
 						</div>
 					))}
@@ -166,6 +164,6 @@ export const PricingSection = React.memo(function PricingSection({
 					placeholder="Describe your pricing options, packages, and custom quotes..."
 				/>
 			)}
-		</section>
+		</SectionShell>
 	);
 });

--- a/apps/web/src/app/(workspace)/community/edit/sections/section-shell.tsx
+++ b/apps/web/src/app/(workspace)/community/edit/sections/section-shell.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface SectionShellProps {
+	id: string;
+	sectionRef: (el: HTMLElement | null) => void;
+	icon: React.ComponentType<{ className?: string }>;
+	title: string;
+	description: string;
+	/** Rendered to the right of the header (badges, counters). */
+	headerAccessory?: React.ReactNode;
+	/** First section skips the top separator. */
+	first?: boolean;
+	children: React.ReactNode;
+	contentClassName?: string;
+}
+
+/** Shared chrome for editor sections: separator, icon tile, title, description. */
+export function SectionShell({
+	id,
+	sectionRef,
+	icon: Icon,
+	title,
+	description,
+	headerAccessory,
+	first = false,
+	children,
+	contentClassName,
+}: SectionShellProps) {
+	return (
+		<section
+			id={id}
+			ref={sectionRef}
+			className={cn(
+				"scroll-mt-44",
+				!first && "border-t border-border/40 pt-12",
+			)}
+		>
+			<div className="mb-6 flex items-start justify-between gap-4">
+				<div className="flex items-start gap-3">
+					<div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+						<Icon className="size-4.5 text-primary" />
+					</div>
+					<div>
+						<h2 className="text-lg font-semibold text-fg">{title}</h2>
+						<p className="mt-0.5 text-sm text-muted-fg">{description}</p>
+					</div>
+				</div>
+				{headerAccessory}
+			</div>
+			<div className={cn("space-y-6", contentClassName)}>{children}</div>
+		</section>
+	);
+}

--- a/apps/web/src/app/(workspace)/community/edit/sections/services-section.tsx
+++ b/apps/web/src/app/(workspace)/community/edit/sections/services-section.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import React from "react";
+import { Wrench } from "lucide-react";
 import type { JSONContent } from "@tiptap/react";
 import { CommunityEditor } from "@/components/tiptap/community-editor";
+import { SectionShell } from "./section-shell";
 
 interface ServicesSectionProps {
 	servicesContent: JSONContent | undefined;
@@ -16,22 +18,18 @@ export const ServicesSection = React.memo(function ServicesSection({
 	sectionRef,
 }: ServicesSectionProps) {
 	return (
-		<section
+		<SectionShell
 			id="services"
-			ref={sectionRef}
-			className="scroll-mt-44"
+			sectionRef={sectionRef}
+			icon={Wrench}
+			title="Services"
+			description="Describe your services and what clients can expect."
 		>
-			<div className="mb-4">
-				<h2 className="text-lg font-semibold text-fg">Services</h2>
-				<p className="text-sm text-muted-fg">
-					Describe your services and what clients can expect.
-				</p>
-			</div>
 			<CommunityEditor
 				content={servicesContent}
 				onChange={setServicesContent}
 				placeholder="List services, specialties, and service areas..."
 			/>
-		</section>
+		</SectionShell>
 	);
 });

--- a/apps/web/src/app/(workspace)/community/edit/use-community-page-form.ts
+++ b/apps/web/src/app/(workspace)/community/edit/use-community-page-form.ts
@@ -688,6 +688,12 @@ export function useCommunityPageForm() {
 		[dirtyBySection],
 	);
 
+	// Slug availability still debouncing or query in flight — treat as
+	// unresolved so save/publish can't race a taken slug.
+	const isCheckingSlug =
+		slug.length >= 3 &&
+		(debouncedSlug !== slug || isSlugAvailable === undefined);
+
 	const hasPublishableContent = useMemo(
 		() =>
 			!!bioContent ||
@@ -1084,6 +1090,7 @@ export function useCommunityPageForm() {
 			hasInvalidSocialUrls,
 			slugError,
 			isSlugAvailable,
+			isCheckingSlug,
 		},
 		// Section navigation
 		activeSection,

--- a/apps/web/src/app/(workspace)/community/page.tsx
+++ b/apps/web/src/app/(workspace)/community/page.tsx
@@ -3,6 +3,7 @@
 import { PermissionGate } from "@/components/domain/permission-gate";
 import React, { useState, useCallback, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { useMutation, useQuery } from "convex/react";
 import {
 	Globe,
@@ -12,22 +13,243 @@ import {
 	Clock,
 	CheckCircle2,
 	ExternalLink,
-	Edit,
 	Copy,
 	Check,
-	Eye,
+	Pencil,
+	Circle,
+	Sparkles,
+	Palette,
+	BadgeCheck,
+	FileText,
+	Images,
+	Wrench,
+	Tags,
+	ArrowRight,
 } from "lucide-react";
 
-import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Field, FieldLabel, FieldDescription } from "@/components/ui/field";
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupInput,
+	InputGroupText,
+} from "@/components/ui/input-group";
+import { Progress } from "@/components/ui/progress";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+	Frame,
+	FramePanel,
+	FrameHeader,
+	FrameTitle,
+	FrameDescription,
+} from "@/components/reui/frame";
+import { DotField } from "@/components/ui/dot-field";
+import { NodesIllustration } from "./components/nodes-illustration";
 import { StatusBadge } from "@/components/domain/status-badge";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 import { api } from "@onetool/backend/convex/_generated/api";
+import type { Doc } from "@onetool/backend/convex/_generated/dataModel";
 import { useOrganization } from "@clerk/nextjs";
 
 const COPY_FEEDBACK_DURATION_MS = 2000;
+
+type CommunityPageDoc = Doc<"communityPages">;
+
+/** Mirrors the editor's SECTION_LIST ids so deep links land on the right section. */
+const SECTION_CHECKLIST: Array<{
+	id: string;
+	label: string;
+	blurb: string;
+	icon: React.ComponentType<{ className?: string }>;
+	isComplete: (page: CommunityPageDoc) => boolean;
+}> = [
+	{
+		id: "mainSettings",
+		label: "Branding & SEO",
+		blurb: "Banner, logo, and search description",
+		icon: Sparkles,
+		isComplete: (p) =>
+			!!p.bannerStorageId || !!p.avatarStorageId || !!p.metaDescription,
+	},
+	{
+		id: "design",
+		label: "Design",
+		blurb: "Pick a visual theme",
+		icon: Palette,
+		isComplete: (p) => !!p.draftTheme,
+	},
+	{
+		id: "businessInfo",
+		label: "Business info",
+		blurb: "Credentials, hours, and social links",
+		icon: BadgeCheck,
+		isComplete: (p) =>
+			!!p.draftOwnerInfo ||
+			!!p.draftCredentials ||
+			!!p.draftBusinessHours ||
+			!!p.draftSocialLinks,
+	},
+	{
+		id: "bio",
+		label: "Bio",
+		blurb: "Tell your story",
+		icon: FileText,
+		isComplete: (p) => !!p.draftBioContent || !!p.draftContent,
+	},
+	{
+		id: "imageGallery",
+		label: "Gallery",
+		blurb: "Show off your best work",
+		icon: Images,
+		isComplete: (p) => (p.galleryItemsDraft?.length ?? 0) > 0,
+	},
+	{
+		id: "services",
+		label: "Services",
+		blurb: "What you offer",
+		icon: Wrench,
+		isComplete: (p) => !!p.draftServicesContent,
+	},
+	{
+		id: "pricing",
+		label: "Pricing",
+		blurb: "Tiers or a custom write-up",
+		icon: Tags,
+		isComplete: (p) =>
+			(p.draftPricingTiers?.length ?? 0) > 0 || !!p.draftPricingContent,
+	},
+];
+
+const CREATE_PROOF_POINTS = [
+	{
+		icon: Globe,
+		title: "A real web presence",
+		description:
+			"A polished public landing page for your business — no website builder required.",
+	},
+	{
+		icon: ImageIcon,
+		title: "Rich content",
+		description:
+			"Banner, photo gallery, services, pricing, credentials, and business hours.",
+	},
+	{
+		icon: Send,
+		title: "Leads, captured",
+		description:
+			"Visitors submit interest forms that land in your tasks automatically.",
+	},
+] as const;
+
+function formatDate(timestamp?: number) {
+	if (!timestamp) return null;
+	return new Date(timestamp).toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+	});
+}
+
+function PageHeader({
+	subtitle,
+	children,
+}: {
+	subtitle: string;
+	children?: React.ReactNode;
+}) {
+	return (
+		<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+			<div className="flex items-center gap-3">
+				<div className="h-6 w-1.5 rounded-full bg-linear-to-b from-primary to-primary/60" />
+				<div>
+					<h1 className="text-2xl font-bold text-foreground">Community</h1>
+					<p className="text-sm text-muted-foreground">{subtitle}</p>
+				</div>
+			</div>
+			{children}
+		</div>
+	);
+}
+
+/** Miniature browser-framed mock of the public page that live-mirrors the claim form. */
+function GhostPreview({
+	slug,
+	pageTitle,
+	orgName,
+}: {
+	slug: string;
+	pageTitle: string;
+	orgName?: string;
+}) {
+	const displayTitle = pageTitle || orgName || "Your Business";
+	const initial = displayTitle.charAt(0).toUpperCase() || "B";
+	return (
+		<div className="relative w-full max-w-sm">
+			<div className="rounded-xl border border-border/80 bg-background shadow-lg shadow-black/[0.06] overflow-hidden">
+				{/* Browser chrome */}
+				<div className="flex items-center gap-2 border-b border-border/60 bg-muted/40 px-3 py-2.5">
+					<div className="flex gap-1.5" aria-hidden>
+						<span className="size-2.5 rounded-full bg-border" />
+						<span className="size-2.5 rounded-full bg-border" />
+						<span className="size-2.5 rounded-full bg-border" />
+					</div>
+					<div className="ml-2 flex-1 truncate rounded-md bg-background border border-border/60 px-2.5 py-1 text-[11px] font-mono text-muted-foreground">
+						onetool.biz/communities/
+						<span className="text-foreground">{slug || "your-business"}</span>
+					</div>
+				</div>
+				{/* Mock page body */}
+				<div className="relative h-20">
+					<DotField className="text-primary opacity-60 [mask-image:linear-gradient(to_bottom,black,transparent)]" />
+				</div>
+				<div className="px-5 pb-5">
+					<div className="-mt-7 mb-3 flex size-14 items-center justify-center rounded-xl border-4 border-background bg-primary/15 text-lg font-bold text-primary">
+						{initial}
+					</div>
+					<p className="truncate text-sm font-semibold text-foreground">
+						{displayTitle}
+					</p>
+					<div className="mt-3 space-y-2" aria-hidden>
+						<div className="h-2 w-4/5 rounded-full bg-muted" />
+						<div className="h-2 w-3/5 rounded-full bg-muted" />
+					</div>
+					<div className="mt-4 grid grid-cols-3 gap-2" aria-hidden>
+						<div className="aspect-square rounded-lg bg-muted/80" />
+						<div className="aspect-square rounded-lg bg-muted/80" />
+						<div className="aspect-square rounded-lg bg-muted/80" />
+					</div>
+					<div className="mt-4 flex gap-2" aria-hidden>
+						<div className="h-7 flex-1 rounded-md bg-primary/80" />
+						<div className="h-7 w-16 rounded-md bg-muted" />
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function HeroSkeleton() {
+	return (
+		<div className="space-y-8 p-6">
+			<div className="flex items-center gap-3">
+				<div className="h-6 w-1.5 rounded-full bg-muted" />
+				<div className="space-y-2">
+					<Skeleton className="h-6 w-40" />
+					<Skeleton className="h-4 w-64" />
+				</div>
+			</div>
+			<Skeleton className="h-56 w-full rounded-xl" />
+			<div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+				{Array.from({ length: 4 }).map((_, i) => (
+					<Skeleton key={i} className="h-20 rounded-xl" />
+				))}
+			</div>
+		</div>
+	);
+}
 
 function CommunityPageContent() {
 	const router = useRouter();
@@ -37,6 +259,18 @@ function CommunityPageContent() {
 	// Queries
 	const communityPage = useQuery(api.communityPages.get);
 	const organization = useQuery(api.organizations.get);
+	const bannerUrl = useQuery(
+		api.communityPages.getImageUrl,
+		communityPage?.bannerStorageId
+			? { storageId: communityPage.bannerStorageId }
+			: "skip",
+	);
+	const avatarUrl = useQuery(
+		api.communityPages.getImageUrl,
+		communityPage?.avatarStorageId
+			? { storageId: communityPage.avatarStorageId }
+			: "skip",
+	);
 
 	// Mutations
 	const upsert = useMutation(api.communityPages.upsert);
@@ -103,14 +337,12 @@ function CommunityPageContent() {
 		return true;
 	}, []);
 
-	// Handle slug change
 	const handleSlugChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const value = e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, "");
 		setSlug(value);
 		validateSlug(value);
 	};
 
-	// Create initial community page
 	const handleCreatePage = async () => {
 		if (!validateSlug(slug)) return;
 
@@ -133,7 +365,6 @@ function CommunityPageContent() {
 		}
 	};
 
-	// Copy URL
 	const communitySlug = communityPage?.slug;
 	const handleCopyUrl = useCallback(() => {
 		if (!communitySlug) return;
@@ -144,339 +375,470 @@ function CommunityPageContent() {
 		toast.success("URL copied", "Share this link with your audience");
 	}, [communitySlug, toast]);
 
-	// Format date helper
-	const formatDate = (timestamp?: number) => {
-		if (!timestamp) return null;
-		return new Date(timestamp).toLocaleDateString("en-US", {
-			month: "short",
-			day: "numeric",
-			year: "numeric",
-		});
-	};
-
 	const pageUrl = communityPage?.slug
 		? `${typeof window !== "undefined" ? window.location.origin : ""}/communities/${communityPage.slug}`
 		: "";
 
 	// Loading state
 	if (communityPage === undefined) {
-		return (
-			<div className="flex items-center justify-center min-h-[400px]">
-				<Loader2 className="size-8 animate-spin text-muted-fg" />
-			</div>
-		);
+		return <HeroSkeleton />;
 	}
 
-	// No community page exists - show creation prompt
+	// ------------------------------------------------------------------
+	// No page yet — claim hero
+	// ------------------------------------------------------------------
 	if (communityPage === null) {
+		const slugStatus =
+			slug.length >= 3 && !slugError
+				? debouncedSlug !== slug || isSlugAvailable === undefined
+					? "checking"
+					: isSlugAvailable
+						? "available"
+						: "taken"
+				: null;
+
 		return (
-			<div className="p-6 lg:p-8 space-y-12">
-				{/* Header */}
-				<div className="text-center space-y-4 mt-8">
-					<div className="size-16 rounded-2xl bg-primary/10 flex items-center justify-center mx-auto mb-6">
-						<Globe className="size-8 text-primary" />
-					</div>
-					<div>
-						<h1 className="text-3xl font-bold text-fg tracking-tight">
-							Create Your Community Page
-						</h1>
-						<p className="text-muted-fg mt-3 max-w-md mx-auto text-base">
-							Build a public page to showcase your business, share your
-							services, and let potential customers express their interest.
-						</p>
-					</div>
-				</div>
+			<div className="space-y-8 p-6">
+				<PageHeader subtitle="Claim a free public page for your business" />
 
-				{/* Benefits */}
-				<div className="grid gap-6 sm:grid-cols-3">
-					<div className="flex flex-col items-center text-center p-6 rounded-2xl bg-muted/20 border border-border/40">
-						<div className="size-10 rounded-full bg-primary/10 flex items-center justify-center mb-4">
-							<Globe className="size-5 text-primary" />
-						</div>
-						<h3 className="font-semibold text-fg mb-2">Online Presence</h3>
-						<p className="text-sm text-muted-fg">
-							Create a professional landing page for your business
-						</p>
-					</div>
-					<div className="flex flex-col items-center text-center p-6 rounded-2xl bg-muted/20 border border-border/40">
-						<div className="size-10 rounded-full bg-primary/10 flex items-center justify-center mb-4">
-							<ImageIcon className="size-5 text-primary" />
-						</div>
-						<h3 className="font-semibold text-fg mb-2">Rich Content</h3>
-						<p className="text-sm text-muted-fg">
-							Add banners, images, and formatted content
-						</p>
-					</div>
-					<div className="flex flex-col items-center text-center p-6 rounded-2xl bg-muted/20 border border-border/40">
-						<div className="size-10 rounded-full bg-primary/10 flex items-center justify-center mb-4">
-							<Send className="size-5 text-primary" />
-						</div>
-						<h3 className="font-semibold text-fg mb-2">Collect Leads</h3>
-						<p className="text-sm text-muted-fg">
-							Let visitors submit interest forms directly
-						</p>
-					</div>
-				</div>
-
-				<hr className="border-border/40" />
-
-				{/* Setup Form */}
-				<div className="max-w-xl mx-auto space-y-6">
-					<div className="space-y-2">
-						<Label htmlFor="pageTitle">Page Title</Label>
-						<Input
-							id="pageTitle"
-							value={pageTitle}
-							onChange={(e) => setPageTitle(e.target.value)}
-							placeholder={organization?.name || "Your Business Name"}
-						/>
-					</div>
-
-					<div className="space-y-2">
-						<Label htmlFor="slug">Page URL</Label>
-						<div className="flex items-center gap-3">
-							<div className="flex">
-								<div className="flex shrink-0 items-center rounded-l-md bg-muted/50 px-3 py-2 text-sm text-muted-fg border border-r-0 border-border">
-									onetool.biz/communities/
+				{/* Claim hero */}
+				<Frame>
+					<FramePanel className="p-0 overflow-hidden">
+						<div className="grid items-stretch lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)]">
+							{/* Left: pitch + claim form */}
+							<div className="space-y-7 px-7 py-8 sm:px-9">
+								<div className="space-y-3">
+									<NodesIllustration className="-ml-4 h-24 w-auto" />
+									<span className="inline-flex items-center gap-1.5 rounded-full border border-primary/20 bg-primary/5 px-3 py-1 text-xs font-medium text-primary">
+										<Globe className="size-3.5" />
+										Your public page
+									</span>
+									<h2 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+										Put your business on the map
+									</h2>
+									<p className="max-w-lg text-sm/relaxed text-muted-foreground sm:text-base/relaxed">
+										Claim a free public page that showcases your work, builds
+										trust with credentials, and turns visitors into leads.
+									</p>
 								</div>
-								<input
-									id="slug"
-									type="text"
-									value={slug}
-									onChange={handleSlugChange}
-									placeholder="your-business-name"
-									className={cn(
-										"block w-full sm:w-48 rounded-r-md border border-border bg-bg px-3 py-2 text-sm text-fg placeholder:text-muted-fg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent",
-										slugError && "border-danger focus:ring-danger",
-										!slugError &&
-											isSlugAvailable === false &&
-											"border-danger focus:ring-danger",
-									)}
+
+								<div className="max-w-lg space-y-5">
+									<Field>
+										<FieldLabel htmlFor="pageTitle">Page title</FieldLabel>
+										<Input
+											id="pageTitle"
+											value={pageTitle}
+											onChange={(e) => setPageTitle(e.target.value)}
+											placeholder={organization?.name || "Your Business Name"}
+										/>
+									</Field>
+
+									<Field>
+										<FieldLabel htmlFor="slug">Page URL</FieldLabel>
+										<InputGroup>
+											<InputGroupAddon>
+												<InputGroupText className="font-mono text-xs">
+													onetool.biz/communities/
+												</InputGroupText>
+											</InputGroupAddon>
+											<InputGroupInput
+												id="slug"
+												value={slug}
+												onChange={handleSlugChange}
+												placeholder="your-business-name"
+												aria-invalid={
+													!!slugError || slugStatus === "taken" || undefined
+												}
+											/>
+											<InputGroupAddon align="inline-end">
+												{slugStatus === "checking" && (
+													<Loader2 className="size-4 animate-spin text-muted-foreground" />
+												)}
+												{slugStatus === "available" && (
+													<span className="flex items-center gap-1.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
+														<span className="size-1.5 rounded-full bg-emerald-500" />
+														Available
+													</span>
+												)}
+												{slugStatus === "taken" && (
+													<span className="flex items-center gap-1.5 text-xs font-medium text-red-600 dark:text-red-400">
+														<span className="size-1.5 rounded-full bg-red-500" />
+														Taken
+													</span>
+												)}
+											</InputGroupAddon>
+										</InputGroup>
+										<FieldDescription>
+											{slugError ??
+												"Only lowercase letters, numbers, and hyphens allowed"}
+										</FieldDescription>
+									</Field>
+
+									<Button
+										variant="default"
+										size="lg"
+										className="w-full justify-center"
+										onClick={handleCreatePage}
+										disabled={
+											isCreating ||
+											!slug ||
+											!!slugError ||
+											isSlugAvailable === false
+										}
+									>
+										{isCreating ? (
+											<Loader2 className="size-4 mr-2 animate-spin" />
+										) : (
+											<Sparkles className="size-4 mr-2" />
+										)}
+										Claim your page
+									</Button>
+
+									<ul className="flex flex-wrap items-center gap-x-5 gap-y-2 text-xs text-muted-foreground">
+										{[
+											"Free on every plan",
+											"Lead capture built in",
+											"Live in minutes",
+										].map((point) => (
+											<li key={point} className="flex items-center gap-1.5">
+												<Check className="size-3.5 text-primary" />
+												{point}
+											</li>
+										))}
+									</ul>
+								</div>
+							</div>
+
+							{/* Right: live-mirroring ghost preview */}
+							<div className="relative hidden items-center justify-center border-l border-border/60 bg-muted/40 p-8 lg:flex">
+								<DotField className="text-primary opacity-[0.45] [mask-image:radial-gradient(ellipse_at_center,black_35%,transparent_78%)]" />
+								<GhostPreview
+									slug={slug}
+									pageTitle={pageTitle}
+									orgName={organization?.name}
 								/>
 							</div>
-							{slugError ? (
-								<span className="text-sm text-danger">{slugError}</span>
-							) : slug.length >= 3 &&
-							  (debouncedSlug !== slug || isSlugAvailable === undefined) ? (
-								<Loader2 className="size-4 animate-spin text-muted-fg" />
-							) : slug.length >= 3 &&
-							  debouncedSlug === slug &&
-							  isSlugAvailable !== undefined ? (
-								<div className="flex items-center gap-1.5">
-									<span
-										className={cn(
-											"size-2 rounded-full",
-											isSlugAvailable ? "bg-emerald-500" : "bg-red-500",
-										)}
-									/>
-									<span
-										className={cn(
-											"text-sm font-medium",
-											isSlugAvailable
-												? "text-emerald-600 dark:text-emerald-400"
-												: "text-red-600 dark:text-red-400",
-										)}
-									>
-										{isSlugAvailable ? "Available" : "Taken"}
-									</span>
-								</div>
-							) : null}
 						</div>
-						<p className="text-xs text-muted-fg">
-							Only lowercase letters, numbers, and hyphens allowed
-						</p>
-					</div>
+					</FramePanel>
+				</Frame>
 
-					{/* Create Button */}
-					<div className="pt-6">
-						<Button
-							variant="default"
-							className="w-full justify-center py-6 text-base"
-							onClick={handleCreatePage}
-							disabled={isCreating || !slug || !!slugError || isSlugAvailable === false}
-						>
-							{isCreating ? (
-								<Loader2 className="size-5 mr-2 animate-spin" />
-							) : (
-								<Globe className="size-5 mr-2" />
-							)}
-							Create Community Page
-						</Button>
-					</div>
-				</div>
-			</div>
-		);
-	}
-
-	// Page exists but not public (draft)
-	if (!communityPage.isPublic) {
-		return (
-			<div className="p-6 lg:p-8 space-y-8">
-				<div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 border-b border-border/40 pb-6">
-					<div className="space-y-2">
-						<div className="flex items-center gap-3">
-							<h1 className="text-2xl font-bold text-fg tracking-tight">
-								Community Page
-							</h1>
-							<StatusBadge role="warning" appearance="soft" className="gap-1.5">
-								<Clock className="size-3" />
-								Draft
-							</StatusBadge>
-						</div>
-						<p className="text-muted-fg text-sm">
-							Your community page is set up but not yet visible to the public.
-						</p>
-					</div>
-				</div>
-
-				<div className="flex flex-col md:flex-row items-start gap-8 py-4">
-					<div className="size-16 rounded-2xl bg-amber-100/50 dark:bg-amber-900/20 flex items-center justify-center shrink-0 border border-amber-200/50 dark:border-amber-800/30">
-						<Globe className="size-8 text-amber-600 dark:text-amber-400" />
-					</div>
-
-					<div className="flex-1 space-y-2">
-						<h3 className="text-xl font-semibold text-fg">
-							{communityPage.pageTitle ||
-								clerkOrganization?.name ||
-								"Your Community Page"}
-						</h3>
-						<div className="flex items-center gap-2 text-sm text-muted-fg font-mono">
-							<span>{pageUrl || `/communities/${communityPage.slug}`}</span>
-						</div>
-						{communityPage.updatedAt && (
-							<p className="text-xs text-muted-fg pt-1">
-								Last updated: {formatDate(communityPage.updatedAt)}
+				{/* Proof points */}
+				<Frame className="grid gap-1 sm:grid-cols-3">
+					{CREATE_PROOF_POINTS.map(({ icon: Icon, title, description }) => (
+						<FramePanel key={title} className="p-5">
+							<div className="mb-3 flex size-9 items-center justify-center rounded-lg bg-primary/10">
+								<Icon className="size-4.5 text-primary" />
+							</div>
+							<h3 className="text-sm font-semibold text-foreground">
+								{title}
+							</h3>
+							<p className="mt-1 text-sm text-muted-foreground">
+								{description}
 							</p>
-						)}
-					</div>
-
-					<div className="flex flex-col sm:flex-row gap-3 w-full md:w-auto mt-4 md:mt-0">
-						<Button
-							variant="secondary"
-							onClick={() => router.push("/community/edit")}
-							className="w-full sm:w-auto"
-						>
-							<Edit className="size-4 mr-2" />
-							Edit Page
-						</Button>
-						<Button
-							variant="default"
-							onClick={() => router.push("/community/edit")}
-							className="w-full sm:w-auto"
-						>
-							<Eye className="size-4 mr-2" />
-							Publish to Public
-						</Button>
-					</div>
-				</div>
-
-				<div className="rounded-xl border border-border/40 bg-muted/20 p-5 mt-4">
-					<p className="text-sm text-muted-fg flex items-center gap-2">
-						<strong className="text-fg font-medium">Ready to go live?</strong>
-						Once you make your page public, anyone with the link can view it and
-						submit interest forms.
-					</p>
-				</div>
+						</FramePanel>
+					))}
+				</Frame>
 			</div>
 		);
 	}
 
-	// Page exists and is public
+	// ------------------------------------------------------------------
+	// Page exists — profile hero (draft or live)
+	// ------------------------------------------------------------------
+	const isLive = communityPage.isPublic;
+	const displayTitle =
+		communityPage.pageTitle ||
+		clerkOrganization?.name ||
+		"Your Community Page";
+	const completedSections = SECTION_CHECKLIST.filter((s) =>
+		s.isComplete(communityPage),
+	);
+	const completionPct = Math.round(
+		(completedSections.length / SECTION_CHECKLIST.length) * 100,
+	);
+
 	return (
-		<div className="p-6 lg:p-8 space-y-8">
-			<div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 border-b border-border/40 pb-6">
-				<div className="space-y-2">
-					<div className="flex items-center gap-3">
-						<h1 className="text-2xl font-bold text-fg tracking-tight">
-							Community Page
-						</h1>
-						<StatusBadge role="success" appearance="soft" className="gap-1.5">
-							<CheckCircle2 className="size-3" />
-							Live
-						</StatusBadge>
-					</div>
-					<p className="text-muted-fg text-sm">
-						Your community page is live and accessible to anyone with the link.
-					</p>
-				</div>
-			</div>
-
-			<div className="flex flex-col md:flex-row items-start gap-8 py-4">
-				<div className="size-16 rounded-2xl bg-emerald-100/50 dark:bg-emerald-900/20 flex items-center justify-center shrink-0 border border-emerald-200/50 dark:border-emerald-800/30">
-					<Globe className="size-8 text-emerald-600 dark:text-emerald-400" />
-				</div>
-
-				<div className="flex-1 space-y-2">
-					<h3 className="text-xl font-semibold text-fg">
-						{communityPage.pageTitle ||
-							clerkOrganization?.name ||
-							"Your Community Page"}
-					</h3>
-					<div className="flex items-center gap-2 text-sm text-muted-fg font-mono">
-						<a
-							href={pageUrl}
-							target="_blank"
-							rel="noopener noreferrer"
-							className="hover:text-fg hover:underline transition-colors flex items-center gap-1"
-						>
-							{pageUrl}
-							<ExternalLink className="size-3" />
-						</a>
-					</div>
-					{communityPage.publishedAt && (
-						<p className="text-xs text-muted-fg pt-1">
-							Published: {formatDate(communityPage.publishedAt)}
-						</p>
+		<div className="space-y-8 p-6">
+			<PageHeader
+				subtitle={
+					isLive
+						? "Your public page is live and collecting leads"
+						: "Your public page is in draft — publish when ready"
+				}
+			>
+				<div className="flex flex-wrap items-center gap-2.5">
+					{isLive ? (
+						<>
+							<Button variant="ghost" size="sm" onClick={handleCopyUrl}>
+								{copied ? (
+									<>
+										<Check className="size-4 mr-2 text-emerald-600" />
+										Copied!
+									</>
+								) : (
+									<>
+										<Copy className="size-4 mr-2" />
+										Copy link
+									</>
+								)}
+							</Button>
+							<a href={pageUrl} target="_blank" rel="noopener noreferrer">
+								<Button variant="outline" size="sm">
+									<ExternalLink className="size-4 mr-2" />
+									View live
+								</Button>
+							</a>
+							<Button
+								variant="default"
+								size="sm"
+								onClick={() => router.push("/community/edit")}
+							>
+								<Pencil className="size-4 mr-2" />
+								Edit page
+							</Button>
+						</>
+					) : (
+						<>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={() => router.push("/community/edit")}
+							>
+								<Pencil className="size-4 mr-2" />
+								Edit page
+							</Button>
+							<Button
+								variant="default"
+								size="sm"
+								onClick={() => router.push("/community/edit")}
+							>
+								<Send className="size-4 mr-2" />
+								Publish to public
+							</Button>
+						</>
 					)}
 				</div>
+			</PageHeader>
 
-				<div className="flex flex-col sm:flex-row gap-3 w-full md:w-auto mt-4 md:mt-0">
-					<Button
-						variant="ghost"
-						onClick={handleCopyUrl}
-						className="w-full sm:w-auto"
-					>
-						{copied ? (
-							<>
-								<Check className="size-4 mr-2 text-emerald-600" />
-								Copied!
-							</>
+			{/* Profile hero */}
+			<Frame>
+				<FramePanel className="p-0 overflow-hidden">
+					<DotField className="text-primary opacity-45 [mask-image:radial-gradient(120%_160%_at_100%_0%,black,transparent_75%)]" />
+					{bannerUrl && (
+						<div className="relative h-40 md:h-52">
+							{/* eslint-disable-next-line @next/next/no-img-element */}
+							<img
+								src={bannerUrl}
+								alt=""
+								className="size-full object-cover"
+							/>
+						</div>
+					)}
+
+					{/* Identity row — text vertically centered; illustration card right */}
+					<div className="relative flex flex-col gap-6 p-6 md:flex-row md:items-center md:justify-between sm:p-7">
+						<div
+							className={cn(
+								"flex gap-4 min-w-0",
+								bannerUrl ? "items-end" : "items-center",
+							)}
+						>
+							<div
+								className={cn(
+									"flex size-20 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-primary/10 shadow-sm",
+									bannerUrl &&
+										"-mt-16 border-4 border-[var(--frame-panel-bg)]",
+								)}
+							>
+								{avatarUrl ? (
+									// eslint-disable-next-line @next/next/no-img-element
+									<img
+										src={avatarUrl}
+										alt={`${displayTitle} logo`}
+										className="size-full object-cover"
+									/>
+								) : (
+									<span className="text-2xl font-bold text-primary">
+										{displayTitle.charAt(0).toUpperCase()}
+									</span>
+								)}
+							</div>
+							<div className="min-w-0">
+								<div className="flex items-center gap-3">
+									<h2 className="truncate text-xl font-bold tracking-tight text-foreground sm:text-2xl">
+										{displayTitle}
+									</h2>
+									{isLive ? (
+										<StatusBadge
+											role="success"
+											appearance="soft"
+											className="shrink-0 gap-1.5"
+										>
+											<span className="relative flex size-2">
+												<span className="absolute inline-flex size-full animate-ping rounded-full bg-emerald-400 opacity-75 motion-reduce:animate-none" />
+												<span className="relative inline-flex size-2 rounded-full bg-emerald-500" />
+											</span>
+											Live
+										</StatusBadge>
+									) : (
+										<StatusBadge
+											role="warning"
+											appearance="soft"
+											className="shrink-0 gap-1.5"
+										>
+											<Clock className="size-3" />
+											Draft
+										</StatusBadge>
+									)}
+								</div>
+								<div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+									{isLive ? (
+										<a
+											href={pageUrl}
+											target="_blank"
+											rel="noopener noreferrer"
+											className="flex items-center gap-1 font-mono text-xs hover:text-foreground hover:underline transition-colors"
+										>
+											{pageUrl || `/communities/${communityPage.slug}`}
+											<ExternalLink className="size-3" />
+										</a>
+									) : (
+										<span className="font-mono text-xs">
+											{pageUrl || `/communities/${communityPage.slug}`}
+										</span>
+									)}
+									<span className="text-xs">
+										{isLive
+											? communityPage.publishedAt
+												? `Published ${formatDate(communityPage.publishedAt)}`
+												: "Published"
+											: communityPage.updatedAt
+												? `Updated ${formatDate(communityPage.updatedAt)}`
+												: "Not yet published"}
+									</span>
+								</div>
+							</div>
+						</div>
+
+						{/* Illustration card */}
+						<div className="relative hidden shrink-0 items-center justify-center overflow-hidden rounded-xl border border-border/60 bg-muted/30 px-14 py-7 md:flex">
+							<DotField className="text-primary opacity-40 [mask-image:radial-gradient(ellipse_at_center,black_40%,transparent_80%)]" />
+							<NodesIllustration className="relative h-36 w-auto" />
+						</div>
+					</div>
+				</FramePanel>
+			</Frame>
+
+			{/* Section completeness */}
+			<Frame>
+				<FrameHeader className="flex-row items-center justify-between gap-4">
+					<div>
+						<FrameTitle>Page sections</FrameTitle>
+						<FrameDescription>
+							{completedSections.length === SECTION_CHECKLIST.length
+								? "All sections filled in — your page is looking sharp."
+								: `${completedSections.length} of ${SECTION_CHECKLIST.length} sections have content.`}
+						</FrameDescription>
+					</div>
+					<div className="flex shrink-0 items-center gap-3">
+						<Progress value={completionPct} className="w-28" />
+						<span className="text-sm font-medium tabular-nums text-muted-foreground">
+							{completionPct}%
+						</span>
+					</div>
+				</FrameHeader>
+				<div className="grid gap-1 sm:grid-cols-2 xl:grid-cols-4">
+					{SECTION_CHECKLIST.map((section) => {
+						const complete = section.isComplete(communityPage);
+						const Icon = section.icon;
+						return (
+							<FramePanel
+								key={section.id}
+								className={cn("p-0", !complete && "border-dashed")}
+							>
+								<Link
+									href={`/community/edit#${section.id}`}
+									className="group flex h-full items-start gap-3 p-4 transition-colors hover:bg-accent/50"
+								>
+									<div
+										className={cn(
+											"flex size-8 shrink-0 items-center justify-center rounded-lg",
+											complete
+												? "bg-primary/10 text-primary"
+												: "bg-muted text-muted-foreground",
+										)}
+									>
+										<Icon className="size-4" />
+									</div>
+									<div className="min-w-0 flex-1">
+										<p className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+											{section.label}
+											{complete ? (
+												<CheckCircle2 className="size-3.5 shrink-0 text-emerald-500" />
+											) : (
+												<Circle className="size-3.5 shrink-0 text-border" />
+											)}
+										</p>
+										<p className="mt-0.5 truncate text-xs text-muted-foreground">
+											{complete ? section.blurb : "Not added yet"}
+										</p>
+									</div>
+									<ArrowRight className="size-3.5 shrink-0 self-center text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+								</Link>
+							</FramePanel>
+						);
+					})}
+					{/* Footer action panel completes the grid */}
+					<FramePanel className="bg-primary/5 p-4">
+						{isLive ? (
+							<div className="flex h-full flex-col justify-between gap-3">
+								<div>
+									<p className="text-sm font-medium text-foreground">
+										Share your page
+									</p>
+									<p className="mt-0.5 text-xs text-muted-foreground">
+										Social media, business cards, email signatures.
+									</p>
+								</div>
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={handleCopyUrl}
+									className="w-full"
+								>
+									{copied ? (
+										<Check className="size-4 mr-2 text-emerald-600" />
+									) : (
+										<Copy className="size-4 mr-2" />
+									)}
+									Copy link
+								</Button>
+							</div>
 						) : (
-							<>
-								<Copy className="size-4 mr-2" />
-								Copy Link
-							</>
+							<div className="flex h-full flex-col justify-between gap-3">
+								<div>
+									<p className="text-sm font-medium text-foreground">
+										Ready to go live?
+									</p>
+									<p className="mt-0.5 text-xs text-muted-foreground">
+										Anyone with the link can view your page and submit
+										interest forms.
+									</p>
+								</div>
+								<Button
+									variant="default"
+									size="sm"
+									onClick={() => router.push("/community/edit")}
+									className="w-full"
+								>
+									<Send className="size-4 mr-2" />
+									Publish to public
+								</Button>
+							</div>
 						)}
-					</Button>
-					<Button
-						variant="secondary"
-						onClick={() => router.push("/community/edit")}
-						className="w-full sm:w-auto"
-					>
-						<Edit className="size-4 mr-2" />
-						Edit Page
-					</Button>
-					<a
-						href={pageUrl}
-						target="_blank"
-						rel="noopener noreferrer"
-						className="w-full sm:w-auto"
-					>
-						<Button variant="default" className="w-full sm:w-auto">
-							<ExternalLink className="size-4 mr-2" />
-							View Live
-						</Button>
-					</a>
+					</FramePanel>
 				</div>
-			</div>
-
-			<div className="rounded-xl border border-border/40 bg-muted/20 p-5 mt-4">
-				<p className="text-sm text-muted-fg">
-					<strong className="text-fg font-medium">Tip:</strong> Share your
-					community page link on social media, business cards, or email
-					signatures to attract potential customers and generate leads.
-				</p>
-			</div>
+			</Frame>
 		</div>
 	);
 }

--- a/apps/web/src/app/(workspace)/community/page.tsx
+++ b/apps/web/src/app/(workspace)/community/page.tsx
@@ -97,7 +97,9 @@ const SECTION_CHECKLIST: Array<{
 		label: "Bio",
 		blurb: "Tell your story",
 		icon: FileText,
-		isComplete: (p) => !!p.draftBioContent || !!p.draftContent,
+		isComplete: (p) =>
+			hasRichTextContent(p.draftBioContent) ||
+			hasRichTextContent(p.draftContent),
 	},
 	{
 		id: "imageGallery",
@@ -111,7 +113,7 @@ const SECTION_CHECKLIST: Array<{
 		label: "Services",
 		blurb: "What you offer",
 		icon: Wrench,
-		isComplete: (p) => !!p.draftServicesContent,
+		isComplete: (p) => hasRichTextContent(p.draftServicesContent),
 	},
 	{
 		id: "pricing",
@@ -119,7 +121,8 @@ const SECTION_CHECKLIST: Array<{
 		blurb: "Tiers or a custom write-up",
 		icon: Tags,
 		isComplete: (p) =>
-			(p.draftPricingTiers?.length ?? 0) > 0 || !!p.draftPricingContent,
+			(p.draftPricingTiers?.length ?? 0) > 0 ||
+			hasRichTextContent(p.draftPricingContent),
 	},
 ];
 
@@ -143,6 +146,17 @@ const CREATE_PROOF_POINTS = [
 			"Visitors submit interest forms that land in your tasks automatically.",
 	},
 ] as const;
+
+/** True when TipTap JSON actually contains text or media, not just empty nodes. */
+function hasRichTextContent(doc: unknown): boolean {
+	if (!doc || typeof doc !== "object") return false;
+	const node = doc as { type?: string; text?: string; content?: unknown[] };
+	if (node.type === "text") return !!node.text?.trim();
+	if (node.type === "image") return true;
+	return (
+		Array.isArray(node.content) && node.content.some(hasRichTextContent)
+	);
+}
 
 function formatDate(timestamp?: number) {
 	if (!timestamp) return null;
@@ -375,8 +389,10 @@ function CommunityPageContent() {
 		toast.success("URL copied", "Share this link with your audience");
 	}, [communitySlug, toast]);
 
-	const pageUrl = communityPage?.slug
-		? `${typeof window !== "undefined" ? window.location.origin : ""}/communities/${communityPage.slug}`
+	// Relative path keeps SSR/client markup identical; the absolute URL is only
+	// built inside handleCopyUrl where window is guaranteed.
+	const pagePath = communityPage?.slug
+		? `/communities/${communityPage.slug}`
 		: "";
 
 	// Loading state
@@ -479,12 +495,7 @@ function CommunityPageContent() {
 										size="lg"
 										className="w-full justify-center"
 										onClick={handleCreatePage}
-										disabled={
-											isCreating ||
-											!slug ||
-											!!slugError ||
-											isSlugAvailable === false
-										}
+										disabled={isCreating || slugStatus !== "available"}
 									>
 										{isCreating ? (
 											<Loader2 className="size-4 mr-2 animate-spin" />
@@ -582,12 +593,21 @@ function CommunityPageContent() {
 									</>
 								)}
 							</Button>
-							<a href={pageUrl} target="_blank" rel="noopener noreferrer">
-								<Button variant="outline" size="sm">
-									<ExternalLink className="size-4 mr-2" />
-									View live
-								</Button>
-							</a>
+							<Button
+								variant="outline"
+								size="sm"
+								nativeButton={false}
+								render={
+									<a
+										href={pagePath}
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								}
+							>
+								<ExternalLink className="size-4 mr-2" />
+								View live
+							</Button>
 							<Button
 								variant="default"
 								size="sm"
@@ -694,18 +714,16 @@ function CommunityPageContent() {
 								<div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
 									{isLive ? (
 										<a
-											href={pageUrl}
+											href={pagePath}
 											target="_blank"
 											rel="noopener noreferrer"
 											className="flex items-center gap-1 font-mono text-xs hover:text-foreground hover:underline transition-colors"
 										>
-											{pageUrl || `/communities/${communityPage.slug}`}
+											{pagePath}
 											<ExternalLink className="size-3" />
 										</a>
 									) : (
-										<span className="font-mono text-xs">
-											{pageUrl || `/communities/${communityPage.slug}`}
-										</span>
+										<span className="font-mono text-xs">{pagePath}</span>
 									)}
 									<span className="text-xs">
 										{isLive

--- a/apps/web/src/components/reui/scrollspy.tsx
+++ b/apps/web/src/components/reui/scrollspy.tsx
@@ -13,7 +13,6 @@ type ScrollspyProps = {
   className?: string
   dataAttribute?: string
   history?: boolean
-  throttleTime?: number
 }
 
 export function Scrollspy({
@@ -44,7 +43,9 @@ export function Scrollspy({
       })
       if (onUpdate) onUpdate(sectionId)
       if (history && (force || prevIdTracker.current !== sectionId)) {
-        window.history.replaceState({}, "", `#${sectionId}`)
+        // Preserve existing history state — Next.js App Router stores router
+        // state there; replacing it with {} breaks back/forward navigation.
+        window.history.replaceState(window.history.state, "", `#${sectionId}`)
       }
       prevIdTracker.current = sectionId
     },
@@ -198,10 +199,14 @@ export function Scrollspy({
       )
     }
 
-    const currentAnchors = anchorElementsRef.current
-    currentAnchors?.forEach((item) => {
-      item.addEventListener("click", scrollTo(item as HTMLElement))
-    })
+    // Hold the exact handler references so cleanup removes what was added —
+    // scrollTo(item) returns a fresh closure on every call.
+    const handlerPairs =
+      anchorElementsRef.current?.map((item) => {
+        const handler = scrollTo(item as HTMLElement)
+        item.addEventListener("click", handler)
+        return { item, handler } as const
+      }) ?? []
 
     const onScroll = (event: Event) => {
       const scrollElement =
@@ -230,8 +235,8 @@ export function Scrollspy({
 
     return () => {
       window.removeEventListener("scroll", onScroll, true)
-      currentAnchors?.forEach((item) => {
-        item.removeEventListener("click", scrollTo(item as HTMLElement))
+      handlerPairs.forEach(({ item, handler }) => {
+        item.removeEventListener("click", handler)
       })
       clearTimeout(initialTimeout)
     }

--- a/apps/web/src/components/reui/scrollspy.tsx
+++ b/apps/web/src/components/reui/scrollspy.tsx
@@ -1,0 +1,252 @@
+"use client"
+
+import { ReactNode, RefObject, useCallback, useEffect, useRef } from "react"
+
+type ScrollspyProps = {
+  children: ReactNode
+  targetRef?: RefObject<
+    HTMLElement | HTMLDivElement | Document | null | undefined
+  >
+  onUpdate?: (id: string) => void
+  offset?: number
+  smooth?: boolean
+  className?: string
+  dataAttribute?: string
+  history?: boolean
+  throttleTime?: number
+}
+
+export function Scrollspy({
+  children,
+  targetRef,
+  onUpdate,
+  className,
+  offset = 0,
+  smooth = true,
+  dataAttribute = "scrollspy",
+  history = true,
+}: ScrollspyProps) {
+  const selfRef = useRef<HTMLDivElement | null>(null)
+  const anchorElementsRef = useRef<Element[] | null>(null)
+  const prevIdTracker = useRef<string | null>(null)
+
+  // Sets active nav, hash, prevIdTracker, and calls onUpdate
+  const setActiveSection = useCallback(
+    (sectionId: string | null, force = false) => {
+      if (!sectionId) return
+      anchorElementsRef.current?.forEach((item) => {
+        const id = item.getAttribute(`data-${dataAttribute}-anchor`)
+        if (id === sectionId) {
+          item.setAttribute("data-active", "true")
+        } else {
+          item.removeAttribute("data-active")
+        }
+      })
+      if (onUpdate) onUpdate(sectionId)
+      if (history && (force || prevIdTracker.current !== sectionId)) {
+        window.history.replaceState({}, "", `#${sectionId}`)
+      }
+      prevIdTracker.current = sectionId
+    },
+    [anchorElementsRef, dataAttribute, history, onUpdate]
+  )
+
+  const handleScroll = useCallback(() => {
+    if (!anchorElementsRef.current || anchorElementsRef.current.length === 0)
+      return
+
+    let scrollElement =
+      targetRef?.current === document
+        ? document.documentElement
+        : (targetRef?.current as HTMLElement)
+
+    if (!scrollElement) return
+
+    // If the scrollElement has a data-slot="scroll-area-viewport" inside, use that
+    const viewport = scrollElement.querySelector(
+      '[data-slot="scroll-area-viewport"]'
+    )
+    if (viewport instanceof HTMLElement) {
+      scrollElement = viewport
+    }
+
+    const scrollTop =
+      scrollElement === document.documentElement
+        ? window.scrollY || document.documentElement.scrollTop
+        : scrollElement.scrollTop
+
+    // Find the anchor whose section is closest to but not past the top.
+    // Positions come from getBoundingClientRect (not offsetTop) so sections
+    // nested in positioned ancestors still measure relative to the scroller.
+    let activeIdx = 0
+    let minDelta = Infinity
+
+    anchorElementsRef.current.forEach((anchor, idx) => {
+      const sectionId = anchor.getAttribute(`data-${dataAttribute}-anchor`)
+      const sectionElement = document.getElementById(sectionId!)
+      if (!sectionElement) return
+
+      let customOffset = offset
+      const dataOffset = anchor.getAttribute(`data-${dataAttribute}-offset`)
+      if (dataOffset) customOffset = parseInt(dataOffset, 10)
+
+      const rectTop = sectionElement.getBoundingClientRect().top
+      const sectionTop =
+        scrollElement === document.documentElement
+          ? rectTop + scrollTop
+          : rectTop - scrollElement.getBoundingClientRect().top + scrollTop
+
+      const delta = Math.abs(sectionTop - customOffset - scrollTop)
+
+      if (sectionTop - customOffset <= scrollTop && delta < minDelta) {
+        minDelta = delta
+        activeIdx = idx
+      }
+    })
+
+    // If at bottom, force last anchor
+    const scrollHeight = (scrollElement as HTMLElement).scrollHeight
+    const clientHeight = (scrollElement as HTMLElement).clientHeight
+
+    if (scrollTop + clientHeight >= scrollHeight - 2) {
+      activeIdx = anchorElementsRef.current.length - 1
+    }
+
+    // Set only one anchor active and sync the URL hash
+    const activeAnchor = anchorElementsRef.current[activeIdx]
+    const sectionId =
+      activeAnchor?.getAttribute(`data-${dataAttribute}-anchor`) || null
+
+    setActiveSection(sectionId)
+  }, [anchorElementsRef, targetRef, dataAttribute, offset, setActiveSection])
+
+  const scrollTo = useCallback(
+    (anchorElement: HTMLElement) => (event?: Event) => {
+      if (event) event.preventDefault()
+      const sectionId =
+        anchorElement
+          .getAttribute(`data-${dataAttribute}-anchor`)
+          ?.replace("#", "") || null
+      if (!sectionId) return
+      const sectionElement = document.getElementById(sectionId)
+      if (!sectionElement) return
+
+      let scrollToElement: HTMLElement | Window | null =
+        targetRef?.current === document
+          ? window
+          : (targetRef?.current as HTMLElement)
+
+      if (scrollToElement instanceof HTMLElement) {
+        const viewport = scrollToElement.querySelector(
+          '[data-slot="scroll-area-viewport"]'
+        )
+        if (viewport instanceof HTMLElement) {
+          scrollToElement = viewport
+        }
+      }
+
+      let customOffset = offset
+      const dataOffset = anchorElement.getAttribute(
+        `data-${dataAttribute}-offset`
+      )
+      if (dataOffset) {
+        customOffset = parseInt(dataOffset, 10)
+      }
+
+      // Rect-based position: correct even inside positioned ancestors.
+      const rectTop = sectionElement.getBoundingClientRect().top
+      const sectionTop =
+        scrollToElement instanceof HTMLElement
+          ? rectTop -
+            scrollToElement.getBoundingClientRect().top +
+            scrollToElement.scrollTop
+          : rectTop + (window.scrollY || document.documentElement.scrollTop)
+
+      const scrollTop = sectionTop - customOffset
+
+      if (scrollToElement && "scrollTo" in scrollToElement) {
+        scrollToElement.scrollTo({
+          top: scrollTop,
+          left: 0,
+          behavior: smooth ? "smooth" : "auto",
+        })
+      }
+      setActiveSection(sectionId, true)
+    },
+    [dataAttribute, offset, smooth, targetRef, setActiveSection]
+  )
+
+  // Scroll to the section if the ID is present in the URL hash
+  const scrollToHashSection = useCallback(() => {
+    const hash = CSS.escape(window.location.hash.replace("#", ""))
+
+    if (hash) {
+      const targetElement = document.querySelector(
+        `[data-${dataAttribute}-anchor="${hash}"]`
+      ) as HTMLElement
+      if (targetElement) {
+        scrollTo(targetElement)()
+      }
+    }
+  }, [dataAttribute, scrollTo])
+
+  useEffect(() => {
+    // Query elements and store them in the ref, avoiding unnecessary re-renders
+    if (selfRef.current) {
+      anchorElementsRef.current = Array.from(
+        selfRef.current.querySelectorAll(`[data-${dataAttribute}-anchor]`)
+      )
+    }
+
+    const currentAnchors = anchorElementsRef.current
+    currentAnchors?.forEach((item) => {
+      item.addEventListener("click", scrollTo(item as HTMLElement))
+    })
+
+    const onScroll = (event: Event) => {
+      const scrollElement =
+        targetRef?.current === document
+          ? window
+          : (targetRef?.current as HTMLElement)
+      if (!scrollElement) return
+
+      if (
+        scrollElement === window ||
+        (scrollElement instanceof HTMLElement &&
+          scrollElement.contains(event.target as Node))
+      ) {
+        handleScroll()
+      }
+    }
+
+    // Use window listener with capture to catch scroll events from targetRef even if set later
+    window.addEventListener("scroll", onScroll, true)
+
+    // Check if there's a hash in the URL and scroll to the corresponding section
+    const initialTimeout = setTimeout(() => {
+      scrollToHashSection()
+      handleScroll()
+    }, 100)
+
+    return () => {
+      window.removeEventListener("scroll", onScroll, true)
+      currentAnchors?.forEach((item) => {
+        item.removeEventListener("click", scrollTo(item as HTMLElement))
+      })
+      clearTimeout(initialTimeout)
+    }
+  }, [
+    targetRef,
+    selfRef,
+    handleScroll,
+    dataAttribute,
+    scrollTo,
+    scrollToHashSection,
+  ])
+
+  return (
+    <div data-slot="scrollspy" className={className} ref={selfRef}>
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
Status page: full-width Reports-style layout with accent-bar header; claim hero with live-mirroring browser mock + slug availability InputGroup; profile hero on Frame panels with DotField texture, nodes illustration card, and a section-completeness grid deep-linking into the editor via #hash.

Editor: vendored ReUI Scrollspy (rect-based positions, .workspace-canvas scroll target) replaces the hand-rolled IntersectionObserver nav; icon rail + mobile chips; sections restyled onto a shared SectionShell with Field/ InputGroup adoption; content seated on opaque Frame panels over the canvas dot texture. Fixes latent sticky-header death: min-h-screen overrode the flex item's automatic minimum, letting the canvas flex-shrink the page root to one viewport.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a redesigned community page with live previews, completion progress, status indicators, and streamlined claim and publishing actions.
  * Added responsive section navigation with scrollspy support and direct links to editor sections.
  * Added a reusable node illustration and standardized editor section layouts.
* **Improvements**
  * Refined community editing controls, form layouts, image uploads, gallery actions, pricing tiers, themes, and validation states.
  * Improved accessibility with clearer controls, labels, focus behavior, and status feedback.
  * Updated visual styling, transitions, spacing, and responsive behavior across the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers a full ReUI redesign of the community status page and editor. The status page gains a claim hero with a live-mirroring browser mock, a section-completeness grid with editor deep-links, and a unified profile hero for both draft and live states. The editor replaces the hand-rolled `IntersectionObserver` nav with a vendored `Scrollspy`, extracts a shared `SectionShell` component used by all seven sections, and fixes a latent sticky-header layout bug caused by `min-h-screen` overriding the flex item's automatic minimum.

- **New `Scrollspy` component** (`components/reui/scrollspy.tsx`): rect-based position tracking, URL hash sync, and scroll-area viewport detection; contains a cleanup bug where click listener handlers are never actually removed (see inline comment).
- **`SectionShell` abstraction**: cleanly consolidates icon tile, title, description, and separator across all section files, reducing boilerplate significantly.
- **Status page overhaul** (`community/page.tsx`): new Frame-based layout with `DotField` texture, `NodesIllustration`, `Progress` bar, and `InputGroup` slug widget; all three states (loading, claim, profile) are now distinct, structured code paths.

<h3>Confidence Score: 3/5</h3>

Safe to merge pending a one-line fix in the Scrollspy cleanup; all other changes are well-structured UI refactors with no data or auth impact.

The new Scrollspy removeEventListener calls create fresh closures that do not match the originals, so click handlers on nav anchors accumulate each time the effect re-runs rather than being swapped out. In current wiring the effect deps are mostly stable so doubling is unlikely in normal use, but on breakpoint changes or hot-reload cycles it can silently stack handlers. Every other change in this PR is correct and well-considered.

apps/web/src/components/reui/scrollspy.tsx — the click-handler cleanup and the unused throttleTime prop both need attention before this component is extended further.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/reui/scrollspy.tsx | New vendored Scrollspy component; click-handler cleanup calls `scrollTo(item)` which creates a new closure each time, so `removeEventListener` never removes the original handler — listeners accumulate. Also declares `throttleTime` in the prop type but never uses it. |
| apps/web/src/app/(workspace)/community/edit/community-edit-content.tsx | Replaces hand-rolled IntersectionObserver nav with vendored Scrollspy; fixes min-h-screen sticky header issue with shrink-0; adds scroll-target resolution for desktop canvas vs. mobile window. |
| apps/web/src/app/(workspace)/community/edit/sections/section-shell.tsx | New shared section chrome component with icon, title, description, separator, and scroll-margin; cleanly extracts repetitive boilerplate from all seven section files. |
| apps/web/src/app/(workspace)/community/page.tsx | Complete redesign of the status page: adds claim hero with live-mirroring browser mock, section-completeness progress grid with deep links into the editor, and unifies draft/live states into a single profile hero using Frame panels. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/web/src/components/reui/scrollspy.tsx`, line 2971-3006 ([link](https://github.com/xcarter93/onetool/blob/4852669ed251cca31918844f85f5cdbd62bc9f68/apps/web/src/components/reui/scrollspy.tsx#L2971-L3006)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Click listener never removed — handlers accumulate**

   `scrollTo(item as HTMLElement)` is a curried function that returns a *new* closure on every call. The `removeEventListener` in the cleanup creates a fresh closure that has a different reference than the one passed to `addEventListener`, so the original handler is never detached. If the effect re-runs (e.g., when `scrollTo` or another dep changes reference), every anchor element gains an additional click handler without shedding the old one.

   Fix: capture the returned handlers before attaching them and hold the references for cleanup:

   ```typescript
   const handlerPairs = currentAnchors?.map((item) => {
     const handler = scrollTo(item as HTMLElement)
     item.addEventListener("click", handler)
     return { item, handler } as const
   }) ?? []
   // in cleanup:
   handlerPairs.forEach(({ item, handler }) => {
     item.removeEventListener("click", handler)
   })
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/components/reui/scrollspy.tsx
   Line: 2971-3006

   Comment:
   **Click listener never removed — handlers accumulate**

   `scrollTo(item as HTMLElement)` is a curried function that returns a *new* closure on every call. The `removeEventListener` in the cleanup creates a fresh closure that has a different reference than the one passed to `addEventListener`, so the original handler is never detached. If the effect re-runs (e.g., when `scrollTo` or another dep changes reference), every anchor element gains an additional click handler without shedding the old one.

   Fix: capture the returned handlers before attaching them and hold the references for cleanup:

   ```typescript
   const handlerPairs = currentAnchors?.map((item) => {
     const handler = scrollTo(item as HTMLElement)
     item.addEventListener("click", handler)
     return { item, handler } as const
   }) ?? []
   // in cleanup:
   handlerPairs.forEach(({ item, handler }) => {
     item.removeEventListener("click", handler)
   })
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/web/src/components/reui/scrollspy.tsx`, line 2783-2786 ([link](https://github.com/xcarter93/onetool/blob/4852669ed251cca31918844f85f5cdbd62bc9f68/apps/web/src/components/reui/scrollspy.tsx#L2783-L2786)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`throttleTime` declared but never consumed**

   `throttleTime` appears in `ScrollspyProps` but is not destructured in the function signature and the `onScroll` handler fires on every event without any rate-limiting. Callers passing this prop get no effect, and the missing throttle causes expensive `getBoundingClientRect` reads on every scroll frame. Either wire the prop up or remove it from the type to avoid misleading consumers.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/components/reui/scrollspy.tsx
   Line: 2783-2786

   Comment:
   **`throttleTime` declared but never consumed**

   `throttleTime` appears in `ScrollspyProps` but is not destructured in the function signature and the `onScroll` handler fires on every event without any rate-limiting. Callers passing this prop get no effect, and the missing throttle causes expensive `getBoundingClientRect` reads on every scroll frame. Either wire the prop up or remove it from the type to avoid misleading consumers.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/src/components/reui/scrollspy.tsx:2971-3006
**Click listener never removed — handlers accumulate**

`scrollTo(item as HTMLElement)` is a curried function that returns a *new* closure on every call. The `removeEventListener` in the cleanup creates a fresh closure that has a different reference than the one passed to `addEventListener`, so the original handler is never detached. If the effect re-runs (e.g., when `scrollTo` or another dep changes reference), every anchor element gains an additional click handler without shedding the old one.

Fix: capture the returned handlers before attaching them and hold the references for cleanup:

```typescript
const handlerPairs = currentAnchors?.map((item) => {
  const handler = scrollTo(item as HTMLElement)
  item.addEventListener("click", handler)
  return { item, handler } as const
}) ?? []
// in cleanup:
handlerPairs.forEach(({ item, handler }) => {
  item.removeEventListener("click", handler)
})
```

### Issue 2 of 2
apps/web/src/components/reui/scrollspy.tsx:2783-2786
**`throttleTime` declared but never consumed**

`throttleTime` appears in `ScrollspyProps` but is not destructured in the function signature and the `onScroll` handler fires on every event without any rate-limiting. Callers passing this prop get no effect, and the missing throttle causes expensive `getBoundingClientRect` reads on every scroll frame. Either wire the prop up or remove it from the type to avoid misleading consumers.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(community): ReUI redesign of commun..."](https://github.com/xcarter93/onetool/commit/4852669ed251cca31918844f85f5cdbd62bc9f68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45263572)</sub>

<!-- /greptile_comment -->