### PR TITLE
ReUI treatment for customer portal with new layouts and components

### DIFF
--- a/apps/web/src/app/(portal)/portal/c/[clientPortalId]/(authenticated)/invoices/[invoiceId]/page.tsx
+++ b/apps/web/src/app/(portal)/portal/c/[clientPortalId]/(authenticated)/invoices/[invoiceId]/page.tsx
@@ -7,7 +7,6 @@ import { ArrowLeft } from "lucide-react";
 
 import { readSessionCookie } from "@/lib/portal/cookie";
 import { InvoiceDetailIsland } from "@/components/portal/invoices/invoice-detail-island";
-import { HeaderActionsClient } from "@/components/portal/invoices/header-actions-client";
 
 export default async function InvoiceDetailPage({
 	params,
@@ -50,7 +49,7 @@ export default async function InvoiceDetailPage({
 		<div className="-mx-6 md:-mx-9 -my-6 flex flex-col">
 			<header
 				data-sticky-detail-header
-				className="sticky top-0 z-20 flex h-[68px] items-center justify-between gap-4 border-b border-border bg-background px-6 md:px-9"
+				className="sticky top-0 z-20 flex h-[68px] items-center gap-4 border-b border-border bg-background px-6 md:px-9"
 			>
 				<div className="flex min-w-0 items-center gap-3">
 					<Link
@@ -65,7 +64,6 @@ export default async function InvoiceDetailPage({
 						Invoice #{data.invoice.invoiceNumber}
 					</h2>
 				</div>
-				<HeaderActionsClient invoiceId={invoiceId} hasPdf={hasPdf} />
 			</header>
 
 			{/* Mobile-only title block */}

--- a/apps/web/src/app/(portal)/portal/expired/page.tsx
+++ b/apps/web/src/app/(portal)/portal/expired/page.tsx
@@ -1,15 +1,46 @@
+import Image from "next/image";
+import { LinkIcon } from "lucide-react";
+import { SecuredByOneTool } from "@/components/portal/powered-by-onetool";
+
 export default function PortalExpiredPage() {
 	return (
-		<div className="flex min-h-screen items-center justify-center p-8">
-			<div className="text-center max-w-md">
-				<h1 className="text-2xl font-semibold mb-3">
-					This link is no longer valid
-				</h1>
-				<p className="text-sm text-muted-foreground">
-					Please use the link from your most recent email to return to the
-					portal.
-				</p>
-			</div>
+		<div className="flex min-h-screen flex-col bg-card">
+			<header className="flex items-center justify-between px-6 py-5 md:px-12">
+				<div className="flex items-center gap-2">
+					<Image
+						src="/OneTool.png"
+						alt=""
+						width={32}
+						height={32}
+						className="dark:brightness-0 dark:invert"
+						aria-hidden="true"
+					/>
+					<span className="text-sm font-semibold">OneTool</span>
+				</div>
+			</header>
+
+			<main className="flex flex-1 items-center justify-center px-6 py-10">
+				<div className="flex w-full max-w-md flex-col items-center gap-6 text-center">
+					<div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-muted">
+						<LinkIcon
+							className="h-7 w-7 text-muted-foreground"
+							aria-hidden="true"
+						/>
+					</div>
+
+					<div className="flex flex-col gap-2">
+						<h1 className="text-[26px] font-semibold tracking-[-0.02em]">
+							This link is no longer valid
+						</h1>
+						<p className="text-sm text-muted-foreground">
+							Please use the link from your most recent email to return to
+							the portal.
+						</p>
+					</div>
+
+					<SecuredByOneTool className="mt-6" />
+				</div>
+			</main>
 		</div>
 	);
 }

--- a/apps/web/src/components/portal/invoices/invoice-detail-island.tsx
+++ b/apps/web/src/components/portal/invoices/invoice-detail-island.tsx
@@ -9,6 +9,7 @@ import type { Id } from "@onetool/backend/convex/_generated/dataModel";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { formatMoney } from "@/lib/portal/format";
 
+import { DownloadPdfButton } from "./download-pdf-button";
 import { InvoicePaper } from "./invoice-paper";
 import {
 	InstallmentList,
@@ -18,6 +19,7 @@ import { PaidStatusPanel } from "./paid-status-panel";
 import { PaidSuccessOverlay } from "./paid-success-overlay";
 import { PaymentBottomSheet } from "./payment-bottom-sheet";
 import { PaymentRail } from "./payment-rail";
+import { PrintButton } from "./print-button";
 
 const CELEBRATION_DURATION_MS = 1900;
 
@@ -141,17 +143,6 @@ export function InvoiceDetailIsland({
 		return () => clearTimeout(timer);
 	}, [celebration]);
 
-	const paper = (
-		<InvoicePaper
-			invoice={data.invoice}
-			lineItems={data.lineItems}
-			businessName={data.businessName}
-			businessLogoUrl={data.businessLogoUrl}
-			clientName={data.clientName}
-			clientEmail={data.clientEmail}
-		/>
-	);
-
 	// Zero-payment-row invoices fall through to the normal render: an empty
 	// installment list with no pay surface (view-only).
 	const baseRail = (() => {
@@ -239,15 +230,22 @@ export function InvoiceDetailIsland({
 
 	return (
 		<>
-			<div className="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_480px]">
-				<div className="px-6 py-8 pb-24 md:px-9 md:pb-10">{paper}</div>
-				{isDesktop !== false ? (
-					<aside className="border-l border-border bg-card px-6 py-8 md:min-h-[calc(100vh-68px)] md:px-7">
-						{rightRail}
-					</aside>
-				) : (
-					<div className="px-6 pb-10">{rightRail}</div>
-				)}
+			<div className="px-6 py-8 pb-28 md:px-9 md:pb-10">
+				<InvoicePaper
+					invoice={data.invoice}
+					lineItems={data.lineItems}
+					businessName={data.businessName}
+					businessLogoUrl={data.businessLogoUrl}
+					clientName={data.clientName}
+					clientEmail={data.clientEmail}
+					displayStatus={data.paymentSummary.displayStatus}
+					paymentSummary={data.paymentSummary}
+					paySlot={rightRail}
+				/>
+				<div className="mx-auto mt-6 flex w-full max-w-4xl flex-wrap items-center justify-center gap-2">
+					<DownloadPdfButton invoiceId={data.invoice._id} hasPdf={hasPdf} />
+					<PrintButton />
+				</div>
 			</div>
 			{mobileSheet}
 		</>

--- a/apps/web/src/components/portal/invoices/invoice-list.tsx
+++ b/apps/web/src/components/portal/invoices/invoice-list.tsx
@@ -15,12 +15,16 @@ import {
 	getCoreRowModel,
 	useReactTable,
 } from "@tanstack/react-table";
-import { Download, Receipt, Search } from "lucide-react";
+import { Receipt, Search } from "lucide-react";
 
 import { formatDate, formatMoney } from "@/lib/portal/format";
 import { Input } from "@/components/ui/input";
 import { EmptyState } from "@/components/domain/empty-state";
-import { StatusBadge, type StatusRole } from "@/components/domain/status-badge";
+import { StatusBadge } from "@/components/domain/status-badge";
+import {
+	INVOICE_STATUS_LABEL,
+	INVOICE_STATUS_ROLE,
+} from "./invoice-paper";
 import {
 	Frame,
 	FrameDescription,
@@ -63,24 +67,6 @@ const FILTERS: Array<{ value: Filter; label: string }> = [
 	{ value: "paid", label: "Paid" },
 ];
 
-type DisplayStatus = PortalInvoiceListItem["paymentSummary"]["displayStatus"];
-
-// "awaiting"/"partial" aren't domain StatusKeys in status-badge.tsx, so these
-// map to the same semantic roles (warning/info) via the `role` override
-// rather than inventing new colors.
-const DISPLAY_STATUS_ROLE: Record<DisplayStatus, StatusRole> = {
-	paid: "success",
-	overdue: "danger",
-	partial: "info",
-	awaiting: "warning",
-};
-
-const DISPLAY_STATUS_LABEL: Record<DisplayStatus, string> = {
-	paid: "Paid",
-	overdue: "Overdue",
-	partial: "Partially paid",
-	awaiting: "Awaiting payment",
-};
 
 function createColumns(
 	clientPortalId: string,
@@ -128,8 +114,8 @@ function createColumns(
 			cell: ({ row }) => {
 				const displayStatus = row.original.paymentSummary.displayStatus;
 				return (
-					<StatusBadge role={DISPLAY_STATUS_ROLE[displayStatus]} appearance="soft">
-						{DISPLAY_STATUS_LABEL[displayStatus]}
+					<StatusBadge role={INVOICE_STATUS_ROLE[displayStatus]} appearance="soft">
+						{INVOICE_STATUS_LABEL[displayStatus]}
 					</StatusBadge>
 				);
 			},
@@ -171,8 +157,7 @@ function createColumns(
 								onKeyDown={(e) => e.stopPropagation()}
 								className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-medium text-muted-foreground transition-colors duration-200 hover:bg-muted hover:text-foreground"
 							>
-								<Download className="h-3.5 w-3.5" aria-hidden="true" />
-								PDF
+								View
 							</Link>
 						)}
 					</div>

--- a/apps/web/src/components/portal/invoices/invoice-list.tsx
+++ b/apps/web/src/components/portal/invoices/invoice-list.tsx
@@ -1,10 +1,38 @@
 "use client";
 
+/**
+ * InvoiceList — portal-facing invoice index. ReUI Frame + DataGrid treatment
+ * (matches apps/web/src/app/(workspace)/invoices/page.tsx). Search + filter
+ * chips + a prebuilt TanStack table. Row click navigates to the detail page;
+ * the action link uses stopPropagation so it does not double-fire navigation.
+ */
+
 import { useMemo, useState } from "react";
 import Link from "next/link";
-import { Download, Search } from "lucide-react";
+import { useRouter } from "next/navigation";
+import {
+	type ColumnDef,
+	getCoreRowModel,
+	useReactTable,
+} from "@tanstack/react-table";
+import { Download, Receipt, Search } from "lucide-react";
 
 import { formatDate, formatMoney } from "@/lib/portal/format";
+import { Input } from "@/components/ui/input";
+import { EmptyState } from "@/components/domain/empty-state";
+import { StatusBadge, type StatusRole } from "@/components/domain/status-badge";
+import {
+	Frame,
+	FrameDescription,
+	FrameHeader,
+	FramePanel,
+	FrameTitle,
+} from "@/components/reui/frame";
+import {
+	DataGrid,
+	DataGridContainer,
+} from "@/components/reui/data-grid/data-grid";
+import { DataGridTable } from "@/components/reui/data-grid/data-grid-table";
 
 // Mirror of PortalInvoiceListItemPublic in portal/invoices.ts. Kept locally
 // because the backend module export only flows through Convex codegen at the
@@ -35,36 +63,123 @@ const FILTERS: Array<{ value: Filter; label: string }> = [
 	{ value: "paid", label: "Paid" },
 ];
 
-function pillClassFor(
-	status: PortalInvoiceListItem["paymentSummary"]["displayStatus"],
-): string {
-	switch (status) {
-		case "paid":
-			return "bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900";
-		case "overdue":
-			return "bg-rose-50 text-rose-700 border-rose-200 dark:bg-rose-950/40 dark:text-rose-300 dark:border-rose-900";
-		case "partial":
-			return "bg-sky-50 text-sky-700 border-sky-200 dark:bg-sky-950/40 dark:text-sky-300 dark:border-sky-900";
-		case "awaiting":
-		default:
-			return "bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-900";
-	}
-}
+type DisplayStatus = PortalInvoiceListItem["paymentSummary"]["displayStatus"];
 
-function pillLabelFor(
-	status: PortalInvoiceListItem["paymentSummary"]["displayStatus"],
-): string {
-	switch (status) {
-		case "paid":
-			return "Paid";
-		case "overdue":
-			return "Overdue";
-		case "partial":
-			return "Partially paid";
-		case "awaiting":
-		default:
-			return "Awaiting payment";
-	}
+// "awaiting"/"partial" aren't domain StatusKeys in status-badge.tsx, so these
+// map to the same semantic roles (warning/info) via the `role` override
+// rather than inventing new colors.
+const DISPLAY_STATUS_ROLE: Record<DisplayStatus, StatusRole> = {
+	paid: "success",
+	overdue: "danger",
+	partial: "info",
+	awaiting: "warning",
+};
+
+const DISPLAY_STATUS_LABEL: Record<DisplayStatus, string> = {
+	paid: "Paid",
+	overdue: "Overdue",
+	partial: "Partially paid",
+	awaiting: "Awaiting payment",
+};
+
+function createColumns(
+	clientPortalId: string,
+): ColumnDef<PortalInvoiceListItem>[] {
+	return [
+		{
+			accessorKey: "invoiceNumber",
+			header: "Invoice",
+			cell: ({ row }) => (
+				<span className="font-semibold text-primary tabular-nums">
+					#{row.original.invoiceNumber}
+				</span>
+			),
+		},
+		{
+			accessorKey: "issuedDate",
+			header: "Issued",
+			cell: ({ row }) => (
+				<span className="text-foreground">
+					{formatDate(row.original.issuedDate)}
+				</span>
+			),
+		},
+		{
+			accessorKey: "clientName",
+			header: "For",
+			cell: ({ row }) => (
+				<span className="font-medium text-foreground">
+					{row.original.clientName}
+				</span>
+			),
+		},
+		{
+			accessorKey: "dueDate",
+			header: "Due",
+			cell: ({ row }) => (
+				<span className="text-muted-foreground">
+					{formatDate(row.original.dueDate)}
+				</span>
+			),
+		},
+		{
+			accessorKey: "paymentSummary",
+			header: "Status",
+			cell: ({ row }) => {
+				const displayStatus = row.original.paymentSummary.displayStatus;
+				return (
+					<StatusBadge role={DISPLAY_STATUS_ROLE[displayStatus]} appearance="soft">
+						{DISPLAY_STATUS_LABEL[displayStatus]}
+					</StatusBadge>
+				);
+			},
+		},
+		{
+			accessorKey: "total",
+			header: () => <div className="text-right">Total</div>,
+			cell: ({ row }) => (
+				<div className="text-right font-semibold tabular-nums">
+					{formatMoney(row.original.total)}
+				</div>
+			),
+		},
+		{
+			id: "actions",
+			header: "",
+			cell: ({ row }) => {
+				const inv = row.original;
+				const href = `/portal/c/${clientPortalId}/invoices/${inv._id}`;
+				const isLegacy = inv.paymentSummary.isLegacy;
+				const showPayNow =
+					!isLegacy && inv.paymentSummary.displayStatus !== "paid";
+				return (
+					<div
+						className="flex items-center justify-end"
+						onClick={(e) => e.stopPropagation()}
+					>
+						{showPayNow ? (
+							<Link
+								href={href}
+								onKeyDown={(e) => e.stopPropagation()}
+								className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-[13px] font-medium text-primary-foreground transition-colors duration-200 hover:bg-primary/90"
+							>
+								Pay now
+							</Link>
+						) : (
+							<Link
+								href={href}
+								onKeyDown={(e) => e.stopPropagation()}
+								className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-medium text-muted-foreground transition-colors duration-200 hover:bg-muted hover:text-foreground"
+							>
+								<Download className="h-3.5 w-3.5" aria-hidden="true" />
+								PDF
+							</Link>
+						)}
+					</div>
+				);
+			},
+		},
+	];
 }
 
 export interface InvoiceListProps {
@@ -78,6 +193,7 @@ export function InvoiceList({
 	clientPortalId,
 	businessName,
 }: InvoiceListProps) {
+	const router = useRouter();
 	const [search, setSearch] = useState("");
 	const [filterStatus, setFilterStatus] = useState<Filter>("all");
 
@@ -100,6 +216,17 @@ export function InvoiceList({
 	const isEmpty = invoices.length === 0;
 	const isFilterEmpty = !isEmpty && filtered.length === 0;
 
+	const columns = useMemo(
+		() => createColumns(clientPortalId),
+		[clientPortalId],
+	);
+
+	const table = useReactTable({
+		data: filtered,
+		columns,
+		getCoreRowModel: getCoreRowModel(),
+	});
+
 	return (
 		<div>
 			<header className="flex flex-col gap-1">
@@ -114,262 +241,86 @@ export function InvoiceList({
 				</p>
 			</header>
 
-			<div className="mt-6 md:rounded-2xl md:border md:border-border md:bg-card md:overflow-hidden md:shadow-xs">
-				<div className="hidden md:flex flex-wrap items-center gap-2 border-b border-border p-3">
-					<div className="relative flex-1 max-w-[280px]">
-						<Search
-							className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground"
-							aria-hidden="true"
-						/>
-						<input
-							type="search"
-							value={search}
-							onChange={(e) => setSearch(e.target.value)}
-							placeholder="Search invoices…"
-							aria-label="Search invoices"
-							className="w-full rounded-lg border border-border bg-card pl-9 pr-3 py-2 text-[13px] transition-colors focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/25"
-						/>
+			<Frame className="mt-6">
+				<FrameHeader className="flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
+					<div className="flex flex-col gap-0.5">
+						<FrameTitle className="text-base">Invoices</FrameTitle>
+						<FrameDescription>
+							Search and filter your invoices
+						</FrameDescription>
 					</div>
-					<div className="flex flex-wrap gap-1.5">
-						{FILTERS.map((f) => {
-							const active = filterStatus === f.value;
-							return (
-								<button
-									key={f.value}
-									type="button"
-									onClick={() => setFilterStatus(f.value)}
-									aria-pressed={active}
-									className={`rounded-lg border px-3 py-1.5 text-[13px] font-medium transition-colors ${
-										active
-											? "bg-primary text-primary-foreground border-primary"
-											: "bg-card text-muted-foreground border-border hover:bg-muted hover:text-foreground"
-									}`}
-								>
-									{f.label}
-								</button>
-							);
-						})}
-					</div>
-				</div>
-
-				{/* Mobile filter row */}
-				<div className="md:hidden flex flex-wrap items-center gap-2 mb-3">
-					<div className="relative flex-1 min-w-[160px]">
-						<Search
-							className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground"
-							aria-hidden="true"
-						/>
-						<input
-							type="search"
-							value={search}
-							onChange={(e) => setSearch(e.target.value)}
-							placeholder="Search invoices…"
-							aria-label="Search invoices"
-							className="w-full rounded-lg border border-border bg-background pl-9 pr-3 py-2 text-[13px] focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/25"
-						/>
-					</div>
-					<div className="flex flex-wrap gap-1.5">
-						{FILTERS.map((f) => {
-							const active = filterStatus === f.value;
-							return (
-								<button
-									key={f.value}
-									type="button"
-									onClick={() => setFilterStatus(f.value)}
-									aria-pressed={active}
-									className={`rounded-lg border px-3 py-1.5 text-[13px] font-medium transition-colors ${
-										active
-											? "bg-primary text-primary-foreground border-primary"
-											: "bg-background text-muted-foreground border-border hover:bg-muted hover:text-foreground"
-									}`}
-								>
-									{f.label}
-								</button>
-							);
-						})}
-					</div>
-				</div>
-
-				{isEmpty ? (
-					<div className="px-6 py-20 text-center">
-						<p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-							No invoices yet
-						</p>
-						<h2 className="mt-3 text-[18px] font-semibold text-foreground">
-							No invoices yet
-						</h2>
-						<p className="mt-2 text-sm text-muted-foreground">
-							When {businessName} sends you an invoice, you&rsquo;ll see it
-							here.
-						</p>
-					</div>
-				) : isFilterEmpty ? (
-					<div className="px-6 py-20 text-center">
-						<h2 className="text-[18px] font-semibold text-foreground">
-							Nothing here right now
-						</h2>
-						<p className="mt-2 text-sm text-muted-foreground">
-							Try a different filter, or clear the search.
-						</p>
-					</div>
-				) : (
-					<>
-						{/* Desktop table (>=768px) */}
-						<table className="hidden md:table w-full">
-							<thead>
-								<tr className="bg-muted/40">
-									<th className="text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-3 px-4 border-b border-border">
-										Invoice
-									</th>
-									<th className="text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-3 px-4 border-b border-border">
-										Issued
-									</th>
-									<th className="text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-3 px-4 border-b border-border">
-										For
-									</th>
-									<th className="text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-3 px-4 border-b border-border">
-										Due
-									</th>
-									<th className="text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-3 px-4 border-b border-border">
-										Status
-									</th>
-									<th className="text-right text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-3 px-4 border-b border-border">
-										Total
-									</th>
-									<th className="py-3 px-4 w-[130px] border-b border-border" />
-								</tr>
-							</thead>
-							<tbody>
-								{filtered.map((inv, i) => {
-									const href = `/portal/c/${clientPortalId}/invoices/${inv._id}`;
-									const isLegacy = inv.paymentSummary.isLegacy;
-									const displayStatus = inv.paymentSummary.displayStatus;
-									const showPayNow = !isLegacy && displayStatus !== "paid";
-									const isLast = i === filtered.length - 1;
-									return (
-										<tr
-											key={inv._id}
-											className={`hover:bg-muted/50 transition-colors ${
-												isLast ? "" : "border-b border-border"
-											}`}
-										>
-											<td className="py-3.5 px-4">
-												<Link
-													href={href}
-													className="font-semibold text-primary tabular-nums hover:underline"
-												>
-													#{inv.invoiceNumber}
-												</Link>
-											</td>
-											<td className="py-3.5 px-4 text-[14px] text-foreground">
-												{formatDate(inv.issuedDate)}
-											</td>
-											<td className="py-3.5 px-4 text-[14px] font-medium text-foreground">
-												{inv.clientName}
-											</td>
-											<td className="py-3.5 px-4 text-[14px] text-muted-foreground">
-												{formatDate(inv.dueDate)}
-											</td>
-											<td className="py-3.5 px-4">
-												<span
-													className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[11px] font-medium ${pillClassFor(
-														displayStatus,
-													)}`}
-												>
-													<span className="h-1.5 w-1.5 rounded-full bg-current" />
-													{pillLabelFor(displayStatus)}
-												</span>
-											</td>
-											<td className="py-3.5 px-4 text-right font-semibold tabular-nums">
-												{formatMoney(inv.total)}
-											</td>
-											<td className="py-3.5 px-4 text-right">
-												<div className="inline-flex items-center gap-1.5">
-													{showPayNow ? (
-														<Link
-															href={href}
-															className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-[13px] font-medium text-primary-foreground hover:bg-primary/90"
-														>
-															Pay now
-														</Link>
-													) : (
-														<Link
-															href={href}
-															className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
-														>
-															<Download
-																className="h-3.5 w-3.5"
-																aria-hidden="true"
-															/>
-															PDF
-														</Link>
-													)}
-												</div>
-											</td>
-										</tr>
-									);
-								})}
-							</tbody>
-						</table>
-
-					{/* Mobile card stack (<768px) */}
-					<ul className="md:hidden flex flex-col gap-3 mt-2">
-						{filtered.map((inv) => {
-							const href = `/portal/c/${clientPortalId}/invoices/${inv._id}`;
-							const isLegacy = inv.paymentSummary.isLegacy;
-							const displayStatus = inv.paymentSummary.displayStatus;
-							const showPayNow =
-								!isLegacy && displayStatus !== "paid";
-							return (
-								<li
-									key={inv._id}
-									className="grid grid-cols-[1fr_auto] gap-3 rounded-xl border border-border bg-card p-4"
-								>
-									<Link
-										href={href}
-										className="flex flex-col gap-1 min-w-0"
+					<div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
+						<div className="relative w-full sm:w-64">
+							<Search
+								className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
+								aria-hidden="true"
+							/>
+							<Input
+								type="search"
+								value={search}
+								onChange={(e) => setSearch(e.target.value)}
+								placeholder="Search invoices…"
+								aria-label="Search invoices"
+								className="pl-9"
+							/>
+						</div>
+						<div className="flex flex-wrap gap-1.5">
+							{FILTERS.map((f) => {
+								const active = filterStatus === f.value;
+								return (
+									<button
+										key={f.value}
+										type="button"
+										onClick={() => setFilterStatus(f.value)}
+										aria-pressed={active}
+										className={`rounded-lg border px-3 py-1.5 text-[13px] font-medium transition-colors duration-200 ${
+											active
+												? "border-primary bg-primary text-primary-foreground"
+												: "border-border bg-card text-muted-foreground hover:bg-muted hover:text-foreground"
+										}`}
 									>
-										<span className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
-											{formatDate(inv.issuedDate)}
-										</span>
-										<span className="text-[15px] font-semibold text-primary">
-											{inv.invoiceNumber}
-										</span>
-										<span className="text-[13px] text-muted-foreground truncate">
-											{inv.clientName}
-										</span>
-										<div className="mt-1 flex items-center gap-2">
-											<span
-												className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-[11px] font-medium ${pillClassFor(
-													displayStatus,
-												)}`}
-											>
-												<span className="h-1.5 w-1.5 rounded-full bg-current" />
-												{pillLabelFor(displayStatus)}
-											</span>
-											<span className="text-[13px] font-semibold tabular-nums">
-												{formatMoney(inv.total)}
-											</span>
-										</div>
-									</Link>
-									<div className="flex items-end justify-end">
-										{showPayNow ? (
-											<Link
-												href={href}
-												className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-[13px] font-medium text-primary-foreground"
-												aria-label={`Pay invoice ${inv.invoiceNumber}`}
-											>
-												Pay
-											</Link>
-										) : null}
-									</div>
-								</li>
-							);
-						})}
-					</ul>
-				</>
-			)}
-			</div>
+										{f.label}
+									</button>
+								);
+							})}
+						</div>
+					</div>
+				</FrameHeader>
+
+				<DataGrid
+					table={table}
+					recordCount={filtered.length}
+					onRowClick={(row) =>
+						router.push(`/portal/c/${clientPortalId}/invoices/${row._id}`)
+					}
+					emptyMessage="No invoices match your filters."
+					tableLayout={{ width: "auto", headerBackground: true }}
+				>
+					<FramePanel className="p-0">
+						{isEmpty ? (
+							<EmptyState
+								size="md"
+								icon={<Receipt />}
+								title="No invoices yet"
+								description={`When ${businessName} sends you an invoice, you'll see it here.`}
+							/>
+						) : isFilterEmpty ? (
+							<EmptyState
+								size="md"
+								icon={<Search />}
+								title="Nothing here right now"
+								description="Try a different filter, or clear the search."
+							/>
+						) : (
+							<div className="overflow-x-auto">
+								<DataGridContainer>
+									<DataGridTable />
+								</DataGridContainer>
+							</div>
+						)}
+					</FramePanel>
+				</DataGrid>
+			</Frame>
 		</div>
 	);
 }

--- a/apps/web/src/components/portal/invoices/invoice-paper.tsx
+++ b/apps/web/src/components/portal/invoices/invoice-paper.tsx
@@ -14,7 +14,9 @@ import { TotalsBreakdown } from "../totals-breakdown";
 
 export type InvoiceDisplayStatus = "awaiting" | "partial" | "paid" | "overdue";
 
-const STATUS_ROLE: Record<
+// Single source of truth for portal invoice status colors/labels — the list
+// view imports these so list and detail never disagree.
+export const INVOICE_STATUS_ROLE: Record<
 	InvoiceDisplayStatus,
 	"success" | "warning" | "danger" | "info"
 > = {
@@ -24,7 +26,7 @@ const STATUS_ROLE: Record<
 	awaiting: "info",
 };
 
-const STATUS_LABEL: Record<InvoiceDisplayStatus, string> = {
+export const INVOICE_STATUS_LABEL: Record<InvoiceDisplayStatus, string> = {
 	paid: "Paid",
 	partial: "Partially paid",
 	overdue: "Overdue",
@@ -120,8 +122,8 @@ export function InvoicePaper({
 									{businessName}
 								</span>
 							</div>
-							<StatusBadge role={STATUS_ROLE[displayStatus]}>
-								{STATUS_LABEL[displayStatus]}
+							<StatusBadge role={INVOICE_STATUS_ROLE[displayStatus]}>
+								{INVOICE_STATUS_LABEL[displayStatus]}
 							</StatusBadge>
 						</div>
 

--- a/apps/web/src/components/portal/invoices/invoice-paper.tsx
+++ b/apps/web/src/components/portal/invoices/invoice-paper.tsx
@@ -1,8 +1,35 @@
 "use client";
 
+import type { ReactNode } from "react";
 import Image from "next/image";
 
+import { Card, CardContent } from "@/components/ui/card";
+import { Item, ItemMedia } from "@/components/ui/item";
+import { Separator } from "@/components/ui/separator";
+import { StatusBadge } from "@/components/domain/status-badge";
+import { cn } from "@/lib/utils";
 import { formatDate, formatMoney } from "@/lib/portal/format";
+
+import { TotalsBreakdown } from "../totals-breakdown";
+
+export type InvoiceDisplayStatus = "awaiting" | "partial" | "paid" | "overdue";
+
+const STATUS_ROLE: Record<
+	InvoiceDisplayStatus,
+	"success" | "warning" | "danger" | "info"
+> = {
+	paid: "success",
+	partial: "warning",
+	overdue: "danger",
+	awaiting: "info",
+};
+
+const STATUS_LABEL: Record<InvoiceDisplayStatus, string> = {
+	paid: "Paid",
+	partial: "Partially paid",
+	overdue: "Overdue",
+	awaiting: "Awaiting payment",
+};
 
 export interface InvoicePaperLineItem {
 	_id?: string;
@@ -19,7 +46,15 @@ export interface InvoicePaperInvoice {
 	dueDate: number;
 	subtotal: number;
 	taxAmount: number | null;
+	discountAmount: number | null;
 	total: number;
+	paidAt: number | null;
+}
+
+export interface InvoicePaperPaymentSummary {
+	totalPaid: number;
+	totalRemaining: number;
+	installmentCount: number;
 }
 
 export interface InvoicePaperProps {
@@ -29,6 +64,10 @@ export interface InvoicePaperProps {
 	businessLogoUrl: string | null;
 	clientName: string;
 	clientEmail: string;
+	displayStatus: InvoiceDisplayStatus;
+	paymentSummary: InvoicePaperPaymentSummary;
+	/** Installment list + Stripe pay surface (desktop) — mounted unchanged. */
+	paySlot: ReactNode;
 }
 
 export function InvoicePaper({
@@ -38,125 +77,196 @@ export function InvoicePaper({
 	businessLogoUrl,
 	clientName,
 	clientEmail,
+	displayStatus,
+	paymentSummary,
+	paySlot,
 }: InvoicePaperProps) {
-	const tax = invoice.taxAmount ?? 0;
+	const heroIsPaid = displayStatus === "paid";
+	const heroLabel = heroIsPaid ? "Total paid" : "Total due";
+	const heroAmount = heroIsPaid ? invoice.total : paymentSummary.totalRemaining;
+	const showProgress =
+		!heroIsPaid &&
+		paymentSummary.totalPaid > 0 &&
+		paymentSummary.installmentCount > 1;
+
+	return (
+		<Card data-portal-paper-invoice className="mx-auto w-full max-w-4xl">
+			<CardContent>
+				<div className="grid grid-cols-1 gap-8 md:grid-cols-[18rem_minmax(0,1fr)] md:gap-10">
+					{/* Sidebar: brand + status, hero total, metadata, pay surface */}
+					<aside className="flex flex-col gap-5 md:border-r md:border-border md:pr-8">
+						<div className="flex items-center justify-between gap-3">
+							<div className="flex min-w-0 items-center gap-3">
+								<Item
+									variant="muted"
+									size="sm"
+									className="size-9 shrink-0 items-center justify-center overflow-hidden rounded-md p-0"
+									aria-hidden="true"
+								>
+									<ItemMedia variant="image" className="size-full">
+										{businessLogoUrl ? (
+											<Image
+												src={businessLogoUrl}
+												alt=""
+												width={36}
+												height={36}
+												className="size-full object-contain"
+												unoptimized
+											/>
+										) : null}
+									</ItemMedia>
+								</Item>
+								<span className="truncate text-[14px] font-semibold text-foreground">
+									{businessName}
+								</span>
+							</div>
+							<StatusBadge role={STATUS_ROLE[displayStatus]}>
+								{STATUS_LABEL[displayStatus]}
+							</StatusBadge>
+						</div>
+
+						<div className="flex flex-col gap-1.5">
+							<span className="text-[0.6875rem] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+								{heroLabel}
+							</span>
+							<span className="text-3xl leading-none font-bold tracking-tight tabular-nums text-foreground md:text-4xl">
+								{formatMoney(heroAmount)}
+							</span>
+							{heroIsPaid && invoice.paidAt ? (
+								<span className="text-xs text-muted-foreground">
+									on {formatDate(invoice.paidAt)}
+								</span>
+							) : null}
+						</div>
+
+						<Separator />
+
+						<div className="flex flex-col gap-4">
+							<MetaSection label="Invoice">
+								<p className="font-mono text-sm tabular-nums text-foreground">
+									#{invoice.invoiceNumber}
+								</p>
+							</MetaSection>
+							<MetaSection label="Issued">
+								<p className="text-sm font-medium text-foreground">
+									{formatDate(invoice.issuedDate)}
+								</p>
+							</MetaSection>
+							<MetaSection label="Due">
+								<p className="text-sm font-medium text-foreground">
+									{formatDate(invoice.dueDate)}
+								</p>
+							</MetaSection>
+							<MetaSection label="Bill To">
+								<p className="text-sm font-medium text-foreground">
+									{clientName}
+								</p>
+								{clientEmail ? (
+									<p className="text-xs text-muted-foreground">{clientEmail}</p>
+								) : null}
+							</MetaSection>
+							{showProgress ? (
+								<MetaSection label="Payment Progress">
+									<p className="text-sm font-medium text-foreground">
+										{formatMoney(paymentSummary.totalPaid)} paid
+									</p>
+									<p className="text-xs text-muted-foreground">
+										{formatMoney(paymentSummary.totalRemaining)} remaining
+									</p>
+								</MetaSection>
+							) : null}
+						</div>
+
+						<Separator />
+
+						{paySlot}
+					</aside>
+
+					{/* Main: line items + totals */}
+					<div className="flex min-w-0 flex-col gap-6">
+						<div className="flex flex-col gap-4">
+							<div className="flex items-baseline justify-between gap-3">
+								<span className="text-[0.6875rem] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+									Line Items
+								</span>
+								<span className="text-xs text-muted-foreground">
+									{lineItems.length}{" "}
+									{lineItems.length === 1 ? "item" : "items"}
+								</span>
+							</div>
+							<div className="flex flex-col divide-y divide-border">
+								{lineItems.map((li, i) => (
+									<LineItemRow
+										key={li._id ?? i}
+										item={li}
+										isFirst={i === 0}
+										isLast={i === lineItems.length - 1}
+									/>
+								))}
+							</div>
+						</div>
+
+						<Separator />
+
+						<TotalsBreakdown
+							subtotal={invoice.subtotal}
+							discount={invoice.discountAmount}
+							tax={invoice.taxAmount}
+							total={invoice.total}
+							className="sm:ml-auto sm:w-72"
+						/>
+					</div>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+function MetaSection({
+	label,
+	children,
+}: {
+	label: string;
+	children: ReactNode;
+}) {
+	return (
+		<div className="flex flex-col gap-1">
+			<span className="text-[0.625rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+				{label}
+			</span>
+			<div className="flex flex-col gap-0.5">{children}</div>
+		</div>
+	);
+}
+
+function LineItemRow({
+	item,
+	isFirst,
+	isLast,
+}: {
+	item: InvoicePaperLineItem;
+	isFirst: boolean;
+	isLast: boolean;
+}) {
 	return (
 		<div
-			data-portal-paper-invoice
-			className="mx-auto max-w-[760px] rounded-2xl border border-border bg-card p-6 shadow-xs md:p-9"
+			className={cn(
+				"flex items-start justify-between gap-4",
+				isFirst ? "pt-0" : "pt-4",
+				isLast ? "pb-0" : "pb-4",
+			)}
 		>
-			<div className="flex items-start justify-between gap-6">
-				<div className="flex items-center gap-3">
-					{businessLogoUrl ? (
-						<Image
-							src={businessLogoUrl}
-							alt=""
-							width={40}
-							height={40}
-							className="h-10 w-10 rounded-md object-contain"
-							unoptimized
-						/>
-					) : (
-						<div className="h-10 w-10 rounded-md bg-muted" aria-hidden="true" />
-					)}
-					<div>
-						<p className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
-							INVOICE #{invoice.invoiceNumber}
-						</p>
-						<div className="mt-1 text-[16px] font-semibold leading-[1.15]">
-							{businessName}
-						</div>
-					</div>
-				</div>
-				<div className="text-right text-[12px] text-muted-foreground">
-					<div>Bill to</div>
-					<div className="mt-1 font-medium text-foreground">{clientName}</div>
-					{clientEmail ? <div className="mt-0.5">{clientEmail}</div> : null}
-				</div>
+			<div className="min-w-0 flex-1">
+				<p className="text-sm font-semibold text-foreground">
+					{item.description}
+				</p>
+				<p className="mt-0.5 text-xs text-muted-foreground">
+					Qty {item.quantity} · {formatMoney(item.unitPrice)} each
+				</p>
 			</div>
-
-			<div className="mt-6 grid grid-cols-2 gap-6 border-y border-border py-4">
-				<div>
-					<p className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
-						Issued
-					</p>
-					<p className="mt-1 text-[14px] font-medium">
-						{formatDate(invoice.issuedDate)}
-					</p>
-				</div>
-				<div className="text-right">
-					<p className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
-						Due
-					</p>
-					<p className="mt-1 text-[14px] font-medium">
-						{formatDate(invoice.dueDate)}
-					</p>
-				</div>
-			</div>
-
-			<div className="mt-6">
-				<table className="w-full border-collapse">
-					<thead>
-						<tr className="border-b-2 border-foreground">
-							<th className="text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-2.5">
-								Description
-							</th>
-							<th className="text-right text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-2.5 w-[60px]">
-								Qty
-							</th>
-							<th className="text-right text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-2.5 w-[110px]">
-								Unit Price
-							</th>
-							<th className="text-right text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-2.5 w-[110px]">
-								Amount
-							</th>
-						</tr>
-					</thead>
-					<tbody>
-						{lineItems.map((li, i) => (
-							<tr
-								key={li._id ?? i}
-								className="border-b border-border last:border-b-0"
-							>
-								<td className="py-4 align-top">
-									<div className="text-[14px] font-semibold">
-										{li.description}
-									</div>
-								</td>
-								<td className="py-4 align-top text-right text-[14px] tabular-nums">
-									{li.quantity}
-								</td>
-								<td className="py-4 align-top text-right text-[14px] tabular-nums">
-									{formatMoney(li.unitPrice)}
-								</td>
-								<td className="py-4 align-top text-right text-[14px] font-semibold tabular-nums">
-									{formatMoney(li.total)}
-								</td>
-							</tr>
-						))}
-					</tbody>
-				</table>
-			</div>
-
-			<div className="mt-6 border-t-2 border-foreground pt-4 flex flex-col items-end gap-1.5">
-				<div className="flex items-center gap-8 text-[14px]">
-					<span className="text-muted-foreground">Subtotal</span>
-					<span className="tabular-nums">{formatMoney(invoice.subtotal)}</span>
-				</div>
-				{tax > 0 ? (
-					<div className="flex items-center gap-8 text-[14px]">
-						<span className="text-muted-foreground">Tax</span>
-						<span className="tabular-nums">{formatMoney(tax)}</span>
-					</div>
-				) : null}
-				<div
-					data-paper-total
-					className="flex items-center gap-8 text-[16px] font-semibold border-t border-foreground pt-2 mt-1"
-				>
-					<span>Total</span>
-					<span className="tabular-nums">{formatMoney(invoice.total)}</span>
-				</div>
-			</div>
+			<span className="shrink-0 text-sm font-semibold tabular-nums text-foreground">
+				{formatMoney(item.total)}
+			</span>
 		</div>
 	);
 }

--- a/apps/web/src/components/portal/otp-form.tsx
+++ b/apps/web/src/components/portal/otp-form.tsx
@@ -235,7 +235,7 @@ export default function OtpForm({
 				<button
 					type="submit"
 					disabled={loading}
-					className="inline-flex h-11 items-center justify-center gap-2 rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground shadow-sm transition-all hover:bg-primary/90 active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60"
+					className="inline-flex h-11 cursor-pointer items-center justify-center gap-2 rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground shadow-sm outline-none transition-all hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60"
 				>
 					{loading ? "Sending..." : "Send code"}
 					{!loading ? (
@@ -318,7 +318,7 @@ export default function OtpForm({
 						? loading
 						: cellsDisabled || code.length !== 6
 				}
-				className="inline-flex h-11 items-center justify-center gap-2 rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground shadow-sm transition-all hover:bg-primary/90 active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60"
+				className="inline-flex h-11 cursor-pointer items-center justify-center gap-2 rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground shadow-sm outline-none transition-all hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60"
 			>
 				{attemptsRemaining === 0
 					? "Send a new code"
@@ -330,7 +330,7 @@ export default function OtpForm({
 			<div className="flex flex-col items-start gap-1.5">
 				<button
 					type="button"
-					className="text-sm font-medium text-primary underline-offset-4 hover:underline disabled:opacity-50"
+					className="cursor-pointer rounded-sm text-sm font-medium text-primary outline-none underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card disabled:cursor-not-allowed disabled:opacity-50"
 					onClick={handleResend}
 					disabled={resendCooldown > 0 || loading}
 				>
@@ -340,7 +340,7 @@ export default function OtpForm({
 				</button>
 				<button
 					type="button"
-					className="text-sm text-muted-foreground hover:text-foreground disabled:opacity-50"
+					className="cursor-pointer rounded-sm text-sm text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card disabled:cursor-not-allowed disabled:opacity-50"
 					onClick={handleUseDifferentEmail}
 					disabled={loading}
 				>

--- a/apps/web/src/components/portal/quotes/approval-rail.tsx
+++ b/apps/web/src/components/portal/quotes/approval-rail.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 /**
- * ApprovalRail — desktop sticky right rail (380px). Owns the local form
- * state (signature, terms, intent, declineReason) and delegates submission
- * to the shared `useQuoteDecision` hook.
+ * ApprovalRail — desktop approval actions. Owns the local form state
+ * (signature, terms, intent, declineReason) and delegates submission to the
+ * shared `useQuoteDecision` hook. Rendered inside the "Next Step" block of
+ * the sticky Quote Journey panel (quote-detail-island.tsx) — the quote
+ * total/validUntil are shown in the page hero, not repeated here.
  *
  * Branches:
  *  - effectiveReceipt (= submitted receipt or REVIEWS-mandated initialReceipt)
@@ -23,7 +25,6 @@ import { Check, Loader2 } from "lucide-react";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
 
-import { formatMoney } from "@/lib/portal/format";
 import {
 	SignatureCard,
 	type SignaturePayload,
@@ -98,12 +99,6 @@ const NON_USABLE: SignaturePayload = {
 	isUsable: false,
 };
 
-function daysRemaining(validUntil?: number): number | null {
-	if (!validUntil) return null;
-	const ms = validUntil - Date.now();
-	return Math.ceil(ms / (1000 * 60 * 60 * 24));
-}
-
 export function ApprovalRail({
 	quote,
 	latestDocument,
@@ -174,14 +169,6 @@ export function ApprovalRail({
 		documentDrifted,
 	]);
 
-	const days = daysRemaining(quote.validUntil);
-	const expiresLine =
-		quote.validUntil && days !== null
-			? days > 0
-				? `Expires in ${days} day${days === 1 ? "" : "s"}`
-				: "Expired"
-			: undefined;
-
 	const handleApprove = async () => {
 		if (!signaturePayload.isUsable) return;
 		await submitApprove({
@@ -212,26 +199,8 @@ export function ApprovalRail({
 	};
 
 	return (
-		<aside
-			className="w-full self-start border-l-0 border-t border-border bg-card md:border-l md:border-t-0 md:sticky md:top-[68px] md:h-[calc(100vh-68px)] md:overflow-y-auto"
-			aria-label="Quote approval"
-		>
-			<div className="flex flex-col gap-8 p-6 md:gap-9 md:p-7">
-				{/* Quote total — flat top section */}
-				<div className="border-b border-border pb-6">
-					<p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-						Quote total
-					</p>
-					<p className="mt-2 text-[36px] font-semibold tracking-[-0.025em] leading-[1] tabular-nums">
-						{formatMoney(quote.total)}
-					</p>
-					{expiresLine && (
-						<p className="mt-2 text-[13px] text-muted-foreground">
-							{expiresLine}
-						</p>
-					)}
-				</div>
-
+		<div className="flex w-full flex-col gap-6" aria-label="Quote approval">
+			<div className="flex flex-col gap-8">
 				{/* Branches */}
 				{effectiveReceipt ? (
 					<ApprovalReceipt
@@ -370,6 +339,6 @@ export function ApprovalRail({
 				onConfirm={handleDecline}
 				businessName={businessName}
 			/>
-		</aside>
+		</div>
 	);
 }

--- a/apps/web/src/components/portal/quotes/quote-detail-island.tsx
+++ b/apps/web/src/components/portal/quotes/quote-detail-island.tsx
@@ -79,7 +79,7 @@ function badgeVariantFor(status: string): "success-light" | "outline" | "info-li
 function statusLabelFor(status: string): string {
 	switch (status) {
 		case "approved":
-			return "Approved";
+			return "Accepted";
 		case "declined":
 			return "Declined";
 		case "expired":
@@ -143,7 +143,7 @@ function buildJourneySteps(
 		});
 		steps.push({
 			id: "resolution",
-			title: "Approved",
+			title: "Accepted",
 			timestamp: formatDate(quote.approvedAt),
 			meta: latestApproval ? `Signed by ${clientName}` : undefined,
 			status: "complete",
@@ -180,7 +180,7 @@ function buildJourneySteps(
 		});
 		steps.push({
 			id: "resolution",
-			title: "Approved or declined",
+			title: "Accepted or declined",
 			status: "upcoming",
 		});
 	}
@@ -334,7 +334,13 @@ export function QuoteDetailIsland({ quoteId }: QuoteDetailIslandProps) {
 				}
 			: undefined;
 
-	const journeySteps = buildJourneySteps(quote, latestApproval, clientName);
+	// CR-02 alignment: the journey's "Signed by" meta must come from the same
+	// validated receipt the approval surfaces use, not the raw audit row.
+	const journeySteps = buildJourneySteps(
+		quote,
+		effectiveInitialReceipt,
+		clientName,
+	);
 	const currentStepIndex = journeySteps.findIndex(
 		(step) => step.status === "current",
 	);
@@ -451,7 +457,7 @@ export function QuoteDetailIsland({ quoteId }: QuoteDetailIslandProps) {
 
 					{/* Two-pane: Quote Journey (sticky) + Quote Details */}
 					<div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,20rem)_minmax(0,1fr)] lg:gap-8">
-						<Card className="lg:sticky lg:top-6">
+						<Card className="lg:sticky lg:top-[calc(68px+1.5rem)]">
 							<CardHeader>
 								<CardTitle className="text-base">Quote Journey</CardTitle>
 							</CardHeader>
@@ -535,7 +541,7 @@ export function QuoteDetailIsland({ quoteId }: QuoteDetailIslandProps) {
 				</div>
 			</div>
 
-			{!isDesktop && (
+			{isDesktop === false && (
 				<ApprovalBottomSheet key={approvalKey} {...approvalRailProps} />
 			)}
 		</div>

--- a/apps/web/src/components/portal/quotes/quote-detail-island.tsx
+++ b/apps/web/src/components/portal/quotes/quote-detail-island.tsx
@@ -2,8 +2,10 @@
 
 /**
  * QuoteDetailIsland — top-level client island that owns the reactive
- * useQuery(api.portal.quotes.get) subscription and renders the desktop rail
- * or mobile bottom sheet based on viewport. Wires REVIEWS-mandated
+ * useQuery(api.portal.quotes.get) subscription. Renders a ReUI "receipt-2"
+ * style layout: a hero status card, a sticky left Quote Journey panel
+ * (Timeline + the "Next Step" approval actions), and a details pane with
+ * the printable quote paper. Wires REVIEWS-mandated
  * `initialReceipt={data.latestApproval ?? undefined}` so previously-approved
  * quotes render the receipt panel on first render.
  */
@@ -19,6 +21,19 @@ import type { Id } from "@onetool/backend/convex/_generated/dataModel";
 
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { useToast } from "@/hooks/use-toast";
+import { cn } from "@/lib/utils";
+import { formatMoney } from "@/lib/portal/format";
+
+import { Badge } from "@/components/reui/badge";
+import {
+	Timeline,
+	TimelineContent,
+	TimelineIndicator,
+	TimelineItem,
+	TimelineSeparator,
+} from "@/components/reui/timeline";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
 
 import { QuotePaper } from "./quote-paper";
 import { ApprovalRail } from "./approval-rail";
@@ -27,6 +42,16 @@ import { StaleVersionBanner } from "./stale-version-banner";
 
 export interface QuoteDetailIslandProps {
 	quoteId: Id<"quotes">;
+}
+
+type JourneyStepStatus = "complete" | "current" | "upcoming";
+
+interface JourneyStep {
+	id: string;
+	title: string;
+	timestamp?: string;
+	meta?: string;
+	status: JourneyStepStatus;
 }
 
 function formatDate(ts?: number): string {
@@ -38,24 +63,23 @@ function formatDate(ts?: number): string {
 	});
 }
 
-function pillClassFor(status: string): string {
+function badgeVariantFor(status: string): "success-light" | "outline" | "info-light" {
 	switch (status) {
 		case "approved":
-			return "bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900";
+			return "success-light";
 		case "declined":
-			return "bg-muted text-muted-foreground border-border";
 		case "expired":
-			return "bg-muted/70 text-muted-foreground border-border opacity-90";
+			return "outline";
 		case "sent":
 		default:
-			return "bg-sky-50 text-sky-700 border-sky-200 dark:bg-sky-950/40 dark:text-sky-300 dark:border-sky-900";
+			return "info-light";
 	}
 }
 
-function pillLabelFor(status: string): string {
+function statusLabelFor(status: string): string {
 	switch (status) {
 		case "approved":
-			return "Accepted";
+			return "Approved";
 		case "declined":
 			return "Declined";
 		case "expired":
@@ -64,6 +88,104 @@ function pillLabelFor(status: string): string {
 		default:
 			return "Awaiting decision";
 	}
+}
+
+// Per-status Timeline indicator + separator styling — mirrors the ReUI
+// receipt-2 pattern so the vertical dot column stays aligned regardless of
+// how many steps are completed vs. upcoming.
+const TL_INDICATOR_BASE =
+	"size-2.5 border-0 group-data-[orientation=vertical]/timeline:-left-3 group-data-[orientation=vertical]/timeline:-translate-x-1/2 group-data-[orientation=vertical]/timeline:top-1.25";
+
+const TL_INDICATOR_BY_STATUS: Record<JourneyStepStatus, string> = {
+	complete: cn(TL_INDICATOR_BASE, "bg-foreground"),
+	current: cn(TL_INDICATOR_BASE, "bg-foreground ring-foreground/20 ring-2"),
+	upcoming: cn(TL_INDICATOR_BASE, "bg-background border-input border-2"),
+};
+
+const TL_SEPARATOR_BASE =
+	"group-data-[orientation=vertical]/timeline:-left-3 group-data-[orientation=vertical]/timeline:-translate-x-1/2 group-data-[orientation=vertical]/timeline:h-[calc(100%-1.5rem)] group-data-[orientation=vertical]/timeline:translate-y-5.5";
+
+const TL_SEPARATOR_BY_STATUS: Record<JourneyStepStatus, string> = {
+	complete: cn(TL_SEPARATOR_BASE, "bg-foreground"),
+	current: cn(TL_SEPARATOR_BASE, "bg-input"),
+	upcoming: cn(TL_SEPARATOR_BASE, "bg-input"),
+};
+
+const TL_ITEM_CLASS =
+	"group-data-[orientation=vertical]/timeline:ms-5 group-data-[orientation=vertical]/timeline:not-last:pb-5";
+
+/** Builds the Quote Journey steps from real quote data — no fabricated events. */
+function buildJourneySteps(
+	quote: {
+		status: string;
+		sentAt?: number;
+		validUntil?: number;
+		approvedAt?: number;
+		declinedAt?: number;
+	},
+	latestApproval: { action: "approved" | "declined" } | null | undefined,
+	clientName: string,
+): JourneyStep[] {
+	const steps: JourneyStep[] = [
+		{
+			id: "sent",
+			title: "Quote sent",
+			timestamp: quote.sentAt ? formatDate(quote.sentAt) : undefined,
+			status: "complete",
+		},
+	];
+
+	if (quote.status === "approved") {
+		steps.push({
+			id: "review",
+			title: "Reviewed by client",
+			status: "complete",
+		});
+		steps.push({
+			id: "resolution",
+			title: "Approved",
+			timestamp: formatDate(quote.approvedAt),
+			meta: latestApproval ? `Signed by ${clientName}` : undefined,
+			status: "complete",
+		});
+	} else if (quote.status === "declined") {
+		steps.push({
+			id: "review",
+			title: "Reviewed by client",
+			status: "complete",
+		});
+		steps.push({
+			id: "resolution",
+			title: "Declined",
+			timestamp: formatDate(quote.declinedAt),
+			status: "complete",
+		});
+	} else if (quote.status === "expired") {
+		steps.push({
+			id: "review",
+			title: "Awaiting review",
+			status: "complete",
+		});
+		steps.push({
+			id: "resolution",
+			title: "Expired",
+			timestamp: quote.validUntil ? formatDate(quote.validUntil) : undefined,
+			status: "complete",
+		});
+	} else {
+		steps.push({
+			id: "review",
+			title: "Awaiting your decision",
+			status: "current",
+		});
+		steps.push({
+			id: "resolution",
+			title: "Approved or declined",
+			status: "upcoming",
+		});
+	}
+
+	return steps;
 }
 
 export function QuoteDetailIsland({ quoteId }: QuoteDetailIslandProps) {
@@ -102,23 +224,13 @@ export function QuoteDetailIsland({ quoteId }: QuoteDetailIslandProps) {
 				<div className="sticky top-0 z-20 flex h-[68px] items-center border-b border-border bg-background px-6">
 					<div className="h-5 w-32 animate-pulse rounded bg-muted" />
 				</div>
-				<div className="grid grid-cols-1 gap-0 md:grid-cols-[minmax(0,1fr)_480px]">
-					<div className="px-6 py-8 md:px-9">
-						<div className="mx-auto max-w-[760px] rounded-2xl border border-border bg-card p-9">
-							<div className="h-8 w-1/2 animate-pulse rounded bg-muted" />
-							<div className="mt-6 space-y-2">
-								{Array.from({ length: 4 }).map((_, i) => (
-									<div
-										key={i}
-										className="h-6 w-full animate-pulse rounded bg-muted"
-									/>
-								))}
-							</div>
+				<div className="px-6 py-8 md:px-9">
+					<div className="mx-auto max-w-5xl">
+						<div className="mb-6 h-28 animate-pulse rounded-2xl border border-border bg-card md:mb-8" />
+						<div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,20rem)_minmax(0,1fr)] lg:gap-8">
+							<div className="h-64 animate-pulse rounded-2xl border border-border bg-card" />
+							<div className="h-96 animate-pulse rounded-2xl border border-border bg-card" />
 						</div>
-					</div>
-					<div className="border-l border-border bg-card p-6 md:min-h-[calc(100vh-68px)]">
-						<div className="h-12 w-32 animate-pulse rounded bg-muted" />
-						<div className="mt-4 h-40 w-full animate-pulse rounded bg-muted" />
 					</div>
 				</div>
 			</div>
@@ -222,74 +334,61 @@ export function QuoteDetailIsland({ quoteId }: QuoteDetailIslandProps) {
 				}
 			: undefined;
 
+	const journeySteps = buildJourneySteps(quote, latestApproval, clientName);
+	const currentStepIndex = journeySteps.findIndex(
+		(step) => step.status === "current",
+	);
+	const timelineDefaultStep =
+		currentStepIndex >= 0 ? currentStepIndex + 1 : journeySteps.length;
+
+	// REVIEWS-mandated (CR-04): force-remount on documentId change so all
+	// useState (signaturePayload, terms, intent) resets to non-usable when
+	// the underlying document version drifts.
+	const approvalKey = latestDocument?._id ?? "no-doc";
+	const approvalRailProps = {
+		quote: {
+			_id: quote._id,
+			quoteNumber: quote.quoteNumber,
+			title: quote.title,
+			status: quote.status,
+			total: quote.total,
+			validUntil: quote.validUntil,
+		},
+		latestDocument: latestDocument
+			? { _id: latestDocument._id, version: latestDocument.version }
+			: null,
+		businessName,
+		clientName,
+		clientEmail,
+		initialReceipt: effectiveInitialReceipt,
+		resolvedFallback,
+		documentDrifted: !!documentDrifted,
+	};
+
 	return (
 		// Negative margins to escape the PortalShell <main> px/py padding so the
-		// sticky header bar and right-rail aside can run edge-to-edge of the main
-		// area on desktop, matching the HiFi 2-col workspace pattern.
+		// sticky header bar can run edge-to-edge of the main area on desktop.
 		<div className="-mx-6 md:-mx-9 -my-6 flex flex-col">
 			{/* Sticky top header bar */}
 			<header className="sticky top-0 z-20 flex h-[68px] items-center justify-between gap-4 border-b border-border bg-background px-6 md:px-9">
-				<div className="flex min-w-0 items-center gap-3">
-					<Link
-						href={`/portal/c/${clientPortalId}/quotes`}
-						className="inline-flex items-center gap-1.5 text-[13px] text-muted-foreground transition-colors hover:text-foreground"
-					>
-						<ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
-						Back
-					</Link>
-					<div className="hidden h-5 w-px bg-border md:block" />
-					<div className="hidden min-w-0 md:block">
-						<div className="flex items-center gap-2">
-							<h2 className="truncate text-[16px] font-semibold">
-								Quote {quote.quoteNumber} · {quote.title}
-							</h2>
-							<span
-								className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-[11px] font-medium ${pillClassFor(quote.status)}`}
-							>
-								<span className="h-1.5 w-1.5 rounded-full bg-current" />
-								{pillLabelFor(quote.status)}
-							</span>
-						</div>
-						<p className="mt-0.5 text-[12px] text-muted-foreground">
-							Sent {formatDate(quote.sentAt)}
-							{quote.validUntil
-								? ` · Expires ${formatDate(quote.validUntil)}`
-								: ""}
-						</p>
-					</div>
-				</div>
+				<Link
+					href={`/portal/c/${clientPortalId}/quotes`}
+					className="inline-flex items-center gap-1.5 text-[13px] text-muted-foreground transition-colors hover:text-foreground"
+				>
+					<ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+					Back
+				</Link>
 				{latestDocument && (
 					<button
 						type="button"
 						onClick={handleDownloadPdf}
-						className="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-3 py-1.5 text-[13px] font-medium hover:bg-accent"
+						className="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-3 py-1.5 text-[13px] font-medium hover:bg-accent cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
 					>
 						<Download className="h-3.5 w-3.5" aria-hidden="true" />
 						Download PDF
 					</button>
 				)}
 			</header>
-
-			{/* Mobile-only title block (the desktop title sits in the sticky bar) */}
-			<div className="border-b border-border bg-background px-6 py-4 md:hidden">
-				<div className="flex flex-wrap items-center gap-2">
-					<h2 className="text-[16px] font-semibold">
-						Quote {quote.quoteNumber} · {quote.title}
-					</h2>
-					<span
-						className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-[11px] font-medium ${pillClassFor(quote.status)}`}
-					>
-						<span className="h-1.5 w-1.5 rounded-full bg-current" />
-						{pillLabelFor(quote.status)}
-					</span>
-				</div>
-				<p className="mt-1 text-[12px] text-muted-foreground">
-					Sent {formatDate(quote.sentAt)}
-					{quote.validUntil
-						? ` · Expires ${formatDate(quote.validUntil)}`
-						: ""}
-				</p>
-			</div>
 
 			{documentDrifted && (
 				<div className="border-b border-border bg-background px-6 py-4 md:px-9">
@@ -301,68 +400,144 @@ export function QuoteDetailIsland({ quoteId }: QuoteDetailIslandProps) {
 				</div>
 			)}
 
-			{/* Body grid: paper left, signing rail right */}
-			<div className="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_480px]">
-				<div className="px-6 py-8 pb-24 md:px-9 md:pb-10">
-					<QuotePaper
-						quote={quote}
-						lineItems={lineItems}
-						businessName={businessName}
-					/>
-				</div>
+			<div className="px-6 py-8 pb-24 md:px-9 md:pb-10">
+				<div className="mx-auto max-w-5xl">
+					{/* Hero: status + quote id/title + business + total */}
+					<Card className="mb-6 md:mb-8">
+						<CardContent>
+							<div className="grid grid-cols-1 gap-5 md:grid-cols-[minmax(0,1fr)_auto_auto] md:items-center md:gap-8">
+								<div className="flex min-w-0 flex-col gap-2">
+									<div className="flex flex-wrap items-center gap-2">
+										<Badge
+											variant={badgeVariantFor(quote.status)}
+											radius="full"
+											className="w-fit"
+										>
+											{statusLabelFor(quote.status)}
+										</Badge>
+										<span className="text-muted-foreground text-xs">
+											Sent {formatDate(quote.sentAt)}
+										</span>
+									</div>
+									<CardTitle className="text-xl tracking-tight md:text-2xl">
+										Quote {quote.quoteNumber} · {quote.title}
+									</CardTitle>
+									<p className="text-muted-foreground text-sm leading-snug">
+										{businessName}
+									</p>
+								</div>
 
-				{isDesktop ? (
-					<ApprovalRail
-						// REVIEWS-mandated (CR-04): force-remount on documentId change
-						// so all useState (signaturePayload, terms, intent) resets to
-						// non-usable when the underlying document version drifts.
-						key={latestDocument?._id ?? "no-doc"}
-						quote={{
-							_id: quote._id,
-							quoteNumber: quote.quoteNumber,
-							title: quote.title,
-							status: quote.status,
-							total: quote.total,
-							validUntil: quote.validUntil,
-						}}
-						latestDocument={
-							latestDocument
-								? { _id: latestDocument._id, version: latestDocument.version }
-								: null
-						}
-						businessName={businessName}
-						clientName={clientName}
-						clientEmail={clientEmail}
-						initialReceipt={effectiveInitialReceipt}
-						resolvedFallback={resolvedFallback}
-						documentDrifted={!!documentDrifted}
-					/>
-				) : (
-					<ApprovalBottomSheet
-						// REVIEWS-mandated (CR-04): see ApprovalRail above.
-						key={latestDocument?._id ?? "no-doc"}
-						quote={{
-							_id: quote._id,
-							quoteNumber: quote.quoteNumber,
-							title: quote.title,
-							status: quote.status,
-							total: quote.total,
-							validUntil: quote.validUntil,
-						}}
-						latestDocument={
-							latestDocument
-								? { _id: latestDocument._id, version: latestDocument.version }
-								: null
-						}
-						businessName={businessName}
-						clientName={clientName}
-						clientEmail={clientEmail}
-						initialReceipt={effectiveInitialReceipt}
-						resolvedFallback={resolvedFallback}
-						documentDrifted={!!documentDrifted}
-					/>
-				)}
+								<Separator
+									orientation="vertical"
+									className="hidden h-14 data-vertical:self-center md:block"
+								/>
+
+								<div className="flex flex-col gap-1 md:items-end">
+									<span className="text-muted-foreground text-xs font-medium tracking-[0.16em] uppercase">
+										Total
+									</span>
+									<span className="text-foreground text-2xl leading-none font-semibold tracking-tight tabular-nums md:text-3xl">
+										{formatMoney(quote.total)}
+									</span>
+									{quote.validUntil && (
+										<span className="text-muted-foreground text-xs tabular-nums">
+											Valid until {formatDate(quote.validUntil)}
+										</span>
+									)}
+								</div>
+							</div>
+						</CardContent>
+					</Card>
+
+					{/* Two-pane: Quote Journey (sticky) + Quote Details */}
+					<div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,20rem)_minmax(0,1fr)] lg:gap-8">
+						<Card className="lg:sticky lg:top-6">
+							<CardHeader>
+								<CardTitle className="text-base">Quote Journey</CardTitle>
+							</CardHeader>
+							<CardContent className="flex flex-col gap-5">
+								<Timeline defaultValue={timelineDefaultStep} className="gap-0">
+									{journeySteps.map((step, index) => {
+										const isLast = index === journeySteps.length - 1;
+										return (
+											<TimelineItem
+												key={step.id}
+												step={index + 1}
+												className={TL_ITEM_CLASS}
+											>
+												{!isLast ? (
+													<TimelineSeparator
+														className={TL_SEPARATOR_BY_STATUS[step.status]}
+													/>
+												) : null}
+												<TimelineIndicator
+													className={TL_INDICATOR_BY_STATUS[step.status]}
+												/>
+												<TimelineContent className="text-foreground ps-3">
+													<div className="flex flex-col gap-0.5">
+														<span
+															className={cn(
+																"text-sm leading-snug font-medium",
+																step.status === "upcoming" &&
+																	"text-muted-foreground",
+															)}
+														>
+															{step.title}
+														</span>
+														{step.timestamp && (
+															<time
+																className={cn(
+																	"text-xs tabular-nums",
+																	step.status === "upcoming"
+																		? "text-muted-foreground/70"
+																		: "text-muted-foreground",
+																)}
+															>
+																{step.timestamp}
+															</time>
+														)}
+														{step.meta && (
+															<p className="text-muted-foreground text-xs">
+																{step.meta}
+															</p>
+														)}
+													</div>
+												</TimelineContent>
+											</TimelineItem>
+										);
+									})}
+								</Timeline>
+
+								{/* Next Step — hosts the approval actions (desktop only; mobile
+								    uses the docked ApprovalBottomSheet instead). ApprovalRail
+								    already branches internally between the signing form, the
+								    receipt, the resolved-status panel, and error banners. */}
+								{isDesktop && (
+									<div className="flex flex-col gap-4 border-t border-border pt-4">
+										<span className="text-muted-foreground text-xs font-medium tracking-[0.16em] uppercase">
+											{quote.status === "sent" ? "Next Step" : "Outcome"}
+										</span>
+										<ApprovalRail key={approvalKey} {...approvalRailProps} />
+									</div>
+								)}
+							</CardContent>
+						</Card>
+
+						{/* Quote Details */}
+						<div className="flex flex-col gap-6">
+							<QuotePaper
+								quote={quote}
+								lineItems={lineItems}
+								businessName={businessName}
+							/>
+						</div>
+					</div>
+				</div>
 			</div>
+
+			{!isDesktop && (
+				<ApprovalBottomSheet key={approvalKey} {...approvalRailProps} />
+			)}
 		</div>
 	);
 }

--- a/apps/web/src/components/portal/quotes/quote-list.tsx
+++ b/apps/web/src/components/portal/quotes/quote-list.tsx
@@ -1,22 +1,56 @@
 "use client";
 
 /**
- * QuoteList — portal-facing quote index. Search + filter chips + table.
- * Renders the four UI-SPEC filter chips: All / Awaiting decision / Accepted /
- * Declined / Expired. Row click navigates to the detail page; action button
- * uses stopPropagation so it does not double-fire navigation.
+ * QuoteList — portal-facing quote index. ReUI Frame + DataGrid treatment
+ * (matches apps/web/src/app/(workspace)/quotes/page.tsx). Search + filter
+ * chips + a prebuilt TanStack table. Row click navigates to the detail page;
+ * the action link uses stopPropagation so it does not double-fire navigation.
  */
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useQuery } from "convex/react";
-import { ArrowRight, Search } from "lucide-react";
+import {
+	type ColumnDef,
+	getCoreRowModel,
+	useReactTable,
+} from "@tanstack/react-table";
+import { ArrowRight, FileText, Search } from "lucide-react";
 
 import { api } from "@onetool/backend/convex/_generated/api";
-import { formatMoney } from "@/lib/portal/format";
+import { formatDate, formatMoney } from "@/lib/portal/format";
+import { Input } from "@/components/ui/input";
+import { EmptyState } from "@/components/domain/empty-state";
+import { StatusBadge } from "@/components/domain/status-badge";
+import {
+	Frame,
+	FrameDescription,
+	FrameHeader,
+	FramePanel,
+	FrameTitle,
+} from "@/components/reui/frame";
+import {
+	DataGrid,
+	DataGridContainer,
+} from "@/components/reui/data-grid/data-grid";
+import { DataGridTable } from "@/components/reui/data-grid/data-grid-table";
 
-type Filter = "all" | "sent" | "approved" | "declined" | "expired";
+type QuoteStatus = "sent" | "approved" | "declined" | "expired";
+
+interface QuoteListRow {
+	_id: string;
+	quoteNumber?: string;
+	title?: string;
+	status: QuoteStatus;
+	sentAt?: number;
+	validUntil?: number;
+	total: number;
+	approvedAt?: number;
+	declinedAt?: number;
+}
+
+type Filter = "all" | QuoteStatus;
 
 const FILTERS: Array<{ value: Filter; label: string }> = [
 	{ value: "all", label: "All" },
@@ -26,41 +60,115 @@ const FILTERS: Array<{ value: Filter; label: string }> = [
 	{ value: "expired", label: "Expired" },
 ];
 
-function formatDate(ts?: number): string {
-	if (!ts) return "—";
-	return new Date(ts).toLocaleDateString("en-US", {
-		month: "short",
-		day: "numeric",
-		year: "numeric",
-	});
+const STATUS_LABEL: Record<QuoteStatus, string> = {
+	sent: "Awaiting decision",
+	approved: "Accepted",
+	declined: "Declined",
+	expired: "Expired",
+};
+
+function expiryLineFor(q: QuoteListRow): string {
+	if (q.status === "sent" && q.validUntil)
+		return `Expires ${formatDate(q.validUntil)}`;
+	if (q.status === "approved" && q.approvedAt)
+		return `Approved ${formatDate(q.approvedAt)}`;
+	if (q.status === "declined" && q.declinedAt)
+		return `Declined ${formatDate(q.declinedAt)}`;
+	if (q.status === "expired") return `Expired ${formatDate(q.validUntil)}`;
+	return "";
 }
 
-function pillClassFor(status: string): string {
-	switch (status) {
-		case "approved":
-			return "bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900";
-		case "declined":
-			return "bg-muted text-muted-foreground border-border";
-		case "expired":
-			return "bg-muted/70 text-muted-foreground border-border opacity-90";
-		case "sent":
-		default:
-			return "bg-sky-50 text-sky-700 border-sky-200 dark:bg-sky-950/40 dark:text-sky-300 dark:border-sky-900";
-	}
-}
-
-function pillLabelFor(status: string): string {
-	switch (status) {
-		case "approved":
-			return "Accepted";
-		case "declined":
-			return "Declined";
-		case "expired":
-			return "Expired";
-		case "sent":
-		default:
-			return "Awaiting decision";
-	}
+function createColumns(
+	clientPortalId: string,
+): ColumnDef<QuoteListRow>[] {
+	return [
+		{
+			accessorKey: "quoteNumber",
+			header: "Quote",
+			cell: ({ row }) => (
+				<span className="font-semibold text-primary tabular-nums">
+					{row.original.quoteNumber ?? "—"}
+				</span>
+			),
+		},
+		{
+			accessorKey: "sentAt",
+			header: "Sent",
+			cell: ({ row }) => (
+				<span className="text-muted-foreground">
+					{formatDate(row.original.sentAt)}
+				</span>
+			),
+		},
+		{
+			accessorKey: "title",
+			header: "For",
+			cell: ({ row }) => (
+				<span className="font-medium text-foreground">
+					{row.original.title ?? "Quote"}
+				</span>
+			),
+		},
+		{
+			accessorKey: "status",
+			header: "Status",
+			cell: ({ row }) => {
+				const q = row.original;
+				const expiryLine = expiryLineFor(q);
+				return (
+					<div>
+						<StatusBadge status={q.status} appearance="soft">
+							{STATUS_LABEL[q.status]}
+						</StatusBadge>
+						{expiryLine && (
+							<div className="mt-1 text-[11px] text-muted-foreground">
+								{expiryLine}
+							</div>
+						)}
+					</div>
+				);
+			},
+		},
+		{
+			accessorKey: "total",
+			header: () => <div className="text-right">Total</div>,
+			cell: ({ row }) => (
+				<div className="text-right font-semibold tabular-nums">
+					{formatMoney(row.original.total)}
+				</div>
+			),
+		},
+		{
+			id: "actions",
+			header: "",
+			cell: ({ row }) => {
+				const q = row.original;
+				const href = `/portal/c/${clientPortalId}/quotes/${q._id}`;
+				const isPending = q.status === "sent";
+				return (
+					<div
+						className="flex items-center justify-end"
+						onClick={(e) => e.stopPropagation()}
+					>
+						<Link
+							href={href}
+							onKeyDown={(e) => e.stopPropagation()}
+							className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-medium transition-colors duration-200 ${
+								isPending
+									? "bg-primary text-primary-foreground hover:bg-primary/90"
+									: "text-muted-foreground hover:bg-muted hover:text-foreground"
+							}`}
+						>
+							{isPending ? "Review" : "View"}
+							{isPending && (
+								<ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+							)}
+						</Link>
+					</div>
+				);
+			},
+		},
+	];
 }
 
 export interface QuoteListProps {
@@ -72,7 +180,9 @@ export function QuoteList({ businessName }: QuoteListProps) {
 	const router = useRouter();
 	const clientPortalId = params?.clientPortalId ?? "";
 
-	const quotes = useQuery(api.portal.quotes.list, {});
+	const quotes = useQuery(api.portal.quotes.list, {}) as
+		| QuoteListRow[]
+		| undefined;
 
 	const [search, setSearch] = useState("");
 	const [filter, setFilter] = useState<Filter>("all");
@@ -94,6 +204,17 @@ export function QuoteList({ businessName }: QuoteListProps) {
 	const isEmpty = !isLoading && (quotes?.length ?? 0) === 0;
 	const isFilterEmpty = !isLoading && !isEmpty && filtered.length === 0;
 
+	const columns = useMemo(
+		() => createColumns(clientPortalId),
+		[clientPortalId],
+	);
+
+	const table = useReactTable({
+		data: filtered,
+		columns,
+		getCoreRowModel: getCoreRowModel(),
+	});
+
 	return (
 		<div>
 			<header className="flex flex-col gap-1">
@@ -108,189 +229,87 @@ export function QuoteList({ businessName }: QuoteListProps) {
 				</p>
 			</header>
 
-			<div className="mt-6 rounded-2xl border border-border bg-card overflow-hidden shadow-xs">
-				<div className="flex flex-wrap items-center gap-2 border-b border-border p-3">
-					<div className="relative flex-1 max-w-[280px]">
-						<Search
-							className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground"
-							aria-hidden="true"
-						/>
-						<input
-							type="search"
-							value={search}
-							onChange={(e) => setSearch(e.target.value)}
-							placeholder="Search quotes…"
-							aria-label="Search quotes"
-							className="w-full rounded-lg border border-border bg-card pl-9 pr-3 py-2 text-[13px] transition-colors focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/25"
-						/>
+			<Frame className="mt-6">
+				<FrameHeader className="flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
+					<div className="flex flex-col gap-0.5">
+						<FrameTitle className="text-base">Quotes</FrameTitle>
+						<FrameDescription>
+							Search and filter your quotes
+						</FrameDescription>
 					</div>
-					<div className="flex flex-wrap gap-1.5">
-						{FILTERS.map((f) => {
-							const active = filter === f.value;
-							return (
-								<button
-									key={f.value}
-									type="button"
-									onClick={() => setFilter(f.value)}
-									aria-pressed={active}
-									className={`rounded-lg border px-3 py-1.5 text-[13px] font-medium transition-colors ${
-										active
-											? "bg-primary text-primary-foreground border-primary"
-											: "bg-card text-muted-foreground border-border hover:bg-muted hover:text-foreground"
-									}`}
-								>
-									{f.label}
-								</button>
-							);
-						})}
-					</div>
-				</div>
-
-				{isLoading ? (
-					<div className="divide-y divide-border">
-						{Array.from({ length: 4 }).map((_, i) => (
-							<div
-								key={i}
-								className="flex items-center gap-4 px-4 py-4 animate-pulse"
-							>
-								<div className="h-4 w-16 bg-muted rounded" />
-								<div className="h-4 w-24 bg-muted rounded" />
-								<div className="h-4 flex-1 bg-muted rounded" />
-								<div className="h-5 w-28 bg-muted rounded-full" />
-								<div className="h-4 w-20 bg-muted rounded" />
-								<div className="h-8 w-24 bg-muted rounded-md" />
-							</div>
-						))}
-					</div>
-				) : isEmpty ? (
-					<div className="px-6 py-20 text-center">
-						<p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-							No quotes yet
-						</p>
-						<h2 className="mt-3 text-[18px] font-semibold text-foreground">
-							Nothing here yet
-						</h2>
-						<p className="mt-2 text-sm text-muted-foreground">
-							When {businessName} sends you a quote, it will show up here.
-						</p>
-					</div>
-				) : isFilterEmpty ? (
-					<div className="px-6 py-20 text-center">
-						<h2 className="text-[18px] font-semibold text-foreground">
-							Nothing here right now
-						</h2>
-						<p className="mt-2 text-sm text-muted-foreground">
-							Try a different filter, or clear the search.
-						</p>
-					</div>
-				) : (
-					<table className="w-full">
-						<thead>
-							<tr className="bg-muted/40">
-								<th className="text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-3 px-4 border-b border-border">
-									Quote
-								</th>
-								<th className="text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-3 px-4 border-b border-border">
-									Sent
-								</th>
-								<th className="text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-3 px-4 border-b border-border">
-									For
-								</th>
-								<th className="text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-3 px-4 border-b border-border">
-									Status
-								</th>
-								<th className="text-right text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-3 px-4 border-b border-border">
-									Total
-								</th>
-								<th className="py-3 px-4 w-[140px] border-b border-border" />
-							</tr>
-						</thead>
-						<tbody>
-							{filtered.map((q, i) => {
-								const href = `/portal/c/${clientPortalId}/quotes/${q._id}`;
-								const isPending = q.status === "sent";
-								const isLast = i === filtered.length - 1;
-								const expiryLine = (() => {
-									if (q.status === "sent" && q.validUntil)
-										return `Expires ${formatDate(q.validUntil)}`;
-									if (q.status === "approved" && q.approvedAt)
-										return `Approved ${formatDate(q.approvedAt)}`;
-									if (q.status === "declined" && q.declinedAt)
-										return `Declined ${formatDate(q.declinedAt)}`;
-									if (q.status === "expired")
-										return `Expired ${formatDate(q.validUntil)}`;
-									return "";
-								})();
+					<div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
+						<div className="relative w-full sm:w-64">
+							<Search
+								className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
+								aria-hidden="true"
+							/>
+							<Input
+								type="search"
+								value={search}
+								onChange={(e) => setSearch(e.target.value)}
+								placeholder="Search quotes…"
+								aria-label="Search quotes"
+								className="pl-9"
+							/>
+						</div>
+						<div className="flex flex-wrap gap-1.5">
+							{FILTERS.map((f) => {
+								const active = filter === f.value;
 								return (
-									<tr
-										key={q._id}
-										onClick={() => router.push(href)}
-										onKeyDown={(e) => {
-											if (e.key === "Enter" || e.key === " ") {
-												e.preventDefault();
-												router.push(href);
-											}
-										}}
-										role="button"
-										tabIndex={0}
-										className={`hover:bg-muted/50 cursor-pointer transition-colors ${
-											isLast ? "" : "border-b border-border"
+									<button
+										key={f.value}
+										type="button"
+										onClick={() => setFilter(f.value)}
+										aria-pressed={active}
+										className={`rounded-lg border px-3 py-1.5 text-[13px] font-medium transition-colors duration-200 ${
+											active
+												? "border-primary bg-primary text-primary-foreground"
+												: "border-border bg-card text-muted-foreground hover:bg-muted hover:text-foreground"
 										}`}
 									>
-										<td className="py-3.5 px-4 font-semibold text-primary tabular-nums">
-											{q.quoteNumber ?? "—"}
-										</td>
-										<td className="py-3.5 px-4 text-[14px] text-muted-foreground">
-											{formatDate(q.sentAt)}
-										</td>
-										<td className="py-3.5 px-4 text-[14px]">
-											<div className="font-medium text-foreground">
-												{q.title ?? "Quote"}
-											</div>
-										</td>
-										<td className="py-3.5 px-4">
-											<span
-												className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[11px] font-medium ${pillClassFor(q.status)}`}
-											>
-												<span className="h-1.5 w-1.5 rounded-full bg-current" />
-												{pillLabelFor(q.status)}
-											</span>
-											{expiryLine && (
-												<div className="text-[11px] text-muted-foreground mt-1">
-													{expiryLine}
-												</div>
-											)}
-										</td>
-										<td className="py-3.5 px-4 text-right font-semibold tabular-nums">
-											{formatMoney(q.total)}
-										</td>
-										<td className="py-3.5 px-4 text-right">
-											<Link
-												href={href}
-												onClick={(e) => e.stopPropagation()}
-												onKeyDown={(e) => e.stopPropagation()}
-												className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-medium transition-colors ${
-													isPending
-														? "bg-primary text-primary-foreground hover:bg-primary/90"
-														: "text-muted-foreground hover:bg-muted hover:text-foreground"
-												}`}
-											>
-												{isPending ? "Review" : "View"}
-												{isPending && (
-													<ArrowRight
-														className="h-3.5 w-3.5"
-														aria-hidden="true"
-													/>
-												)}
-											</Link>
-										</td>
-									</tr>
+										{f.label}
+									</button>
 								);
 							})}
-						</tbody>
-					</table>
-				)}
-			</div>
+						</div>
+					</div>
+				</FrameHeader>
+
+				<DataGrid
+					table={table}
+					recordCount={filtered.length}
+					isLoading={isLoading}
+					onRowClick={(row) =>
+						router.push(`/portal/c/${clientPortalId}/quotes/${row._id}`)
+					}
+					emptyMessage="No quotes match your filters."
+					tableLayout={{ width: "auto", headerBackground: true }}
+				>
+					<FramePanel className="p-0">
+						{isEmpty ? (
+							<EmptyState
+								size="md"
+								icon={<FileText />}
+								title="No quotes yet"
+								description={`When ${businessName} sends you a quote, it will show up here.`}
+							/>
+						) : isFilterEmpty ? (
+							<EmptyState
+								size="md"
+								icon={<Search />}
+								title="Nothing here right now"
+								description="Try a different filter, or clear the search."
+							/>
+						) : (
+							<div className="overflow-x-auto">
+								<DataGridContainer>
+									<DataGridTable />
+								</DataGridContainer>
+							</div>
+						)}
+					</FramePanel>
+				</DataGrid>
+			</Frame>
 		</div>
 	);
 }

--- a/apps/web/src/components/portal/quotes/quote-list.tsx
+++ b/apps/web/src/components/portal/quotes/quote-list.tsx
@@ -74,7 +74,8 @@ function expiryLineFor(q: QuoteListRow): string {
 		return `Approved ${formatDate(q.approvedAt)}`;
 	if (q.status === "declined" && q.declinedAt)
 		return `Declined ${formatDate(q.declinedAt)}`;
-	if (q.status === "expired") return `Expired ${formatDate(q.validUntil)}`;
+	if (q.status === "expired")
+		return q.validUntil ? `Expired ${formatDate(q.validUntil)}` : "Expired";
 	return "";
 }
 

--- a/apps/web/src/components/portal/quotes/quote-paper.tsx
+++ b/apps/web/src/components/portal/quotes/quote-paper.tsx
@@ -8,6 +8,7 @@
 import type { Doc } from "@onetool/backend/convex/_generated/dataModel";
 
 import { formatMoney } from "@/lib/portal/format";
+import { TotalsBreakdown } from "@/components/portal/totals-breakdown";
 
 export interface QuotePaperLineItem {
 	description: string;
@@ -27,6 +28,9 @@ export interface QuotePaperProps {
 		| "taxAmount"
 		| "total"
 		| "terms"
+		| "discountEnabled"
+		| "discountAmount"
+		| "discountType"
 	>;
 	lineItems: QuotePaperLineItem[];
 	businessName: string;
@@ -36,6 +40,14 @@ export function QuotePaper({ quote, lineItems, businessName }: QuotePaperProps) 
 	const subtotal = quote.subtotal ?? 0;
 	const tax = quote.taxAmount ?? 0;
 	const total = quote.total ?? 0;
+	// Discount applies before tax: total = (subtotal - discount) + tax, so the
+	// display discount is derived from the resolved totals — never re-derived
+	// from discountType math (backend never emits discount dollars directly).
+	const discountDollars = subtotal + tax - total;
+	const discountLabel =
+		quote.discountEnabled && quote.discountType === "percentage"
+			? `Discount (${quote.discountAmount}%)`
+			: "Discount";
 
 	return (
 		<div className="mx-auto max-w-[760px] rounded-2xl border border-border bg-card p-6 shadow-xs md:p-9">
@@ -94,22 +106,15 @@ export function QuotePaper({ quote, lineItems, businessName }: QuotePaperProps) 
 				</table>
 			</div>
 
-			<div className="mt-6 border-t-2 border-foreground pt-4 flex flex-col items-end gap-1.5">
-				<div className="flex items-center gap-8 text-[14px]">
-					<span className="text-muted-foreground">Subtotal</span>
-					<span className="tabular-nums">{formatMoney(subtotal)}</span>
-				</div>
-				{tax > 0 && (
-					<div className="flex items-center gap-8 text-[14px]">
-						<span className="text-muted-foreground">Estimated tax</span>
-						<span className="tabular-nums">{formatMoney(tax)}</span>
-					</div>
-				)}
-				<div className="flex items-center gap-8 text-[16px] font-semibold border-t border-foreground pt-2 mt-1">
-					<span>Total</span>
-					<span className="tabular-nums">{formatMoney(total)}</span>
-				</div>
-			</div>
+			<TotalsBreakdown
+				className="mt-6"
+				subtotal={subtotal}
+				discount={discountDollars}
+				discountLabel={discountLabel}
+				tax={tax}
+				taxLabel="Estimated tax"
+				total={total}
+			/>
 
 			{quote.terms ? (
 				<div className="mt-10 pt-6 border-t border-dashed border-border">

--- a/apps/web/src/components/portal/totals-breakdown.tsx
+++ b/apps/web/src/components/portal/totals-breakdown.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+/**
+ * TotalsBreakdown — shared portal totals stack for quote/invoice papers.
+ * Renders Subtotal → Discount → Tax → Total so the portal always shows
+ * every contribution to the total. Discount/tax rows hide when zero.
+ */
+
+import { formatMoney } from "@/lib/portal/format";
+import { cn } from "@/lib/utils";
+
+export interface TotalsBreakdownProps {
+	subtotal: number;
+	/** Display discount in dollars (already resolved from percent/fixed). */
+	discount?: number | null;
+	/** e.g. "Discount (10%)" — defaults to "Discount". */
+	discountLabel?: string;
+	tax?: number | null;
+	taxLabel?: string;
+	total: number;
+	totalLabel?: string;
+	className?: string;
+}
+
+export function TotalsBreakdown({
+	subtotal,
+	discount,
+	discountLabel = "Discount",
+	tax,
+	taxLabel = "Tax",
+	total,
+	totalLabel = "Total",
+	className,
+}: TotalsBreakdownProps) {
+	// Guard against float dust so a rounding remainder never renders a row.
+	const discountValue = discount != null && discount > 0.005 ? discount : 0;
+	const taxValue = tax != null && tax > 0.005 ? tax : 0;
+
+	return (
+		<dl
+			className={cn(
+				"border-t-2 border-foreground pt-4 flex flex-col items-end gap-1.5",
+				className
+			)}
+		>
+			<div className="flex items-center gap-8 text-[14px]">
+				<dt className="text-muted-foreground">Subtotal</dt>
+				<dd className="tabular-nums">{formatMoney(subtotal)}</dd>
+			</div>
+			{discountValue > 0 && (
+				<div className="flex items-center gap-8 text-[14px]">
+					<dt className="text-muted-foreground">{discountLabel}</dt>
+					<dd className="tabular-nums text-emerald-600 dark:text-emerald-400">
+						-{formatMoney(discountValue)}
+					</dd>
+				</div>
+			)}
+			{taxValue > 0 && (
+				<div className="flex items-center gap-8 text-[14px]">
+					<dt className="text-muted-foreground">{taxLabel}</dt>
+					<dd className="tabular-nums">{formatMoney(taxValue)}</dd>
+				</div>
+			)}
+			<div
+				data-paper-total
+				className="flex items-center gap-8 text-[16px] font-semibold border-t border-foreground pt-2 mt-1"
+			>
+				<dt>{totalLabel}</dt>
+				<dd className="tabular-nums">{formatMoney(total)}</dd>
+			</div>
+		</dl>
+	);
+}

--- a/apps/web/src/components/portal/welcome-content.tsx
+++ b/apps/web/src/components/portal/welcome-content.tsx
@@ -133,7 +133,7 @@ export function WelcomeContent({
 							</div>
 							<Link
 								href={viewAllHref}
-								className="text-[13px] font-medium text-primary hover:text-primary/80"
+								className="cursor-pointer rounded-sm text-[13px] font-medium text-primary outline-none transition-colors hover:text-primary/80 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card"
 							>
 								View all →
 							</Link>
@@ -277,7 +277,7 @@ function AttentionCard({
 					{awaitingQuotesCount > 0 && (
 						<Link
 							href={quoteHref}
-							className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-border bg-card px-3 py-1.5 text-[13px] font-medium text-foreground shadow-xs hover:bg-muted"
+							className="inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-lg border border-border bg-card px-3 py-1.5 text-[13px] font-medium text-foreground shadow-xs outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card"
 						>
 							{awaitingQuotesCount === 1 ? "Review quote" : "Review quotes"}
 						</Link>
@@ -285,7 +285,7 @@ function AttentionCard({
 					{outstandingCount > 0 && (
 						<Link
 							href={invoiceHref}
-							className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-[13px] font-medium text-primary-foreground shadow-sm hover:bg-primary/90"
+							className="inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-[13px] font-medium text-primary-foreground shadow-sm outline-none transition-colors hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card"
 						>
 							Pay {formatMoney(outstandingTotal)}
 							<ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />


### PR DESCRIPTION
This pull request introduces a major redesign of the client portal's invoice detail and expired portal pages, with a focus on improved UI structure, accessibility, and code maintainability. The invoice detail view now uses a more modular and visually clear layout, with enhanced payment status and summary information, and improved action button placement. The expired portal page is also updated for a more branded, cohesive experience. Additionally, accessibility improvements have been made to the OTP form buttons. Below are the most important changes:

**Invoice Detail Page Redesign**
* Refactored the invoice detail layout: moved from a two-column grid to a single-column layout on mobile, with the right rail (actions and payment) now passed as a `paySlot` prop to the `InvoicePaper` component for better modularity and flexibility. [[1]](diffhunk://#diff-08a7c744d5866ead2046a7c0e115034e1127b70b39b2e6cc7c6547756235b266L144-L154) [[2]](diffhunk://#diff-08a7c744d5866ead2046a7c0e115034e1127b70b39b2e6cc7c6547756235b266L242-R248)
* The invoice header actions (`HeaderActionsClient`) have been removed from the detail page, and related layout adjustments were made for a cleaner header. ([apps/web/src/app/(portal)/portal/c/[clientPortalId]/(authenticated)/invoices/[invoiceId]/page.tsxL10](diffhunk://#diff-7d1e5cb8641b74d4fffccabf2a1a8323cd6313ff775cf81bd154b347618273e8L10), [apps/web/src/app/(portal)/portal/c/[clientPortalId]/(authenticated)/invoices/[invoiceId]/page.tsxL53-R52](diffhunk://#diff-7d1e5cb8641b74d4fffccabf2a1a8323cd6313ff775cf81bd154b347618273e8L53-R52), [apps/web/src/app/(portal)/portal/c/[clientPortalId]/(authenticated)/invoices/[invoiceId]/page.tsxL68](diffhunk://#diff-7d1e5cb8641b74d4fffccabf2a1a8323cd6313ff775cf81bd154b347618273e8L68))

**Invoice Paper Component Enhancements**
* Major rewrite of `InvoicePaper` to support:
  - New props: `displayStatus`, `paymentSummary`, and `paySlot` for richer status display and custom payment UI injection.
  - Improved sidebar with business branding, status badge, hero total/paid amount, and payment progress.
  - Refined line items and totals breakdown, using the new `TotalsBreakdown` component and improved visual structure.
  - Extraction of reusable subcomponents like `MetaSection` and `LineItemRow`. [[1]](diffhunk://#diff-611a91418e31837a3ab33b3a14f813327cb8ca8757cba56d9a0dbd104270c40aR3-R33) [[2]](diffhunk://#diff-611a91418e31837a3ab33b3a14f813327cb8ca8757cba56d9a0dbd104270c40aR49-R57) [[3]](diffhunk://#diff-611a91418e31837a3ab33b3a14f813327cb8ca8757cba56d9a0dbd104270c40aR67-R70) [[4]](diffhunk://#diff-611a91418e31837a3ab33b3a14f813327cb8ca8757cba56d9a0dbd104270c40aR80-R269)

**Invoice Actions and Utilities**
* Added download PDF and print buttons below the invoice for easier access to invoice actions. [[1]](diffhunk://#diff-08a7c744d5866ead2046a7c0e115034e1127b70b39b2e6cc7c6547756235b266R12) [[2]](diffhunk://#diff-08a7c744d5866ead2046a7c0e115034e1127b70b39b2e6cc7c6547756235b266R22) [[3]](diffhunk://#diff-08a7c744d5866ead2046a7c0e115034e1127b70b39b2e6cc7c6547756235b266L242-R248)

**Portal Expired Page Redesign**
* Updated the expired portal page with OneTool branding, improved layout, and clearer messaging, enhancing the user experience and consistency.

**Accessibility Improvements**
* Improved accessibility and focus styles for OTP form buttons, adding `focus-visible` rings and better disabled/cursor handling for keyboard navigation. [[1]](diffhunk://#diff-f022b117c6750a8cabaf1e1c2dff499dbc764fa67bec870b33dbad0de7344d5eL238-R238) [[2]](diffhunk://#diff-f022b117c6750a8cabaf1e1c2dff499dbc764fa67bec870b33dbad0de7344d5eL321-R321) [[3]](diffhunk://#diff-f022b117c6750a8cabaf1e1c2dff499dbc764fa67bec870b33dbad0de7344d5eL333-R333) [[4]](diffhunk://#diff-f022b117c6750a8cabaf1e1c2dff499dbc764fa67bec870b33dbad0de7344d5eL343-R343)

**Code Quality and Documentation**
* Updated comments and removed unused imports for clarity and maintainability in the quotes approval rail and other components. [[1]](diffhunk://#diff-c488831004c6104089200b2e7d6168fd14546ff73902eea2da9f0fd5032093aaL4-R8) [[2]](diffhunk://#diff-c488831004c6104089200b2e7d6168fd14546ff73902eea2da9f0fd5032093aaL26)

These changes collectively improve the user interface, accessibility, and maintainability of the client portal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Refreshed invoices and quotes UI with DataGrid-based lists, status badges, search/filter chips, and improved empty states.
  - Invoice paper now supports display status, payment progress, and inline Download PDF / Print controls; quote paper uses a shared totals breakdown and a Quote Journey timeline.
  - Redesigned the portal expired screen with updated branding and secured messaging.
  - Added a shared Totals breakdown component (subtotal, optional discount/tax, total).

- **Style & Accessibility**
  - Improved focus-visible and pointer/keyboard interaction styling across portal screens and adjusted key header/layout spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a comprehensive ReUI redesign of the client portal's invoice and quote experiences, replacing hand-rolled table/card layouts with TanStack DataGrid + Frame components, a modular `InvoicePaper` sidebar layout, a new Quote Journey timeline panel, and accessibility improvements across OTP form buttons and action links.

- **Invoice detail** is rewritten to a single-column layout where the payment rail moves into `InvoicePaper` via a `paySlot` prop; download and print actions are placed below the paper.
- **Invoice and quote lists** drop the duplicated desktop/mobile rendering paths in favor of a unified `DataGrid` table with `EmptyState` components.
- **Quote detail** gains a hero status card, a sticky Quote Journey timeline sidebar, and moves the total/validity info out of `ApprovalRail` and into the hero; a new shared `TotalsBreakdown` component unifies subtotal/discount/tax/total rendering across both papers.

<h3>Confidence Score: 3/5</h3>

The redesign is broadly solid, but the invoice status badge role mismatch (partial/awaiting mapped to opposite roles in the list vs. detail) will visibly confuse clients who navigate between pages.

The STATUS_ROLE maps for partial and awaiting are inverted between invoice-paper.tsx and invoice-list.tsx, so a client sees an amber badge on the list and a blue badge on the detail page (or vice-versa) for the same invoice. This is a live, user-visible discrepancy on a core payment-status UI element. The sticky top-6 on the Quote Journey card and the Approved/Accepted label split are cosmetic, but the badge inconsistency needs to be resolved before shipping.

invoice-paper.tsx and invoice-list.tsx both define their own STATUS_ROLE/DISPLAY_STATUS_ROLE maps that disagree on partial and awaiting; and quote-detail-island.tsx for the sticky-top offset and label mismatch with quote-list.tsx.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/portal/invoices/invoice-paper.tsx | Major rewrite adding sidebar layout, hero total, status badge, and paySlot prop — STATUS_ROLE for partial/awaiting is flipped relative to invoice-list.tsx, causing inconsistent badge colors between list and detail views. |
| apps/web/src/components/portal/invoices/invoice-list.tsx | Migrated from custom table/card to TanStack + ReUI DataGrid; DISPLAY_STATUS_ROLE maps partial→info and awaiting→warning, which conflicts with invoice-paper.tsx mappings. |
| apps/web/src/components/portal/quotes/quote-detail-island.tsx | New receipt-2 layout with hero card, Timeline-based Quote Journey panel, and sticky left sidebar; sticky top offset (top-6) is too small to clear the 68px header, and statusLabelFor("approved") returns "Approved" while the list shows "Accepted". |
| apps/web/src/components/portal/quotes/quote-list.tsx | Migrated to TanStack + ReUI DataGrid with proper isLoading support; clean replacement of manual table/card markup with consistent empty states. |
| apps/web/src/components/portal/totals-breakdown.tsx | New shared component for subtotal/discount/tax/total display; uses dl/dt/dd semantics, guards float dust with > 0.005 threshold, and supports customisable labels. |
| apps/web/src/components/portal/otp-form.tsx | Accessibility improvements: added focus-visible ring styles and cursor-not-allowed to all interactive buttons for better keyboard navigation. |
| apps/web/src/app/(portal)/portal/expired/page.tsx | Redesigned expired portal page with OneTool branding, LinkIcon illustration, and SecuredByOneTool footer; straightforward presentational change. |
| apps/web/src/components/portal/quotes/approval-rail.tsx | Removed the total/validUntil display block (now shown in the hero card), cleaned up unused imports, and simplified the wrapper from aside to a div. |
| apps/web/src/components/portal/quotes/quote-paper.tsx | Replaced manual totals block with TotalsBreakdown; discount is derived via subtotal+tax-total (correct math, guarded against float dust downstream). |
| apps/web/src/components/portal/invoices/invoice-detail-island.tsx | Simplified to a single-column layout, passing rightRail as paySlot to InvoicePaper; DownloadPdfButton and PrintButton moved below the paper. |
| apps/web/src/components/portal/welcome-content.tsx | Applied focus-visible ring and cursor-pointer to action links for accessibility parity with other portal components. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    IL[InvoiceList\nDataGrid + Frame] -->|row click| ID[InvoiceDetailPage]
    ID --> IDI[InvoiceDetailIsland]
    IDI --> IP[InvoicePaper\nsidebar layout]
    IP -- paySlot --> PR[PaymentRail\nInstallmentList]
    IP --> TB1[TotalsBreakdown]
    IDI --> DL[DownloadPdfButton\nPrintButton]

    QL[QuoteList\nDataGrid + Frame] -->|row click| QD[QuoteDetailIsland]
    QD --> HC[Hero Card\nstatus + total]
    QD --> QJP[Quote Journey Panel\nTimeline + ApprovalRail]
    QD --> QP[QuotePaper]
    QP --> TB2[TotalsBreakdown]
    QD -->|mobile| ABS[ApprovalBottomSheet]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    IL[InvoiceList\nDataGrid + Frame] -->|row click| ID[InvoiceDetailPage]
    ID --> IDI[InvoiceDetailIsland]
    IDI --> IP[InvoicePaper\nsidebar layout]
    IP -- paySlot --> PR[PaymentRail\nInstallmentList]
    IP --> TB1[TotalsBreakdown]
    IDI --> DL[DownloadPdfButton\nPrintButton]

    QL[QuoteList\nDataGrid + Frame] -->|row click| QD[QuoteDetailIsland]
    QD --> HC[Hero Card\nstatus + total]
    QD --> QJP[Quote Journey Panel\nTimeline + ApprovalRail]
    QD --> QP[QuotePaper]
    QP --> TB2[TotalsBreakdown]
    QD -->|mobile| ABS[ApprovalBottomSheet]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/web/src/components/portal/invoices/invoice-paper.tsx:17-25
**Invoice status badge roles are flipped vs. the list view**

`invoice-paper.tsx` maps `partial → "warning"` and `awaiting → "info"`, but `invoice-list.tsx` maps them the other way around (`partial → "info"`, `awaiting → "warning"`). A customer who navigates from the invoice list to the detail page will see the status badge change color for the same invoice, undermining trust in the status indicator. One of these two maps needs to be updated to match the other.

### Issue 2 of 3
apps/web/src/components/portal/quotes/quote-detail-island.tsx:79-82
The detail hero uses `statusLabelFor("approved") → "Approved"`, while `quote-list.tsx` uses `STATUS_LABEL.approved = "Accepted"`. A client sees "Accepted" on the list page and "Approved" on the detail page for the same quote, which is inconsistent. Both should agree on one term.

```suggestion
function statusLabelFor(status: string): string {
	switch (status) {
		case "approved":
			return "Accepted";
```

### Issue 3 of 3
apps/web/src/components/portal/quotes/quote-detail-island.tsx:452-454
The Quote Journey card uses `lg:top-6` (24 px), but the page has a `sticky top-0 h-[68px]` header bar. On large screens, as the user scrolls, the card will dock 24 px from the viewport top — sliding 44 px behind the sticky header and becoming partially hidden. The `top` offset should clear the header height (68 px) plus the desired visual gap.

```suggestion
					{/* Two-pane: Quote Journey (sticky) + Quote Details */}
					<div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,20rem)_minmax(0,1fr)] lg:gap-8">
						<Card className="lg:sticky lg:top-[calc(68px+1.5rem)]">
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(portal): ReUI treatment for custome..."](https://github.com/xcarter93/onetool/commit/fa557372dd1f62adb09edf7f0fafe398c2bf4502) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45326067)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->