### PR TITLE
fix(portal): SSR quote detail + wider pay/approve rails with larger type

### DIFF
--- a/apps/web/src/app/(portal)/portal/c/[clientPortalId]/(authenticated)/quotes/[quoteId]/page.tsx
+++ b/apps/web/src/app/(portal)/portal/c/[clientPortalId]/(authenticated)/quotes/[quoteId]/page.tsx
@@ -1,11 +1,40 @@
-import { QuoteDetailIsland } from "@/components/portal/quotes/quote-detail-island";
+import { fetchQuery } from "convex/nextjs";
+import { api } from "@onetool/backend/convex/_generated/api";
+import { notFound, redirect } from "next/navigation";
+
+import { readSessionCookie } from "@/lib/portal/cookie";
 import { quoteIdFromParam } from "@/lib/portal/quotes/ids";
+import { QuoteDetailIsland } from "@/components/portal/quotes/quote-detail-island";
 
 export default async function QuoteDetailPage({
 	params,
 }: {
 	params: Promise<{ clientPortalId: string; quoteId: string }>;
 }) {
-	const { quoteId } = await params;
-	return <QuoteDetailIsland quoteId={quoteIdFromParam(quoteId)} />;
+	const { clientPortalId, quoteId: rawId } = await params;
+	const quoteId = quoteIdFromParam(rawId);
+
+	const token = (await readSessionCookie()) ?? undefined;
+	if (!token) {
+		redirect(`/portal/c/${clientPortalId}/verify`);
+	}
+
+	// Server-fetch mirrors the invoice detail page: the island renders from
+	// this data immediately and layers the reactive useQuery on top, so a
+	// pending/stalled client query can never strand the loading skeleton.
+	let data;
+	try {
+		data = await fetchQuery(api.portal.quotes.get, { quoteId }, { token });
+	} catch {
+		// NOT_FOUND, FORBIDDEN, draft masquerade — all collapse to 404.
+		notFound();
+		return null;
+	}
+
+	if (!data) {
+		notFound();
+		return null;
+	}
+
+	return <QuoteDetailIsland quoteId={quoteId} initialData={data} />;
 }

