### PR TITLE
Refactor audience assertions and enhance date handling in automations

### DIFF
--- a/apps/web/src/app/(workspace)/automations/components/editor/formula-editor-modal.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/editor/formula-editor-modal.tsx
@@ -108,10 +108,14 @@ function formatPreviewValue(value: Val, tz: string): string {
 /**
  * The IANA tz this automation's formulas evaluate in at run time. Must stay in
  * lockstep with automationFormulaTz() in automationExecutor.ts: scheduled
- * automations use their schedule's tz, everything else runs in UTC.
+ * automations use their schedule's tz, everything else runs in the org
+ * timezone, falling back to UTC.
  */
-function runtimeTimezone(trigger: TriggerConfig | AutomationTrigger | null): string {
-	if (!trigger || trigger.type !== "scheduled") return "UTC";
+function runtimeTimezone(
+	trigger: TriggerConfig | AutomationTrigger | null,
+	orgTimezone: string | undefined
+): string {
+	if (!trigger || trigger.type !== "scheduled") return orgTimezone ?? "UTC";
 	// A stale `schedule` can linger on the draft config after a type switch, so
 	// read it only once the trigger is actually scheduled.
 	return "schedule" in trigger && trigger.schedule?.timezone
@@ -211,10 +215,15 @@ export function FormulaEditorModal({
 		| null
 		| undefined;
 
+	const organization = useQuery(api.organizations.get);
+
 	// The tz the automation will ACTUALLY run in — mirrors automationFormulaTz on
 	// the backend. Previewing in the browser's tz made authoring-time results
 	// differ from production for every non-local user.
-	const tz = useMemo(() => runtimeTimezone(trigger), [trigger]);
+	const tz = useMemo(
+		() => runtimeTimezone(trigger, organization?.timezone),
+		[trigger, organization?.timezone]
+	);
 
 	// Formulas this one may reference — excludes itself (no self-reference).
 	const referenceFormulas = useMemo(

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/adjust-time-config.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/adjust-time-config.tsx
@@ -103,7 +103,10 @@ export function AdjustTimeConfigPanel({
 						/>
 					</PanelField>
 
-					<PanelField label="Adjust by">
+					<PanelField
+						label="Adjust by"
+						helper="Days and weeks follow the calendar in the automation's timezone (daylight saving safe); minutes and hours are exact offsets."
+					>
 						<div className="flex items-center gap-2">
 							<Input
 								type="number"

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/trigger-config.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/trigger-config.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { Zap } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { TIMEZONES, browserTimezone } from "@/lib/timezones";
 import { TRIGGER_NODE_ID } from "../../../lib/flow-adapter";
 import {
 	Select,
@@ -60,18 +61,10 @@ const DAY_OF_MONTH_OPTIONS = Array.from({ length: 31 }, (_, i) => ({
 	label: `The ${ordinal(i + 1)}`,
 }));
 
-const TIMEZONES: string[] = (() => {
-	try {
-		return Intl.supportedValuesOf("timeZone");
-	} catch {
-		return ["UTC"];
-	}
-})();
-
 function defaultSchedule(): AutomationSchedule {
 	return {
 		frequency: "daily",
-		timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+		timezone: browserTimezone(),
 		time: DEFAULT_SCHEDULE_TIME,
 	};
 }

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/value-input.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/value-input.tsx
@@ -433,6 +433,9 @@ function TypedPrimitiveControl({
 					aria-invalid={invalid || undefined}
 					value={timeText}
 					onChange={(e) => {
+						// "".split(":") yields [""] -> m === undefined, which
+						// Number.isNaN misses and compose() would turn into NaN.
+						if (!e.target.value) return;
 						const [h, m] = e.target.value.split(":").map(Number);
 						if (Number.isNaN(h) || Number.isNaN(m)) return;
 						onChange(compose(current ?? new Date(), h, m));

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/value-input.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/value-input.tsx
@@ -4,6 +4,10 @@ import React, { useMemo, useState } from "react";
 import { Braces, Check, ChevronsUpDown, X } from "lucide-react";
 import { useQuery } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
+import {
+	utcMidnightMsToLocalDate,
+	localDateToUtcMidnightMs,
+} from "@/lib/dates";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -75,18 +79,6 @@ export type ValueInputFieldSpec = {
 /** A resolved static/fallback primitive. `null` means "cleared / no value". */
 type PrimitiveValue = string | number | boolean | null;
 
-// Calendar dates are stored as UTC-midnight epoch ms (the A2 invariant, checked
-// at runtime by isCalendarDateEpoch). The DatePicker speaks a wall-clock Date,
-// so convert at the boundary: read/write the UTC calendar day via LOCAL parts so
-// the picker shows the right day and storage stays UTC-midnight in every tz.
-function utcMidnightMsToLocalDate(ms: number): Date {
-	const d = new Date(ms);
-	return new Date(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
-}
-function localDateToUtcMidnightMs(d: Date): number {
-	return Date.UTC(d.getFullYear(), d.getMonth(), d.getDate());
-}
-
 /** A stored fallback that doesn't match the field's type (legacy / hand-authored). */
 function fallbackTypeError(
 	type: FieldType,
@@ -101,6 +93,10 @@ function fallbackTypeError(
 			return typeof fallback === "number" ? null : "Fallback must be a number.";
 		case "date":
 			return typeof fallback === "number" ? null : "Fallback must be a date.";
+		case "datetime":
+			return typeof fallback === "number"
+				? null
+				: "Fallback must be a date and time.";
 		case "text":
 		case "select":
 		case "id":
@@ -130,8 +126,11 @@ function variableNeedsConversion(
 		case "number":
 		case "currency":
 			return optionType !== "number" && optionType !== "currency";
+		// A datetime feeding a date field is normalized to the day by the engine,
+		// so date and datetime are interchangeable in both directions.
 		case "date":
-			return optionType !== "date";
+		case "datetime":
+			return optionType !== "date" && optionType !== "datetime";
 		case "id":
 			return (
 				optionType !== "id" ||
@@ -390,6 +389,57 @@ function TypedPrimitiveControl({
 				className={cn("w-full", invalid && "border-destructive")}
 				placeholder={placeholder}
 			/>
+		);
+	}
+
+	if (field.type === "datetime") {
+		// Datetime stores an exact epoch-ms instant, composed/decomposed in the
+		// browser's local zone (plain Date getters — the UTC helpers above are
+		// for calendar dates only).
+		const current =
+			typeof value === "number" && !Number.isNaN(value)
+				? new Date(value)
+				: null;
+		const timeText = current
+			? `${String(current.getHours()).padStart(2, "0")}:${String(
+					current.getMinutes()
+				).padStart(2, "0")}`
+			: "";
+		const compose = (day: Date, hours: number, minutes: number) =>
+			new Date(
+				day.getFullYear(),
+				day.getMonth(),
+				day.getDate(),
+				hours,
+				minutes
+			).getTime();
+		return (
+			<div className="flex items-center gap-1.5">
+				<DatePicker
+					value={current ?? undefined}
+					onChange={(d) =>
+						onChange(
+							d
+								? compose(d, current?.getHours() ?? 0, current?.getMinutes() ?? 0)
+								: null
+						)
+					}
+					className={cn("flex-1 min-w-0", invalid && "border-destructive")}
+					placeholder={placeholder}
+				/>
+				<Input
+					type="time"
+					aria-label="Time"
+					aria-invalid={invalid || undefined}
+					value={timeText}
+					onChange={(e) => {
+						const [h, m] = e.target.value.split(":").map(Number);
+						if (Number.isNaN(h) || Number.isNaN(m)) return;
+						onChange(compose(current ?? new Date(), h, m));
+					}}
+					className="w-28 shrink-0"
+				/>
+			</div>
 		);
 	}
 

--- a/apps/web/src/app/(workspace)/automations/lib/condition-sentence.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/condition-sentence.ts
@@ -28,6 +28,7 @@ export const OPERATOR_LABELS: Record<ConditionOperator, string> = {
 	is_false: "is false",
 	before: "is before",
 	after: "is after",
+	on: "is on (day)",
 };
 
 export type SentencePart = { kind: "rule" | "text"; text: string };

--- a/apps/web/src/app/(workspace)/automations/lib/validation.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/validation.ts
@@ -91,6 +91,8 @@ function varFallbackTypeError(
 			return typeof fb === "number" ? null : "fallback must be a number";
 		case "date":
 			return typeof fb === "number" ? null : "fallback must be a date";
+		case "datetime":
+			return typeof fb === "number" ? null : "fallback must be a date and time";
 		case "text":
 		case "select":
 		case "id":

--- a/apps/web/src/app/(workspace)/automations/lib/variables.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/variables.ts
@@ -154,7 +154,7 @@ function effectiveTriggerType(
 
 /** Built-in globals, resolved on every run — shared by both variable-listing functions. */
 const GLOBAL_VARIABLE_OPTIONS: VariableOption[] = [
-	{ path: "workflow.now", label: "Current time", group: "Globals", fieldType: "date" },
+	{ path: "workflow.now", label: "Current time", group: "Globals", fieldType: "datetime" },
 	{ path: "org.id", label: "Organization ID", group: "Globals", fieldType: "text" },
 	{ path: "org.name", label: "Organization name", group: "Globals", fieldType: "text" },
 	{
@@ -360,7 +360,7 @@ export function getAvailableVariables(
 					? "Aggregate result"
 					: "Adjusted time result",
 			group: "Computed",
-			fieldType: node.type === "aggregate" ? "number" : "date",
+			fieldType: node.type === "aggregate" ? "number" : "datetime",
 		});
 	}
 
@@ -484,7 +484,7 @@ export function getAllVariableOptions(
 					? "Aggregate result"
 					: "Adjusted time result",
 			group: "Computed",
-			fieldType: node.type === "aggregate" ? "number" : "date",
+			fieldType: node.type === "aggregate" ? "number" : "datetime",
 		});
 	}
 

--- a/apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-sidebar.tsx
+++ b/apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-sidebar.tsx
@@ -46,6 +46,7 @@ import { usePermissions } from "@/hooks/use-permissions";
 import { formatCurrency } from "@/lib/money";
 import {
 	localDateToUtcMidnightMs,
+	todayUtcMidnightMs,
 	utcMidnightMsToLocalDate,
 } from "@/lib/dates";
 
@@ -130,13 +131,14 @@ export function InvoiceDetailSidebar({
 	const [editDateValue, setEditDateValue] = useState<Date | undefined>(
 		undefined
 	);
-	// Capture "now" once at mount to keep the overdue check pure across renders
-	const [now] = useState(() => Date.now());
+	// Capture today's calendar-day start once at mount to keep the overdue
+	// check pure across renders; dueDate is a UTC-midnight calendar epoch.
+	const [todayStart] = useState(() => todayUtcMidnightMs());
 
 	const currentStatus =
 		invoice.status === "sent" &&
 		invoice.dueDate &&
-		invoice.dueDate < now
+		invoice.dueDate < todayStart
 			? "overdue"
 			: (invoice.status as InvoiceStatus);
 

--- a/apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-sidebar.tsx
+++ b/apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-sidebar.tsx
@@ -44,6 +44,10 @@ import {
 import Link from "next/link";
 import { usePermissions } from "@/hooks/use-permissions";
 import { formatCurrency } from "@/lib/money";
+import {
+	localDateToUtcMidnightMs,
+	utcMidnightMsToLocalDate,
+} from "@/lib/dates";
 
 type InvoiceStatus = "draft" | "sent" | "paid" | "overdue" | "cancelled";
 
@@ -54,6 +58,12 @@ function formatDate(timestamp?: number) {
 		day: "numeric",
 		year: "numeric",
 	});
+}
+
+/** Stored UTC-midnight calendar dates re-projected so the local render shows the right day. */
+function formatCalendarDate(timestamp?: number) {
+	if (!timestamp) return "\u2014";
+	return formatDate(utcMidnightMsToLocalDate(timestamp).getTime());
 }
 
 const STATUS_OPTIONS = [
@@ -143,7 +153,7 @@ export function InvoiceDetailSidebar({
 		if (!canModify) return;
 		setEditingField(field);
 		setEditDateValue(
-			currentTimestamp ? new Date(currentTimestamp) : undefined
+			currentTimestamp ? utcMidnightMsToLocalDate(currentTimestamp) : undefined
 		);
 	};
 
@@ -307,7 +317,7 @@ export function InvoiceDetailSidebar({
 									if (date) {
 										saveField(
 											"dueDate",
-											date.getTime()
+											localDateToUtcMidnightMs(date)
 										);
 									}
 								}}
@@ -324,7 +334,7 @@ export function InvoiceDetailSidebar({
 								}`}
 							>
 								{invoice.dueDate ? (
-									formatDate(invoice.dueDate)
+									formatCalendarDate(invoice.dueDate)
 								) : (
 									<span className="text-muted-foreground italic">
 										Not set
@@ -357,7 +367,7 @@ export function InvoiceDetailSidebar({
 					</span>
 					<div className="flex-1 min-w-0">
 						<span className="text-sm text-foreground">
-							{formatDate(invoice.issuedDate)}
+							{formatCalendarDate(invoice.issuedDate)}
 						</span>
 					</div>
 				</div>

--- a/apps/web/src/app/(workspace)/invoices/components/InvoicePDF.tsx
+++ b/apps/web/src/app/(workspace)/invoices/components/InvoicePDF.tsx
@@ -345,6 +345,15 @@ const formatDate = (timestamp: number) =>
 		day: "2-digit",
 	});
 
+// Calendar-date fields (issued/due) are stored as UTC-midnight epochs; format in UTC so the day never shifts.
+const formatCalendarDate = (timestamp: number) =>
+	new Date(timestamp).toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		timeZone: "UTC",
+	});
+
 export const InvoicePDF: React.FC<InvoicePDFProps> = ({
 	invoice,
 	client,
@@ -407,11 +416,15 @@ export const InvoicePDF: React.FC<InvoicePDFProps> = ({
 					</View>
 					<View style={styles.metaItem}>
 						<Text style={styles.metaLabel}>Issued</Text>
-						<Text style={styles.metaValue}>{formatDate(invoice.issuedDate)}</Text>
+						<Text style={styles.metaValue}>
+							{formatCalendarDate(invoice.issuedDate)}
+						</Text>
 					</View>
 					<View style={styles.metaItem}>
 						<Text style={styles.metaLabel}>Due Date</Text>
-						<Text style={styles.metaValue}>{formatDate(invoice.dueDate)}</Text>
+						<Text style={styles.metaValue}>
+							{formatCalendarDate(invoice.dueDate)}
+						</Text>
 					</View>
 				</View>
 
@@ -525,7 +538,7 @@ export const InvoicePDF: React.FC<InvoicePDFProps> = ({
 											{formatCurrency(payment.paymentAmount)}
 										</Text>
 										<Text style={styles.colPayDueDate}>
-											{formatDate(payment.dueDate)}
+											{formatCalendarDate(payment.dueDate)}
 										</Text>
 									</View>
 								))}
@@ -545,7 +558,7 @@ export const InvoicePDF: React.FC<InvoicePDFProps> = ({
 								{formatCurrency(invoice.total)}
 							</Text>
 							<Text style={styles.amountDueDate}>
-								Payment due by {formatDate(invoice.dueDate)}
+								Payment due by {formatCalendarDate(invoice.dueDate)}
 							</Text>
 						</View>
 					)}

--- a/apps/web/src/app/(workspace)/invoices/components/invoice-detail-drawer.tsx
+++ b/apps/web/src/app/(workspace)/invoices/components/invoice-detail-drawer.tsx
@@ -47,6 +47,7 @@ import {
 	formatActivityTime,
 } from "@/components/shared/detail-drawer";
 import { formatCurrency } from "@/lib/money";
+import { utcMidnightMsToLocalDate } from "@/lib/dates";
 import { useToast } from "@/hooks/use-toast";
 
 type InvoiceStatus = Doc<"invoices">["status"];
@@ -80,6 +81,12 @@ function formatDate(ts: number | null | undefined): string {
 		day: "numeric",
 		year: "numeric",
 	});
+}
+
+/** Stored UTC-midnight calendar dates re-projected so the local render shows the right day. */
+function formatCalendarDate(ts: number | null | undefined): string {
+	if (!ts) return "—";
+	return formatDate(utcMidnightMsToLocalDate(ts).getTime());
 }
 
 // Overdue is computed from a past-due "sent" invoice. Reads the clock inside a
@@ -289,7 +296,7 @@ export function InvoiceDetailDrawer({
 												{payment.description ?? "Payment"}
 											</span>
 											<span className="text-muted-foreground text-xs">
-												Due {formatDate(payment.dueDate)}
+												Due {formatCalendarDate(payment.dueDate)}
 												{payment.paidAt
 													? ` · Paid ${formatDate(payment.paidAt)}`
 													: ""}
@@ -321,9 +328,11 @@ export function InvoiceDetailDrawer({
 							</DrawerField>
 							<DrawerField label="Project">{project?.title ?? "—"}</DrawerField>
 							<DrawerField label="Issued">
-								{formatDate(invoice.issuedDate)}
+								{formatCalendarDate(invoice.issuedDate)}
 							</DrawerField>
-							<DrawerField label="Due">{formatDate(invoice.dueDate)}</DrawerField>
+							<DrawerField label="Due">
+								{formatCalendarDate(invoice.dueDate)}
+							</DrawerField>
 							<DrawerField label="From quote">
 								{data.sourceQuote?.quoteNumber
 									? `#${data.sourceQuote.quoteNumber}`

--- a/apps/web/src/app/(workspace)/invoices/components/payments-configuration-modal.tsx
+++ b/apps/web/src/app/(workspace)/invoices/components/payments-configuration-modal.tsx
@@ -21,6 +21,10 @@ import Modal from "@/components/ui/modal";
 import { cn } from "@/lib/utils";
 import { useToast } from "@/hooks/use-toast";
 import { formatCurrency, parseCurrencyInput } from "@/lib/money";
+import {
+	localDateToUtcMidnightMs,
+	utcMidnightMsToLocalDate,
+} from "@/lib/dates";
 
 // ============================================================================
 // Types
@@ -231,9 +235,16 @@ function PaymentRow({
 								Due Date
 							</label>
 							<DatePicker
-								value={payment.dueDate ? new Date(payment.dueDate) : undefined}
+								value={
+									payment.dueDate
+										? utcMidnightMsToLocalDate(payment.dueDate)
+										: undefined
+								}
 								onChange={(date) =>
-									date && onUpdate(payment.id, { dueDate: date.getTime() })
+									date &&
+									onUpdate(payment.id, {
+										dueDate: localDateToUtcMidnightMs(date),
+									})
 								}
 								disabled={payment.isPaid}
 								formatDate={formatDueDate}
@@ -450,7 +461,8 @@ export function PaymentsConfigurationModal({
 		const newPayment: LocalPayment = {
 			id: generateLocalId(),
 			paymentAmount: Math.round(remaining * 100) / 100,
-			dueDate: Date.now() + 30 * 24 * 60 * 60 * 1000, // 30 days from now
+			dueDate:
+				localDateToUtcMidnightMs(new Date()) + 30 * 24 * 60 * 60 * 1000, // 30 days from today
 			description: `Payment ${unpaidPayments.length + 1}`,
 			isPaid: false,
 			sortOrder: maxSortOrder + 1,

--- a/apps/web/src/app/(workspace)/invoices/page.tsx
+++ b/apps/web/src/app/(workspace)/invoices/page.tsx
@@ -155,9 +155,10 @@ const formatStatus = (status: InvoiceStatus) => {
 	}
 };
 
+// Calendar-date fields are stored as UTC-midnight epochs; format in UTC so the day never shifts.
 const formatInvoiceDate = (timestamp?: number) => {
 	if (!timestamp) return "Not set";
-	return new Date(timestamp).toLocaleDateString();
+	return new Date(timestamp).toLocaleDateString(undefined, { timeZone: "UTC" });
 };
 
 const createColumns = (
@@ -216,7 +217,7 @@ const createColumns = (
 		header: "Issued",
 		cell: ({ row }) => (
 			<span className="text-foreground">
-				{new Date(row.original.issuedDate).toLocaleDateString()}
+				{formatInvoiceDate(row.original.issuedDate)}
 			</span>
 		),
 	},

--- a/apps/web/src/app/(workspace)/invoices/page.tsx
+++ b/apps/web/src/app/(workspace)/invoices/page.tsx
@@ -56,6 +56,7 @@ import {
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useQuery, useMutation } from "convex/react";
+import { todayUtcMidnightMs } from "@/lib/dates";
 import { api } from "@onetool/backend/convex/_generated/api";
 import { useIsOrgSwitching } from "@/hooks/use-is-org-switching";
 import { useActivitySparklines } from "@/hooks/use-activity-sparklines";
@@ -111,7 +112,7 @@ const getEffectiveStatus = (
 	status: InvoiceStatus,
 	dueDate: number
 ): InvoiceStatus =>
-	status === "sent" && dueDate < Date.now() ? "overdue" : status;
+	status === "sent" && dueDate < todayUtcMidnightMs() ? "overdue" : status;
 
 // appearance chosen to match the legacy statusVariant() boldness: solid for the
 // primary/positive status, soft for the mid-weight statuses, outline for the rest.
@@ -225,8 +226,9 @@ const createColumns = (
 		accessorKey: "dueDate",
 		header: "Due Date",
 		cell: ({ row }) => {
-			const d = new Date(row.original.dueDate);
-			const isOverdue = d < new Date() && row.original.status !== "paid";
+			const isOverdue =
+				row.original.dueDate < todayUtcMidnightMs() &&
+				row.original.status !== "paid";
 			return (
 				<span
 					className={cn(
@@ -234,7 +236,7 @@ const createColumns = (
 						isOverdue && "text-destructive font-medium"
 					)}
 				>
-					{d.toLocaleDateString()}
+					{formatInvoiceDate(row.original.dueDate)}
 				</span>
 			);
 		},
@@ -646,7 +648,9 @@ function InvoicesPageContent() {
 						? undefined
 						: `${
 								data.filter(
-									(inv) => inv.status === "sent" && inv.dueDate < Date.now()
+									(inv) =>
+										inv.status === "sent" &&
+										inv.dueDate < todayUtcMidnightMs()
 								).length
 							} overdue · ${formatCurrency(
 								data
@@ -841,7 +845,7 @@ function InvoicesPageContent() {
 																	<span aria-hidden>·</span>
 																	<span
 																		className={cn(
-																			item.dueDate < Date.now() &&
+																			item.dueDate < todayUtcMidnightMs() &&
 																				item.status !== "paid" &&
 																				"text-destructive font-medium"
 																		)}

--- a/apps/web/src/app/(workspace)/organization/profile/_components/business-info-tab.tsx
+++ b/apps/web/src/app/(workspace)/organization/profile/_components/business-info-tab.tsx
@@ -640,9 +640,10 @@ export function BusinessInfoTab() {
 									value={businessForm.timezone}
 									placeholder="Search timezones..."
 									disabled={controlsDisabled}
+									// Not clearable: organizations.update drops undefined, so a
+									// cleared field would revert on reload while showing empty.
+									clearable={false}
 									onSelect={(tz) => {
-										// Ignore the clear action: organizations.update drops
-										// undefined, so "cleared" would silently revert on reload.
 										if (!tz) return;
 										setBusinessDirty(true);
 										setBusinessForm((prev) => ({

--- a/apps/web/src/app/(workspace)/organization/profile/_components/business-info-tab.tsx
+++ b/apps/web/src/app/(workspace)/organization/profile/_components/business-info-tab.tsx
@@ -37,6 +37,8 @@ import {
 	type AddressData,
 } from "@/components/ui/address-autocomplete";
 import SelectService from "@/components/shared/choice-set";
+import ComboBox from "@/components/ui/combo-box";
+import { TIMEZONES } from "@/lib/timezones";
 import {
 	Frame,
 	FrameHeader,
@@ -89,6 +91,7 @@ type BusinessFormState = {
 	latitude: number | null;
 	longitude: number | null;
 	companySize: string;
+	timezone: string;
 	logoInvertInDarkMode: boolean;
 };
 
@@ -104,6 +107,7 @@ const initialBusinessForm: BusinessFormState = {
 	latitude: null,
 	longitude: null,
 	companySize: "",
+	timezone: "",
 	logoInvertInDarkMode: true,
 };
 
@@ -184,6 +188,7 @@ export function BusinessInfoTab() {
 				latitude: organization?.latitude ?? null,
 				longitude: organization?.longitude ?? null,
 				companySize: organization?.companySize ?? "",
+				timezone: organization?.timezone ?? "",
 				logoInvertInDarkMode: organization?.logoInvertInDarkMode ?? true,
 			});
 		}
@@ -267,6 +272,7 @@ export function BusinessInfoTab() {
 				latitude: businessForm.latitude ?? undefined,
 				longitude: businessForm.longitude ?? undefined,
 				companySize: businessForm.companySize as "1-10" | "10-100" | "100+",
+				timezone: businessForm.timezone || undefined,
 				logoUrl: clerkOrgImageUrl ?? undefined,
 				logoInvertInDarkMode: businessForm.logoInvertInDarkMode,
 			});
@@ -316,6 +322,7 @@ export function BusinessInfoTab() {
 			latitude: organization?.latitude ?? null,
 			longitude: organization?.longitude ?? null,
 			companySize: organization?.companySize ?? "",
+			timezone: organization?.timezone ?? "",
 			logoInvertInDarkMode: organization?.logoInvertInDarkMode ?? true,
 		});
 		setBusinessDirty(false);
@@ -624,6 +631,30 @@ export function BusinessInfoTab() {
 										Please select your company size.
 									</FieldError>
 								)}
+							</Field>
+
+							<Field className="mt-4">
+								<FieldLabel>Timezone</FieldLabel>
+								<ComboBox
+									options={TIMEZONES}
+									value={businessForm.timezone}
+									placeholder="Search timezones..."
+									disabled={controlsDisabled}
+									onSelect={(tz) => {
+										// Ignore the clear action: organizations.update drops
+										// undefined, so "cleared" would silently revert on reload.
+										if (!tz) return;
+										setBusinessDirty(true);
+										setBusinessForm((prev) => ({
+											...prev,
+											timezone: tz,
+										}));
+									}}
+								/>
+								<FieldDescription>
+									Used for date and time calculations in automations and
+									reports.
+								</FieldDescription>
 							</Field>
 						</FramePanel>
 					</Frame>

--- a/apps/web/src/app/(workspace)/projects/components/invoice-generation-modal.tsx
+++ b/apps/web/src/app/(workspace)/projects/components/invoice-generation-modal.tsx
@@ -14,6 +14,7 @@ import { Loader2, Receipt } from "lucide-react";
 import type { Id } from "@onetool/backend/convex/_generated/dataModel";
 import { ApprovedQuote } from "@/types/quote";
 import { formatCurrency } from "@/lib/money";
+import { localDateToUtcMidnightMs } from "@/lib/dates";
 
 interface InvoiceGenerationModalProps {
 	isOpen: boolean;
@@ -59,11 +60,12 @@ export function InvoiceGenerationModal({
 				"Converting quote to invoice..."
 			);
 
-			// Create invoice with default dates (issued now, due in 30 days)
+			// Create invoice with default dates (issued today, due in 30 days) as UTC-midnight calendar days
+			const issuedDate = localDateToUtcMidnightMs(new Date());
 			const invoiceId = await createInvoiceFromQuote({
 				quoteId: selectedQuoteId,
-				issuedDate: Date.now(),
-				dueDate: Date.now() + 30 * 24 * 60 * 60 * 1000, // 30 days from now
+				issuedDate,
+				dueDate: issuedDate + 30 * 24 * 60 * 60 * 1000,
 			});
 
 			toast.removeToast(loadingId);

--- a/apps/web/src/app/(workspace)/projects/components/new-project-dialog.tsx
+++ b/apps/web/src/app/(workspace)/projects/components/new-project-dialog.tsx
@@ -31,6 +31,7 @@ import {
 import { MultiSelector } from "@/components/shared/multi-selector";
 import { usePermissions } from "@/hooks/use-permissions";
 import { useToast } from "@/hooks/use-toast";
+import { localDateToUtcMidnightMs } from "@/lib/dates";
 
 type ClientId = Id<"clients">;
 type UserId = Id<"users">;
@@ -103,8 +104,12 @@ export function NewProjectDialog({
 					description: value.description.trim() || undefined,
 					status: "planned",
 					projectType: value.projectType,
-					startDate: value.startDate?.getTime(),
-					endDate: value.endDate?.getTime(),
+					startDate: value.startDate
+						? localDateToUtcMidnightMs(value.startDate)
+						: undefined,
+					endDate: value.endDate
+						? localDateToUtcMidnightMs(value.endDate)
+						: undefined,
 					assignedUserIds: value.assignedUserIds.length
 						? (value.assignedUserIds as UserId[])
 						: undefined,

--- a/apps/web/src/app/(workspace)/projects/components/project-detail-drawer.tsx
+++ b/apps/web/src/app/(workspace)/projects/components/project-detail-drawer.tsx
@@ -55,6 +55,7 @@ import {
 	formatActivityTime,
 } from "@/components/shared/detail-drawer";
 import { formatCurrency } from "@/lib/money";
+import { utcMidnightMsToLocalDate } from "@/lib/dates";
 
 type ProjectStatus = Doc<"projects">["status"];
 
@@ -79,6 +80,12 @@ function formatDate(ts: number | null | undefined): string {
 		day: "numeric",
 		year: "numeric",
 	});
+}
+
+/** Stored UTC-midnight calendar dates re-projected so the local render shows the right day. */
+function formatCalendarDate(ts: number | null | undefined): string {
+	if (!ts) return "—";
+	return formatDate(utcMidnightMsToLocalDate(ts).getTime());
 }
 
 // Share of the start→due window that has elapsed, or null if not schedulable.
@@ -234,13 +241,13 @@ export function ProjectDetailDrawer({
 							<div className="flex flex-col">
 								<span className="text-muted-foreground text-xs">Start</span>
 								<span className="text-foreground text-sm font-medium">
-									{formatDate(project.startDate)}
+									{formatCalendarDate(project.startDate)}
 								</span>
 							</div>
 							<div className="flex flex-col text-right">
 								<span className="text-muted-foreground text-xs">Due</span>
 								<span className="text-foreground text-sm font-medium">
-									{formatDate(project.endDate)}
+									{formatCalendarDate(project.endDate)}
 								</span>
 							</div>
 						</div>

--- a/apps/web/src/app/(workspace)/projects/components/project-detail-sidebar.tsx
+++ b/apps/web/src/app/(workspace)/projects/components/project-detail-sidebar.tsx
@@ -42,6 +42,10 @@ import { usePermissions } from "@/hooks/use-permissions";
 import { Badge } from "@/components/ui/badge";
 import { ProjectDocumentsSection } from "./project-documents-section";
 import { formatCurrency } from "@/lib/money";
+import {
+	localDateToUtcMidnightMs,
+	utcMidnightMsToLocalDate,
+} from "@/lib/dates";
 
 function formatDate(timestamp?: number) {
 	if (!timestamp) return "\u2014";
@@ -50,6 +54,12 @@ function formatDate(timestamp?: number) {
 		day: "numeric",
 		year: "numeric",
 	});
+}
+
+/** Stored UTC-midnight calendar dates re-projected so the local render shows the right day. */
+function formatCalendarDate(timestamp?: number) {
+	if (!timestamp) return "\u2014";
+	return formatDate(utcMidnightMsToLocalDate(timestamp).getTime());
 }
 
 const STATUS_OPTIONS = [
@@ -110,7 +120,9 @@ export function ProjectDetailSidebar({
 	const startEditingDate = (field: "startDate" | "endDate", currentTimestamp?: number) => {
 		if (!canModify) return;
 		setEditingField(field);
-		setEditDateValue(currentTimestamp ? new Date(currentTimestamp) : undefined);
+		setEditDateValue(
+			currentTimestamp ? utcMidnightMsToLocalDate(currentTimestamp) : undefined
+		);
 	};
 
 	const startEditingAssignedUsers = () => {
@@ -323,7 +335,7 @@ export function ProjectDetailSidebar({
 								value={editDateValue}
 								onChange={(date) => {
 									if (date) {
-										saveField("startDate", date.getTime());
+										saveField("startDate", localDateToUtcMidnightMs(date));
 									}
 								}}
 								formatDate={(date) => formatDate(date.getTime())}
@@ -332,7 +344,7 @@ export function ProjectDetailSidebar({
 							/>
 						) : (
 							<span className="text-sm text-foreground">
-								{project.startDate ? formatDate(project.startDate) : <span className="text-muted-foreground italic">Not set</span>}
+								{project.startDate ? formatCalendarDate(project.startDate) : <span className="text-muted-foreground italic">Not set</span>}
 							</span>
 						)}
 					</div>
@@ -354,13 +366,12 @@ export function ProjectDetailSidebar({
 								value={editDateValue}
 								onChange={(date) => {
 									if (date) {
-										saveField("endDate", date.getTime());
+										saveField("endDate", localDateToUtcMidnightMs(date));
 									}
 								}}
 								disabledDates={(date) => {
 									if (!project.startDate) return false;
-									const start = new Date(project.startDate);
-									start.setHours(0, 0, 0, 0);
+									const start = utcMidnightMsToLocalDate(project.startDate);
 									const checkDate = new Date(date);
 									checkDate.setHours(0, 0, 0, 0);
 									return checkDate < start;
@@ -371,7 +382,7 @@ export function ProjectDetailSidebar({
 							/>
 						) : (
 							<span className="text-sm text-foreground">
-								{project.endDate ? formatDate(project.endDate) : <span className="text-muted-foreground italic">Not set</span>}
+								{project.endDate ? formatCalendarDate(project.endDate) : <span className="text-muted-foreground italic">Not set</span>}
 							</span>
 						)}
 					</div>

--- a/apps/web/src/app/(workspace)/projects/components/tabs/overview-tab.tsx
+++ b/apps/web/src/app/(workspace)/projects/components/tabs/overview-tab.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { ClipboardList, DollarSign, CheckCircle, FileText, Receipt, Pencil } from "lucide-react";
 import { formatCurrency } from "@/lib/money";
+import { utcMidnightMsToLocalDate } from "@/lib/dates";
 
 interface OverviewTabProps {
 	projectId: Id<"projects">;
@@ -25,12 +26,14 @@ interface OverviewTabProps {
 	invoices: Doc<"invoices">[] | undefined;
 }
 
+// start/end dates are stored as UTC-midnight epochs; format in UTC so the day never shifts.
 function formatDate(timestamp?: number) {
 	if (!timestamp) return "\u2014";
 	return new Date(timestamp).toLocaleDateString("en-US", {
 		month: "short",
 		day: "numeric",
 		year: "numeric",
+		timeZone: "UTC",
 	});
 }
 
@@ -62,6 +65,7 @@ function formatDisplayDate(timestamp?: number) {
 		year: "numeric",
 		month: "long",
 		day: "numeric",
+		timeZone: "UTC",
 	});
 }
 
@@ -124,7 +128,7 @@ export function OverviewTab({
 	};
 
 	const initialCalendarDate = startDate
-		? new Date(startDate)
+		? utcMidnightMsToLocalDate(startDate)
 		: new Date();
 	const [calendarDate, setCalendarDate] = useState(
 		new Date(initialCalendarDate.getFullYear(), initialCalendarDate.getMonth(), 1)
@@ -353,21 +357,18 @@ export function OverviewTab({
 							if (currentDayDate) currentDayDate.setHours(0, 0, 0, 0);
 
 							if (day && startDate && currentDayDate) {
-								const start = new Date(startDate);
-								start.setHours(0, 0, 0, 0);
+								const start = utcMidnightMsToLocalDate(startDate);
 								isStart = currentDayDate.getTime() === start.getTime();
 
 								if (endDate && !isStart) {
-									const end = new Date(endDate);
-									end.setHours(0, 0, 0, 0);
+									const end = utcMidnightMsToLocalDate(endDate);
 									isInRange =
 										currentDayDate > start && currentDayDate < end;
 								}
 							}
 
 							if (day && endDate && currentDayDate) {
-								const end = new Date(endDate);
-								end.setHours(0, 0, 0, 0);
+								const end = utcMidnightMsToLocalDate(endDate);
 								isEnd = currentDayDate.getTime() === end.getTime();
 							}
 

--- a/apps/web/src/app/(workspace)/projects/page.tsx
+++ b/apps/web/src/app/(workspace)/projects/page.tsx
@@ -157,12 +157,13 @@ const formatStatus = (status: Doc<"projects">["status"]) => {
 	}
 };
 
+// Calendar-date fields are stored as UTC-midnight epochs; format in UTC so the day never shifts.
 const formatProjectDate = (timestamp?: number) => {
 	if (!timestamp) {
 		return "Not set";
 	}
 	const date = new Date(timestamp);
-	return date.toLocaleDateString();
+	return date.toLocaleDateString(undefined, { timeZone: "UTC" });
 };
 
 const createColumns = (
@@ -215,8 +216,9 @@ const createColumns = (
 			const startDate = row.original.startDate;
 			if (!startDate)
 				return <span className="text-muted-foreground">Not set</span>;
-			const d = new Date(startDate);
-			return <span className="text-foreground">{d.toLocaleDateString()}</span>;
+			return (
+				<span className="text-foreground">{formatProjectDate(startDate)}</span>
+			);
 		},
 	},
 	{

--- a/apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-sidebar.tsx
+++ b/apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-sidebar.tsx
@@ -45,6 +45,10 @@ import {
 import Link from "next/link";
 import { usePermissions } from "@/hooks/use-permissions";
 import { formatCurrency } from "@/lib/money";
+import {
+	localDateToUtcMidnightMs,
+	utcMidnightMsToLocalDate,
+} from "@/lib/dates";
 
 type QuoteStatus = "draft" | "sent" | "approved" | "declined" | "expired";
 
@@ -55,6 +59,12 @@ function formatDate(timestamp?: number) {
 		day: "numeric",
 		year: "numeric",
 	});
+}
+
+/** Stored UTC-midnight calendar dates re-projected so the local render shows the right day. */
+function formatCalendarDate(timestamp?: number) {
+	if (!timestamp) return "\u2014";
+	return formatDate(utcMidnightMsToLocalDate(timestamp).getTime());
 }
 
 const STATUS_OPTIONS = [
@@ -135,7 +145,7 @@ export function QuoteDetailSidebar({
 		if (!canModify) return;
 		setEditingField(field);
 		setEditDateValue(
-			currentTimestamp ? new Date(currentTimestamp) : undefined
+			currentTimestamp ? utcMidnightMsToLocalDate(currentTimestamp) : undefined
 		);
 	};
 
@@ -351,7 +361,7 @@ export function QuoteDetailSidebar({
 									if (date) {
 										saveField(
 											"validUntil",
-											date.getTime()
+											localDateToUtcMidnightMs(date)
 										);
 									}
 								}}
@@ -362,7 +372,7 @@ export function QuoteDetailSidebar({
 						) : (
 							<span className="text-sm text-foreground">
 								{quote.validUntil ? (
-									formatDate(quote.validUntil)
+									formatCalendarDate(quote.validUntil)
 								) : (
 									<span className="text-muted-foreground italic">
 										Not set

--- a/apps/web/src/app/(workspace)/quotes/[quoteId]/page.tsx
+++ b/apps/web/src/app/(workspace)/quotes/[quoteId]/page.tsx
@@ -17,6 +17,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import { QuoteDetailHeader } from "./components/quote-detail-header";
 import { QuoteDetailTabs } from "./components/quote-detail-tabs";
+import { localDateToUtcMidnightMs } from "@/lib/dates";
 
 type QuoteStatus = "draft" | "sent" | "approved" | "declined" | "expired";
 
@@ -154,10 +155,12 @@ function QuoteDetailPageContent() {
 		if (isConverting) return;
 		setIsConverting(true);
 		try {
+			// Default dates as UTC-midnight calendar days (issued today, due in 30 days)
+			const issuedDate = localDateToUtcMidnightMs(new Date());
 			const invoiceId = await createInvoiceFromQuote({
 				quoteId,
-				issuedDate: Date.now(),
-				dueDate: Date.now() + 30 * 24 * 60 * 60 * 1000,
+				issuedDate,
+				dueDate: issuedDate + 30 * 24 * 60 * 60 * 1000,
 			});
 			toast.success(
 				"Invoice Created",

--- a/apps/web/src/app/(workspace)/quotes/components/QuotePDF.tsx
+++ b/apps/web/src/app/(workspace)/quotes/components/QuotePDF.tsx
@@ -309,6 +309,15 @@ const formatDate = (timestamp: number) =>
 		day: "2-digit",
 	});
 
+// validUntil is stored as a UTC-midnight epoch; format in UTC so the day never shifts.
+const formatCalendarDate = (timestamp: number) =>
+	new Date(timestamp).toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		timeZone: "UTC",
+	});
+
 export const QuotePDF: React.FC<QuotePDFProps> = ({
 	quote,
 	client,
@@ -377,7 +386,9 @@ export const QuotePDF: React.FC<QuotePDFProps> = ({
 					{quote.validUntil && (
 						<View style={styles.metaItem}>
 							<Text style={styles.metaLabel}>Valid Until</Text>
-							<Text style={styles.metaValue}>{formatDate(quote.validUntil)}</Text>
+							<Text style={styles.metaValue}>
+								{formatCalendarDate(quote.validUntil)}
+							</Text>
 						</View>
 					)}
 				</View>

--- a/apps/web/src/app/(workspace)/quotes/components/new-quote-dialog.tsx
+++ b/apps/web/src/app/(workspace)/quotes/components/new-quote-dialog.tsx
@@ -28,6 +28,7 @@ import {
 import { DatePicker } from "@/components/ui/date-picker";
 import { useToast } from "@/hooks/use-toast";
 import { usePermissions } from "@/hooks/use-permissions";
+import { localDateToUtcMidnightMs } from "@/lib/dates";
 
 const DEFAULT_TERMS = "Payment due within 30 days of acceptance";
 
@@ -108,7 +109,9 @@ export function NewQuoteDialog({
 					status: "draft",
 					subtotal: 0, // Line items are added in the line editor.
 					total: 0,
-					validUntil: value.validUntil ? value.validUntil.getTime() : undefined,
+					validUntil: value.validUntil
+						? localDateToUtcMidnightMs(value.validUntil)
+						: undefined,
 					clientMessage: value.clientMessage.trim() || undefined,
 					terms: value.terms.trim() || undefined,
 					pdfSettings: {

--- a/apps/web/src/app/(workspace)/quotes/components/quote-detail-drawer.tsx
+++ b/apps/web/src/app/(workspace)/quotes/components/quote-detail-drawer.tsx
@@ -49,6 +49,7 @@ import {
 	formatActivityTime,
 } from "@/components/shared/detail-drawer";
 import { formatCurrency } from "@/lib/money";
+import { utcMidnightMsToLocalDate } from "@/lib/dates";
 
 type QuoteStatus = Doc<"quotes">["status"];
 
@@ -75,6 +76,12 @@ function formatDate(ts: number | null | undefined): string {
 		day: "numeric",
 		year: "numeric",
 	});
+}
+
+/** Stored UTC-midnight calendar dates re-projected so the local render shows the right day. */
+function formatCalendarDate(ts: number | null | undefined): string {
+	if (!ts) return "—";
+	return formatDate(utcMidnightMsToLocalDate(ts).getTime());
 }
 
 export interface QuoteDetailDrawerProps {
@@ -338,7 +345,7 @@ export function QuoteDetailDrawer({
 								{data.project?.title ?? "—"}
 							</DrawerField>
 							<DrawerField label="Valid Until">
-								{formatDate(quote.validUntil)}
+								{formatCalendarDate(quote.validUntil)}
 							</DrawerField>
 							{quote.sentAt ? (
 								<DrawerField label="Sent">

--- a/apps/web/src/app/(workspace)/quotes/page.tsx
+++ b/apps/web/src/app/(workspace)/quotes/page.tsx
@@ -57,6 +57,7 @@ import {
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useQuery, useMutation } from "convex/react";
+import { todayUtcMidnightMs } from "@/lib/dates";
 import { api } from "@onetool/backend/convex/_generated/api";
 import type { Doc, Id } from "@onetool/backend/convex/_generated/dataModel";
 import { useActivitySparklines } from "@/hooks/use-activity-sparklines";
@@ -203,8 +204,10 @@ const createColumns = (
 			if (!row.original.validUntil) {
 				return <span className="text-muted-foreground">Not set</span>;
 			}
-			const d = new Date(row.original.validUntil);
-			const isExpired = d < new Date();
+			// Calendar-day compare: validUntil is a UTC-midnight epoch, so an
+			// instant compare would mark it expired at UTC midnight, hours into
+			// the viewer's validUntil day.
+			const isExpired = row.original.validUntil < todayUtcMidnightMs();
 			return (
 				<span className={cn("text-foreground", isExpired && "text-destructive")}>
 					{formatQuoteDate(row.original.validUntil)}

--- a/apps/web/src/app/(workspace)/quotes/page.tsx
+++ b/apps/web/src/app/(workspace)/quotes/page.tsx
@@ -142,9 +142,10 @@ const formatStatus = (status: Doc<"quotes">["status"]) => {
 	}
 };
 
+// Calendar-date fields are stored as UTC-midnight epochs; format in UTC so the day never shifts.
 const formatQuoteDate = (timestamp?: number) => {
 	if (!timestamp) return "Not set";
-	return new Date(timestamp).toLocaleDateString();
+	return new Date(timestamp).toLocaleDateString(undefined, { timeZone: "UTC" });
 };
 
 const createColumns = (
@@ -206,7 +207,7 @@ const createColumns = (
 			const isExpired = d < new Date();
 			return (
 				<span className={cn("text-foreground", isExpired && "text-destructive")}>
-					{d.toLocaleDateString()}
+					{formatQuoteDate(row.original.validUntil)}
 				</span>
 			);
 		},

--- a/apps/web/src/components/shared/task-sheet.tsx
+++ b/apps/web/src/components/shared/task-sheet.tsx
@@ -36,6 +36,10 @@ import {
 	Loader2,
 } from "lucide-react";
 import { Task } from "@/types/task";
+import {
+	localDateToUtcMidnightMs,
+	utcMidnightMsToLocalDate,
+} from "@/lib/dates";
 
 interface TaskSheetProps {
 	task?: Task | null;
@@ -130,11 +134,13 @@ export function TaskSheet({
 				type: task.type || "external",
 				clientId: task.clientId || "",
 				projectId: task.projectId || "",
-				date: new Date(task.date),
+				date: utcMidnightMsToLocalDate(task.date),
 				assigneeUserId: task.assigneeUserId || "",
 				status: task.status,
 				repeat: task.repeat || "none",
-				repeatUntil: task.repeatUntil ? new Date(task.repeatUntil) : undefined,
+				repeatUntil: task.repeatUntil
+					? utcMidnightMsToLocalDate(task.repeatUntil)
+					: undefined,
 			});
 		} else if (isCreateMode) {
 			const today = new Date();
@@ -193,20 +199,9 @@ export function TaskSheet({
 		setIsSubmitting(true);
 
 		try {
-			// Normalize dates to midnight UTC to avoid timezone issues
-			const normalizeDate = (date: Date): number => {
-				const normalized = new Date(date);
-				// Get the date components in local timezone
-				const year = normalized.getFullYear();
-				const month = normalized.getMonth();
-				const day = normalized.getDate();
-				// Create a new date in UTC with these components
-				return Date.UTC(year, month, day);
-			};
-
-			const taskDate = normalizeDate(formData.date);
+			const taskDate = localDateToUtcMidnightMs(formData.date);
 			const repeatUntil = formData.repeatUntil
-				? normalizeDate(formData.repeatUntil)
+				? localDateToUtcMidnightMs(formData.repeatUntil)
 				: undefined;
 
 			const taskData = {

--- a/apps/web/src/components/ui/combo-box.tsx
+++ b/apps/web/src/components/ui/combo-box.tsx
@@ -8,6 +8,8 @@ interface ComboBoxProps {
 	value?: string;
 	onSelect?: (option: string | null) => void;
 	disabled?: boolean;
+	/** Hide the clear (×) button for fields where "no selection" is not a valid state. */
+	clearable?: boolean;
 }
 
 const ComboBox = ({
@@ -16,6 +18,7 @@ const ComboBox = ({
 	value,
 	onSelect,
 	disabled = false,
+	clearable = true,
 }: ComboBoxProps) => {
 	const [inputValue, setInputValue] = useState<string>(value || "");
 	const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -183,7 +186,7 @@ const ComboBox = ({
 						highlightedIndex >= 0 ? `option-${highlightedIndex}` : undefined
 					}
 				/>
-				{selectedOption && !disabled && (
+				{clearable && selectedOption && !disabled && (
 					<button
 						type="button"
 						onClick={handleClearSelection}

--- a/apps/web/src/lib/dates.ts
+++ b/apps/web/src/lib/dates.ts
@@ -1,0 +1,19 @@
+/**
+ * Calendar-date epoch convention: date-only fields (project start/end, invoice
+ * issued/due, quote validUntil, task date) store the UTC midnight of the
+ * calendar day, regardless of the browser's timezone. Every form writer must
+ * round-trip through these helpers — `date.getTime()` off a local-midnight
+ * picker Date stores a value the automation engine's exact-day (`on`)
+ * comparisons read as the wrong day.
+ */
+
+/** Stored UTC-midnight epoch -> local Date carrying the same calendar day (for pickers). */
+export function utcMidnightMsToLocalDate(ms: number): Date {
+	const d = new Date(ms);
+	return new Date(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+}
+
+/** Picker-selected local Date -> UTC-midnight epoch of that calendar day. */
+export function localDateToUtcMidnightMs(d: Date): number {
+	return Date.UTC(d.getFullYear(), d.getMonth(), d.getDate());
+}

--- a/apps/web/src/lib/dates.ts
+++ b/apps/web/src/lib/dates.ts
@@ -17,3 +17,13 @@ export function utcMidnightMsToLocalDate(ms: number): Date {
 export function localDateToUtcMidnightMs(d: Date): number {
 	return Date.UTC(d.getFullYear(), d.getMonth(), d.getDate());
 }
+
+/**
+ * UTC-midnight epoch of the viewer's current local calendar day. Compare stored
+ * calendar-date epochs against this (`stored < todayUtcMidnightMs()` = "past"),
+ * never against `Date.now()` — the raw instant flips at UTC midnight, hours off
+ * from the viewer's day.
+ */
+export function todayUtcMidnightMs(): number {
+	return localDateToUtcMidnightMs(new Date());
+}

--- a/apps/web/src/lib/timezones.ts
+++ b/apps/web/src/lib/timezones.ts
@@ -1,0 +1,12 @@
+/** IANA timezone list; older runtimes without supportedValuesOf fall back to UTC. */
+export const TIMEZONES: string[] = (() => {
+	try {
+		return Intl.supportedValuesOf("timeZone");
+	} catch {
+		return ["UTC"];
+	}
+})();
+
+export function browserTimezone(): string {
+	return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+}

--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -1594,6 +1594,86 @@ describe("automationExecutor (v2 engine)", () => {
 		});
 	});
 
+	describe("org timezone drives event-trigger formula evaluation (C2-2a)", () => {
+		/** record_created(project) -> write TODAY() into startDate. */
+		function stampTodayAutomation() {
+			return {
+				name: "Stamp today",
+				trigger: {
+					type: "record_created" as const,
+					objectType: "project" as const,
+				},
+				formulas: [
+					{
+						id: "today",
+						name: "Today",
+						returnType: "date" as const,
+						expression: "TODAY()",
+					},
+				],
+				nodes: [
+					{
+						id: "act-1",
+						type: "action" as const,
+						config: {
+							kind: "action" as const,
+							action: {
+								type: "update_field" as const,
+								target: "self" as const,
+								field: "startDate",
+								value: { kind: "var" as const, path: "formula.today" },
+							},
+						},
+					},
+				],
+				isActive: true,
+			};
+		}
+
+		async function createProject(asUser: ReturnType<typeof t.withIdentity>) {
+			const clientId = await asUser.mutation(api.clients.create, {
+				portalAccessId: crypto.randomUUID(),
+				companyName: "Acme Co",
+				status: "lead",
+			});
+			return asUser.mutation(api.projects.create, {
+				clientId,
+				title: "Kitchen remodel",
+				status: "planned",
+				projectType: "one-off",
+			});
+		}
+
+		it("evaluates TODAY() in the org timezone", async () => {
+			const { orgId, asUser } = await setupUser();
+			await t.run(async (ctx) =>
+				ctx.db.patch(orgId, { timezone: "America/New_York" })
+			);
+			// 02:00 UTC on Jul 4 is still Jul 3 in New York — the two clocks
+			// disagree about the calendar day.
+			vi.setSystemTime(Date.UTC(2026, 6, 4, 2, 0));
+
+			await asUser.mutation(api.automations.create, stampTodayAutomation());
+			const projectId = await createProject(asUser);
+			await drainEvents();
+
+			const project = await t.run(async (ctx) => ctx.db.get(projectId));
+			expect(project?.startDate).toBe(Date.UTC(2026, 6, 3));
+		});
+
+		it("falls back to UTC when the org has no timezone", async () => {
+			const { asUser } = await setupUser();
+			vi.setSystemTime(Date.UTC(2026, 6, 4, 2, 0));
+
+			await asUser.mutation(api.automations.create, stampTodayAutomation());
+			const projectId = await createProject(asUser);
+			await drainEvents();
+
+			const project = await t.run(async (ctx) => ctx.db.get(projectId));
+			expect(project?.startDate).toBe(Date.UTC(2026, 6, 4));
+		});
+	});
+
 	describe("org isolation", () => {
 		it("does not fire an org A automation for an org B record", async () => {
 			const orgA = await setupUser({

--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -3555,6 +3555,64 @@ describe("automationExecutor (v2 engine)", () => {
 			expect(result("minus")).toBe(base - 2 * 3_600_000);
 		});
 
+		it("adjust_time: whole-day shifts preserve wall-clock across DST (C2-3)", async () => {
+			const { asUser, orgId } = await setupUser();
+			await makeOrgPremium(orgId);
+
+			// Mar 7 2026 12:00 EST; +3 days crosses the Mar 8 spring-forward.
+			const instantBase = Date.UTC(2026, 2, 7, 17, 0);
+			// A calendar date advances in pure UTC and must stay UTC midnight.
+			const calendarBase = Date.UTC(2026, 2, 7);
+
+			const adjustNode = (id: string, base: number, next: string) => ({
+				id,
+				type: "adjust_time" as const,
+				config: {
+					kind: "adjust_time" as const,
+					base: { kind: "static" as const, value: base },
+					amount: 3,
+					unit: "days" as const,
+					direction: "add" as const,
+				},
+				nextNodeId: next,
+			});
+
+			const automationId = await asUser.mutation(api.automations.create, {
+				name: "DST shift",
+				trigger: {
+					type: "scheduled",
+					schedule: {
+						frequency: "daily",
+						timezone: "America/New_York",
+						time: "09:00",
+					},
+				},
+				nodes: [
+					adjustNode("instant", instantBase, "calendar"),
+					adjustNode("calendar", calendarBase, "end-1"),
+					endNode("end-1"),
+				],
+				isActive: true,
+			});
+
+			await runScheduledOnce(automationId);
+
+			const executions = await t.run(async (ctx) =>
+				ctx.db.query("workflowExecutions").collect()
+			);
+			expect(executions).toHaveLength(1);
+			expect(executions[0].status).toBe("completed");
+			const result = (nodeId: string) =>
+				(
+					executions[0].nodesExecuted.find((n) => n.nodeId === nodeId)
+						?.output as { result: number } | undefined
+				)?.result;
+			// Still 12:00 on the wall in New York — now EDT, i.e. 16:00 UTC.
+			// Fixed-ms math would return 17:00 UTC (a 1pm wall time).
+			expect(result("instant")).toBe(Date.UTC(2026, 2, 10, 16, 0));
+			expect(result("calendar")).toBe(Date.UTC(2026, 2, 10));
+		});
+
 		it("send_notification recipient org_admins: creates an automation_message notification per admin", async () => {
 			const { asUser, orgId } = await setupUser();
 

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -362,7 +362,8 @@ export const findMatchingAutomations = internalQuery({
 				criteria.logic,
 				criteria.groups,
 				record,
-				scope
+				scope,
+				args.objectType
 			);
 		});
 	},
@@ -2315,7 +2316,13 @@ async function runFetchNode(
 			env.orgId,
 			{
 				predicate: (row) =>
-					evaluateConditionGroups("and", config.filters, row, env.scope),
+					evaluateConditionGroups(
+						"and",
+						config.filters,
+						row,
+						env.scope,
+						config.objectType
+					),
 				// Sorting needs every match in range; without one, rows already
 				// arrive newest-first so the scan can stop at the node's limit.
 				stopAfterMatches: config.sortBy ? undefined : limit,

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -2841,6 +2841,24 @@ function coerceFieldValue(
 			// instant from then on.
 			return { ok: true, value: calendarDayEpoch(n, tz) };
 		}
+		case "datetime": {
+			// An instant field stores the exact moment — no day normalization.
+			// (All datetime fields are writable:false today; this keeps the
+			// switch exhaustive and correct if one ever opens up.)
+			const n =
+				raw instanceof Date
+					? raw.getTime()
+					: typeof raw === "number"
+						? raw
+						: Date.parse(String(raw));
+			if (Number.isNaN(n)) {
+				return {
+					ok: false,
+					error: `"${String(raw)}" is not a valid date for field "${fieldDef.key}"`,
+				};
+			}
+			return { ok: true, value: n };
+		}
 		case "id": {
 			// An array-valued source (project.assignedUserIds) feeding a
 			// single-id destination (task.assigneeUserId) takes the first

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -27,7 +27,13 @@ import {
 	resolveValueRef,
 	type VariableScope,
 } from "./lib/conditionEval";
-import { calendarDayEpoch, toEpochMs } from "./lib/formula";
+import {
+	calendarDayEpoch,
+	getZonedParts,
+	isCalendarDateEpoch,
+	toEpochMs,
+	zonedPartsToEpoch,
+} from "./lib/formula";
 import {
 	FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT,
 	FREE_MAX_CLIENTS,
@@ -2420,8 +2426,30 @@ function runAdjustTimeNode(
 		};
 	}
 	const sign = config.direction === "subtract" ? -1 : 1;
-	const value =
-		baseMs + sign * config.amount * ADJUST_TIME_UNIT_MS[config.unit];
+	const days =
+		config.unit === "days"
+			? sign * config.amount
+			: config.unit === "weeks"
+				? sign * config.amount * 7
+				: null;
+	let value: number;
+	if (days !== null && Number.isInteger(days)) {
+		// Whole-day math mirrors ADDDAYS: a calendar date advances in UTC (no
+		// DST there, result stays exactly UTC midnight); an instant preserves
+		// its wall-clock time in the run tz across DST transitions. Fixed-ms
+		// day math would drift an hour over a DST boundary.
+		if (isCalendarDateEpoch(baseMs)) {
+			value = baseMs + days * 86_400_000;
+		} else {
+			const tz = scope.workflow?.tz ?? "UTC";
+			const parts = getZonedParts(baseMs, tz);
+			value = zonedPartsToEpoch({ ...parts, day: parts.day + days }, tz);
+		}
+	} else {
+		// Minutes/hours are absolute offsets; fractional day amounts keep the
+		// legacy fixed-ms behavior (parts math needs whole days).
+		value = baseMs + sign * config.amount * ADJUST_TIME_UNIT_MS[config.unit];
+	}
 	scope.nodes ??= {};
 	scope.nodes[nodeId] = { ...scope.nodes[nodeId], result: value };
 	return { ok: true, value };

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -2569,6 +2569,7 @@ async function executeNodeV2(
 	switch (config.kind) {
 		case "condition": {
 			let record: Record<string, unknown>;
+			let recordType: AutomationObjectType | undefined;
 			if (config.source && typeof config.source === "object") {
 				const loopScope = env.scope.loops?.[config.source.loopNodeId];
 				if (!loopScope) {
@@ -2578,14 +2579,17 @@ async function executeNodeV2(
 					};
 				}
 				record = loopScope.item;
+				recordType = loopScope.objectType;
 			} else {
 				record = scopeRecord?.record ?? {};
+				recordType = scopeRecord?.type;
 			}
 			const conditionMet = evaluateConditionGroups(
 				config.logic,
 				config.groups,
 				record,
-				env.scope
+				env.scope,
+				recordType
 			);
 			return { success: true, conditionMet };
 		}
@@ -4842,6 +4846,7 @@ async function dryExecuteNode(
 	const config = node.config;
 	if (config?.kind === "condition") {
 		let record: Record<string, unknown>;
+		let recordType: AutomationObjectType | undefined;
 		if (config.source && typeof config.source === "object") {
 			const loopScope = env.scope.loops?.[config.source.loopNodeId];
 			if (!loopScope) {
@@ -4851,14 +4856,17 @@ async function dryExecuteNode(
 				};
 			}
 			record = loopScope.item;
+			recordType = loopScope.objectType;
 		} else {
 			record = scopeRecord?.record ?? {};
+			recordType = scopeRecord?.type;
 		}
 		const conditionMet = evaluateConditionGroups(
 			config.logic,
 			config.groups,
 			record,
-			env.scope
+			env.scope,
+			recordType
 		);
 		return {
 			success: true,

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -117,13 +117,17 @@ function executableDefinition(automation: AutomationDoc): {
 
 /**
  * IANA timezone for formula date math. Scheduled automations use their schedule
- * timezone; everything else defaults to UTC (there is no per-org tz field).
+ * timezone; event triggers use the org timezone (auto-detected at onboarding,
+ * editable in org settings), falling back to UTC for orgs that never set one.
  */
-function automationFormulaTz(trigger: AutomationTrigger): string {
+function automationFormulaTz(
+	trigger: AutomationTrigger,
+	orgTimezone: string | undefined
+): string {
 	if ("type" in trigger && trigger.type === "scheduled") {
 		return trigger.schedule.timezone;
 	}
-	return "UTC";
+	return orgTimezone ?? "UTC";
 }
 
 /** Extract a user id from a "manual:"/"test:"/"actor:" triggeredBy marker. */
@@ -164,15 +168,15 @@ async function buildGlobalsScope(
 	ctx: MutationCtx,
 	orgId: Id<"organizations">,
 	nowMs: number,
-	tz: string,
+	trigger: AutomationTrigger,
 	triggeredBy: string,
 	run: NonNullable<VariableScope["run"]>
 ): Promise<Pick<VariableScope, "workflow" | "org" | "user" | "run">> {
+	const org = await ctx.db.get(orgId);
 	const globals: Pick<VariableScope, "workflow" | "org" | "user" | "run"> = {
-		workflow: { now: nowMs, tz },
+		workflow: { now: nowMs, tz: automationFormulaTz(trigger, org?.timezone) },
 		run,
 	};
-	const org = await ctx.db.get(orgId);
 	if (org) globals.org = { id: orgId, name: org.name };
 
 	const actorUserId = parseActorUserId(ctx, triggeredBy);
@@ -338,7 +342,10 @@ export const findMatchingAutomations = internalQuery({
 							? { oldValue: args.fromStatus, newValue: args.toStatus }
 							: undefined,
 				},
-				workflow: { now: Date.now(), tz: automationFormulaTz(trigger) },
+				workflow: {
+					now: Date.now(),
+					tz: automationFormulaTz(trigger, org?.timezone),
+				},
 				org: org ? { id: args.orgId, name: org.name } : undefined,
 				user: actor
 					? { id: actor._id, name: actor.name, email: actor.email }
@@ -1110,7 +1117,7 @@ export const executeAutomation = systemMutation({
 			ctx,
 			automation.orgId,
 			execution.triggeredAt,
-			automationFormulaTz(definition.trigger),
+			definition.trigger,
 			execution.triggeredBy,
 			runMetadata(automation, args.executionId, definition.trigger)
 		);
@@ -1306,7 +1313,7 @@ export const resumeExecution = systemMutation({
 			ctx,
 			automation.orgId,
 			execution.triggeredAt,
-			automationFormulaTz(definition.trigger),
+			definition.trigger,
 			execution.triggeredBy,
 			runMetadata(automation, args.executionId, definition.trigger)
 		);
@@ -5299,7 +5306,7 @@ export const startTestRun = userMutation({
 		// The tester is always the actor for a dry run.
 		const testerOrg = await ctx.db.get(ctx.orgId);
 		const globals: Pick<VariableScope, "workflow" | "org" | "user" | "run"> = {
-			workflow: { now, tz: automationFormulaTz(trigger) },
+			workflow: { now, tz: automationFormulaTz(trigger, testerOrg?.timezone) },
 			org: testerOrg ? { id: ctx.orgId, name: testerOrg.name } : undefined,
 			user: { id: ctx.user._id, name: ctx.user.name, email: ctx.user.email },
 			// executionId is omitted — the workflowExecutions row isn't inserted until

--- a/packages/backend/convex/automations.ts
+++ b/packages/backend/convex/automations.ts
@@ -471,13 +471,16 @@ function validateFallbackType(
 			? "a boolean"
 			: fieldType === "number" || fieldType === "currency"
 				? "a number"
-				: fieldType === "date"
+				: fieldType === "date" || fieldType === "datetime"
 					? "a date"
 					: "text";
 	const ok =
 		fieldType === "boolean"
 			? typeof fallback === "boolean"
-			: fieldType === "number" || fieldType === "currency" || fieldType === "date"
+			: fieldType === "number" ||
+					fieldType === "currency" ||
+					fieldType === "date" ||
+					fieldType === "datetime"
 				? typeof fallback === "number"
 				: typeof fallback === "string";
 	if (!ok) {

--- a/packages/backend/convex/invoices.ts
+++ b/packages/backend/convex/invoices.ts
@@ -1,3 +1,4 @@
+import { calendarDayEpoch } from "./lib/formula";
 import {
 	query,
 	internalMutation,
@@ -1019,9 +1020,14 @@ export const createFromQuote = userMutation({
 
 		const invoiceNumber = `INV-${String(maxNumber + 1).padStart(6, "0")}`;
 
-		// Set default dates if not provided
-		const issuedDate = args.issuedDate || Date.now();
-		const dueDate = args.dueDate || Date.now() + 30 * 24 * 60 * 60 * 1000; // 30 days default
+		// Default dates are calendar dates (UTC-midnight epochs), not instants —
+		// today / today+30d as seen from the org timezone.
+		const todayUtcMidnight = calendarDayEpoch(
+			Date.now(),
+			(await ctx.db.get(ctx.orgId))?.timezone ?? "UTC"
+		);
+		const issuedDate = args.issuedDate || todayUtcMidnight;
+		const dueDate = args.dueDate || todayUtcMidnight + 30 * 24 * 60 * 60 * 1000;
 
 		const quoteLineItems = await ctx.db
 			.query("quoteLineItems")

--- a/packages/backend/convex/lib/conditionEval.test.ts
+++ b/packages/backend/convex/lib/conditionEval.test.ts
@@ -720,12 +720,23 @@ describe("evaluateRule", () => {
 			nothing: null,
 		};
 
-		it("compares epoch numbers", () => {
+		it("compares epoch numbers (granularity-matched, C2-2b)", () => {
+			// dueEpoch is a calendar date (UTC midnight); jan1±1000 are instants on
+			// the same/previous calendar day, so mixed compares work in day space:
+			// "before an instant later the same day" is false, not true.
 			expect(
 				evaluateRule(rule("dueEpoch", "before", staticRef(jan1 + 1000)), record, emptyScope)
-			).toBe(true);
+			).toBe(false);
 			expect(
 				evaluateRule(rule("dueEpoch", "after", staticRef(jan1 - 1000)), record, emptyScope)
+			).toBe(true);
+			// Same kind (both calendar dates) stays exact.
+			expect(
+				evaluateRule(
+					rule("dueEpoch", "before", staticRef(jan1 + 86_400_000)),
+					record,
+					emptyScope
+				)
 			).toBe(true);
 			expect(
 				evaluateRule(rule("dueEpoch", "before", staticRef(jan1)), record, emptyScope)
@@ -834,6 +845,78 @@ describe("evaluateRule", () => {
 			).toBe(false);
 			expect(
 				evaluateRule(rule("dueDate", "on", staticRef("junk")), record, nyScope)
+			).toBe(false);
+		});
+	});
+
+	describe("registry-aware date equality (C2-2b)", () => {
+		const nyScope: VariableScope = {
+			workflow: { now: Date.UTC(2026, 6, 4, 12, 0), tz: "America/New_York" },
+		};
+		const calJul4 = Date.UTC(2026, 6, 4);
+		const instantJul4Utc = Date.UTC(2026, 6, 4, 2, 0); // Jul 3 in New York
+		const invoice = { dueDate: calJul4, total: 0, notes: null };
+
+		it("equals on a date field compares calendar days for mixed kinds", () => {
+			// Same kind: exact.
+			expect(
+				evaluateRule(
+					rule("dueDate", "equals", staticRef(calJul4)),
+					invoice,
+					nyScope,
+					"invoice"
+				)
+			).toBe(true);
+			// Mixed kind: the instant is Jul 3 in the run tz, the date is Jul 4.
+			expect(
+				evaluateRule(
+					rule("dueDate", "equals", staticRef(instantJul4Utc)),
+					invoice,
+					nyScope,
+					"invoice"
+				)
+			).toBe(false);
+			expect(
+				evaluateRule(
+					rule("dueDate", "not_equals", staticRef(instantJul4Utc)),
+					invoice,
+					nyScope,
+					"invoice"
+				)
+			).toBe(true);
+		});
+
+		it("non-date fields never get day semantics", () => {
+			// 0 and one hour later are the same UTC day, but total is a number
+			// field — day-equality here would corrupt numeric comparisons.
+			expect(
+				evaluateRule(
+					rule("total", "equals", staticRef(3_600_000)),
+					invoice,
+					nyScope,
+					"invoice"
+				)
+			).toBe(false);
+		});
+
+		it("null on either side keeps loose semantics", () => {
+			expect(
+				evaluateRule(
+					rule("notes", "equals", staticRef(null)),
+					invoice,
+					nyScope,
+					"invoice"
+				)
+			).toBe(true);
+		});
+
+		it("without objectType equals stays exact (legacy callers)", () => {
+			expect(
+				evaluateRule(
+					rule("dueDate", "equals", staticRef(instantJul4Utc)),
+					invoice,
+					nyScope
+				)
 			).toBe(false);
 		});
 	});

--- a/packages/backend/convex/lib/conditionEval.test.ts
+++ b/packages/backend/convex/lib/conditionEval.test.ts
@@ -772,6 +772,72 @@ describe("evaluateRule", () => {
 		});
 	});
 
+	describe("on (same calendar day, C2-1)", () => {
+		const nyScope: VariableScope = {
+			workflow: { now: Date.UTC(2026, 6, 4, 12, 0), tz: "America/New_York" },
+		};
+		const utcScope: VariableScope = {
+			workflow: { now: Date.UTC(2026, 6, 4, 12, 0), tz: "UTC" },
+		};
+		// Calendar dates are UTC-midnight epochs; anything off-midnight is an instant.
+		const calJul4 = Date.UTC(2026, 6, 4);
+		const calJul3 = Date.UTC(2026, 6, 3);
+		const record = {
+			dueDate: calJul4,
+			// 02:00 UTC on Jul 4 — still Jul 3 in New York.
+			paidAt: Date.UTC(2026, 6, 4, 2, 0),
+			// A legacy local-midnight write from a New York browser: "Jul 18"
+			// stored as Jul 18 04:00 UTC. Not a calendar-date epoch, so it is
+			// read as an instant in the run tz — which lands on the right day.
+			legacyLocalMidnight: Date.UTC(2026, 6, 18, 4, 0),
+			bad: "not a date",
+		};
+
+		it("matches two calendar dates exactly", () => {
+			expect(
+				evaluateRule(rule("dueDate", "on", staticRef(calJul4)), record, nyScope)
+			).toBe(true);
+			expect(
+				evaluateRule(rule("dueDate", "on", staticRef(calJul3)), record, nyScope)
+			).toBe(false);
+		});
+
+		it("an instant matches the calendar day it falls on in the run tz", () => {
+			// 02:00 UTC Jul 4: "paid on Jul 4" in UTC, "paid on Jul 3" in New York.
+			expect(
+				evaluateRule(rule("paidAt", "on", staticRef(calJul4)), record, utcScope)
+			).toBe(true);
+			expect(
+				evaluateRule(rule("paidAt", "on", staticRef(calJul4)), record, nyScope)
+			).toBe(false);
+			expect(
+				evaluateRule(rule("paidAt", "on", staticRef(calJul3)), record, nyScope)
+			).toBe(true);
+		});
+
+		it("tolerates legacy local-midnight calendar writes in the org tz", () => {
+			expect(
+				evaluateRule(
+					rule("legacyLocalMidnight", "on", staticRef(Date.UTC(2026, 6, 18))),
+					record,
+					nyScope
+				)
+			).toBe(true);
+		});
+
+		it("defaults to UTC without a scope tz and rejects invalid dates", () => {
+			expect(
+				evaluateRule(rule("paidAt", "on", staticRef(calJul4)), record, emptyScope)
+			).toBe(true);
+			expect(
+				evaluateRule(rule("bad", "on", staticRef(calJul4)), record, nyScope)
+			).toBe(false);
+			expect(
+				evaluateRule(rule("dueDate", "on", staticRef("junk")), record, nyScope)
+			).toBe(false);
+		});
+	});
+
 	describe("var comparison values", () => {
 		it("compares a record field against a trigger event value", () => {
 			const scope: VariableScope = {

--- a/packages/backend/convex/lib/conditionEval.ts
+++ b/packages/backend/convex/lib/conditionEval.ts
@@ -6,6 +6,7 @@ import type {
 	ValueRef,
 } from "./workflowTypes";
 import {
+	calendarDayEpoch,
 	evaluateFormula,
 	isCalendarDateEpoch,
 	parseFormula,
@@ -378,6 +379,22 @@ function compareDates(
 	return cmp(a, b);
 }
 
+/**
+ * "on (day)": both values denote the same calendar day in the run tz.
+ * calendarDayEpoch reads calendar-date epochs as UTC parts and instants as
+ * zoned parts, so `dueDate on TODAY()` and `paidAt on <date>` both work.
+ */
+function onSameDay(
+	fieldValue: unknown,
+	compareValue: unknown,
+	tz: string
+): boolean {
+	const a = toEpochMs(fieldValue);
+	const b = toEpochMs(compareValue);
+	if (Number.isNaN(a) || Number.isNaN(b)) return false;
+	return calendarDayEpoch(a, tz) === calendarDayEpoch(b, tz);
+}
+
 /** Evaluate one rule against a record. */
 export function evaluateRule(
 	rule: ConditionRule,
@@ -423,6 +440,8 @@ export function evaluateRule(
 			return compareDates(fieldValue, compareValue, (a, b) => a < b);
 		case "after":
 			return compareDates(fieldValue, compareValue, (a, b) => a > b);
+		case "on":
+			return onSameDay(fieldValue, compareValue, scope.workflow?.tz ?? "UTC");
 		default: {
 			const _exhaustive: never = rule.operator;
 			return _exhaustive;

--- a/packages/backend/convex/lib/conditionEval.ts
+++ b/packages/backend/convex/lib/conditionEval.ts
@@ -1,10 +1,12 @@
 import type {
+	AutomationObjectType,
 	ConditionGroup,
 	ConditionRule,
 	FormulaResource,
 	FormulaReturnType,
 	ValueRef,
 } from "./workflowTypes";
+import { getFieldDefinition } from "./fieldRegistry";
 import {
 	calendarDayEpoch,
 	evaluateFormula,
@@ -33,7 +35,12 @@ export type VariableScope = {
 	};
 	loops?: Record<
 		string,
-		{ item: Record<string, unknown>; index: number; count?: number }
+		{
+			item: Record<string, unknown>;
+			index: number;
+			count?: number;
+			objectType?: AutomationObjectType;
+		}
 	>;
 	/** Per-node outputs: fetch → count; aggregate/adjust-time → result. */
 	nodes?: Record<string, { count?: number; result?: unknown }>;
@@ -368,17 +375,6 @@ function compareNumeric(
 	return cmp(a, b);
 }
 
-function compareDates(
-	fieldValue: unknown,
-	compareValue: unknown,
-	cmp: (a: number, b: number) => boolean
-): boolean {
-	const a = toEpochMs(fieldValue);
-	const b = toEpochMs(compareValue);
-	if (Number.isNaN(a) || Number.isNaN(b)) return false;
-	return cmp(a, b);
-}
-
 /**
  * "on (day)": both values denote the same calendar day in the run tz.
  * calendarDayEpoch reads calendar-date epochs as UTC parts and instants as
@@ -395,11 +391,36 @@ function onSameDay(
 	return calendarDayEpoch(a, tz) === calendarDayEpoch(b, tz);
 }
 
-/** Evaluate one rule against a record. */
+/**
+ * Granularity-matched comparison shared by before/after and date equality
+ * (mirrors formula compareValues/dateEquals): same kind (both calendar dates
+ * or both instants) compares exact epochs; mixed compares the calendar day
+ * each denotes in the run tz. Without this, `dueDate before NOW()` flips
+ * depending on the hour the run happens to fire.
+ */
+function zonedDateCmp(
+	fieldValue: unknown,
+	compareValue: unknown,
+	tz: string,
+	cmp: (a: number, b: number) => boolean
+): boolean {
+	const a = toEpochMs(fieldValue);
+	const b = toEpochMs(compareValue);
+	if (Number.isNaN(a) || Number.isNaN(b)) return false;
+	if (isCalendarDateEpoch(a) === isCalendarDateEpoch(b)) return cmp(a, b);
+	return cmp(calendarDayEpoch(a, tz), calendarDayEpoch(b, tz));
+}
+
+/**
+ * Evaluate one rule against a record. `objectType` (when the caller knows the
+ * record's type) makes equals/before/after registry-aware for date-typed
+ * fields; without it they keep the raw exact-value semantics.
+ */
 export function evaluateRule(
 	rule: ConditionRule,
 	record: Record<string, unknown>,
-	scope: VariableScope
+	scope: VariableScope,
+	objectType?: AutomationObjectType
 ): boolean {
 	// A rule with an explicit `left` compares a scope value (aggregate result,
 	// fetch count) and never touches the record — that is how a record-less run
@@ -411,10 +432,25 @@ export function evaluateRule(
 		? resolveValueRef(rule.value, scope)
 		: undefined;
 
+	const tz = scope.workflow?.tz ?? "UTC";
+	// Date-typed fields get zoned, granularity-matched semantics; a scope-left
+	// rule (rule.left) or unknown objectType falls back to raw comparison.
+	const fieldDateKind =
+		objectType && !rule.left
+			? getFieldDefinition(objectType, rule.field)?.type
+			: undefined;
+	const isDateField = fieldDateKind === "date" || fieldDateKind === "datetime";
+
 	switch (rule.operator) {
 		case "equals":
+			if (isDateField && fieldValue != null && compareValue != null) {
+				return zonedDateCmp(fieldValue, compareValue, tz, (a, b) => a === b);
+			}
 			return looseEquals(fieldValue, compareValue);
 		case "not_equals":
+			if (isDateField && fieldValue != null && compareValue != null) {
+				return !zonedDateCmp(fieldValue, compareValue, tz, (a, b) => a === b);
+			}
 			return !looseEquals(fieldValue, compareValue);
 		case "contains":
 			return contains(fieldValue, compareValue);
@@ -437,11 +473,11 @@ export function evaluateRule(
 		case "is_false":
 			return fieldValue === false;
 		case "before":
-			return compareDates(fieldValue, compareValue, (a, b) => a < b);
+			return zonedDateCmp(fieldValue, compareValue, tz, (a, b) => a < b);
 		case "after":
-			return compareDates(fieldValue, compareValue, (a, b) => a > b);
+			return zonedDateCmp(fieldValue, compareValue, tz, (a, b) => a > b);
 		case "on":
-			return onSameDay(fieldValue, compareValue, scope.workflow?.tz ?? "UTC");
+			return onSameDay(fieldValue, compareValue, tz);
 		default: {
 			const _exhaustive: never = rule.operator;
 			return _exhaustive;
@@ -453,12 +489,13 @@ export function evaluateRule(
 export function evaluateGroup(
 	group: ConditionGroup,
 	record: Record<string, unknown>,
-	scope: VariableScope
+	scope: VariableScope,
+	objectType?: AutomationObjectType
 ): boolean {
 	if (group.rules.length === 0) return true;
 	return group.logic === "and"
-		? group.rules.every((rule) => evaluateRule(rule, record, scope))
-		: group.rules.some((rule) => evaluateRule(rule, record, scope));
+		? group.rules.every((rule) => evaluateRule(rule, record, scope, objectType))
+		: group.rules.some((rule) => evaluateRule(rule, record, scope, objectType));
 }
 
 /** Evaluate groups combined with top-level logic; empty groups => true. */
@@ -466,10 +503,11 @@ export function evaluateConditionGroups(
 	logic: "and" | "or",
 	groups: ConditionGroup[],
 	record: Record<string, unknown>,
-	scope: VariableScope
+	scope: VariableScope,
+	objectType?: AutomationObjectType
 ): boolean {
 	if (groups.length === 0) return true;
 	return logic === "and"
-		? groups.every((group) => evaluateGroup(group, record, scope))
-		: groups.some((group) => evaluateGroup(group, record, scope));
+		? groups.every((group) => evaluateGroup(group, record, scope, objectType))
+		: groups.some((group) => evaluateGroup(group, record, scope, objectType));
 }

--- a/packages/backend/convex/lib/fieldRegistry.test.ts
+++ b/packages/backend/convex/lib/fieldRegistry.test.ts
@@ -254,6 +254,7 @@ describe("operatorsForField", () => {
 
 	it("returns date operators for date fields", () => {
 		expect(operatorsForField("task", "date")).toEqual([
+			"on",
 			"before",
 			"after",
 			"is_empty",
@@ -376,5 +377,49 @@ describe("line items are fetch+aggregate only (B7)", () => {
 		expect(isFetchOnlyObjectType("quote")).toBe(false);
 		expect(isFetchOnlyObjectType("invoice")).toBe(false);
 		expect(isFetchOnlyObjectType("task")).toBe(false);
+	});
+});
+
+describe("date/datetime split (C2-1)", () => {
+	const instants: [string, string][] = [
+		["client", "archivedAt"],
+		["project", "completedAt"],
+		["quote", "sentAt"],
+		["quote", "approvedAt"],
+		["quote", "declinedAt"],
+		["invoice", "paidAt"],
+		["task", "completedAt"],
+	];
+
+	it("classifies code-written timestamps as datetime", () => {
+		for (const [objectType, key] of instants) {
+			expect(
+				getFieldDefinition(objectType as never, key)?.type,
+				`${objectType}.${key}`
+			).toBe("datetime");
+		}
+	});
+
+	it("keeps calendar dates as date", () => {
+		for (const [objectType, key] of [
+			["project", "startDate"],
+			["project", "endDate"],
+			["quote", "validUntil"],
+			["invoice", "issuedDate"],
+			["invoice", "dueDate"],
+			["task", "date"],
+		] as [string, string][]) {
+			expect(
+				getFieldDefinition(objectType as never, key)?.type,
+				`${objectType}.${key}`
+			).toBe("date");
+		}
+	});
+
+	it("offers the on operator for both date kinds", () => {
+		expect(OPERATORS_BY_TYPE.date).toContain("on");
+		expect(OPERATORS_BY_TYPE.datetime).toContain("on");
+		expect(operatorsForField("invoice", "paidAt")).toContain("on");
+		expect(operatorsForField("invoice", "dueDate")).toContain("on");
 	});
 });

--- a/packages/backend/convex/lib/fieldRegistry.ts
+++ b/packages/backend/convex/lib/fieldRegistry.ts
@@ -24,6 +24,7 @@ export type FieldType =
 	| "number"
 	| "boolean"
 	| "date"
+	| "datetime"
 	| "select"
 	| "currency"
 	| "id";
@@ -121,7 +122,7 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 		{
 			key: "archivedAt",
 			label: "Archived At",
-			type: "date",
+			type: "datetime",
 			writable: false,
 			writeExclusionReason: "Set by archive/unarchive code alongside status",
 			filterable: true,
@@ -167,7 +168,7 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 		{
 			key: "completedAt",
 			label: "Completed At",
-			type: "date",
+			type: "datetime",
 			writable: false,
 			writeExclusionReason: "Set automatically when status changes to completed",
 			filterable: true,
@@ -265,7 +266,7 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 		{
 			key: "sentAt",
 			label: "Sent At",
-			type: "date",
+			type: "datetime",
 			writable: false,
 			writeExclusionReason: "Timestamp set by code when the quote is sent",
 			filterable: true,
@@ -273,7 +274,7 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 		{
 			key: "approvedAt",
 			label: "Approved At",
-			type: "date",
+			type: "datetime",
 			writable: false,
 			writeExclusionReason: "Timestamp set by code on client approval",
 			filterable: true,
@@ -281,7 +282,7 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 		{
 			key: "declinedAt",
 			label: "Declined At",
-			type: "date",
+			type: "datetime",
 			writable: false,
 			writeExclusionReason: "Timestamp set by code on client decline",
 			filterable: true,
@@ -366,7 +367,7 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 		{
 			key: "paidAt",
 			label: "Paid At",
-			type: "date",
+			type: "datetime",
 			writable: false,
 			writeExclusionReason: "Set by code when payment is recorded",
 			filterable: true,
@@ -559,7 +560,7 @@ export const FIELD_REGISTRY: Record<AutomationObjectType, FieldDefinition[]> = {
 		{
 			key: "completedAt",
 			label: "Completed At",
-			type: "date",
+			type: "datetime",
 			writable: false,
 			writeExclusionReason: "Set automatically when status changes to completed",
 			filterable: true,
@@ -635,7 +636,8 @@ export const OPERATORS_BY_TYPE: Record<FieldType, ConditionOperator[]> = {
 		"is_not_empty",
 	],
 	boolean: ["is_true", "is_false"],
-	date: ["before", "after", "is_empty", "is_not_empty"],
+	date: ["on", "before", "after", "is_empty", "is_not_empty"],
+	datetime: ["on", "before", "after", "is_empty", "is_not_empty"],
 	select: ["equals", "not_equals", "is_empty", "is_not_empty"],
 	id: ["equals", "not_equals", "is_empty", "is_not_empty"],
 };

--- a/packages/backend/convex/lib/formula/formula.test.ts
+++ b/packages/backend/convex/lib/formula/formula.test.ts
@@ -526,6 +526,225 @@ describe("calendar dates vs instants", () => {
 	});
 });
 
+/* ---------------------- C2-4 date functions (PRD) -------------------------- */
+
+describe("HOUR / MINUTE / WEEKDAY", () => {
+	it("reads an instant's time in ctx.tz", () => {
+		const t = Date.UTC(2026, 6, 4, 15, 30, 0);
+		expect(run("HOUR({t})", { t }, { tz: "UTC" })).toBe(15);
+		expect(run("MINUTE({t})", { t }, { tz: "UTC" })).toBe(30);
+		// 2026-07-04T02:15Z is 2026-07-03 22:15 in New York (UTC-4 DST).
+		const nearBoundary = Date.UTC(2026, 6, 4, 2, 15, 0);
+		expect(run("HOUR({t})", { t: nearBoundary }, { tz: "America/New_York" })).toBe(22);
+		expect(run("MINUTE({t})", { t: nearBoundary }, { tz: "America/New_York" })).toBe(15);
+	});
+
+	it("returns 0 for a calendar date (it has no time), in any tz", () => {
+		expect(run("HOUR(DATE(2026,7,4))", {}, { tz: "America/New_York" })).toBe(0);
+		expect(run("MINUTE(DATE(2026,7,4))", {}, { tz: "America/New_York" })).toBe(0);
+	});
+
+	it("WEEKDAY is 0-6 with 0 = Sunday, on the day the value denotes", () => {
+		expect(run("WEEKDAY(DATE(2026,7,4))")).toBe(6); // Saturday
+		expect(run("WEEKDAY(DATE(2026,7,5))")).toBe(0); // Sunday
+		expect(run("WEEKDAY(DATE(2026,7,6))")).toBe(1); // Monday
+		// 2026-07-05T02:00Z is still Sat Jul 4 in New York, but Sun Jul 5 in UTC.
+		const lateJul4NY = Date.UTC(2026, 6, 5, 2, 0, 0);
+		expect(run("WEEKDAY({t})", { t: lateJul4NY }, { tz: "America/New_York" })).toBe(6);
+		expect(run("WEEKDAY({t})", { t: lateJul4NY }, { tz: "UTC" })).toBe(0);
+	});
+});
+
+describe("FORMAT_DATE", () => {
+	it("formats numeric and padded tokens", () => {
+		expect(run('FORMAT_DATE(DATE(2026,7,4), "YYYY-MM-DD")')).toBe("2026-07-04");
+		expect(run('FORMAT_DATE(DATE(2026,7,4), "M/D/YYYY")')).toBe("7/4/2026");
+	});
+
+	it("formats month and weekday names (longest token wins)", () => {
+		expect(run('FORMAT_DATE(DATE(2026,7,4), "dddd, MMMM D, YYYY")')).toBe(
+			"Saturday, July 4, 2026"
+		);
+		expect(run('FORMAT_DATE(DATE(2026,7,4), "ddd MMM D")')).toBe("Sat Jul 4");
+	});
+
+	it("formats 24-hour, 12-hour and AM/PM from an instant in ctx.tz", () => {
+		const t = Date.UTC(2026, 6, 4, 15, 30, 0);
+		expect(run('FORMAT_DATE({t}, "HH:mm")', { t }, { tz: "UTC" })).toBe("15:30");
+		expect(run('FORMAT_DATE({t}, "h:mm A")', { t }, { tz: "UTC" })).toBe("3:30 PM");
+		// Same instant is 11:30 AM in New York.
+		expect(run('FORMAT_DATE({t}, "h:mm A")', { t }, { tz: "America/New_York" })).toBe(
+			"11:30 AM"
+		);
+		// 12-hour edge cases: midnight and noon are both 12.
+		const midnight = Date.UTC(2026, 6, 4, 0, 30, 0);
+		const noon = Date.UTC(2026, 6, 4, 12, 0, 0);
+		expect(run('FORMAT_DATE({t}, "h A")', { t: midnight }, { tz: "UTC" })).toBe("12 AM");
+		expect(run('FORMAT_DATE({t}, "h A")', { t: noon }, { tz: "UTC" })).toBe("12 PM");
+	});
+
+	it("renders the calendar day the value denotes (calendar UTC, instant in tz)", () => {
+		// 2026-07-04T02:00Z is Jul 3 in New York — an instant formats as Jul 3 there...
+		const t = Date.UTC(2026, 6, 4, 2, 0, 0);
+		expect(run('FORMAT_DATE({t}, "YYYY-MM-DD")', { t }, { tz: "America/New_York" })).toBe(
+			"2026-07-03"
+		);
+		// ...but a calendar DATE stays Jul 4 in every run timezone.
+		expect(
+			run('FORMAT_DATE(DATE(2026,7,4), "YYYY-MM-DD")', {}, { tz: "America/New_York" })
+		).toBe("2026-07-04");
+	});
+
+	it("rejects a non-string pattern (TYPE)", () => {
+		expect(code(() => run("FORMAT_DATE(DATE(2026,7,4), 5)"))).toBe("TYPE");
+	});
+});
+
+describe("START_OF", () => {
+	const DAY = 86_400_000;
+
+	it("day: snaps an instant to the calendar date of its day", () => {
+		const t = Date.UTC(2026, 6, 4, 15, 30, 0);
+		const d = run('START_OF({t}, "day")', { t }, { tz: "UTC" }) as Date;
+		expect(d.toISOString()).toBe("2026-07-04T00:00:00.000Z");
+		expect(d.getTime() % DAY).toBe(0); // stays a calendar date
+	});
+
+	it("week: goes back to Sunday (documented week start)", () => {
+		// Sat Jul 4 → Sun Jun 28; Sun Jul 5 is already a week start.
+		expect((run('START_OF(DATE(2026,7,4), "week")') as Date).toISOString()).toBe(
+			"2026-06-28T00:00:00.000Z"
+		);
+		expect((run('START_OF(DATE(2026,7,5), "week")') as Date).toISOString()).toBe(
+			"2026-07-05T00:00:00.000Z"
+		);
+	});
+
+	it("month: first of the month, resolved on the day the value denotes", () => {
+		expect((run('START_OF(DATE(2026,7,31), "month")') as Date).toISOString()).toBe(
+			"2026-07-01T00:00:00.000Z"
+		);
+		// 2026-07-01T02:00Z is still Jun 30 in New York → start of JUNE there.
+		const t = Date.UTC(2026, 6, 1, 2, 0, 0);
+		expect(
+			(run('START_OF({t}, "month")', { t }, { tz: "America/New_York" }) as Date).toISOString()
+		).toBe("2026-06-01T00:00:00.000Z");
+	});
+
+	it("unit is case-insensitive; unknown unit throws TYPE", () => {
+		expect((run('START_OF(DATE(2026,7,4), "WEEK")') as Date).toISOString()).toBe(
+			"2026-06-28T00:00:00.000Z"
+		);
+		expect(code(() => run('START_OF(DATE(2026,7,4), "year")'))).toBe("TYPE");
+		expect(code(() => run("START_OF(DATE(2026,7,4), 1)"))).toBe("TYPE");
+	});
+});
+
+describe("WORKDAY_ADD / WORKDAY_DIFF", () => {
+	const DAY = 86_400_000;
+
+	it("WORKDAY_ADD skips weekends in both directions", () => {
+		// Fri Jul 3 + 1 working day → Mon Jul 6.
+		expect((run("WORKDAY_ADD(DATE(2026,7,3), 1)") as Date).toISOString()).toBe(
+			"2026-07-06T00:00:00.000Z"
+		);
+		// Mon Jul 6 + 5 → next Mon Jul 13; Mon Jul 6 - 1 → Fri Jul 3.
+		expect((run("WORKDAY_ADD(DATE(2026,7,6), 5)") as Date).toISOString()).toBe(
+			"2026-07-13T00:00:00.000Z"
+		);
+		expect((run("WORKDAY_ADD(DATE(2026,7,6), -1)") as Date).toISOString()).toBe(
+			"2026-07-03T00:00:00.000Z"
+		);
+		// From a Saturday, +1 lands on Monday and -1 on Friday.
+		expect((run("WORKDAY_ADD(DATE(2026,7,4), 1)") as Date).toISOString()).toBe(
+			"2026-07-06T00:00:00.000Z"
+		);
+		expect((run("WORKDAY_ADD(DATE(2026,7,4), -1)") as Date).toISOString()).toBe(
+			"2026-07-03T00:00:00.000Z"
+		);
+	});
+
+	it("WORKDAY_ADD with n = 0 returns the same calendar day (even a weekend)", () => {
+		expect((run("WORKDAY_ADD(DATE(2026,7,4), 0)") as Date).toISOString()).toBe(
+			"2026-07-04T00:00:00.000Z"
+		);
+	});
+
+	it("WORKDAY_ADD operates on the day an instant denotes and returns a calendar date", () => {
+		// 2026-07-04T02:00Z is Fri Jul 3 in New York → +1 working day = Mon Jul 6.
+		const t = Date.UTC(2026, 6, 4, 2, 0, 0);
+		const d = run("WORKDAY_ADD({t}, 1)", { t }, { tz: "America/New_York" }) as Date;
+		expect(d.toISOString()).toBe("2026-07-06T00:00:00.000Z");
+		expect(d.getTime() % DAY).toBe(0);
+	});
+
+	it("WORKDAY_ADD guards an out-of-range result (TYPE, not a hang or RangeError)", () => {
+		expect(code(() => run("WORKDAY_ADD(DATE(2026,7,4), 100000000000000)"))).toBe("TYPE");
+	});
+
+	it("WORKDAY_DIFF counts both endpoints (Airtable semantics)", () => {
+		// Mon Jul 6 .. Fri Jul 10 → 5; Fri Jul 3 .. Mon Jul 6 → 2 (Fri + Mon).
+		expect(run("WORKDAY_DIFF(DATE(2026,7,6), DATE(2026,7,10))")).toBe(5);
+		expect(run("WORKDAY_DIFF(DATE(2026,7,3), DATE(2026,7,6))")).toBe(2);
+		// Fri Jul 3 .. Tue Jul 7 spans a weekend → Fri, Mon, Tue = 3.
+		expect(run("WORKDAY_DIFF(DATE(2026,7,3), DATE(2026,7,7))")).toBe(3);
+		// Same weekday → 1; same Saturday → 0.
+		expect(run("WORKDAY_DIFF(DATE(2026,7,6), DATE(2026,7,6))")).toBe(1);
+		expect(run("WORKDAY_DIFF(DATE(2026,7,4), DATE(2026,7,4))")).toBe(0);
+	});
+
+	it("WORKDAY_DIFF is negated when b is before a", () => {
+		expect(run("WORKDAY_DIFF(DATE(2026,7,10), DATE(2026,7,6))")).toBe(-5);
+	});
+
+	it("WORKDAY_DIFF reads an instant on the day it denotes in ctx.tz", () => {
+		// paidAt mid-Monday (instant) to Fri Jul 10 (calendar) → 5.
+		const paidAt = Date.UTC(2026, 6, 6, 15, 0, 0);
+		expect(
+			run("WORKDAY_DIFF({paidAt}, DATE(2026,7,10))", { paidAt }, { tz: "UTC" })
+		).toBe(5);
+	});
+});
+
+describe("IS_BEFORE / IS_AFTER", () => {
+	it("compares two calendar dates exactly", () => {
+		expect(run("IS_BEFORE(DATE(2026,7,1), DATE(2026,7,4))")).toBe(true);
+		expect(run("IS_BEFORE(DATE(2026,7,4), DATE(2026,7,1))")).toBe(false);
+		expect(run("IS_AFTER(DATE(2026,7,4), DATE(2026,7,1))")).toBe(true);
+		expect(run("IS_AFTER(DATE(2026,7,1), DATE(2026,7,4))")).toBe(false);
+	});
+
+	it("compares two instants at exact-instant granularity", () => {
+		const a = Date.UTC(2026, 6, 4, 9, 0, 0);
+		const b = Date.UTC(2026, 6, 4, 15, 0, 0);
+		expect(run("IS_BEFORE({a}, {b})", { a, b })).toBe(true);
+		expect(run("IS_AFTER({b}, {a})", { a, b })).toBe(true);
+	});
+
+	it("mixed kind compares by calendar day in ctx.tz (matches ==/< semantics)", () => {
+		// An instant during Jul 4 vs TODAY() (Jul 4): same day, so neither before nor after.
+		const midJul4 = Date.UTC(2026, 6, 4, 15, 30, 0);
+		const opts = { now: midJul4, tz: "UTC" };
+		expect(run("IS_BEFORE({paidAt}, TODAY())", { paidAt: midJul4 }, opts)).toBe(false);
+		expect(run("IS_AFTER({paidAt}, TODAY())", { paidAt: midJul4 }, opts)).toBe(false);
+		// 2026-07-04T02:00Z denotes Jul 3 in New York → before the Jul 4 calendar date.
+		const t = Date.UTC(2026, 6, 4, 2, 0, 0);
+		expect(
+			run("IS_BEFORE({t}, DATE(2026,7,4))", { t }, { tz: "America/New_York" })
+		).toBe(true);
+		expect(run("IS_BEFORE({t}, DATE(2026,7,4))", { t }, { tz: "UTC" })).toBe(false);
+	});
+
+	it("coerces epoch numbers and ISO strings; non-dates throw TYPE", () => {
+		expect(
+			run("IS_BEFORE({d}, DATE(2026,7,4))", { d: Date.UTC(2026, 6, 1) })
+		).toBe(true);
+		expect(run('IS_AFTER("2026-07-05T00:00:00Z", DATE(2026,7,4))')).toBe(true);
+		expect(code(() => run("IS_BEFORE(true, DATE(2026,7,4))"))).toBe("TYPE");
+		expect(code(() => run('IS_BEFORE("not-a-date", DATE(2026,7,4))'))).toBe("TYPE");
+	});
+});
+
 /* ------------------------ date range / invalid dates ---------------------- */
 
 describe("date range and invalid-date guards", () => {

--- a/packages/backend/convex/lib/formula/functions.ts
+++ b/packages/backend/convex/lib/formula/functions.ts
@@ -64,6 +64,51 @@ function guardEpoch(ms: number, label: string): number {
 	return ms;
 }
 
+const DAY_MS = 86_400_000;
+
+const MONTH_NAMES = [
+	"January", "February", "March", "April", "May", "June",
+	"July", "August", "September", "October", "November", "December",
+];
+const WEEKDAY_NAMES = [
+	"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
+];
+
+/** 0-6 (0 = Sunday) for a UTC-midnight calendar-day epoch. */
+function dayOfWeek(dayEpoch: number): number {
+	return new Date(dayEpoch).getUTCDay();
+}
+
+function isWeekendDay(dayEpoch: number): boolean {
+	const dow = dayOfWeek(dayEpoch);
+	return dow === 0 || dow === 6;
+}
+
+/** Working days from startDay to endDay inclusive (UTC-midnight epochs, start <= end). O(1) in the span. */
+function countWorkdaysInclusive(startDay: number, endDay: number): number {
+	const totalDays = Math.round((endDay - startDay) / DAY_MS) + 1;
+	const fullWeeks = Math.floor(totalDays / 7);
+	let count = fullWeeks * 5;
+	const startDow = dayOfWeek(startDay);
+	for (let i = fullWeeks * 7; i < totalDays; i++) {
+		const dow = (startDow + i) % 7;
+		if (dow !== 0 && dow !== 6) count++;
+	}
+	return count;
+}
+
+/**
+ * Signed ordering delta matching the engine's compareValues rule for dates:
+ * same kind (both calendar dates or both instants) compares exact epochs,
+ * mixed compares the calendar day each side denotes in the run timezone.
+ */
+function dateOrderDelta(a: Val, b: Val, tz: string, label: string): number {
+	const da = toDate(a, `${label}(a)`).getTime();
+	const db = toDate(b, `${label}(b)`).getTime();
+	if (isCalendarDateEpoch(da) === isCalendarDateEpoch(db)) return da - db;
+	return calendarDayEpoch(da, tz) - calendarDayEpoch(db, tz);
+}
+
 const SPECS: FunctionSpec[] = [
 	/* ------------------------------- number -------------------------------- */
 	{
@@ -550,6 +595,217 @@ const SPECS: FunctionSpec[] = [
 			signature: "DAY(date)",
 			description: "Day of the month in the workflow timezone.",
 			example: "DAY(DATE(2026,7,4)) → 4",
+		},
+	},
+	{
+		name: "HOUR",
+		category: "date",
+		minArgs: 1,
+		maxArgs: 1,
+		// partsFor reads a calendar date in UTC (hour 0) and an instant in ctx.tz.
+		fn: (args, ctx) => partsFor(toDate(args[0], "HOUR(date)").getTime(), ctx.tz).hour,
+		doc: {
+			name: "HOUR",
+			category: "date",
+			signature: "HOUR(date)",
+			description: "Hour of day (0-23) in the workflow timezone. 0 for a plain date (it has no time).",
+			example: "HOUR(NOW()) → 14",
+		},
+	},
+	{
+		name: "MINUTE",
+		category: "date",
+		minArgs: 1,
+		maxArgs: 1,
+		fn: (args, ctx) => partsFor(toDate(args[0], "MINUTE(date)").getTime(), ctx.tz).minute,
+		doc: {
+			name: "MINUTE",
+			category: "date",
+			signature: "MINUTE(date)",
+			description: "Minute of the hour (0-59) in the workflow timezone. 0 for a plain date (it has no time).",
+			example: "MINUTE(NOW()) → 30",
+		},
+	},
+	{
+		name: "WEEKDAY",
+		category: "date",
+		minArgs: 1,
+		maxArgs: 1,
+		fn: (args, ctx) =>
+			dayOfWeek(calendarDayEpoch(toDate(args[0], "WEEKDAY(date)").getTime(), ctx.tz)),
+		doc: {
+			name: "WEEKDAY",
+			category: "date",
+			signature: "WEEKDAY(date)",
+			description: "Day of the week as a number 0-6, where 0 is Sunday (Airtable convention).",
+			example: "WEEKDAY(DATE(2026,7,4)) → 6",
+		},
+	},
+	{
+		name: "FORMAT_DATE",
+		category: "date",
+		minArgs: 2,
+		maxArgs: 2,
+		fn: (args, ctx) => {
+			const ms = toDate(args[0], "FORMAT_DATE(date)").getTime();
+			const pattern = requireString(args[1], "FORMAT_DATE(pattern)");
+			const p = partsFor(ms, ctx.tz);
+			const weekday = dayOfWeek(calendarDayEpoch(ms, ctx.tz));
+			const pad = (n: number) => String(n).padStart(2, "0");
+			// Alternation is ordered longest-first so MMMM never reads as MM + MM.
+			const out = pattern.replace(
+				/YYYY|MMMM|MMM|MM|M|dddd|ddd|DD|D|HH|mm|h|A/g,
+				(tok) => {
+					switch (tok) {
+						case "YYYY": return String(p.year);
+						case "MMMM": return MONTH_NAMES[p.month - 1];
+						case "MMM": return MONTH_NAMES[p.month - 1].slice(0, 3);
+						case "MM": return pad(p.month);
+						case "M": return String(p.month);
+						case "dddd": return WEEKDAY_NAMES[weekday];
+						case "ddd": return WEEKDAY_NAMES[weekday].slice(0, 3);
+						case "DD": return pad(p.day);
+						case "D": return String(p.day);
+						case "HH": return pad(p.hour);
+						case "mm": return pad(p.minute);
+						case "h": return String(p.hour % 12 === 0 ? 12 : p.hour % 12);
+						case "A": return p.hour < 12 ? "AM" : "PM";
+						default: return tok;
+					}
+				}
+			);
+			return guardStr(out);
+		},
+		doc: {
+			name: "FORMAT_DATE",
+			category: "date",
+			signature: "FORMAT_DATE(date, pattern)",
+			description:
+				"Format a date as text (English). Tokens: YYYY, MMMM, MMM, MM, M, DD, D, dddd, ddd, HH, mm, h (12-hour), A (AM/PM). Times read in the workflow timezone.",
+			example: "FORMAT_DATE(DATE(2026,7,4), \"MMMM D, YYYY\") → \"July 4, 2026\"",
+		},
+	},
+	{
+		name: "START_OF",
+		category: "date",
+		minArgs: 2,
+		maxArgs: 2,
+		fn: (args, ctx) => {
+			const date = toDate(args[0], "START_OF(date)");
+			const unit = requireString(args[1], "START_OF(unit)").trim().toLowerCase();
+			// Resolve on the calendar day the value denotes, then snap in UTC day-space
+			// so the result is a calendar DATE (UTC-midnight encoded).
+			const dayMs = calendarDayEpoch(date.getTime(), ctx.tz);
+			if (unit === "day") {
+				return new Date(guardEpoch(dayMs, "START_OF result"));
+			}
+			if (unit === "week") {
+				return new Date(guardEpoch(dayMs - dayOfWeek(dayMs) * DAY_MS, "START_OF result"));
+			}
+			if (unit === "month") {
+				const d = new Date(dayMs);
+				return new Date(
+					guardEpoch(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1), "START_OF result")
+				);
+			}
+			throw new FormulaError(
+				"TYPE",
+				`START_OF unit must be "day", "week", or "month", got "${unit}"`
+			);
+		},
+		doc: {
+			name: "START_OF",
+			category: "date",
+			signature: "START_OF(date, unit)",
+			description:
+				"The date at the start of the period containing the given day. Unit is \"day\", \"week\", or \"month\"; weeks start on Sunday.",
+			example: "START_OF(DATE(2026,7,4), \"month\") → 2026-07-01",
+		},
+	},
+	{
+		name: "WORKDAY_ADD",
+		category: "date",
+		minArgs: 2,
+		maxArgs: 2,
+		fn: (args, ctx) => {
+			const date = toDate(args[0], "WORKDAY_ADD(date)");
+			const n = toInt(args[1], "WORKDAY_ADD(n)");
+			let ms = calendarDayEpoch(date.getTime(), ctx.tz);
+			if (n !== 0) {
+				const step = n > 0 ? 1 : -1;
+				const total = Math.abs(n);
+				// Jump whole weeks (dow-preserving, exactly 5 workdays each), then walk
+				// the last 1-5 working days — O(1) in n, and correct from a weekend start.
+				const fullWeeks = Math.floor((total - 1) / 5);
+				let rem = total - fullWeeks * 5;
+				ms = guardEpoch(ms + step * fullWeeks * 7 * DAY_MS, "WORKDAY_ADD result");
+				while (rem > 0) {
+					ms += step * DAY_MS;
+					if (!isWeekendDay(ms)) rem--;
+				}
+			}
+			return new Date(guardEpoch(ms, "WORKDAY_ADD result"));
+		},
+		doc: {
+			name: "WORKDAY_ADD",
+			category: "date",
+			signature: "WORKDAY_ADD(date, n)",
+			description:
+				"Shift a date by n working days, skipping Saturdays and Sundays (no holiday support). n may be negative; n = 0 returns the same calendar day.",
+			example: "WORKDAY_ADD(DATE(2026,7,3), 1) → 2026-07-06",
+		},
+	},
+	{
+		name: "WORKDAY_DIFF",
+		category: "date",
+		minArgs: 2,
+		maxArgs: 2,
+		fn: (args, ctx) => {
+			const a = toDate(args[0], "WORKDAY_DIFF(a)");
+			const b = toDate(args[1], "WORKDAY_DIFF(b)");
+			const dayA = calendarDayEpoch(a.getTime(), ctx.tz);
+			const dayB = calendarDayEpoch(b.getTime(), ctx.tz);
+			return dayB >= dayA
+				? countWorkdaysInclusive(dayA, dayB)
+				: -countWorkdaysInclusive(dayB, dayA);
+		},
+		doc: {
+			name: "WORKDAY_DIFF",
+			category: "date",
+			signature: "WORKDAY_DIFF(a, b)",
+			description:
+				"Working days (Mon-Fri) from a to b, counting BOTH endpoints (Airtable semantics): Monday to Friday of one week → 5. Negative when b is before a; 0 only when both fall on the same weekend day.",
+			example: "WORKDAY_DIFF(DATE(2026,7,6), DATE(2026,7,10)) → 5",
+		},
+	},
+	{
+		name: "IS_BEFORE",
+		category: "date",
+		minArgs: 2,
+		maxArgs: 2,
+		fn: (args, ctx) => dateOrderDelta(args[0], args[1], ctx.tz, "IS_BEFORE") < 0,
+		doc: {
+			name: "IS_BEFORE",
+			category: "date",
+			signature: "IS_BEFORE(a, b)",
+			description:
+				"True if a is before b. Two plain dates (or two timestamps) compare exactly; a date against a timestamp compares by calendar day in the workflow timezone.",
+			example: "IS_BEFORE({dueDate}, TODAY()) → true when overdue",
+		},
+	},
+	{
+		name: "IS_AFTER",
+		category: "date",
+		minArgs: 2,
+		maxArgs: 2,
+		fn: (args, ctx) => dateOrderDelta(args[0], args[1], ctx.tz, "IS_AFTER") > 0,
+		doc: {
+			name: "IS_AFTER",
+			category: "date",
+			signature: "IS_AFTER(a, b)",
+			description:
+				"True if a is after b. Two plain dates (or two timestamps) compare exactly; a date against a timestamp compares by calendar day in the workflow timezone.",
+			example: "IS_AFTER(TODAY(), {dueDate}) → true when overdue",
 		},
 	},
 ];

--- a/packages/backend/convex/lib/formula/index.ts
+++ b/packages/backend/convex/lib/formula/index.ts
@@ -25,4 +25,10 @@ export type { FormulaFnDoc } from "./functions";
 
 // Calendar-date vs instant classification. Callers that read or write date
 // fields need it to stay in the same day-space the formula layer uses.
-export { calendarDayEpoch, isCalendarDateEpoch, toEpochMs } from "./coerce";
+export {
+	calendarDayEpoch,
+	isCalendarDateEpoch,
+	toEpochMs,
+	getZonedParts,
+	zonedPartsToEpoch,
+} from "./coerce";

--- a/packages/backend/convex/lib/workflowTypes.ts
+++ b/packages/backend/convex/lib/workflowTypes.ts
@@ -150,6 +150,7 @@ export const CONDITION_OPERATORS = [
 	"is_false",
 	"before",
 	"after",
+	"on",
 ] as const;
 
 export type ConditionOperator = (typeof CONDITION_OPERATORS)[number];
@@ -168,7 +169,8 @@ export const conditionOperatorValidator = v.union(
 	v.literal("is_true"),
 	v.literal("is_false"),
 	v.literal("before"),
-	v.literal("after")
+	v.literal("after"),
+	v.literal("on")
 );
 
 /** Operators that do not take a comparison value. */

--- a/packages/backend/convex/portal/auth-provider.test.ts
+++ b/packages/backend/convex/portal/auth-provider.test.ts
@@ -11,9 +11,12 @@ describe("portal auth provider", () => {
 		const path = resolve(__dirname, "../auth.config.ts");
 		const src = readFileSync(path, "utf-8");
 
-		// Both provider applicationIDs must be present.
+		// The Clerk provider is declared literally; the portal providers are
+		// generated from the shared audience list (PR #258: single source of
+		// truth in portal/audiences.ts).
 		expect(src).toContain('applicationID: "convex"');
-		expect(src).toContain('applicationID: "convex-portal"');
+		expect(src).toContain("PORTAL_JWT_AUDIENCES.map");
+		expect(src).toContain("applicationID: audience");
 
 		// The portal provider issuer must read from the server-only env var.
 		expect(src).toContain("process.env.PORTAL_JWT_ISSUER");

--- a/packages/backend/convex/portal/helpers.test.ts
+++ b/packages/backend/convex/portal/helpers.test.ts
@@ -55,11 +55,17 @@ describe("portal helpers jti-validation", () => {
 	});
 
 	it("getPortalSessionOrThrow accepts both convex-portal and convex-portal-access audiences (Review fix #4)", () => {
-		const path = resolve(__dirname, "./helpers.ts");
-		const src = readFileSync(path, "utf-8");
-		expect(src).toContain('"convex-portal"');
-		expect(src).toContain('"convex-portal-access"');
+		const src = readFileSync(resolve(__dirname, "./helpers.ts"), "utf-8");
+		// helpers.ts derives its accepted set from the shared audience list
+		// (PR #258); the literals live in portal/audiences.ts.
+		expect(src).toContain("PORTAL_JWT_AUDIENCES");
 		expect(src).toContain("ACCEPTED_AUDIENCES");
 		expect(src).toContain("sessionJti");
+		const audiences = readFileSync(
+			resolve(__dirname, "./audiences.ts"),
+			"utf-8"
+		);
+		expect(audiences).toContain('"convex-portal"');
+		expect(audiences).toContain('"convex-portal-access"');
 	});
 });

--- a/packages/backend/convex/quotes.ts
+++ b/packages/backend/convex/quotes.ts
@@ -1,3 +1,4 @@
+import { calendarDayEpoch } from "./lib/formula";
 import { query, mutation, QueryCtx, MutationCtx } from "./_generated/server";
 import { ConvexError, v } from "convex/values";
 import { Doc, Id } from "./_generated/dataModel";
@@ -612,9 +613,14 @@ export const create = userMutation({
 			throw new Error("Tax rate cannot be negative");
 		}
 
-		// Validate expiration date
-		if (args.validUntil && args.validUntil <= Date.now()) {
-			throw new Error("Valid until date must be in the future");
+		// validUntil is a calendar date (UTC-midnight epoch): the quote is valid
+		// through that day. Compare day-to-day in the org tz — an exact-instant
+		// check rejects "tomorrow" picked in the evening west of UTC.
+		if (args.validUntil) {
+			const tz = (await ctx.db.get(ctx.orgId))?.timezone ?? "UTC";
+			if (args.validUntil < calendarDayEpoch(Date.now(), tz)) {
+				throw new Error("Valid until date cannot be in the past");
+			}
 		}
 
 		// Type assertion needed because schema still has deprecated publicToken field
@@ -723,9 +729,12 @@ export const update = userMutation({
 			throw new Error("Tax rate cannot be negative");
 		}
 
-		// Validate expiration date
-		if (updates.validUntil && updates.validUntil <= Date.now()) {
-			throw new Error("Valid until date must be in the future");
+		// Same calendar-day semantics as create (see comment there).
+		if (updates.validUntil) {
+			const tz = (await ctx.db.get(ctx.orgId))?.timezone ?? "UTC";
+			if (updates.validUntil < calendarDayEpoch(Date.now(), tz)) {
+				throw new Error("Valid until date cannot be in the past");
+			}
 		}
 
 		// Validate countersignature settings


### PR DESCRIPTION
This pull request introduces improvements to how timezones and date/datetime fields are handled throughout the automations and invoices UI. The most significant changes ensure that calendar dates are consistently stored and displayed in UTC-midnight format, datetime fields are handled with higher fidelity, and automation timezones now respect organization settings. Additionally, several UI and validation enhancements were made for better clarity and correctness.

**Timezone and Date Handling Improvements:**

* Automation runtime timezone logic now uses the organization's timezone for non-scheduled automations, falling back to UTC if not set, ensuring consistency between backend and frontend evaluations (`runtimeTimezone` in `formula-editor-modal.tsx`). [[1]](diffhunk://#diff-d7bbb6dbc6a767dc9d487a12bdcf2da9877e299d3681af8f12756f5c525525f1L111-R118) [[2]](diffhunk://#diff-d7bbb6dbc6a767dc9d487a12bdcf2da9877e299d3681af8f12756f5c525525f1R218-R226)
* Calendar date fields in invoices are now consistently stored as UTC-midnight and rendered in local time for display, preventing day-shifting issues across timezones (`InvoiceDetailSidebar`, `InvoicePDF`, and `InvoiceDetailDrawer`). ([apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-sidebar.tsxR47-R50](diffhunk://#diff-49464ded74ffc6f3ccf29a87aa07eb111e5ebb6d844f60addb94e28b02620c0fR47-R50), [apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-sidebar.tsxR63-R68](diffhunk://#diff-49464ded74ffc6f3ccf29a87aa07eb111e5ebb6d844f60addb94e28b02620c0fR63-R68), [apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-sidebar.tsxL146-R156](diffhunk://#diff-49464ded74ffc6f3ccf29a87aa07eb111e5ebb6d844f60addb94e28b02620c0fL146-R156), [apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-sidebar.tsxL310-R320](diffhunk://#diff-49464ded74ffc6f3ccf29a87aa07eb111e5ebb6d844f60addb94e28b02620c0fL310-R320), [apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-sidebar.tsxL327-R337](diffhunk://#diff-49464ded74ffc6f3ccf29a87aa07eb111e5ebb6d844f60addb94e28b02620c0fL327-R337), [apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-sidebar.tsxL360-R370](diffhunk://#diff-49464ded74ffc6f3ccf29a87aa07eb111e5ebb6d844f60addb94e28b02620c0fL360-R370), [[1]](diffhunk://#diff-95e5fe76b6a5f9b40f3492b4e77f9b43c34e19aee359efe6253c51caee00423fR348-R356) [[2]](diffhunk://#diff-95e5fe76b6a5f9b40f3492b4e77f9b43c34e19aee359efe6253c51caee00423fL410-R427) [[3]](diffhunk://#diff-95e5fe76b6a5f9b40f3492b4e77f9b43c34e19aee359efe6253c51caee00423fL528-R541) [[4]](diffhunk://#diff-95e5fe76b6a5f9b40f3492b4e77f9b43c34e19aee359efe6253c51caee00423fL548-R561) [[5]](diffhunk://#diff-af7d113fc70b3a251c9f53e94ba3eac62ddeaa87c0ee9738512872ac6ed9eb44R50) [[6]](diffhunk://#diff-af7d113fc70b3a251c9f53e94ba3eac62ddeaa87c0ee9738512872ac6ed9eb44R86-R91) [[7]](diffhunk://#diff-af7d113fc70b3a251c9f53e94ba3eac62ddeaa87c0ee9738512872ac6ed9eb44L292-R299) [[8]](diffhunk://#diff-af7d113fc70b3a251c9f53e94ba3eac62ddeaa87c0ee9738512872ac6ed9eb44L324-L326)

**Datetime Field Support in Automations:**

* The automations UI now supports a true `datetime` field type (distinct from `date`), with proper input controls for both date and time, and updated validation and type conversion logic. This allows for precise timestamp handling where needed. [[1]](diffhunk://#diff-edfd75d695e692af8c582bcb0d85fa7b95c9d0d1a0e263d492d275d986936ce2R96-R99) [[2]](diffhunk://#diff-edfd75d695e692af8c582bcb0d85fa7b95c9d0d1a0e263d492d275d986936ce2R129-R133) [[3]](diffhunk://#diff-edfd75d695e692af8c582bcb0d85fa7b95c9d0d1a0e263d492d275d986936ce2R395-R445) [[4]](diffhunk://#diff-943e238b49652cf32b0f1fea7f772589251afd15000869263659637b2fb8a9d6L157-R157) [[5]](diffhunk://#diff-943e238b49652cf32b0f1fea7f772589251afd15000869263659637b2fb8a9d6L363-R363) [[6]](diffhunk://#diff-943e238b49652cf32b0f1fea7f772589251afd15000869263659637b2fb8a9d6L487-R487) [[7]](diffhunk://#diff-d835a52d04c67e9674f3a50f099f3b996f8907965c71b98e393761bc1db3b50eR94-R95)

**UI/UX Enhancements:**

* The "Adjust by" field in automation time adjustment panels now includes a helper text clarifying the semantics of day/week vs. minute/hour adjustments with respect to the automation's timezone.
* The available condition operator labels now clarify the meaning of the "on" operator for dates.

**Technical Cleanups:**

* Timezone selection for scheduled automations now uses a helper to determine the browser's timezone, improving reliability and consistency. [[1]](diffhunk://#diff-59dd78270c6ed87bcec63f4d06d3df9e1a4d4d379556d4a11751967e031cec32R6) [[2]](diffhunk://#diff-59dd78270c6ed87bcec63f4d06d3df9e1a4d4d379556d4a11751967e031cec32L63-R67)
* Date conversion helpers were moved to a shared utility for reuse across invoice and automation components. [[1]](diffhunk://#diff-edfd75d695e692af8c582bcb0d85fa7b95c9d0d1a0e263d492d275d986936ce2R7-R10) [[2]](diffhunk://#diff-edfd75d695e692af8c582bcb0d85fa7b95c9d0d1a0e263d492d275d986936ce2L78-L89) [apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-sidebar.tsxR47-R50](diffhunk://#diff-49464ded74ffc6f3ccf29a87aa07eb111e5ebb6d844f60addb94e28b02620c0fR47-R50), [[3]](diffhunk://#diff-af7d113fc70b3a251c9f53e94ba3eac62ddeaa87c0ee9738512872ac6ed9eb44R50)

These changes collectively improve the accuracy and clarity of time-related fields, reduce timezone-related bugs, and enhance the user experience when working with dates and times in both automations and invoices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization timezone settings to improve automation scheduling and formula previews.
  * Added an **“is on (day)”** condition operator and expanded date/datetime automation support, including new date/time formula functions.
  * Updated the “Timezone” selector and improved date/datetime inputs (including datetime rendering for automation value fields).

* **Bug Fixes**
  * Improved timezone-stable calendar-day handling across invoices, quotes, projects, tasks, and automation editors to prevent day shifts.
  * Made calendar-day math DST-safe (notably **adjust_time**) and tightened datetime/validUntil validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR systematically fixes timezone and calendar-date handling across automations, invoices, quotes, and projects: dates are now stored as UTC-midnight epochs with consistent read/write helpers, automation formula evaluation uses the org's timezone (not always UTC), and the field registry distinguishes calendar `date` fields from true `datetime` timestamps. It also ships new formula functions (WORKDAY_ADD, WORKDAY_DIFF, FORMAT_DATE, START_OF, IS_BEFORE, IS_AFTER, HOUR, MINUTE, WEEKDAY) and an org timezone selector.

- **UTC-midnight convention** is applied uniformly via shared helpers (`localDateToUtcMidnightMs` / `utcMidnightMsToLocalDate`) across all date pickers, table formatters, and the PDF renderer — a sizeable but consistent sweep.
- **Org timezone propagation** now threads from the organization record into automation formula evaluation (backend executor) and the formula-editor preview (frontend), keeping the two in sync.
- **`datetime` type** is split from `date` in the field registry, and the new `on (day)` operator is added for both types with granularity-matched comparison logic.

<h3>Confidence Score: 3/5</h3>

The backend date-handling and automation logic is solid and well-tested, but two frontend defects need fixes before shipping: clearing the datetime time-picker can corrupt an automation config with a NaN epoch, and the quotes table marks valid-until-today quotes as already expired for users west of UTC.

The core engine changes (org-timezone propagation, DST-safe day math, granularity-matched date comparison, new formula functions) are carefully implemented and backed by integration tests. The wide sweep of UTC-midnight date fixes across invoices, projects, and tasks is consistently applied. Two issues in frontend-only files drag the score down: the time-input onChange handler misidentifies undefined as non-NaN, silently storing a NaN epoch in automation configs; and quotes/page.tsx compares a UTC-midnight epoch against new Date() (current instant), causing the expired highlight to fire at UTC midnight rather than at the end of the calendar day — a visible regression for UTC− users.

apps/web/src/app/(workspace)/automations/components/sidebar/panels/value-input.tsx (time-clear NaN) and apps/web/src/app/(workspace)/quotes/page.tsx (isExpired instant comparison) both need fixes before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/(workspace)/automations/components/sidebar/panels/value-input.tsx | Adds datetime field support with date+time picker; time-clear path stores NaN epoch due to misuse of Number.isNaN on undefined. |
| apps/web/src/app/(workspace)/quotes/page.tsx | Switches to UTC-midnight formatting but leaves isExpired comparison against current instant, causing premature expiry display for UTC- users. |
| apps/web/src/lib/dates.ts | New shared utility extracting localDateToUtcMidnightMs and utcMidnightMsToLocalDate helpers; clean and correct. |
| packages/backend/convex/lib/conditionEval.ts | Adds on operator, granularity-matched date comparison, and objectType propagation for registry-aware date field evaluation; well-tested. |
| packages/backend/convex/automationExecutor.ts | Threads org timezone into formula evaluation and DST-safe whole-day adjust_time math; correct and well-tested. |
| packages/backend/convex/lib/formula/functions.ts | Adds HOUR, MINUTE, WEEKDAY, FORMAT_DATE, START_OF, WORKDAY_ADD, WORKDAY_DIFF, IS_BEFORE, IS_AFTER; all implementations look correct and are covered by tests. |
| packages/backend/convex/lib/fieldRegistry.ts | Separates timestamp fields (paidAt, completedAt, sentAt, etc.) into datetime type; adds on operator for both date and datetime. |
| packages/backend/convex/quotes.ts | Fixes validUntil validation to use calendar-day comparison in org timezone so today is not rejected when submitted in the evening west of UTC. |
| apps/web/src/app/(workspace)/invoices/components/InvoicePDF.tsx | Adds formatCalendarDate with timeZone: UTC so issued/due/payment dates render correctly in the PDF regardless of server timezone. |
| apps/web/src/app/(workspace)/organization/profile/_components/business-info-tab.tsx | Adds timezone selector to the organization profile form, wiring it through to the organizations.update mutation. |
| apps/web/src/app/(workspace)/automations/components/editor/formula-editor-modal.tsx | runtimeTimezone now takes org timezone so formula previews evaluate in the same timezone as the backend executor. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as Browser UI
    participant BE as Backend (Convex)
    participant AE as AutomationExecutor
    participant CE as ConditionEval

    UI->>UI: DatePicker selects local day
    UI->>UI: localDateToUtcMidnightMs(date)
    UI->>BE: Save UTC-midnight epoch
    BE->>BE: calendarDayEpoch(Date.now(), org.timezone)
    Note over BE: quotes.ts validUntil validation

    BE->>AE: executeAutomation(trigger)
    AE->>BE: ctx.db.get(orgId) → org.timezone
    AE->>AE: automationFormulaTz(trigger, org.timezone)
    AE->>CE: evaluateConditionGroups(..., objectType)
    CE->>CE: getFieldDefinition(objectType, field).type
    CE->>CE: zonedDateCmp / onSameDay (if date/datetime field)

    UI->>UI: utcMidnightMsToLocalDate(epoch)
    UI->>UI: DatePicker shows correct local day
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as Browser UI
    participant BE as Backend (Convex)
    participant AE as AutomationExecutor
    participant CE as ConditionEval

    UI->>UI: DatePicker selects local day
    UI->>UI: localDateToUtcMidnightMs(date)
    UI->>BE: Save UTC-midnight epoch
    BE->>BE: calendarDayEpoch(Date.now(), org.timezone)
    Note over BE: quotes.ts validUntil validation

    BE->>AE: executeAutomation(trigger)
    AE->>BE: ctx.db.get(orgId) → org.timezone
    AE->>AE: automationFormulaTz(trigger, org.timezone)
    AE->>CE: evaluateConditionGroups(..., objectType)
    CE->>CE: getFieldDefinition(objectType, field).type
    CE->>CE: zonedDateCmp / onSameDay (if date/datetime field)

    UI->>UI: utcMidnightMsToLocalDate(epoch)
    UI->>UI: DatePicker shows correct local day
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/app/(workspace)/quotes/page.tsx`, line 206-207 ([link](https://github.com/xcarter93/onetool/blob/94f78cafd75f18240d241db05ce1bf7618fe7e37/apps/web/src/app/(workspace)/quotes/page.tsx#L206-L207)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`isExpired` compares UTC-midnight epoch against current instant — quotes expire early for negative-UTC-offset users**

   `validUntil` is now stored as a UTC-midnight epoch (the very start of that calendar day). `d < new Date()` becomes `true` the moment UTC midnight ticks over — for a UTC-5 user that is 7 pm local on the `validUntil` day, five hours before their calendar day ends. The intended semantics are "the quote has expired if today is past the valid-until date", so the comparison should use today's UTC midnight (`Date.UTC(new Date().getUTCFullYear(), ...)`) rather than the current instant.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/app/(workspace)/quotes/page.tsx
   Line: 206-207

   Comment:
   **`isExpired` compares UTC-midnight epoch against current instant — quotes expire early for negative-UTC-offset users**

   `validUntil` is now stored as a UTC-midnight epoch (the very start of that calendar day). `d < new Date()` becomes `true` the moment UTC midnight ticks over — for a UTC-5 user that is 7 pm local on the `validUntil` day, five hours before their calendar day ends. The intended semantics are "the quote has expired if today is past the valid-until date", so the comparison should use today's UTC midnight (`Date.UTC(new Date().getUTCFullYear(), ...)`) rather than the current instant.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/web/src/app/(workspace)/automations/components/sidebar/panels/value-input.tsx:434-441
**Time-clear guard misses `undefined` — stores `NaN` epoch**

When the browser clears `<input type="time">`, `e.target.value` becomes `""`. `"".split(":")` returns `[""]`, `.map(Number)` returns `[0]`, so destructuring gives `h = 0, m = undefined`. `Number.isNaN(undefined)` is **`false`** (it only returns `true` for the exact value `NaN`), so the early-return guard is skipped. `compose(current ?? new Date(), 0, undefined)` then calls `new Date(..., undefined)`, and `ToNumber(undefined) = NaN` makes the Date invalid — `.getTime()` returns `NaN`. Calling `onChange(NaN)` can persist an invalid epoch to the automation config.

### Issue 2 of 3
apps/web/src/app/(workspace)/automations/components/sidebar/panels/value-input.tsx:430-439
Add a guard for the empty-string case. When `<input type="time">` is cleared, `e.target.value` is `""`, `"".split(":").map(Number)` produces `[0]`, so `m` is `undefined`. `Number.isNaN(undefined)` is `false`, bypassing the guard, and `compose(..., 0, undefined)` creates an invalid `Date` whose `.getTime()` is `NaN`. Returning early on an empty value fixes this.

```suggestion
				<Input
					type="time"
					aria-label="Time"
					aria-invalid={invalid || undefined}
					value={timeText}
					onChange={(e) => {
						if (!e.target.value) return;
						const [h, m] = e.target.value.split(":").map(Number);
						if (Number.isNaN(h) || Number.isNaN(m)) return;
						onChange(compose(current ?? new Date(), h, m));
					}}
```

### Issue 3 of 3
apps/web/src/app/(workspace)/quotes/page.tsx:206-207
**`isExpired` compares UTC-midnight epoch against current instant — quotes expire early for negative-UTC-offset users**

`validUntil` is now stored as a UTC-midnight epoch (the very start of that calendar day). `d < new Date()` becomes `true` the moment UTC midnight ticks over — for a UTC-5 user that is 7 pm local on the `validUntil` day, five hours before their calendar day ends. The intended semantics are "the quote has expired if today is past the valid-until date", so the comparison should use today's UTC midnight (`Date.UTC(new Date().getUTCFullYear(), ...)`) rather than the current instant.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(automations): C2-4 — date function ..."](https://github.com/xcarter93/onetool/commit/94f78cafd75f18240d241db05ce1bf7618fe7e37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45344288)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->