### PR TITLE
Improve event processing and automation run statistics

### DIFF
--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -6376,6 +6376,32 @@ describe("automationExecutor (v2 engine)", () => {
 				expect(orphan).toBeNull();
 			});
 
+			it("a bump racing a hard delete does not resurrect an orphaned stats row", async () => {
+				// remove() deletes the automation + stats row atomically, but a
+				// bump scheduled by a just-finished run lands in its own later
+				// transaction and must become a no-op.
+				const { asUser, orgId } = await setupUser();
+				const id = await asUser.mutation(
+					api.automations.create,
+					scheduledAutomationArgs("Deleted before bump")
+				);
+				await asUser.mutation(api.automations.remove, { id });
+
+				await t.mutation(internal.automationExecutor.bumpTriggerStats, {
+					automationId: id,
+					orgId,
+					triggeredAt: Date.now(),
+				});
+
+				const orphan = await t.run(async (ctx) =>
+					ctx.db
+						.query("automationRunStats")
+						.withIndex("by_automation", (q) => q.eq("automationId", id))
+						.unique()
+				);
+				expect(orphan).toBeNull();
+			});
+
 			it("a completed production run bumps the stats row and leaves the automation doc unwritten", async () => {
 				const { asUser, orgId } = await setupUser();
 				await makeOrgPremium(orgId);

--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -6184,4 +6184,404 @@ describe("automationExecutor (v2 engine)", () => {
 			).rejects.toThrow(/fallback/i);
 		});
 	});
