### PR TITLE
Fix audience requirement in portal session handling

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -107,6 +107,7 @@ import type * as organizationDocuments from "../organizationDocuments.js";
 import type * as organizations from "../organizations.js";
 import type * as payments from "../payments.js";
 import type * as permissions from "../permissions.js";
+import type * as portal_audiences from "../portal/audiences.js";
 import type * as portal_branding from "../portal/branding.js";
 import type * as portal_email from "../portal/email.js";
 import type * as portal_helpers from "../portal/helpers.js";
@@ -247,6 +248,7 @@ declare const fullApi: ApiFromModules<{
   organizations: typeof organizations;
   payments: typeof payments;
   permissions: typeof permissions;
+  "portal/audiences": typeof portal_audiences;
   "portal/branding": typeof portal_branding;
   "portal/email": typeof portal_email;
   "portal/helpers": typeof portal_helpers;

--- a/packages/backend/convex/auth.config.ts
+++ b/packages/backend/convex/auth.config.ts
@@ -1,3 +1,5 @@
+import { PORTAL_JWT_AUDIENCES } from "./portal/audiences";
+
 if (!process.env.PORTAL_JWT_ISSUER) {
 	throw new Error(
 		"PORTAL_JWT_ISSUER is unset on this Convex deployment — the portal " +
@@ -11,23 +13,16 @@ const authConfig = {
 			domain: process.env.CLERK_ISSUER_DOMAIN,
 			applicationID: "convex",
 		},
-		{
-			// One customJwt provider per portal audience: the httpOnly cookie JWT
-			// and the short-lived browser access token share issuer/JWKS but use
-			// distinct application IDs.
+		// One customJwt provider per portal audience: the httpOnly cookie JWT
+		// and the short-lived browser access token share issuer/JWKS but use
+		// distinct application IDs.
+		...PORTAL_JWT_AUDIENCES.map((audience) => ({
 			type: "customJwt",
 			issuer: process.env.PORTAL_JWT_ISSUER,
 			jwks: `${process.env.PORTAL_JWT_ISSUER}/.well-known/portal-jwks.json`,
 			algorithm: "RS256",
-			applicationID: "convex-portal",
-		},
-		{
-			type: "customJwt",
-			issuer: process.env.PORTAL_JWT_ISSUER,
-			jwks: `${process.env.PORTAL_JWT_ISSUER}/.well-known/portal-jwks.json`,
-			algorithm: "RS256",
-			applicationID: "convex-portal-access",
-		},
+			applicationID: audience,
+		})),
 	],
 };
 

--- a/packages/backend/convex/portal/audiences.ts
+++ b/packages/backend/convex/portal/audiences.ts
@@ -1,0 +1,8 @@
+// Single source of truth for portal JWT audiences. Production enforcement
+// happens in auth.config.ts (one customJwt provider per audience, matched on
+// applicationID); helpers.ts only re-checks when a runtime surfaces the aud
+// claim (convex-test). Both derive from this list so they cannot drift.
+export const PORTAL_JWT_AUDIENCES = [
+	"convex-portal",
+	"convex-portal-access",
+] as const;

--- a/packages/backend/convex/portal/helpers.ts
+++ b/packages/backend/convex/portal/helpers.ts
@@ -55,17 +55,20 @@ export async function getPortalSessionOrThrow(
 		throw new ConvexError({ code: "UNAUTHENTICATED" });
 	}
 
-	// PUB-08: require the aud claim. Convex's customJwt provider enforces
-	// issuer/algorithm/signature but NOT audience, so this ad-hoc check is the
-	// only audience binding — a signed token that simply omitted `aud` would
-	// otherwise bypass it entirely (fail-open).
+	// PUB-08 (corrected): Convex's customJwt provider DOES enforce audience —
+	// `applicationID` must equal the token's `aud` for the provider to match at
+	// all, so a token with a missing/wrong aud never yields an identity (the
+	// !identity throw above covers it). Real deployments then strip `aud` from
+	// the surfaced identity as a housekeeping claim, so it is normally
+	// undefined here; requiring it bricked every prod portal session. When a
+	// runtime (e.g. convex-test identities) does surface aud, still pin it to
+	// the accepted portal audiences.
 	const aud = claims.aud;
-	if (aud === undefined || aud === null) {
-		throw new ConvexError({ code: "UNAUTHENTICATED" });
-	}
-	const audValues = Array.isArray(aud) ? aud : [aud];
-	if (!audValues.some((a) => ACCEPTED_AUDIENCES.has(a))) {
-		throw new ConvexError({ code: "UNAUTHENTICATED" });
+	if (aud !== undefined && aud !== null) {
+		const audValues = Array.isArray(aud) ? aud : [aud];
+		if (!audValues.some((a) => ACCEPTED_AUDIENCES.has(a))) {
+			throw new ConvexError({ code: "UNAUTHENTICATED" });
+		}
 	}
 
 	const orgId = claims.orgId;

--- a/packages/backend/convex/portal/helpers.ts
+++ b/packages/backend/convex/portal/helpers.ts
@@ -1,6 +1,7 @@
 import { ConvexError } from "convex/values";
 import type { QueryCtx, MutationCtx } from "../_generated/server";
 import type { Id } from "../_generated/dataModel";
+import { PORTAL_JWT_AUDIENCES } from "./audiences";
 
 /**
  * Validated portal session — what `getPortalSessionOrThrow` resolves a JWT
@@ -15,10 +16,7 @@ export type PortalSession = {
 	tokenJti: string;
 };
 
-const ACCEPTED_AUDIENCES = new Set([
-	"convex-portal",
-	"convex-portal-access",
-]);
+const ACCEPTED_AUDIENCES = new Set<string>(PORTAL_JWT_AUDIENCES);
 
 // PUB-07: portal sessions previously slid indefinitely — touchSession and the
 // 20h background ping re-anchored expiry to `now` on every request, so a stolen
@@ -64,7 +62,7 @@ export async function getPortalSessionOrThrow(
 	// runtime (e.g. convex-test identities) does surface aud, still pin it to
 	// the accepted portal audiences.
 	const aud = claims.aud;
-	if (aud !== undefined && aud !== null) {
+	if (aud !== undefined) {
 		const audValues = Array.isArray(aud) ? aud : [aud];
 		if (!audValues.some((a) => ACCEPTED_AUDIENCES.has(a))) {
 			throw new ConvexError({ code: "UNAUTHENTICATED" });

--- a/packages/backend/convex/portal/sessions.test.ts
+++ b/packages/backend/convex/portal/sessions.test.ts
@@ -157,7 +157,7 @@ describe("portal sessions", () => {
 	it("succeeds when the identity carries no aud claim (real Convex strips aud after enforcing it against applicationID at provider match)", async () => {
 		const seed = await seedClientPortal(t);
 		const jti = "test-jti-no-aud";
-		await seedSession(t, seed, jti);
+		const sessionId = await seedSession(t, seed, jti);
 
 		const { aud: _aud, ...identityWithoutAud } = portalIdentity(seed, jti);
 		const asPortal = t.withIdentity(identityWithoutAud);
@@ -165,7 +165,7 @@ describe("portal sessions", () => {
 			api.portal.sessions.touchSession,
 			{ tokenJti: jti, newExpiresAt: Date.now() + 1000 }
 		);
-		expect(result).toBeDefined();
+		expect(result).toBe(sessionId);
 	});
 
 	it("throws when no portalSessions row exists for the JWT's jti", async () => {

--- a/packages/backend/convex/portal/sessions.test.ts
+++ b/packages/backend/convex/portal/sessions.test.ts
@@ -154,6 +154,20 @@ describe("portal sessions", () => {
 		).rejects.toThrow(/UNAUTHENTICATED/);
 	});
 
+	it("succeeds when the identity carries no aud claim (real Convex strips aud after enforcing it against applicationID at provider match)", async () => {
+		const seed = await seedClientPortal(t);
+		const jti = "test-jti-no-aud";
+		await seedSession(t, seed, jti);
+
+		const { aud: _aud, ...identityWithoutAud } = portalIdentity(seed, jti);
+		const asPortal = t.withIdentity(identityWithoutAud);
+		const result = await asPortal.mutation(
+			api.portal.sessions.touchSession,
+			{ tokenJti: jti, newExpiresAt: Date.now() + 1000 }
+		);
+		expect(result).toBeDefined();
+	});
+
 	it("throws when no portalSessions row exists for the JWT's jti", async () => {
 		const seed = await seedClientPortal(t);
 		// Do NOT seed a session row for this jti.


### PR DESCRIPTION
This pull request updates the audience (`aud`) claim enforcement logic for portal sessions to correctly reflect how Convex's custom JWT provider handles audience validation. The main change is to no longer require the `aud` claim to be present in the identity for real deployments, since Convex already enforces it during provider matching and then strips it from the surfaced identity. The test suite is updated to cover this behavior.

**Portal session audience claim handling:**

* [`helpers.ts`](diffhunk://#diff-bd84ed0cbb37a2d80dba0d2c9ee33e7906b882aaefd53e1eecc4ec47e2d78286L58-R72): Updates the logic to only check the `aud` claim if it is present, avoiding unnecessary authentication failures when `aud` is missing, which is the expected behavior in production. The comment is revised to explain the correct audience enforcement flow.

**Test coverage:**

* [`sessions.test.ts`](diffhunk://#diff-19bbe8770785c8ea6a10662174cf36dd0d8a71f23ca972317843dc7af0948258R157-R170): Adds a test to ensure that portal sessions succeed when the identity has no `aud` claim, matching the behavior of real Convex deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Portal session activity now succeeds when the portal JWT does not include an audience (`aud`) claim.
  * Audience validation is still enforced when an `aud` claim is present, using the same allowed audience list across the portal authentication flow.

* **Tests**
  * Added coverage confirming `touchSession` succeeds when the JWT omits the audience claim.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a production bug where portal session authentication was failing 100% of the time because the `aud` claim check required the claim to be present, but Convex's customJwt provider strips `aud` from the surfaced identity after using it to match the provider. The fix makes the `aud` check conditional — it validates against `ACCEPTED_AUDIENCES` only when present, preserving the guard for test environments while unblocking real deployments.

- **`helpers.ts`**: Audience check changed from a hard requirement (`aud` must exist) to a conditional guard (`if aud is present, it must be in ACCEPTED_AUDIENCES`), with a revised comment explaining the two-layer enforcement model (Convex provider-level vs. application-level).
- **`sessions.test.ts`**: Adds a test that strips `aud` from the identity before calling `touchSession`, confirming the success path that mirrors real Convex deployment behavior.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the fix correctly unblocks production auth by aligning with how Convex surfaces identities, and auth.config.ts confirms both providers enforce audience at the platform level.

The logic change is well-reasoned and backed by auth.config.ts (both portal providers have applicationID set). The only concern is that ACCEPTED_AUDIENCES in helpers.ts is now a test-only guard and can silently drift from the provider config — a future update to one without the other would go unnoticed until tested in production. The new test accurately covers the intended behavior.

Keep ACCEPTED_AUDIENCES in helpers.ts in sync with the applicationID values in auth.config.ts — they are now the canonical source of audience enforcement and the two can drift invisibly.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/portal/helpers.ts | Relaxes the hard `aud` requirement to an optional check; reasoning is sound given auth.config.ts sets applicationID on both portal providers, but ACCEPTED_AUDIENCES is now effectively dead code in production and can drift from the provider config |
| packages/backend/convex/portal/sessions.test.ts | Adds a test for the no-aud success path; correctly seeds session/identity, strips aud via destructuring, and asserts a successful mutation result |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Convex as Convex Platform
    participant Handler as getPortalSessionOrThrow
    participant DB as portalSessions DB

    Client->>Convex: Request with JWT (aud: "convex-portal")
    Convex->>Convex: "Match against customJwt provider (applicationID must === aud)"
    alt aud missing or wrong
        Convex-->>Client: No identity surfaced
    else aud matches applicationID
        Convex->>Convex: Strip aud from identity (housekeeping)
        Convex->>Handler: identity (no aud claim)
    end
    Handler->>Handler: Check !identity → throws if null
    Handler->>Handler: "Check issuer === PORTAL_JWT_ISSUER"
    Handler->>Handler: Check aud (if present) in ACCEPTED_AUDIENCES
    Note over Handler: aud is absent in prod → check skipped
    Handler->>DB: Query portalSessions by jti
    DB-->>Handler: Session row
    Handler->>Handler: Validate expiry, idle timeout, claim-row match
    Handler-->>Client: PortalSession payload
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Convex as Convex Platform
    participant Handler as getPortalSessionOrThrow
    participant DB as portalSessions DB

    Client->>Convex: Request with JWT (aud: "convex-portal")
    Convex->>Convex: "Match against customJwt provider (applicationID must === aud)"
    alt aud missing or wrong
        Convex-->>Client: No identity surfaced
    else aud matches applicationID
        Convex->>Convex: Strip aud from identity (housekeeping)
        Convex->>Handler: identity (no aud claim)
    end
    Handler->>Handler: Check !identity → throws if null
    Handler->>Handler: "Check issuer === PORTAL_JWT_ISSUER"
    Handler->>Handler: Check aud (if present) in ACCEPTED_AUDIENCES
    Note over Handler: aud is absent in prod → check skipped
    Handler->>DB: Query portalSessions by jti
    DB-->>Handler: Session row
    Handler->>Handler: Validate expiry, idle timeout, claim-row match
    Handler-->>Client: PortalSession payload
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/backend/convex/portal/helpers.ts:66-72
**`ACCEPTED_AUDIENCES` is now a test-only guard — production drift risk**

The `aud` check only executes when `convex-test` surfaces the claim; in production Convex strips `aud` after matching, so this block is never reached. The actual audience enforcement lives exclusively in `auth.config.ts` (`applicationID: "convex-portal"` / `"convex-portal-access"`). If those two sources drift — e.g. a new audience is added to `ACCEPTED_AUDIENCES` here but a matching provider isn't added to `auth.config.ts`, or vice versa — tests would continue to pass while production silently accepts or rejects a new token type. Consider linking these two canonically (e.g. a shared constant or a comment cross-referencing `auth.config.ts`) so the contract stays visible.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(portal): stop requiring aud on surfa..."](https://github.com/xcarter93/onetool/commit/67de6d91052180142ace8f95ada4995d7642a7a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45322672)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->