--- a/apps/web/src/components/portal/invoices/invoice-paper.tsx
+++ b/apps/web/src/components/portal/invoices/invoice-paper.tsx
@@ -94,7 +94,7 @@ export function InvoicePaper({
 	return (
 		<Card data-portal-paper-invoice className="mx-auto w-full">
 			<CardContent>
-				<div className="grid grid-cols-1 gap-8 md:grid-cols-[minmax(0,24rem)_minmax(0,1fr)] md:gap-10">
+				<div className="grid grid-cols-1 gap-8 md:grid-cols-[minmax(0,28rem)_minmax(0,1fr)] md:gap-10">
 					{/* Sidebar: brand + status, hero total, metadata, pay surface */}
 					<aside className="flex flex-col gap-5 md:border-r md:border-border md:pr-8">
 						<div className="flex items-center justify-between gap-3">
@@ -118,7 +118,7 @@ export function InvoicePaper({
 										) : null}
 									</ItemMedia>
 								</Item>
-								<span className="truncate text-[14px] font-semibold text-foreground">
+								<span className="truncate text-[15px] font-semibold text-foreground">
 									{businessName}
 								</span>
 							</div>
@@ -128,10 +128,10 @@ export function InvoicePaper({
 						</div>
 
 						<div className="flex flex-col gap-1.5">
-							<span className="text-[0.6875rem] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+							<span className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
 								{heroLabel}
 							</span>
-							<span className="text-3xl leading-none font-bold tracking-tight tabular-nums text-foreground md:text-4xl">
+							<span className="text-4xl leading-none font-bold tracking-tight tabular-nums text-foreground md:text-5xl">
 								{formatMoney(heroAmount)}
 							</span>
 							{heroIsPaid && invoice.paidAt ? (
@@ -145,22 +145,22 @@ export function InvoicePaper({
 
 						<div className="flex flex-col gap-4">
 							<MetaSection label="Invoice">
-								<p className="font-mono text-sm tabular-nums text-foreground">
+								<p className="font-mono text-[15px] tabular-nums text-foreground">
 									#{invoice.invoiceNumber}
 								</p>
 							</MetaSection>
 							<MetaSection label="Issued">
-								<p className="text-sm font-medium text-foreground">
+								<p className="text-[15px] font-medium text-foreground">
 									{formatDate(invoice.issuedDate)}
 								</p>
 							</MetaSection>
 							<MetaSection label="Due">
-								<p className="text-sm font-medium text-foreground">
+								<p className="text-[15px] font-medium text-foreground">
 									{formatDate(invoice.dueDate)}
 								</p>
 							</MetaSection>
 							<MetaSection label="Bill To">
-								<p className="text-sm font-medium text-foreground">
+								<p className="text-[15px] font-medium text-foreground">
 									{clientName}
 								</p>
 								{clientEmail ? (
@@ -169,7 +169,7 @@ export function InvoicePaper({
 							</MetaSection>
 							{showProgress ? (
 								<MetaSection label="Payment Progress">
-									<p className="text-sm font-medium text-foreground">
+									<p className="text-[15px] font-medium text-foreground">
 										{formatMoney(paymentSummary.totalPaid)} paid
 									</p>
 									<p className="text-xs text-muted-foreground">
@@ -188,7 +188,7 @@ export function InvoicePaper({
 					<div className="flex min-w-0 flex-col gap-6">
 						<div className="flex flex-col gap-4">
 							<div className="flex items-baseline justify-between gap-3">
-								<span className="text-[0.6875rem] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+								<span className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
 									Line Items
 								</span>
 								<span className="text-xs text-muted-foreground">
@@ -215,7 +215,7 @@ export function InvoicePaper({
 							discount={invoice.discountAmount}
 							tax={invoice.taxAmount}
 							total={invoice.total}
-							className="sm:ml-auto sm:w-72"
+							className="sm:ml-auto sm:w-80"
 						/>
 					</div>
 				</div>
@@ -233,7 +233,7 @@ function MetaSection({
 }) {
 	return (
 		<div className="flex flex-col gap-1">
-			<span className="text-[0.625rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+			<span className="text-[0.6875rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
 				{label}
 			</span>
 			<div className="flex flex-col gap-0.5">{children}</div>
@@ -259,14 +259,14 @@ function LineItemRow({
 			)}
 		>
 			<div className="min-w-0 flex-1">
-				<p className="text-sm font-semibold text-foreground">
+				<p className="text-[15px] font-semibold text-foreground">
 					{item.description}
 				</p>
 				<p className="mt-0.5 text-xs text-muted-foreground">
 					Qty {item.quantity} · {formatMoney(item.unitPrice)} each
 				</p>
 			</div>
-			<span className="shrink-0 text-sm font-semibold tabular-nums text-foreground">
+			<span className="shrink-0 text-[15px] font-semibold tabular-nums text-foreground">
 				{formatMoney(item.total)}
 			</span>
 		</div>

--- a/apps/web/src/components/portal/quotes/__tests__/quote-detail-island.download-pdf.test.tsx
+++ b/apps/web/src/components/portal/quotes/__tests__/quote-detail-island.download-pdf.test.tsx
@@ -119,7 +119,7 @@ describe("QuoteDetailIsland — Download PDF button (Plan 14.1-03)", () => {
 		);
 		vi.stubGlobal("fetch", mockFetch);
 
-		render(<QuoteDetailIsland quoteId={"q1" as any} />);
+		render(<QuoteDetailIsland quoteId={"q1" as any} initialData={{} as any} />);
 		const btn = await screen.findByRole("button", {
 			name: /Download PDF/i,
 		});
@@ -150,7 +150,7 @@ describe("QuoteDetailIsland — Download PDF button (Plan 14.1-03)", () => {
 			latestApproval: null,
 		});
 
-		render(<QuoteDetailIsland quoteId={"q1" as any} />);
+		render(<QuoteDetailIsland quoteId={"q1" as any} initialData={{} as any} />);
 		expect(
 			screen.queryByRole("button", { name: /Download PDF/i }),
 		).not.toBeInTheDocument();
@@ -180,7 +180,7 @@ describe("QuoteDetailIsland — Download PDF button (Plan 14.1-03)", () => {
 		);
 		vi.stubGlobal("fetch", mockFetch);
 
-		render(<QuoteDetailIsland quoteId={"q1" as any} />);
+		render(<QuoteDetailIsland quoteId={"q1" as any} initialData={{} as any} />);
 		const btn = await screen.findByRole("button", {
 			name: /Download PDF/i,
 		});

--- a/apps/web/src/components/portal/quotes/__tests__/quote-detail-island.test.tsx
+++ b/apps/web/src/components/portal/quotes/__tests__/quote-detail-island.test.tsx
@@ -104,7 +104,7 @@ describe("QuoteDetailIsland — Gap 6 fallback gate", () => {
 			clientEmail: "jane@example.com",
 			latestApproval: null,
 		});
-		render(<QuoteDetailIsland quoteId={"q1" as any} />);
+		render(<QuoteDetailIsland quoteId={"q1" as any} initialData={{} as any} />);
 		// Resolved panel role=status with "Approved" label inside.
 		const statusRegion = screen.getByRole("status");
 		expect(statusRegion).toHaveTextContent(/Approved/i);
@@ -127,7 +127,7 @@ describe("QuoteDetailIsland — Gap 6 fallback gate", () => {
 			clientEmail: "jane@example.com",
 			latestApproval: null,
 		});
-		render(<QuoteDetailIsland quoteId={"q1" as any} />);
+		render(<QuoteDetailIsland quoteId={"q1" as any} initialData={{} as any} />);
 		const statusRegion = screen.getByRole("status");
 		expect(statusRegion).toHaveTextContent(/Declined/i);
 		expect(
@@ -153,7 +153,7 @@ describe("QuoteDetailIsland — Gap 6 fallback gate", () => {
 				signatureUrl: "https://example.com/sig.png",
 			},
 		});
-		render(<QuoteDetailIsland quoteId={"q1" as any} />);
+		render(<QuoteDetailIsland quoteId={"q1" as any} initialData={{} as any} />);
 		// ApprovalReceipt-specific text — "Approved by Jane" is rendered in the
 		// always-visible header (clientEmail is collapsed behind the expandable
 		// receipt view; we don't depend on that detail here).
@@ -185,7 +185,7 @@ describe("QuoteDetailIsland — Gap 6 fallback gate", () => {
 				signatureUrl: "https://example.com/sig.png",
 			},
 		});
-		render(<QuoteDetailIsland quoteId={"q1" as any} />);
+		render(<QuoteDetailIsland quoteId={"q1" as any} initialData={{} as any} />);
 		const statusRegion = screen.getByRole("status");
 		expect(statusRegion).toHaveTextContent(/Approved/i);
 		expect(

--- a/apps/web/src/components/portal/quotes/quote-detail-island.tsx
+++ b/apps/web/src/components/portal/quotes/quote-detail-island.tsx
@@ -15,6 +15,7 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { ArrowLeft, Download } from "lucide-react";
 import { useQuery } from "convex/react";
+import type { FunctionReturnType } from "convex/server";
 
 import { api } from "@onetool/backend/convex/_generated/api";
 import type { Id } from "@onetool/backend/convex/_generated/dataModel";
@@ -40,8 +41,14 @@ import { ApprovalRail } from "./approval-rail";
 import { ApprovalBottomSheet } from "./approval-bottom-sheet";
 import { StaleVersionBanner } from "./stale-version-banner";
 
+export type QuoteDetailData = NonNullable<
+	FunctionReturnType<typeof api.portal.quotes.get>
+>;
+
 export interface QuoteDetailIslandProps {
 	quoteId: Id<"quotes">;
+	/** Server-fetched snapshot; the reactive query layers on top of it. */
+	initialData: QuoteDetailData;
 }
 
 type JourneyStepStatus = "complete" | "current" | "upcoming";
@@ -188,7 +195,10 @@ function buildJourneySteps(
 	return steps;
 }
 
-export function QuoteDetailIsland({ quoteId }: QuoteDetailIslandProps) {
+export function QuoteDetailIsland({
+	quoteId,
+	initialData,
+}: QuoteDetailIslandProps) {
 	const params = useParams<{ clientPortalId: string }>();
 	const clientPortalId = params?.clientPortalId ?? "";
 
@@ -196,7 +206,10 @@ export function QuoteDetailIsland({ quoteId }: QuoteDetailIslandProps) {
 	// impure Date.now() during render while keeping the same fallback value.
 	const [mountedAt] = useState(() => Date.now());
 
-	const data = useQuery(api.portal.quotes.get, { quoteId });
+	// Subscribes for live updates (approval receipt, document re-send); the
+	// SSR snapshot guarantees content on first paint even if this stays pending.
+	const liveData = useQuery(api.portal.quotes.get, { quoteId });
+	const data: QuoteDetailData = liveData ?? initialData;
 	// Plan 14-08 Gap 4: aligned to PortalShell's md (768px) boundary so the
 	// rail/sheet split matches the desktop-sidebar/mobile-chrome split — no
 	// 256px no-mans-land between PortalShell mobile chrome and the detail-page
@@ -215,45 +228,6 @@ export function QuoteDetailIsland({ quoteId }: QuoteDetailIslandProps) {
 	);
 	if (pinnedDocumentId === null && data?.latestDocument?._id) {
 		setPinnedDocumentId(data.latestDocument._id);
-	}
-
-	// Loading
-	if (data === undefined) {
-		return (
-			<div className="-mx-6 md:-mx-9 -my-6 flex flex-col">
-				<div className="sticky top-0 z-20 flex h-[68px] items-center border-b border-border bg-background px-6">
-					<div className="h-5 w-32 animate-pulse rounded bg-muted" />
-				</div>
-				<div className="px-6 py-8 md:px-9">
-					<div className="mx-auto w-full">
-						<div className="mb-6 h-28 animate-pulse rounded-2xl border border-border bg-card md:mb-8" />
-						<div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,24rem)_minmax(0,1fr)] lg:gap-8">
-							<div className="h-64 animate-pulse rounded-2xl border border-border bg-card" />
-							<div className="h-96 animate-pulse rounded-2xl border border-border bg-card" />
-						</div>
-					</div>
-				</div>
-			</div>
-		);
-	}
-
-	// Missing
-	if (data === null) {
-		return (
-			<div className="mx-auto max-w-2xl py-12 text-center">
-				<h1 className="text-[24px] font-semibold">Quote not found</h1>
-				<p className="mt-2 text-muted-foreground">
-					This quote may have been removed or you no longer have access.
-				</p>
-				<Link
-					href={`/portal/c/${clientPortalId}/quotes`}
-					className="mt-4 inline-flex items-center gap-1.5 text-primary hover:underline"
-				>
-					<ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
-					Back to quotes
-				</Link>
-			</div>
-		);
 	}
 
 	const {
@@ -442,7 +416,7 @@ export function QuoteDetailIsland({ quoteId }: QuoteDetailIslandProps) {
 									<span className="text-muted-foreground text-xs font-medium tracking-[0.16em] uppercase">
 										Total
 									</span>
-									<span className="text-foreground text-2xl leading-none font-semibold tracking-tight tabular-nums md:text-3xl">
+									<span className="text-foreground text-3xl leading-none font-semibold tracking-tight tabular-nums md:text-4xl">
 										{formatMoney(quote.total)}
 									</span>
 									{quote.validUntil && (
@@ -456,10 +430,10 @@ export function QuoteDetailIsland({ quoteId }: QuoteDetailIslandProps) {
 					</Card>
 
 					{/* Two-pane: Quote Journey (sticky) + Quote Details */}
-					<div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,24rem)_minmax(0,1fr)] lg:gap-8">
+					<div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,28rem)_minmax(0,1fr)] lg:gap-8">
 						<Card className="lg:sticky lg:top-[calc(68px+1.5rem)]">
 							<CardHeader>
-								<CardTitle className="text-base">Quote Journey</CardTitle>
+								<CardTitle className="text-lg">Quote Journey</CardTitle>
 							</CardHeader>
 							<CardContent className="flex flex-col gap-5">
 								<Timeline defaultValue={timelineDefaultStep} className="gap-0">

--- a/apps/web/src/components/portal/quotes/quote-paper.tsx
+++ b/apps/web/src/components/portal/quotes/quote-paper.tsx
@@ -53,10 +53,10 @@ export function QuotePaper({ quote, lineItems, businessName }: QuotePaperProps) 
 		<div className="w-full rounded-2xl border border-border bg-card p-6 shadow-xs md:p-9">
 			<div className="flex items-start justify-between gap-6">
 				<div>
-					<p className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+					<p className="text-[12px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
 						Quote {quote.quoteNumber ?? ""}
 					</p>
-					<h1 className="mt-1.5 text-[26px] font-semibold leading-[1.15] tracking-[-0.02em]">
+					<h1 className="mt-1.5 text-[28px] font-semibold leading-[1.15] tracking-[-0.02em]">
 						{quote.title ?? "Quote"}
 					</h1>
 				</div>
@@ -69,16 +69,16 @@ export function QuotePaper({ quote, lineItems, businessName }: QuotePaperProps) 
 				<table className="w-full border-collapse">
 					<thead>
 						<tr className="border-b-2 border-foreground">
-							<th className="text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-2.5">
+							<th className="text-left text-[12px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-2.5">
 								Item
 							</th>
-							<th className="text-right text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-2.5 w-[60px]">
+							<th className="text-right text-[12px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-2.5 w-[60px]">
 								Qty
 							</th>
-							<th className="text-right text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-2.5 w-[110px]">
+							<th className="text-right text-[12px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-2.5 w-[110px]">
 								Rate
 							</th>
-							<th className="text-right text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-2.5 w-[110px]">
+							<th className="text-right text-[12px] font-semibold uppercase tracking-[0.06em] text-muted-foreground py-2.5 w-[110px]">
 								Total
 							</th>
 						</tr>
@@ -87,7 +87,7 @@ export function QuotePaper({ quote, lineItems, businessName }: QuotePaperProps) 
 						{lineItems.map((li, i) => (
 							<tr key={i} className="border-b border-border last:border-b-0">
 								<td className="py-4 align-top">
-									<div className="text-[14px] font-semibold">
+									<div className="text-[15px] font-semibold">
 										{li.description}
 									</div>
 								</td>

--- a/apps/web/src/components/portal/totals-breakdown.tsx
+++ b/apps/web/src/components/portal/totals-breakdown.tsx
@@ -43,12 +43,12 @@ export function TotalsBreakdown({
 				className
 			)}
 		>
-			<div className="flex items-center gap-8 text-[14px]">
+			<div className="flex items-center gap-8 text-[15px]">
 				<dt className="text-muted-foreground">Subtotal</dt>
 				<dd className="tabular-nums">{formatMoney(subtotal)}</dd>
 			</div>
 			{discountValue > 0 && (
-				<div className="flex items-center gap-8 text-[14px]">
+				<div className="flex items-center gap-8 text-[15px]">
 					<dt className="text-muted-foreground">{discountLabel}</dt>
 					<dd className="tabular-nums text-emerald-600 dark:text-emerald-400">
 						-{formatMoney(discountValue)}
@@ -56,14 +56,14 @@ export function TotalsBreakdown({
 				</div>
 			)}
 			{taxValue > 0 && (
-				<div className="flex items-center gap-8 text-[14px]">
+				<div className="flex items-center gap-8 text-[15px]">
 					<dt className="text-muted-foreground">{taxLabel}</dt>
 					<dd className="tabular-nums">{formatMoney(taxValue)}</dd>
 				</div>
 			)}
 			<div
 				data-paper-total
-				className="flex items-center gap-8 text-[16px] font-semibold border-t border-foreground pt-2 mt-1"
+				className="flex items-center gap-8 text-[17px] font-semibold border-t border-foreground pt-2 mt-1"
 			>
 				<dt>{totalLabel}</dt>
 				<dd className="tabular-nums">{formatMoney(total)}</dd>


### PR DESCRIPTION
- Quote detail page now server-fetches api.portal.quotes.get with the session token and passes it to the island as initialData (liveData ?? initialData), mirroring the invoice detail page — a pending/stalled client query can no longer strand the empty loading-skeleton frames (seen on approved quotes); unreachable skeleton/null branches removed, missing/forbidden collapse to 404
- Desktop rails widened 24rem -> 28rem on both invoice statement and quote journey columns to cut vertical scroll in the payment/approval surfaces
- Typography bumped a notch to fill whitespace: invoice hero amount (text-4xl/5xl), meta labels+values, line items, quote paper title/headers, shared TotalsBreakdown rows/total, quote hero total, journey card title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Quote details now load with server-provided information for a faster, more reliable display.
  - Unauthorized access redirects to portal verification, while unavailable or restricted quotes show a not-found page.
  - Quote and invoice layouts have improved typography, spacing, sizing, and readability across totals, metadata, and line items.
  - Quote totals and the Quote Journey panel are more prominent and easier to scan.

- **Tests**
  - Updated quote detail coverage for the revised loading and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR brings the quote detail page up to parity with the invoice detail page by server-fetching quote data via `fetchQuery` on the RSC layer, eliminating the empty-skeleton flicker seen on approved quotes when the client-side Convex subscription is slow or stalled. Visual polish is applied across the payment and approval surfaces: the left rail widens from 24 rem to 28 rem, and typography scales up one notch in heroes, meta labels, line items, and totals.

- **SSR hydration for quotes (`page.tsx` + `quote-detail-island.tsx`):** The page server-fetches the quote with the session token, collapses errors/null to 404, and passes `initialData` to the island; the island uses `liveData ?? initialData` so the reactive subscription layers live updates on top of the first-paint snapshot while the removed loading/null skeleton branches are now handled at the RSC boundary.
- **Rail width + typography (`invoice-paper.tsx`, `quote-paper.tsx`, `quote-detail-island.tsx`, `totals-breakdown.tsx`):** Grid column tracks widen to `minmax(0, 28rem)` and font sizes step up 1–2px across hero amounts, meta values, line-item descriptions, and totals rows.
- **Tests (`quote-detail-island.test.tsx`, `quote-detail-island.download-pdf.test.tsx`):** All render calls updated to supply the now-required `initialData` prop; mocked `useQuery` still supplies real data so `initialData` is not exercised in tests.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the SSR fetch pattern is a faithful copy of the already-shipped invoice detail page, and the visual changes are mechanical size bumps with no interactive logic touched.

The one meaningful observation is that removing the explicit data === null guard means a mid-session access-revocation shows stale SSR data rather than an inline not-found message — a deliberate trade-off that mirrors the invoice island. No logic paths that could corrupt data or break the approval flow were introduced.

quote-detail-island.tsx — the null-fallback behaviour on liveData is worth a second look if access-revocation UX is important; all other files are straightforward.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/(portal)/portal/c/[clientPortalId]/(authenticated)/quotes/[quoteId]/page.tsx | Adds server-side fetchQuery with session token; collapses errors and null to 404; passes initialData to island — mirrors the invoice detail page pattern correctly |
| apps/web/src/components/portal/quotes/quote-detail-island.tsx | Adds initialData prop, removes loading/null skeleton branches, uses liveData ?? initialData fallback — if liveData resolves to null mid-session, stale SSR data is silently displayed (see P2 comment) |
| apps/web/src/components/portal/invoices/invoice-paper.tsx | Typography bumps (text-3xl→4xl hero, sm→15px meta/line-item labels) and left rail width 24rem→28rem; purely cosmetic, no logic changes |
| apps/web/src/components/portal/quotes/quote-paper.tsx | Minor type size bumps (11px→12px headers, 14px→15px line item descriptions); no logic changes |
| apps/web/src/components/portal/totals-breakdown.tsx | Row text bumped 14px→15px, total row 16px→17px; purely cosmetic, no logic changes |
| apps/web/src/components/portal/quotes/__tests__/quote-detail-island.test.tsx | Updated render calls to pass required initialData prop using {} as any; tests remain valid because useQuery is mocked to return actual data so initialData is never consumed |
| apps/web/src/components/portal/quotes/__tests__/quote-detail-island.download-pdf.test.tsx | Same initialData prop threading update as the main test file; no coverage gaps introduced |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant RSC as QuoteDetailPage (RSC)
    participant Convex as Convex (fetchQuery)
    participant Island as QuoteDetailIsland (Client)
    participant Sub as Convex (useQuery subscription)

    Browser->>RSC: GET /portal/c/:id/quotes/:quoteId
    RSC->>RSC: readSessionCookie()
    alt No token
        RSC-->>Browser: redirect → /verify
    end
    RSC->>Convex: "fetchQuery(api.portal.quotes.get, { quoteId }, { token })"
    alt Error / null
        RSC-->>Browser: notFound() → 404
    end
    Convex-->>RSC: QuoteDetailData (initialData)
    RSC-->>Browser: HTML with initialData serialised as prop
    Browser->>Island: hydrate with initialData
    Island->>Sub: "useQuery(api.portal.quotes.get, { quoteId })"
    Note over Island: data = liveData ?? initialData
    Sub-->>Island: live updates (approval, re-send)
    Island-->>Browser: re-render with live data
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant RSC as QuoteDetailPage (RSC)
    participant Convex as Convex (fetchQuery)
    participant Island as QuoteDetailIsland (Client)
    participant Sub as Convex (useQuery subscription)

    Browser->>RSC: GET /portal/c/:id/quotes/:quoteId
    RSC->>RSC: readSessionCookie()
    alt No token
        RSC-->>Browser: redirect → /verify
    end
    RSC->>Convex: "fetchQuery(api.portal.quotes.get, { quoteId }, { token })"
    alt Error / null
        RSC-->>Browser: notFound() → 404
    end
    Convex-->>RSC: QuoteDetailData (initialData)
    RSC-->>Browser: HTML with initialData serialised as prop
    Browser->>Island: hydrate with initialData
    Island->>Sub: "useQuery(api.portal.quotes.get, { quoteId })"
    Note over Island: data = liveData ?? initialData
    Sub-->>Island: live updates (approval, re-send)
    Island-->>Browser: re-render with live data
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/components/portal/quotes/quote-detail-island.tsx:211-212
**Null live data silently falls back to stale SSR snapshot**

When the Convex subscription resolves with `null` (quote deleted, access revoked mid-session), `null ?? initialData` returns `initialData` because `??` treats `null` as nullish. The old code explicitly caught `data === null` and rendered a "Quote not found" panel. Under the new approach, a user whose access is revoked mid-session will continue seeing the stale server-fetched snapshot indefinitely with no in-page indication. Any subsequent mutation attempt (approval submission) would correctly fail at the server level, but the read surface stays visible.

The invoice island takes the same approach (`liveData as PortalInvoiceGetData | undefined` casts null out of the type entirely), so this is a consistent pattern — worth knowing it's a deliberate trade-off rather than an accidental omission of the null guard.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(portal): SSR quote detail + wider pa..."](https://github.com/xcarter93/onetool/commit/adcc56a932bf45f59148837665c306f789129c0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45330463)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->