+
+	describe("Phase C5 — engine scale", () => {
+		async function makeOrgPremium(orgId: Id<"organizations">) {
+			await t.run(async (ctx) =>
+				ctx.db.patch(orgId, {
+					clerkPlanSlug: "onetool_business_plan_org",
+					subscriptionStatus: "active",
+				})
+			);
+		}
+
+		async function drainScheduled() {
+			await t.finishAllScheduledFunctions(vi.runAllTimers);
+		}
+
+		function scheduledAutomationArgs(name: string) {
+			return {
+				name,
+				trigger: {
+					type: "scheduled" as const,
+					schedule: {
+						frequency: "daily" as const,
+						timezone: "UTC",
+						time: "09:00",
+					},
+				},
+				nodes: [notifyNode("notify-1")],
+				isActive: true,
+			};
+		}
+
+		describe("C5-2 scheduled dispatch catch-up", () => {
+			it("a full batch self-reschedules until every due automation is claimed in one tick", async () => {
+				// Non-premium org: each due row just records a skipped execution,
+				// which keeps a 52-automation batch cheap while still counting claims.
+				const { asUser } = await setupUser();
+
+				const firstId = await asUser.mutation(
+					api.automations.create,
+					scheduledAutomationArgs("Batch seed")
+				);
+				const past = Date.now() - 1000;
+				await t.run(async (ctx) => {
+					const template = await ctx.db.get(firstId);
+					if (!template) throw new Error("seed automation missing");
+					const { _id, _creationTime, ...rest } = template;
+					void _id;
+					void _creationTime;
+					await ctx.db.patch(firstId, { nextRunAt: past });
+					for (let i = 0; i < 51; i++) {
+						await ctx.db.insert("workflowAutomations", {
+							...rest,
+							name: `Batch clone ${i}`,
+							nextRunAt: past,
+						});
+					}
+				});
+
+				const result = await t.mutation(
+					internal.automationExecutor.dispatchScheduledAutomations,
+					{}
+				);
+				expect(result.due).toBe(50);
+
+				// The follow-up dispatch runs as a scheduled function, no cron tick.
+				await drainScheduled();
+
+				const executions = await t.run(async (ctx) =>
+					ctx.db.query("workflowExecutions").collect()
+				);
+				expect(executions).toHaveLength(52);
+				expect(executions.every((e) => e.status === "skipped")).toBe(true);
+
+				const unclaimed = await t.run(async (ctx) => {
+					const automations = await ctx.db
+						.query("workflowAutomations")
+						.collect();
+					return automations.filter(
+						(a) => (a.nextRunAt ?? Infinity) <= Date.now()
+					);
+				});
+				expect(unclaimed).toHaveLength(0);
+			});
+		});
+
+		describe("C5-1 event-bus org fairness", () => {
+			it("one org's event burst does not starve another org's newer event out of the batch", async () => {
+				const orgA = await setupUser();
+				const orgB = await setupUser({
+					clerkUserId: "user_fairness_b",
+					clerkOrgId: "org_fairness_b",
+				});
+
+				// 60 older pending events for org A, then 1 newer one for org B —
+				// a global oldest-first FIFO would fill the whole 50-event batch
+				// with org A and leave org B waiting behind the burst.
+				const base = Date.now() - 60_000;
+				const burstEvent = (
+					orgId: Id<"organizations">,
+					createdAt: number
+				) => ({
+					orgId,
+					eventType: "automation.completed",
+					eventSource: "test.fairness",
+					payload: { entityType: "client" as const, entityId: "rec_x" },
+					status: "pending" as const,
+					attemptCount: 0,
+					createdAt,
+				});
+				const orgBEventId = await t.run(async (ctx) => {
+					for (let i = 0; i < 60; i++) {
+						await ctx.db.insert(
+							"domainEvents",
+							burstEvent(orgA.orgId, base + i)
+						);
+					}
+					return ctx.db.insert(
+						"domainEvents",
+						burstEvent(orgB.orgId, base + 10_000)
+					);
+				});
+
+				const result = await t.mutation(internal.eventBus.processEvents, {});
+				expect(result.processed).toBe(50);
+
+				const orgBEvent = await t.run(async (ctx) => ctx.db.get(orgBEventId));
+				expect(orgBEvent?.status).toBe("completed");
+
+				// The burst org keeps draining via the self-rescheduled follow-ups.
+				await drainScheduled();
+				const leftoverPending = await t.run(async (ctx) =>
+					ctx.db
+						.query("domainEvents")
+						.withIndex("by_status", (q) => q.eq("status", "pending"))
+						.collect()
+				);
+				expect(leftoverPending).toHaveLength(0);
+			});
+		});
+
+		describe("C5-3 trigger stats off the automation doc", () => {
+			it("bumpTriggerStats seeds from the legacy on-doc counters, increments, and never regresses lastTriggeredAt", async () => {
+				const { asUser, orgId } = await setupUser();
+				const id = await asUser.mutation(
+					api.automations.create,
+					scheduledAutomationArgs("Stats automation")
+				);
+				await t.run(async (ctx) =>
+					ctx.db.patch(id, { triggerCount: 5, lastTriggeredAt: 1_000 })
+				);
+
+				const at = Date.now();
+				await t.mutation(internal.automationExecutor.bumpTriggerStats, {
+					automationId: id,
+					orgId,
+					triggeredAt: at,
+				});
+				// An out-of-order (older) completion must not move lastTriggeredAt back.
+				await t.mutation(internal.automationExecutor.bumpTriggerStats, {
+					automationId: id,
+					orgId,
+					triggeredAt: at - 500,
+				});
+
+				const stats = await t.run(async (ctx) =>
+					ctx.db
+						.query("automationRunStats")
+						.withIndex("by_automation", (q) => q.eq("automationId", id))
+						.unique()
+				);
+				expect(stats?.triggerCount).toBe(7);
+				expect(stats?.lastTriggeredAt).toBe(at);
+
+				// Reads overlay the stats row; the deprecated doc counters are frozen.
+				const listed = await asUser.query(api.automations.list, {});
+				const row = listed.find((a) => a._id === id);
+				expect(row?.triggerCount).toBe(7);
+				expect(row?.lastTriggeredAt).toBe(at);
+				const rawDoc = await t.run(async (ctx) => ctx.db.get(id));
+				expect(rawDoc?.triggerCount).toBe(5);
+
+				// Hard delete takes the stats row with it.
+				await asUser.mutation(api.automations.remove, { id });
+				const orphan = await t.run(async (ctx) =>
+					ctx.db
+						.query("automationRunStats")
+						.withIndex("by_automation", (q) => q.eq("automationId", id))
+						.unique()
+				);
+				expect(orphan).toBeNull();
+			});
+
+			it("a completed production run bumps the stats row and leaves the automation doc unwritten", async () => {
+				const { asUser, orgId } = await setupUser();
+				await makeOrgPremium(orgId);
+
+				const id = await asUser.mutation(
+					api.automations.create,
+					scheduledAutomationArgs("Completed run stats")
+				);
+				await t.run(async (ctx) =>
+					ctx.db.patch(id, { nextRunAt: Date.now() - 1000 })
+				);
+				await t.mutation(
+					internal.automationExecutor.dispatchScheduledAutomations,
+					{}
+				);
+				await drainScheduled();
+
+				const executions = await t.run(async (ctx) =>
+					ctx.db.query("workflowExecutions").collect()
+				);
+				expect(executions).toHaveLength(1);
+				expect(executions[0].status).toBe("completed");
+
+				const stats = await t.run(async (ctx) =>
+					ctx.db
+						.query("automationRunStats")
+						.withIndex("by_automation", (q) => q.eq("automationId", id))
+						.unique()
+				);
+				expect(stats?.triggerCount).toBe(1);
+				expect(stats?.lastTriggeredAt).toBeTypeOf("number");
+
+				const doc = await t.run(async (ctx) => ctx.db.get(id));
+				expect(doc?.triggerCount).toBeUndefined();
+				expect(doc?.lastTriggeredAt).toBeUndefined();
+			});
+		});
+
+		describe("C5-4 cleanup index fix", () => {
+			it("deletes old terminal executions without touching old running rows, and honors batchSize", async () => {
+				const { asUser, orgId } = await setupUser();
+				const id = await asUser.mutation(
+					api.automations.create,
+					scheduledAutomationArgs("Cleanup automation")
+				);
+
+				const old = Date.now() - 40 * 24 * 60 * 60 * 1000;
+				const executionRow = (
+					status:
+						| "running"
+						| "completed"
+						| "completed_with_errors"
+						| "failed"
+						| "skipped"
+						| "cancelled",
+					triggeredAt: number
+				) => ({
+					orgId,
+					automationId: id,
+					triggeredBy: "schedule",
+					triggeredAt,
+					status,
+					mode: "production" as const,
+					nodesExecuted: [],
+				});
+				await t.run(async (ctx) => {
+					await ctx.db.insert("workflowExecutions", executionRow("completed", old));
+					await ctx.db.insert("workflowExecutions", executionRow("failed", old + 1));
+					await ctx.db.insert(
+						"workflowExecutions",
+						executionRow("completed_with_errors", old + 2)
+					);
+					// Stuck old running row: watchdog territory, cleanup must skip it.
+					await ctx.db.insert("workflowExecutions", executionRow("running", old + 3));
+					// Recent terminal row: inside retention.
+					await ctx.db.insert(
+						"workflowExecutions",
+						executionRow("completed", Date.now() - 1000)
+					);
+				});
+
+				const limited = await t.mutation(
+					internal.automationExecutor.cleanupOldExecutions,
+					{ batchSize: 1 }
+				);
+				expect(limited.deleted).toBe(1);
+				expect(limited.hasMore).toBe(true);
+
+				const rest = await t.mutation(
+					internal.automationExecutor.cleanupOldExecutions,
+					{}
+				);
+				expect(rest.deleted).toBe(2);
+
+				const remaining = await t.run(async (ctx) =>
+					ctx.db.query("workflowExecutions").collect()
+				);
+				expect(remaining).toHaveLength(2);
+				const statuses = remaining.map((e) => e.status).sort();
+				expect(statuses).toEqual(["completed", "running"]);
+				expect(
+					remaining.find((e) => e.status === "running")?.triggeredAt
+				).toBe(old + 3);
+			});
+		});
+
+		describe("C5-4b fetch-heavy walk at scan-budget scale", () => {
+			it("two fetches page through 3,000 rows each in one walk, sharing the budget without truncation", async () => {
+				// convex-test does not enforce Convex's production transaction
+				// limits (32k docs scanned / 16 MiB read / 4,096 index ranges), so
+				// this proves paging + shared-budget accounting at real row counts;
+				// empirical prod-limit headroom needs a dev-deploy load run (see
+				// the WALK_SCAN_BUDGET comment for the verified arithmetic).
+				const { asUser, orgId } = await setupUser();
+				await makeOrgPremium(orgId);
+
+				const clientId = await asUser.mutation(api.clients.create, {
+					portalAccessId: crypto.randomUUID(),
+					companyName: "Bulk Co",
+					status: "active",
+				});
+				await t.run(async (ctx) => {
+					for (let i = 0; i < 3000; i++) {
+						await ctx.db.insert("invoices", {
+							orgId,
+							clientId,
+							invoiceNumber: `INV-${i}`,
+							status: i < 5 ? ("paid" as const) : ("draft" as const),
+							subtotal: 10,
+							total: 10,
+							issuedDate: Date.now(),
+							dueDate: Date.now(),
+							publicToken: crypto.randomUUID(),
+						});
+					}
+				});
+
+				// Nearly-no-match filter: each fetch must page through all 3,000
+				// org rows (6 pages of 500) to find its 5 matches.
+				const fetchPaid = (id: string, next: string) => ({
+					id,
+					type: "fetch_records" as const,
+					config: {
+						kind: "fetch_records" as const,
+						objectType: "invoice" as const,
+						filters: [
+							{
+								logic: "and" as const,
+								rules: [
+									{
+										field: "status",
+										operator: "equals" as const,
+										value: { kind: "static" as const, value: "paid" },
+									},
+								],
+							},
+						],
+					},
+					nextNodeId: next,
+				});
+				const id = await asUser.mutation(api.automations.create, {
+					name: "Scan budget walk",
+					trigger: {
+						type: "scheduled" as const,
+						schedule: {
+							frequency: "daily" as const,
+							timezone: "UTC",
+							time: "09:00",
+						},
+					},
+					nodes: [
+						fetchPaid("fetch-1", "fetch-2"),
+						fetchPaid("fetch-2", "end-1"),
+						{
+							id: "end-1",
+							type: "end" as const,
+							config: { kind: "end" as const },
+						},
+					],
+					isActive: true,
+				});
+
+				await t.run(async (ctx) =>
+					ctx.db.patch(id, { nextRunAt: Date.now() - 1000 })
+				);
+				await t.mutation(
+					internal.automationExecutor.dispatchScheduledAutomations,
+					{}
+				);
+				await drainScheduled();
+
+				const executions = await t.run(async (ctx) =>
+					ctx.db.query("workflowExecutions").collect()
+				);
+				expect(executions).toHaveLength(1);
+				expect(executions[0].status).toBe("completed");
+				expect(executions[0].dataTruncated).toBeFalsy();
+				for (const nodeId of ["fetch-1", "fetch-2"]) {
+					const entry = executions[0].nodesExecuted.find(
+						(n) => n.nodeId === nodeId
+					);
+					expect(entry?.result).toBe("success");
+					expect(entry?.recordsProcessed).toBe(5);
+					expect(entry?.truncated).toBeFalsy();
+				}
+			});
+		});
+	});
 });

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -801,6 +801,18 @@ export const dispatchScheduledAutomations = internalMutation({
 			}
 		}
 
