### PR TITLE
fix(portal): server-fetch quote list + full-width detail layouts

### DIFF
--- a/apps/web/src/app/(portal)/portal/c/[clientPortalId]/(authenticated)/quotes/page.tsx
+++ b/apps/web/src/app/(portal)/portal/c/[clientPortalId]/(authenticated)/quotes/page.tsx
@@ -1,9 +1,14 @@
 import { fetchQuery } from "convex/nextjs";
 import { api } from "@onetool/backend/convex/_generated/api";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 
 import { PortalContainer } from "@/components/portal/portal-container";
-import { QuoteList } from "@/components/portal/quotes/quote-list";
+import {
+	QuoteList,
+	type QuoteListRow,
+} from "@/components/portal/quotes/quote-list";
+import { readSessionCookie } from "@/lib/portal/cookie";
+import { isPortalAuthError } from "@/lib/portal/errors";
 
 export default async function QuotesPage({
 	params,
@@ -19,9 +24,28 @@ export default async function QuotesPage({
 		return null;
 	}
 
+	const token = (await readSessionCookie()) ?? undefined;
+	if (!token) {
+		redirect(`/portal/c/${clientPortalId}/verify`);
+	}
+
+	let quotes: QuoteListRow[] = [];
+	try {
+		quotes = (await fetchQuery(
+			api.portal.quotes.list,
+			{},
+			{ token },
+		)) as QuoteListRow[];
+	} catch (err) {
+		if (isPortalAuthError(err)) {
+			redirect(`/portal/c/${clientPortalId}/verify`);
+		}
+		throw err;
+	}
+
 	return (
 		<PortalContainer width="list">
-			<QuoteList businessName={branding.name} />
+			<QuoteList businessName={branding.name} quotes={quotes} />
 		</PortalContainer>
 	);
 }

--- a/apps/web/src/components/portal/invoices/invoice-detail-island.tsx
+++ b/apps/web/src/components/portal/invoices/invoice-detail-island.tsx
@@ -242,7 +242,7 @@ export function InvoiceDetailIsland({
 					paymentSummary={data.paymentSummary}
 					paySlot={rightRail}
 				/>
-				<div className="mx-auto mt-6 flex w-full max-w-4xl flex-wrap items-center justify-center gap-2">
+				<div className="mx-auto mt-6 flex w-full flex-wrap items-center justify-center gap-2">
 					<DownloadPdfButton invoiceId={data.invoice._id} hasPdf={hasPdf} />
 					<PrintButton />
 				</div>

--- a/apps/web/src/components/portal/invoices/invoice-paper.tsx
+++ b/apps/web/src/components/portal/invoices/invoice-paper.tsx
@@ -92,9 +92,9 @@ export function InvoicePaper({
 		paymentSummary.installmentCount > 1;
 
 	return (
-		<Card data-portal-paper-invoice className="mx-auto w-full max-w-4xl">
+		<Card data-portal-paper-invoice className="mx-auto w-full">
 			<CardContent>
-				<div className="grid grid-cols-1 gap-8 md:grid-cols-[18rem_minmax(0,1fr)] md:gap-10">
+				<div className="grid grid-cols-1 gap-8 md:grid-cols-[minmax(0,24rem)_minmax(0,1fr)] md:gap-10">
 					{/* Sidebar: brand + status, hero total, metadata, pay surface */}
 					<aside className="flex flex-col gap-5 md:border-r md:border-border md:pr-8">
 						<div className="flex items-center justify-between gap-3">

--- a/apps/web/src/components/portal/quotes/quote-detail-island.tsx
+++ b/apps/web/src/components/portal/quotes/quote-detail-island.tsx
@@ -225,9 +225,9 @@ export function QuoteDetailIsland({ quoteId }: QuoteDetailIslandProps) {
 					<div className="h-5 w-32 animate-pulse rounded bg-muted" />
 				</div>
 				<div className="px-6 py-8 md:px-9">
-					<div className="mx-auto max-w-5xl">
+					<div className="mx-auto w-full">
 						<div className="mb-6 h-28 animate-pulse rounded-2xl border border-border bg-card md:mb-8" />
-						<div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,20rem)_minmax(0,1fr)] lg:gap-8">
+						<div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,24rem)_minmax(0,1fr)] lg:gap-8">
 							<div className="h-64 animate-pulse rounded-2xl border border-border bg-card" />
 							<div className="h-96 animate-pulse rounded-2xl border border-border bg-card" />
 						</div>
@@ -407,7 +407,7 @@ export function QuoteDetailIsland({ quoteId }: QuoteDetailIslandProps) {
 			)}
 
 			<div className="px-6 py-8 pb-24 md:px-9 md:pb-10">
-				<div className="mx-auto max-w-5xl">
+				<div className="mx-auto w-full">
 					{/* Hero: status + quote id/title + business + total */}
 					<Card className="mb-6 md:mb-8">
 						<CardContent>
@@ -456,7 +456,7 @@ export function QuoteDetailIsland({ quoteId }: QuoteDetailIslandProps) {
 					</Card>
 
 					{/* Two-pane: Quote Journey (sticky) + Quote Details */}
-					<div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,20rem)_minmax(0,1fr)] lg:gap-8">
+					<div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,24rem)_minmax(0,1fr)] lg:gap-8">
 						<Card className="lg:sticky lg:top-[calc(68px+1.5rem)]">
 							<CardHeader>
 								<CardTitle className="text-base">Quote Journey</CardTitle>