+		// A full batch means more rows may already be due — catch up now instead
+		// of drifting a further 15 minutes per tick. Claim-first nextRunAt
+		// advances (or clears, on failure) above, so the follow-up sees only
+		// still-unclaimed rows and the chain terminates.
+		if (due.length === SCHEDULED_DISPATCH_BATCH) {
+			await ctx.scheduler.runAfter(
+				0,
+				internal.automationExecutor.dispatchScheduledAutomations,
+				{}
+			);
+		}
+
 		return { due: due.length, dispatched };
 	},
 });
@@ -1522,9 +1534,14 @@ async function finishWalk(
 		return;
 	}
 
-	await ctx.db.patch(env.automation._id, {
-		lastTriggeredAt: Date.now(),
-		triggerCount: (env.automation.triggerCount || 0) + 1,
+	// Run counters live on automationRunStats, bumped in a tiny deferred
+	// mutation: every walk chunk reads the automation doc, so patching counters
+	// onto it here would OCC-invalidate all in-flight runs of a burst-triggered
+	// automation.
+	await ctx.scheduler.runAfter(0, internal.automationExecutor.bumpTriggerStats, {
+		automationId: env.automation._id,
+		orgId: env.automation.orgId,
+		triggeredAt: Date.now(),
 	});
 
 	// The walk reached the end, but a loop may have skipped past failing items.
@@ -2140,7 +2157,13 @@ async function checkpointLoopChunk(
 const FETCH_SCAN_BATCH = 500;
 /**
  * Shared scan budget across every fetch in one walk, so multi-fetch workflows
- * stay under Convex's per-transaction read limits (32k docs / 16 MiB).
+ * stay under Convex's per-transaction read limits — verified against the
+ * production limits docs (2026-07-18): 32,000 documents scanned / 16 MiB read
+ * / 4,096 index ranges per transaction. At 10k rows the binding constraint is
+ * data read, not document count: headroom holds while the average scanned doc
+ * stays under ~1.6 KiB, which fits the fetchable object types (rows with long
+ * free-text notes are the ones to watch). Paging at FETCH_SCAN_BATCH=500
+ * costs ~20 index ranges per exhausted budget, far under the 4,096 cap.
  */
 const WALK_SCAN_BUDGET = 10_000;
 
@@ -4256,6 +4279,45 @@ async function executeSendTeamMessageAction(
 	}
 }
 
+/**
+ * Deferred run-counter bump — deliberately its own tiny mutation (see the
+ * finishWalk comment). Conflicts between concurrent completions retry a
+ * two-read patch instead of a whole walk chunk. Seeds from the deprecated
+ * on-doc counters so pre-split history carries over.
+ */
+export const bumpTriggerStats = internalMutation({
+	args: {
+		automationId: v.id("workflowAutomations"),
+		orgId: v.id("organizations"),
+		triggeredAt: v.number(),
+	},
+	handler: async (ctx, args): Promise<void> => {
+		const existing = await ctx.db
+			.query("automationRunStats")
+			.withIndex("by_automation", (q) =>
+				q.eq("automationId", args.automationId)
+			)
+			.unique();
+		if (existing) {
+			await ctx.db.patch(existing._id, {
+				lastTriggeredAt: Math.max(existing.lastTriggeredAt, args.triggeredAt),
+				triggerCount: existing.triggerCount + 1,
+			});
+			return;
+		}
+		const automation = await ctx.db.get(args.automationId);
+		await ctx.db.insert("automationRunStats", {
+			orgId: args.orgId,
+			automationId: args.automationId,
+			lastTriggeredAt: Math.max(
+				automation?.lastTriggeredAt ?? 0,
+				args.triggeredAt
+			),
+			triggerCount: (automation?.triggerCount ?? 0) + 1,
+		});
+	},
+});
+
 // Cleanup configuration
 const EXECUTION_LOG_RETENTION_DAYS = 30;
 
@@ -4274,28 +4336,39 @@ export const cleanupOldExecutions = internalMutation({
 
 		const cutoffTime = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
 
-		// Get completed/failed executions older than retention period
-		// We keep "running" ones in case they're still active
+		// Terminal rows only — "running" rows are left for the stale-run
+		// watchdogs. Status-partitioned index ranges land directly on deletable
+		// rows, so stuck old "running" rows are never re-scanned pass after pass.
+		const terminalStatuses = [
+			"completed",
+			"completed_with_errors",
+			"failed",
+			"skipped",
+			"cancelled",
+		] as const;
+
 		let deleted = 0;
-		let hasMore = true;
+		for (const status of terminalStatuses) {
+			while (deleted < batchSize) {
+				const oldExecutions = await ctx.db
+					.query("workflowExecutions")
+					.withIndex("by_status_triggeredAt", (q) =>
+						q.eq("status", status).lt("triggeredAt", cutoffTime)
+					)
+					.take(Math.min(100, batchSize - deleted));
 
-		while (hasMore && deleted < batchSize) {
-			const oldExecutions = await ctx.db
-				.query("workflowExecutions")
-				.withIndex("by_triggeredAt", (q) => q.lt("triggeredAt", cutoffTime))
-				.filter((q) => q.neq(q.field("status"), "running"))
-				.take(100);
+				if (oldExecutions.length === 0) {
+					break;
+				}
 
-			if (oldExecutions.length === 0) {
-				hasMore = false;
-				break;
-			}
-
-			for (const execution of oldExecutions) {
-				await ctx.db.delete(execution._id);
-				deleted++;
+				for (const execution of oldExecutions) {
+					await ctx.db.delete(execution._id);
+					deleted++;
+				}
 			}
 		}
+
+		const hasMore = deleted >= batchSize;
 
 		console.log(
 			`Cleaned up ${deleted} old automation execution logs (older than ${retentionDays} days)`

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -4306,6 +4306,9 @@ export const bumpTriggerStats = internalMutation({
 			return;
 		}
 		const automation = await ctx.db.get(args.automationId);
+		// remove() deletes the automation and its stats row atomically; a bump
+		// still in the scheduler queue must not resurrect an orphaned row.
+		if (!automation) return;
 		await ctx.db.insert("automationRunStats", {
 			orgId: args.orgId,
 			automationId: args.automationId,

--- a/packages/backend/convex/automations.ts
+++ b/packages/backend/convex/automations.ts
@@ -1263,23 +1263,26 @@ async function withRunStats(
 	ctx: QueryCtx,
 	automations: AutomationDocument[]
 ): Promise<AutomationDocument[]> {
-	return Promise.all(
-		automations.map(async (automation) => {
-			const stats = await ctx.db
-				.query("automationRunStats")
-				.withIndex("by_automation", (q) =>
-					q.eq("automationId", automation._id)
-				)
-				.unique();
-			return stats
-				? {
-						...automation,
-						lastTriggeredAt: stats.lastTriggeredAt,
-						triggerCount: stats.triggerCount,
-					}
-				: automation;
-		})
+	if (automations.length === 0) return automations;
+	// One by_org scan instead of a per-automation index lookup (all callers
+	// pass automations from a single org).
+	const statsRows = await ctx.db
+		.query("automationRunStats")
+		.withIndex("by_org", (q) => q.eq("orgId", automations[0].orgId))
+		.collect();
+	const statsByAutomation = new Map(
+		statsRows.map((row) => [row.automationId, row])
 	);
+	return automations.map((automation) => {
+		const stats = statsByAutomation.get(automation._id);
+		return stats
+			? {
+					...automation,
+					lastTriggeredAt: stats.lastTriggeredAt,
+					triggerCount: stats.triggerCount,
+				}
+			: automation;
+	});
 }
 
 export const list = userQuery({

--- a/packages/backend/convex/automations.ts
+++ b/packages/backend/convex/automations.ts
@@ -1253,6 +1253,35 @@ function scheduledNextRunAt(
 /**
  * Get all automations for the current user's organization
  */
+/**
+ * Overlay live run counters from automationRunStats onto automation docs.
+ * Writes go to the stats table (automationExecutor.bumpTriggerStats); the
+ * deprecated on-doc lastTriggeredAt/triggerCount are the pre-split fallback
+ * for automations that haven't completed a run since.
+ */
+async function withRunStats(
+	ctx: QueryCtx,
+	automations: AutomationDocument[]
+): Promise<AutomationDocument[]> {
+	return Promise.all(
+		automations.map(async (automation) => {
+			const stats = await ctx.db
+				.query("automationRunStats")
+				.withIndex("by_automation", (q) =>
+					q.eq("automationId", automation._id)
+				)
+				.unique();
+			return stats
+				? {
+						...automation,
+						lastTriggeredAt: stats.lastTriggeredAt,
+						triggerCount: stats.triggerCount,
+					}
+				: automation;
+		})
+	);
+}
+
 export const list = userQuery({
 	args: {},
 	handler: async (ctx): Promise<AutomationDocument[]> => {
@@ -1265,7 +1294,10 @@ export const list = userQuery({
 			.collect();
 
 		// Sort by name alphabetically
-		return automations.sort((a, b) => a.name.localeCompare(b.name));
+		return withRunStats(
+			ctx,
+			automations.sort((a, b) => a.name.localeCompare(b.name))
+		);
 	},
 });
 
@@ -1285,7 +1317,10 @@ export const listActive = userQuery({
 			)
 			.collect();
 
-		return automations.sort((a, b) => a.name.localeCompare(b.name));
+		return withRunStats(
+			ctx,
+			automations.sort((a, b) => a.name.localeCompare(b.name))
+		);
 	},
 });
 
@@ -1296,7 +1331,9 @@ export const get = userQuery({
 	args: { id: v.id("workflowAutomations") },
 	handler: async (ctx, args): Promise<AutomationDocument | null> => {
 		await ctx.requireLevel("automations", "view");
-		return await getAutomationWithOrgValidation(ctx, args.id);
+		const automation = await getAutomationWithOrgValidation(ctx, args.id);
+		if (!automation) return null;
+		return (await withRunStats(ctx, [automation]))[0];
 	},
 });
 
@@ -1549,6 +1586,13 @@ export const remove = userMutation({
 		await getAutomationOrThrow(ctx, args.id); // Validate access
 
 		await ctx.db.delete(args.id);
+		const stats = await ctx.db
+			.query("automationRunStats")
+			.withIndex("by_automation", (q) => q.eq("automationId", args.id))
+			.unique();
+		if (stats) {
+			await ctx.db.delete(stats._id);
+		}
 		await deleteExecutionsBatch(ctx, args.id);
 		return args.id;
 	},

--- a/packages/backend/convex/eventBus.ts
+++ b/packages/backend/convex/eventBus.ts
@@ -228,11 +228,12 @@ export async function emitRecordUpdatedEvent(
  * Pick the next batch of pending events with per-org fairness.
  *
  * The old global oldest-first FIFO let one org's bulk import delay every other
- * org's triggers. Instead: skip-scan by_org_status for distinct orgIds (one
- * probe per org with rows in the table), take up to PER_ORG_BATCH pending
- * events per org (oldest first within the org), then top up the remainder
- * from the global-oldest FIFO — so age-based progress is still guaranteed
- * when active orgs outnumber the discovery budget.
+ * org's triggers. Instead: skip-scan by_status_org for distinct orgIds that
+ * have pending work (every probe lands on an org with a queued event), take
+ * up to PER_ORG_BATCH pending events per org (oldest first within the org),
+ * then top up the remainder from the global-oldest FIFO — so age-based
+ * progress is still guaranteed when pending orgs outnumber the discovery
+ * budget.
  */
 async function selectFairBatch(
 	ctx: MutationCtx
@@ -250,10 +251,15 @@ async function selectFairBatch(
 		const cursor: Id<"organizations"> | null = orgCursor;
 		const nextOrgRow: Doc<"domainEvents"> | null =
 			cursor === null
-				? await ctx.db.query("domainEvents").withIndex("by_org_status").first()
+				? await ctx.db
+						.query("domainEvents")
+						.withIndex("by_status_org", (q) => q.eq("status", "pending"))
+						.first()
 				: await ctx.db
 						.query("domainEvents")
-						.withIndex("by_org_status", (q) => q.gt("orgId", cursor))
+						.withIndex("by_status_org", (q) =>
+							q.eq("status", "pending").gt("orgId", cursor)
+						)
 						.first();
 		if (!nextOrgRow) break;
 		orgCursor = nextOrgRow.orgId;

--- a/packages/backend/convex/eventBus.ts
+++ b/packages/backend/convex/eventBus.ts
@@ -48,6 +48,9 @@ export const EVENT_TYPES = {
 const MAX_RETRY_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 5000; // 5 seconds
 const BATCH_SIZE = 50; // Events to process per batch
+const PER_ORG_BATCH = 10; // Fairness cap: max events one org gets from a batch's round-robin share
+const ORG_DISCOVERY_LIMIT = 32; // Max distinct-org index probes per batch
+const FIFO_RESERVE = 10; // Batch share always filled globally-oldest-first
 
 /**
  * The entity types that emit domain events. Derived from AutomationObjectType
@@ -222,18 +225,78 @@ export async function emitRecordUpdatedEvent(
 }
 
 /**
+ * Pick the next batch of pending events with per-org fairness.
+ *
+ * The old global oldest-first FIFO let one org's bulk import delay every other
+ * org's triggers. Instead: skip-scan by_org_status for distinct orgIds (one
+ * probe per org with rows in the table), take up to PER_ORG_BATCH pending
+ * events per org (oldest first within the org), then top up the remainder
+ * from the global-oldest FIFO — so age-based progress is still guaranteed
+ * when active orgs outnumber the discovery budget.
+ */
+async function selectFairBatch(
+	ctx: MutationCtx
+): Promise<Doc<"domainEvents">[]> {
+	const selected: Doc<"domainEvents">[] = [];
+	const selectedIds = new Set<string>();
+	const roundRobinShare = BATCH_SIZE - FIFO_RESERVE;
+
+	let orgCursor: Id<"organizations"> | null = null;
+	for (
+		let probes = 0;
+		probes < ORG_DISCOVERY_LIMIT && selected.length < roundRobinShare;
+		probes++
+	) {
+		const cursor: Id<"organizations"> | null = orgCursor;
+		const nextOrgRow: Doc<"domainEvents"> | null =
+			cursor === null
+				? await ctx.db.query("domainEvents").withIndex("by_org_status").first()
+				: await ctx.db
+						.query("domainEvents")
+						.withIndex("by_org_status", (q) => q.gt("orgId", cursor))
+						.first();
+		if (!nextOrgRow) break;
+		orgCursor = nextOrgRow.orgId;
+
+		const pending = await ctx.db
+			.query("domainEvents")
+			.withIndex("by_org_status", (q) =>
+				q.eq("orgId", nextOrgRow.orgId).eq("status", "pending")
+			)
+			.take(Math.min(PER_ORG_BATCH, roundRobinShare - selected.length));
+		for (const event of pending) {
+			selected.push(event);
+			selectedIds.add(event._id);
+		}
+	}
+
+	// Starvation guard / top-up: the globally oldest pending events fill the
+	// rest of the batch, deduped against the round-robin picks.
+	if (selected.length < BATCH_SIZE) {
+		const oldest = await ctx.db
+			.query("domainEvents")
+			.withIndex("by_status", (q) => q.eq("status", "pending"))
+			.order("asc")
+			.take(BATCH_SIZE);
+		for (const event of oldest) {
+			if (selected.length >= BATCH_SIZE) break;
+			if (!selectedIds.has(event._id)) {
+				selected.push(event);
+			}
+		}
+	}
+
+	return selected;
+}
+
+/**
  * Process pending events from the queue
  * This is the event loop that picks up and dispatches events
  */
 export const processEvents = internalMutation({
 	args: {},
 	handler: async (ctx) => {
-		// Get pending events, oldest first
-		const pendingEvents = await ctx.db
-			.query("domainEvents")
-			.withIndex("by_status", (q) => q.eq("status", "pending"))
-			.order("asc")
-			.take(BATCH_SIZE);
+		const pendingEvents = await selectFairBatch(ctx);
 
 		if (pendingEvents.length === 0) {
 			return { processed: 0 };

--- a/packages/backend/convex/lib/orgCascade.ts
+++ b/packages/backend/convex/lib/orgCascade.ts
@@ -40,6 +40,7 @@ export const ORG_SCOPED_CASCADE_TABLES = [
 	"activities",
 	"notifications",
 	"workflowExecutions",
+	"automationRunStats",
 	"workflowAutomations",
 	"domainEvents",
 	"reports",

--- a/packages/backend/convex/lib/orgCascade.ts
+++ b/packages/backend/convex/lib/orgCascade.ts
@@ -274,6 +274,19 @@ export async function cascadeDeleteOrgDataPage(
 		}
 	}
 
+	// automationRunStats
+	{
+		if (remaining <= 0) return { done: false };
+		const rows = await ctx.db
+			.query("automationRunStats")
+			.withIndex("by_org", (q) => q.eq("orgId", orgId))
+			.take(remaining);
+		for (const row of rows) {
+			await ctx.db.delete(row._id);
+			remaining--;
+		}
+	}
+
 	// workflowAutomations
 	{
 		if (remaining <= 0) return { done: false };

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -1346,6 +1346,8 @@ export default defineSchema({
 		.index("by_org", ["orgId"])
 		.index("by_org_status", ["orgId", "status"])
 		.index("by_status", ["status", "createdAt"])
+		// Fair-batch org discovery: skip-scan distinct orgIds WITH pending work.
+		.index("by_status_org", ["status", "orgId"])
 		.index("by_type_status", ["eventType", "status"])
 		.index("by_correlation", ["correlationId"]),
 

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -1387,12 +1387,28 @@ export default defineSchema({
 		createdBy: v.id("users"),
 		createdAt: v.number(),
 		updatedAt: v.number(),
+		// DEPRECATED run counters — superseded by automationRunStats (writes go
+		// there; reads overlay stats onto these docs). Kept as the seed/fallback
+		// for automations that haven't run since the split.
 		lastTriggeredAt: v.optional(v.number()),
 		triggerCount: v.optional(v.number()),
 	})
 		.index("by_org", ["orgId"])
 		.index("by_org_status", ["orgId", "status"])
 		.index("by_status_nextRunAt", ["status", "nextRunAt"]),
+
+	// Per-automation run counters, kept OFF workflowAutomations: every walk
+	// chunk reads its automation doc, so counter writes there OCC-invalidate
+	// all in-flight runs of a burst-triggered automation. One row per
+	// automation, bumped by automationExecutor.bumpTriggerStats.
+	automationRunStats: defineTable({
+		orgId: v.id("organizations"),
+		automationId: v.id("workflowAutomations"),
+		lastTriggeredAt: v.number(),
+		triggerCount: v.number(),
+	})
+		.index("by_automation", ["automationId"])
+		.index("by_org", ["orgId"]),
 
 	// Workflow Execution Logs - tracks automation execution history
 	workflowExecutions: defineTable({
@@ -1508,7 +1524,10 @@ export default defineSchema({
 		.index("by_automation", ["automationId"])
 		.index("by_org_triggeredAt", ["orgId", "triggeredAt"])
 		.index("by_org_status_triggeredAt", ["orgId", "status", "triggeredAt"])
-		.index("by_triggeredAt", ["triggeredAt"]),
+		.index("by_triggeredAt", ["triggeredAt"])
+		// Retention cleanup: lets terminal-status rows be ranged by age without
+		// re-scanning stuck "running" rows on every pass.
+		.index("by_status_triggeredAt", ["status", "triggeredAt"]),
 
 	// Client Documents - files uploaded directly to client records
 	clientDocuments: defineTable({


### PR DESCRIPTION
This pull request introduces significant improvements to the automation engine’s scalability, fairness, and run statistics tracking. The main changes include new tests for engine scaling scenarios, a shift to tracking run counters in a dedicated stats table (rather than on the automation document), improved fairness in event processing across organizations, and more efficient cleanup of old execution logs. The changes also enhance the batch processing logic to ensure all due automations are promptly dispatched, and update the query layer to overlay live run stats on automation documents.

**Automation engine scaling and fairness:**
- Added comprehensive tests for engine scale scenarios, including batch catch-up for scheduled automations, fairness in event processing between organizations, stats tracking migration, and efficient cleanup of old executions.
- Introduced per-org fairness caps and batch share logic to the event bus, ensuring no single organization can starve others during event bursts.

**Run statistics tracking migration:**
- Moved run counters (`lastTriggeredAt`, `triggerCount`) from automation documents to a dedicated `automationRunStats` table, with a new `bumpTriggerStats` mutation for atomic counter updates. This avoids conflicts between concurrent runs and seeds from legacy counters for backward compatibility. [[1]](diffhunk://#diff-74bb3a617199583fb16225745117cd7177598a19e1c289a41c22938ceca14eb7R4282-R4320) [[2]](diffhunk://#diff-74bb3a617199583fb16225745117cd7177598a19e1c289a41c22938ceca14eb7L1525-R1544)
- Updated automation queries (`list`, `listActive`, `get`) to overlay live run stats from the new table, using the legacy doc fields as fallback only for automations without a completed run since migration. [[1]](diffhunk://#diff-28949ff315bcde2457f348b147064a31c662bd41ee55f784d7290da45f1ba4b2R1256-R1284) [[2]](diffhunk://#diff-28949ff315bcde2457f348b147064a31c662bd41ee55f784d7290da45f1ba4b2L1268-R1300) [[3]](diffhunk://#diff-28949ff315bcde2457f348b147064a31c662bd41ee55f784d7290da45f1ba4b2L1288-R1323) [[4]](diffhunk://#diff-28949ff315bcde2457f348b147064a31c662bd41ee55f784d7290da45f1ba4b2L1299-R1336)

**Batch processing and cleanup improvements:**
- Modified scheduled automation dispatch to immediately reschedule itself if a full batch is processed, ensuring all due automations are claimed without delay.
- Improved cleanup of old execution logs to target only terminal statuses, efficiently skipping "running" executions and honoring the batch size, with direct index range queries for better performance. [[1]](diffhunk://#diff-74bb3a617199583fb16225745117cd7177598a19e1c289a41c22938ceca14eb7L4277-L4290) [[2]](diffhunk://#diff-74bb3a617199583fb16225745117cd7177598a19e1c289a41c22938ceca14eb7R4369-R4371)

**Retention and data consistency:**
- Ensured that deleting an automation also deletes its associated run stats row, maintaining data consistency.

**Documentation and configuration:**
- Clarified documentation for scan budget logic and Convex transaction limits, with comments on paging and index range usage.

These changes collectively improve the reliability, scalability, and fairness of the automation system, while ensuring accurate and conflict-free tracking of automation run statistics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved scheduled automation catch-up to reduce drift when many items are due at once.
  * Improved event processing fairness to prevent one tenant’s backlog from delaying others.
  * Enabled large sequential scans across many rows without truncation.

* **New Features**
  * Automation list and detail views now show live trigger counters from run-stat tracking.

* **Bug Fixes**
  * Kept trigger counts and “last triggered” timestamps monotonic and accurate during concurrent runs.
  * Cleanup now deletes only terminal workflow execution states while preserving running ones.
  * Removing automations or tenants also removes related run statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates run counters (`lastTriggeredAt`, `triggerCount`) from the automation document to a dedicated `automationRunStats` table to avoid OCC conflicts during burst-triggered runs, adds per-org fairness to event processing, improves scheduled dispatch catch-up, and fixes the old execution cleanup to skip stuck "running" rows via a dedicated index.

- **Stats table split**: `bumpTriggerStats` is a deferred internal mutation that upserts into `automationRunStats`, seeding from legacy on-doc counters on first run; `withRunStats` overlays these live counters onto automation docs in `list`, `listActive`, and `get` queries.
- **Org fairness**: `selectFairBatch` round-robins up to `PER_ORG_BATCH=10` events per org (capped at 32 org probes) and fills the remainder from a global-oldest FIFO top-up, preventing a single org's burst from starving others.
- **Dispatch catch-up**: `dispatchScheduledAutomations` now immediately self-reschedules when it fills a full 50-row batch, ensuring all due automations are claimed without waiting for the next cron tick.

<h3>Confidence Score: 3/5</h3>

The core stats migration and cleanup improvements are sound, but the deferred `bumpTriggerStats` mutation can insert an orphaned row when an automation is deleted between walk completion and the mutation executing — a straightforward one-line guard fixes it before merging.

The delete-before-deferred-bump race produces orphaned `automationRunStats` rows that accumulate indefinitely at the per-automation level; no per-automation cleanup path touches them once the parent doc is gone. The fix is minimal, but the bug is real and will reproduce in normal usage whenever a user deletes an automation shortly after its last run.

`automationExecutor.ts` — the `bumpTriggerStats` insert path needs an `if (!automation) return` guard before the `ctx.db.insert` call.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/automationExecutor.ts | Adds `bumpTriggerStats` deferred mutation and self-rescheduling catch-up in `dispatchScheduledAutomations`; the stats insert path lacks a guard for the case where the automation is deleted before the deferred mutation runs, producing orphaned rows. |
| packages/backend/convex/automations.ts | Adds `withRunStats` helper to overlay live counters onto automation docs in `list`, `listActive`, and `get`; correct logic but issues N+1 index lookups per automation which may be costly for large orgs. |
| packages/backend/convex/eventBus.ts | Introduces `selectFairBatch` with per-org round-robin fairness; discovery probes don't filter for pending events, potentially wasting all 32 probe slots on orgs with only non-pending events. |
| packages/backend/convex/schema.ts | Adds `automationRunStats` table with `by_automation` and `by_org` indexes, and `by_status_triggeredAt` index on `workflowExecutions`; schema changes look correct and well-structured. |
| packages/backend/convex/automationExecutor.test.ts | Adds comprehensive Phase C5 test suite covering batch catch-up, org fairness, stats migration, and cleanup index fix; tests are well-structured and cover the main scenarios. |
| packages/backend/convex/lib/orgCascade.ts | Adds `automationRunStats` to the org-scoped cascade delete list, ensuring stats rows are cleaned up on org deletion. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Cron
    participant dispatchScheduled
    participant walkChunk
    participant bumpTriggerStats
    participant automationRunStats
    participant remove

    Cron->>dispatchScheduled: tick
    dispatchScheduled->>dispatchScheduled: "claim due automations (batch=50)"
    alt full batch
        dispatchScheduled->>dispatchScheduled: runAfter(0) self-reschedule
    end
    dispatchScheduled->>walkChunk: runAfter(0, executeWalk)

    walkChunk->>walkChunk: process nodes
    walkChunk->>bumpTriggerStats: runAfter(0) schedule
    Note over walkChunk,bumpTriggerStats: deferred - separate transaction

    alt automation still exists
        bumpTriggerStats->>automationRunStats: upsert (seed from doc on first run)
    else automation deleted (race)
        bumpTriggerStats->>automationRunStats: inserts orphaned row (missing guard)
    end

    remove->>remove: delete workflowAutomations doc
    remove->>automationRunStats: delete stats row (if exists)
    Note over remove,automationRunStats: can miss row if bumpTriggerStats has not run yet
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Cron
    participant dispatchScheduled
    participant walkChunk
    participant bumpTriggerStats
    participant automationRunStats
    participant remove

    Cron->>dispatchScheduled: tick
    dispatchScheduled->>dispatchScheduled: "claim due automations (batch=50)"
    alt full batch
        dispatchScheduled->>dispatchScheduled: runAfter(0) self-reschedule
    end
    dispatchScheduled->>walkChunk: runAfter(0, executeWalk)

    walkChunk->>walkChunk: process nodes
    walkChunk->>bumpTriggerStats: runAfter(0) schedule
    Note over walkChunk,bumpTriggerStats: deferred - separate transaction

    alt automation still exists
        bumpTriggerStats->>automationRunStats: upsert (seed from doc on first run)
    else automation deleted (race)
        bumpTriggerStats->>automationRunStats: inserts orphaned row (missing guard)
    end

    remove->>remove: delete workflowAutomations doc
    remove->>automationRunStats: delete stats row (if exists)
    Note over remove,automationRunStats: can miss row if bumpTriggerStats has not run yet
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/backend/convex/automationExecutor.ts:4308-4311
`bumpTriggerStats` can insert an orphaned `automationRunStats` row when the parent automation is deleted before this deferred mutation runs. The `remove` mutation deletes the automation and any existing stats row atomically, but because `bumpTriggerStats` is scheduled with `runAfter(0, ...)` it executes in a separate transaction. If `remove` wins the race (no stats row to delete yet), then `bumpTriggerStats` runs: `existing` is null, `ctx.db.get(args.automationId)` returns null, and an orphaned row is inserted with a dangling `automationId` reference that no per-automation cleanup will ever reach.

```suggestion
		const automation = await ctx.db.get(args.automationId);
		if (!automation) return; // Automation was deleted before this deferred bump ran.
		await ctx.db.insert("automationRunStats", {
			orgId: args.orgId,
			automationId: args.automationId,
```

### Issue 2 of 3
packages/backend/convex/automations.ts:1262-1283
**N+1 index lookup per automation in `withRunStats`**

`withRunStats` fires one `by_automation` index query per automation inside `Promise.all`. An org with 200 automations calling `list` would issue 200 individual queries in addition to the initial collection scan. Convex reads are bounded by the 16 MiB / 32k-doc transaction limits, and a large list here can approach those limits faster than expected. Consider batching by querying `automationRunStats` for the org with a `by_org` index scan and building a lookup map, reducing to a single extra query.

### Issue 3 of 3
packages/backend/convex/eventBus.ts:250-259
**Org discovery probes don't skip orgs with no pending events**

The org discovery scan queries `by_org_status` without filtering by `status`. Every org that has any event row — regardless of status — consumes one of the 32 `ORG_DISCOVERY_LIMIT` probe slots. In a tenant with 30+ orgs that previously had events (all now completed/failed) sitting before the orgs with active pending events in `orgId` order, all probes could be exhausted discovering orgs that yield 0 pending events, leaving the round-robin share empty and falling back entirely to the FIFO top-up (defeating the fairness goal). Adding `.eq("status", "pending")` to the discovery probe would guarantee probes only land on orgs that actually have work queued.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(automations): C5 — engine scale (or..."](https://github.com/xcarter93/onetool/commit/1ac4fa15abd66d9f759563494ef8a0caf5f0dd86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45379237)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->