--- a/apps/web/src/components/portal/quotes/quote-list.tsx
+++ b/apps/web/src/components/portal/quotes/quote-list.tsx
@@ -10,7 +10,6 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { useQuery } from "convex/react";
 import {
 	type ColumnDef,
 	getCoreRowModel,
@@ -18,7 +17,6 @@ import {
 } from "@tanstack/react-table";
 import { ArrowRight, FileText, Search } from "lucide-react";
 
-import { api } from "@onetool/backend/convex/_generated/api";
 import { formatDate, formatMoney } from "@/lib/portal/format";
 import { Input } from "@/components/ui/input";
 import { EmptyState } from "@/components/domain/empty-state";
@@ -38,7 +36,9 @@ import { DataGridTable } from "@/components/reui/data-grid/data-grid-table";
 
 type QuoteStatus = "sent" | "approved" | "declined" | "expired";
 
-interface QuoteListRow {
+// Mirror of the api.portal.quotes.list item shape — data is fetched
+// server-side in quotes/page.tsx (same pattern as the invoice list).
+export interface QuoteListRow {
 	_id: string;
 	quoteNumber?: string;
 	title?: string;
@@ -174,22 +174,18 @@ function createColumns(
 
 export interface QuoteListProps {
 	businessName: string;
+	quotes: QuoteListRow[];
 }
 
-export function QuoteList({ businessName }: QuoteListProps) {
+export function QuoteList({ businessName, quotes }: QuoteListProps) {
 	const params = useParams<{ clientPortalId: string }>();
 	const router = useRouter();
 	const clientPortalId = params?.clientPortalId ?? "";
-
-	const quotes = useQuery(api.portal.quotes.list, {}) as
-		| QuoteListRow[]
-		| undefined;
 
 	const [search, setSearch] = useState("");
 	const [filter, setFilter] = useState<Filter>("all");
 
 	const filtered = useMemo(() => {
-		if (!quotes) return [];
 		const q = search.trim().toLowerCase();
 		return quotes.filter((row) => {
 			if (filter !== "all" && row.status !== filter) return false;
@@ -201,9 +197,8 @@ export function QuoteList({ businessName }: QuoteListProps) {
 		});
 	}, [quotes, search, filter]);
 
-	const isLoading = quotes === undefined;
-	const isEmpty = !isLoading && (quotes?.length ?? 0) === 0;
-	const isFilterEmpty = !isLoading && !isEmpty && filtered.length === 0;
+	const isEmpty = quotes.length === 0;
+	const isFilterEmpty = !isEmpty && filtered.length === 0;
 
 	const columns = useMemo(
 		() => createColumns(clientPortalId),
@@ -279,7 +274,7 @@ export function QuoteList({ businessName }: QuoteListProps) {
 				<DataGrid
 					table={table}
 					recordCount={filtered.length}
-					isLoading={isLoading}
+					isLoading={false}
 					onRowClick={(row) =>
 						router.push(`/portal/c/${clientPortalId}/quotes/${row._id}`)
 					}

--- a/apps/web/src/components/portal/quotes/quote-paper.tsx
+++ b/apps/web/src/components/portal/quotes/quote-paper.tsx
@@ -50,7 +50,7 @@ export function QuotePaper({ quote, lineItems, businessName }: QuotePaperProps) 
 			: "Discount";
 
 	return (
-		<div className="mx-auto max-w-[760px] rounded-2xl border border-border bg-card p-6 shadow-xs md:p-9">
+		<div className="w-full rounded-2xl border border-border bg-card p-6 shadow-xs md:p-9">
 			<div className="flex items-start justify-between gap-6">
 				<div>
 					<p className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">


### PR DESCRIPTION
- Quotes list page now server-fetches api.portal.quotes.list with the session token and passes rows as props (mirrors the invoice list) — kills the bare-skeleton state when the client query was pending and guarantees the illustrated EmptyState renders when there are no quotes
- Detail surfaces widened to match internal workspace pages (no max-width cap): invoice statement card + utility row, quote hero/journey/details wrapper, and the quote paper now fill the available width; invoice payment sidebar widened 18rem → 24rem so the Stripe Elements form has room

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quotes now load securely in the portal and redirect to verification when authentication is missing or invalid.
  * Quote lists display the loaded quote data with filtering and navigation.

* **Bug Fixes**
  * Improved quote loading and authentication error handling.

* **Style**
  * Updated invoice and quote layouts for better full-width and responsive display across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR converts the quotes list page from client-side `useQuery` to server-side `fetchQuery` (matching the invoice list pattern) and widens several portal detail layouts by removing `max-w-*` caps and growing the left sidebar column from `18–20 rem` to `24 rem`.

- **Server fetch for quotes**: `quotes/page.tsx` now reads the session cookie, redirects unauthenticated visitors to `/verify`, fetches `api.portal.quotes.list` with the token, and passes rows as props — eliminating the bare-skeleton flash on first load and ensuring `EmptyState` renders correctly with zero quotes.
- **Layout widening**: `invoice-paper`, `invoice-detail-island`, `quote-detail-island`, and `quote-paper` all drop their max-width constraints; the invoice sidebar column changes from a fixed `18rem` to `minmax(0,24rem)`, giving Stripe Elements more room.
- **Type cast divergence**: The new page uses `as QuoteListRow[]` instead of the `Awaited<ReturnType<typeof fetchQuery<typeof api.portal.quotes.list>>>` pattern the existing invoice pages use, removing compile-time safety against backend shape changes.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The server-fetch logic mirrors the invoice pages closely and the layout changes are CSS-only with no functional impact.

The quotes page diverges from the invoice pattern by using an `as QuoteListRow[]` cast rather than deriving the type from the API declaration, meaning backend shape changes won't surface as compile errors. Everything else — auth redirect flow, error handling, loading-state removal, and layout widening — is correct and consistent with the rest of the portal.

apps/web/src/app/(portal)/portal/c/[clientPortalId]/(authenticated)/quotes/page.tsx — the type assertion on the `fetchQuery` result.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/(portal)/portal/c/[clientPortalId]/(authenticated)/quotes/page.tsx | Adds server-side quote fetching with session-token auth and redirect-on-error; uses an unsafe `as QuoteListRow[]` cast instead of the `Awaited<ReturnType<...>>` pattern the invoice pages use. |
| apps/web/src/components/portal/quotes/quote-list.tsx | Replaced `useQuery` with props, exported `QuoteListRow`, removed `isLoading` state, and hardcoded `isLoading={false}` — all correct for server-fetched data. |
| apps/web/src/components/portal/invoices/invoice-paper.tsx | Removed `max-w-4xl` cap and changed sidebar column from fixed `18rem` to `minmax(0,24rem)` — wider, more responsive layout. |
| apps/web/src/components/portal/invoices/invoice-detail-island.tsx | Removed `max-w-4xl` from the utility-button row; CSS-only change with no logic impact. |
| apps/web/src/components/portal/quotes/quote-detail-island.tsx | Removes `max-w-5xl` from hero and two-pane wrappers; widens left grid column from `20rem` to `24rem` — consistent with invoice paper change. |
| apps/web/src/components/portal/quotes/quote-paper.tsx | Swaps `mx-auto max-w-[760px]` for `w-full` so the paper fills the now-unconstrained parent wrapper. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant QuotesPage as QuotesPage (Server)
    participant Cookie as readSessionCookie
    participant Convex as Convex (fetchQuery)

    Browser->>QuotesPage: GET /portal/c/:id/quotes
    QuotesPage->>Convex: api.portal.branding.getPortalBranding
    Convex-->>QuotesPage: branding (or null → 404)
    QuotesPage->>Cookie: readSessionCookie()
    Cookie-->>QuotesPage: token (or null → redirect /verify)
    QuotesPage->>Convex: "api.portal.quotes.list {} + token"
    alt Auth error (UNAUTHENTICATED)
        Convex-->>QuotesPage: ConvexError
        QuotesPage->>Browser: redirect /verify
    else Success
        Convex-->>QuotesPage: QuoteListRow[]
        QuotesPage->>Browser: render QuoteList (quotes as props)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant QuotesPage as QuotesPage (Server)
    participant Cookie as readSessionCookie
    participant Convex as Convex (fetchQuery)

    Browser->>QuotesPage: GET /portal/c/:id/quotes
    QuotesPage->>Convex: api.portal.branding.getPortalBranding
    Convex-->>QuotesPage: branding (or null → 404)
    QuotesPage->>Cookie: readSessionCookie()
    Cookie-->>QuotesPage: token (or null → redirect /verify)
    QuotesPage->>Convex: "api.portal.quotes.list {} + token"
    alt Auth error (UNAUTHENTICATED)
        Convex-->>QuotesPage: ConvexError
        QuotesPage->>Browser: redirect /verify
    else Success
        Convex-->>QuotesPage: QuoteListRow[]
        QuotesPage->>Browser: render QuoteList (quotes as props)
    end
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/app/(portal)/portal/c/[clientPortalId]/(authenticated)/quotes/page.tsx:32-38
The quotes page uses an unsafe `as QuoteListRow[]` cast, while both invoice pages (`/invoices/page.tsx` and the authenticated home `page.tsx`) derive the type directly from the API declaration with `Awaited<ReturnType<typeof fetchQuery<typeof api.portal.quotes.list>>>`. With the cast, any shape mismatch between the backend response and `QuoteListRow` — a renamed field, a new required field, a `null` where `undefined` is expected — will pass TypeScript undetected and surface only at runtime (e.g. `STATUS_LABEL[q.status]` returning `undefined` for an unrecognised status).

```suggestion
	let quotes: Awaited<
		ReturnType<typeof fetchQuery<typeof api.portal.quotes.list>>
	> = [];
	try {
		quotes = await fetchQuery(api.portal.quotes.list, {}, { token });
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(portal): server-fetch quote list + f..."](https://github.com/xcarter93/onetool/commit/e65953b5727559faa99c07da03a8b6c01a60e0d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45328591)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->