### PR TITLE
Implement one-hop related-field traversal for automations

### DIFF
--- a/apps/web/src/app/(workspace)/automations/components/editor/formula-editor-modal.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/editor/formula-editor-modal.tsx
@@ -215,6 +215,18 @@ export function FormulaEditorModal({
 		| null
 		| undefined;
 
+	// One-hop related fields (C6): trigger.record.<relation>.<field> in the
+	// preview. Additive alongside the per-type .get queries above.
+	const relatedFields = useQuery(
+		api.automations.getSampleRelatedFields,
+		selectedSample
+			? {
+					entityType: selectedSample.entityType,
+					entityId: selectedSample.entityId,
+				}
+			: "skip"
+	);
+
 	const organization = useQuery(api.organizations.get);
 
 	// The tz the automation will ACTUALLY run in — mirrors automationFormulaTz on
@@ -242,6 +254,16 @@ export function FormulaEditorModal({
 		function resolvePath(path: string, resolving: Set<string>): Val {
 			if (path.startsWith("trigger.record.")) {
 				const field = path.slice("trigger.record.".length);
+				// Flat key first — the runtime resolver gives flat keys (which may
+				// contain dots) precedence over the one-hop relation form.
+				if (recordFields && field in recordFields) {
+					return toFormulaVal(recordFields[field]);
+				}
+				const dot = field.indexOf(".");
+				if (dot !== -1) {
+					const related = relatedFields?.[field.slice(0, dot)];
+					return toFormulaVal(related?.[field.slice(dot + 1)]);
+				}
 				return toFormulaVal(recordFields?.[field]);
 			}
 			if (path === "workflow.now") return Date.now();
@@ -266,7 +288,7 @@ export function FormulaEditorModal({
 			return null;
 		}
 		return (path: string) => resolvePath(path, new Set());
-	}, [recordFields, formulasById, tz]);
+	}, [recordFields, relatedFields, formulasById, tz]);
 
 	// Debounced validate + preview. Never blocks typing.
 	useEffect(() => {

--- a/apps/web/src/app/(workspace)/automations/components/editor/workflow-drawer.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/editor/workflow-drawer.tsx
@@ -75,6 +75,16 @@ export function formatVariableToken(path: string, format: "text" | "formula"): s
 	return format === "formula" ? `{${path}}` : `{{${path}}}`;
 }
 
+/**
+ * Rows sit under their group heading ("Trigger · Client"), so drop the chained
+ * prefix and show only the final segment ("Company Name"). Full labels stay in
+ * the pickers, where rows can appear without group context (flat search).
+ */
+function shortLabel(label: string): string {
+	const idx = label.lastIndexOf(" → ");
+	return idx === -1 ? label : label.slice(idx + 3);
+}
+
 /** Order-preserving group of variable options by their `group` label. */
 function groupVariables(vars: VariableOption[]): [string, VariableOption[]][] {
 	const groups: [string, VariableOption[]][] = [];
@@ -318,7 +328,7 @@ export function WorkflowDrawer({
 	};
 
 	return (
-		<div className="absolute bottom-3 left-3 top-3 z-10 flex w-[280px] flex-col overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+		<div className="absolute bottom-3 left-3 top-3 z-10 flex w-[320px] flex-col overflow-hidden rounded-xl border border-border bg-card shadow-sm">
 			<div className="flex items-center justify-between border-b border-border px-3 py-2.5">
 				<span className="text-sm font-semibold">Workflow</span>
 				<Button
@@ -407,7 +417,7 @@ export function WorkflowDrawer({
 														title={`Copy {{${v.path}}} — for text fields`}
 														className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-0 py-0.5 text-left transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 													>
-														<span className="flex-1 truncate text-sm">{v.label}</span>
+														<span className="flex-1 truncate text-sm">{shortLabel(v.label)}</span>
 														{v.fieldType && (
 															<span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
 																{v.fieldType}

--- a/apps/web/src/app/(workspace)/automations/components/flow/automation-flow.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/flow/automation-flow.tsx
@@ -86,10 +86,10 @@ const edgeTypes = {
 const LAYOUT_ANIMATION_MS = 220;
 
 // Per-side fitView padding so auto-fit keeps nodes clear of the floating chrome:
-// the left WorkflowDrawer (~280px), the right config panel (~380px), and the
+// the left WorkflowDrawer (~320px), the right config panel (~440px), and the
 // bottom assistant notch. maxZoom:1 means small graphs re-center rather than shrink.
 export const FIT_VIEW_OPTIONS = {
-	padding: { top: "24px", right: "400px", bottom: "72px", left: "300px" },
+	padding: { top: "24px", right: "460px", bottom: "72px", left: "340px" },
 	duration: 300,
 	maxZoom: 1,
 } as const;
@@ -387,7 +387,7 @@ function AutomationFlowInner({
 					orientation="vertical"
 					fitViewOptions={FIT_VIEW_OPTIONS}
 					style={{
-						transform: configPanelOpen ? "translateX(-25rem)" : undefined,
+						transform: configPanelOpen ? "translateX(-28.75rem)" : undefined,
 						transition: "transform 200ms ease-out",
 					}}
 				/>

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/automation-sidebar.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/automation-sidebar.tsx
@@ -280,7 +280,7 @@ export function AutomationSidebar({
 			// reliably bound the height — a bounded root is what lets the content
 			// below scroll. bottom clears the assistant notch via the shared var.
 			style={{ top: "0.75rem", right: "0.75rem", bottom: "var(--assistant-notch-clearance)" }}
-			className="absolute z-10 flex w-[380px] flex-col overflow-hidden rounded-xl border border-border bg-card shadow-sm motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-right-4"
+			className="absolute z-10 flex w-[440px] flex-col overflow-hidden rounded-xl border border-border bg-card shadow-sm motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-right-4"
 		>
 			{/* Header -- only shown for node-config modes; pickers have their own headers */}
 			{mode.mode === "node-config" && (

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/action-config.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/action-config.tsx
@@ -52,6 +52,7 @@ import {
 	PanelSection,
 } from "./panel-primitives";
 import { ValueInput, VariableInsertButton } from "./value-input";
+import { PickerChip } from "./picker-chip";
 
 function defaultConfig(objectType: AutomationObjectType): ActionNodeConfig {
 	const firstWritable = getWritableFields(objectType)[0];
@@ -274,7 +275,13 @@ function UpdateFieldsFields({
 										}
 									>
 										<SelectTrigger>
-											<SelectValue placeholder="Select field" />
+											{row.field ? (
+												<PickerChip label={fieldDef?.label ?? row.field} />
+											) : (
+												<span className="truncate text-muted-foreground">
+													Select field
+												</span>
+											)}
 										</SelectTrigger>
 										<SelectContent>
 											{writableFields.map((field) => (
@@ -533,7 +540,13 @@ function CreateRecordFields({
 										}
 									>
 										<SelectTrigger>
-											<SelectValue placeholder="Select field" />
+											{row.field ? (
+												<PickerChip label={fieldDef?.label ?? row.field} />
+											) : (
+												<span className="truncate text-muted-foreground">
+													Select field
+												</span>
+											)}
 										</SelectTrigger>
 										<SelectContent>
 											{availableFields.map((field) => (
@@ -890,7 +903,18 @@ function SendNotificationFields({
 								onValueChange={(field) => field && updateRecordFieldField(field)}
 							>
 								<SelectTrigger>
-									<SelectValue placeholder="Choose a field" />
+									{recordField.field ? (
+										<PickerChip
+											label={
+												fieldOptions.find((f) => f.key === recordField.field)
+													?.label ?? recordField.field
+											}
+										/>
+									) : (
+										<span className="truncate text-muted-foreground">
+											Choose a field
+										</span>
+									)}
 								</SelectTrigger>
 								<SelectContent>
 									{fieldOptions.map((f) => (

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/aggregate-config.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/aggregate-config.tsx
@@ -25,6 +25,7 @@ import {
 	PanelField,
 	PanelSection,
 } from "./panel-primitives";
+import { PickerChip } from "./picker-chip";
 
 const OPERATION_LABELS: Record<AggregateOperation, string> = {
 	sum: "Sum",
@@ -123,13 +124,20 @@ export function AggregateConfigPanel({
 									onValueChange={(field) => field && commit({ ...config, field })}
 								>
 									<SelectTrigger>
-										<SelectValue
-											placeholder={
-												sourceObjectType
-													? "Choose a numeric field"
-													: "Pick a source first"
-											}
-										/>
+										{(() => {
+											const selected = numericFields.find(
+												(f) => f.key === config.field
+											);
+											return selected ? (
+												<PickerChip label={selected.label} />
+											) : (
+												<span className="truncate text-muted-foreground">
+													{sourceObjectType
+														? "Choose a numeric field"
+														: "Pick a source first"}
+												</span>
+											);
+										})()}
 									</SelectTrigger>
 									<SelectContent>
 										{numericFields.map((field) => (

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/filter-groups-editor.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/filter-groups-editor.tsx
@@ -1,17 +1,26 @@
 "use client";
 
-import React from "react";
-import { Plus, X } from "lucide-react";
+import React, { useState } from "react";
+import { ChevronsUpDown, Plus, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import {
 	Select,
 	SelectContent,
-	SelectGroup,
 	SelectItem,
-	SelectLabel,
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+	VariableDrillList,
+	type DrillGroup,
+	type DrillPage,
+} from "./variable-drill-list";
 import {
 	MAX_CONDITION_GROUPS,
 	MAX_RULES_PER_GROUP,
@@ -31,6 +40,7 @@ import {
 	type WorkflowNode,
 } from "../../../lib/node-types";
 import { ValueInput } from "./value-input";
+import { PickerChip } from "./picker-chip";
 import { OPERATOR_LABELS } from "../../../lib/condition-sentence";
 import type { VariableOption } from "../../../lib/variables";
 
@@ -66,6 +76,130 @@ function emptyVariableRule(path: string): ConditionRule {
 		operator: "equals",
 		value: { kind: "static", value: "" },
 	};
+}
+
+type FilterableFields = ReturnType<typeof getFilterableFields>;
+
+type RelationFieldGroup = {
+	relation: AutomationObjectType;
+	label: string;
+	fields: FilterableFields;
+};
+
+/**
+ * The rule's left-side field selector, as a drill-down (own fields + one page
+ * per relation) plus the `var:`-prefixed step-result options. Stores the exact
+ * same string the old Select emitted — a field key, `<relation>.<fieldKey>`, or
+ * `var:<path>` — so saved definitions are unchanged; only the UI differs.
+ */
+function FieldPicker({
+	objectType,
+	fields,
+	relationFieldGroups,
+	variableOptions,
+	value,
+	onSelect,
+}: {
+	objectType: AutomationObjectType | null;
+	fields: FilterableFields;
+	relationFieldGroups: RelationFieldGroup[];
+	variableOptions: VariableOption[];
+	value: string;
+	onSelect: (next: string) => void;
+}) {
+	const [open, setOpen] = useState(false);
+
+	const label = (() => {
+		if (value.startsWith(VAR_PREFIX)) {
+			const path = value.slice(VAR_PREFIX.length);
+			return variableOptions.find((o) => o.path === path)?.label ?? path;
+		}
+		const dot = value.indexOf(".");
+		if (dot > 0) {
+			const rel = value.slice(0, dot);
+			const key = value.slice(dot + 1);
+			const group = relationFieldGroups.find((g) => g.relation === rel);
+			const field = group?.fields.find((f) => f.key === key);
+			if (group && field) return `${group.label} → ${field.label}`;
+		}
+		return fields.find((f) => f.key === value)?.label ?? value;
+	})();
+
+	const pick = (next: string) => {
+		onSelect(next);
+		setOpen(false);
+	};
+
+	const rootGroups: DrillGroup[] = [];
+	if (fields.length > 0) {
+		rootGroups.push({
+			id: "__fields__",
+			heading: objectType ? OBJECT_TYPE_LABELS[objectType] : undefined,
+			items: fields.map((f) => ({
+				id: f.key,
+				value: f.label,
+				label: f.label,
+				onSelect: () => pick(f.key),
+			})),
+		});
+	}
+	if (variableOptions.length > 0) {
+		rootGroups.push({
+			id: "__vars__",
+			heading: "Step results",
+			items: variableOptions.map((o) => ({
+				id: `${VAR_PREFIX}${o.path}`,
+				value: `${o.group} ${o.label}`,
+				label: o.label,
+				onSelect: () => pick(`${VAR_PREFIX}${o.path}`),
+			})),
+		});
+	}
+
+	const pages: DrillPage[] = relationFieldGroups
+		.filter((g) => g.fields.length > 0)
+		.map((g) => ({
+			id: g.relation,
+			navLabel: g.label,
+			items: g.fields.map((f) => ({
+				id: `${g.relation}.${f.key}`,
+				value: `${g.label} ${f.label}`,
+				label: `${g.label} → ${f.label}`,
+				onSelect: () => pick(`${g.relation}.${f.key}`),
+			})),
+		}));
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger
+				render={
+					<Button
+						variant="outline"
+						className={cn(
+							"w-full justify-between font-normal",
+							!value && "text-muted-foreground"
+						)}
+					/>
+				}
+			>
+				{value ? (
+					<PickerChip label={label} />
+				) : (
+					<span className="truncate">Select field</span>
+				)}
+				<ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+			</PopoverTrigger>
+			<PopoverContent align="start" className="w-80 p-0">
+				<VariableDrillList
+					rootGroups={rootGroups}
+					pages={pages}
+					open={open}
+					emptyText="No fields available."
+					placeholder="Search fields..."
+				/>
+			</PopoverContent>
+		</Popover>
+	);
 }
 
 export interface FilterGroupsEditorProps {
@@ -256,11 +390,15 @@ export function FilterGroupsEditor({
 						return (
 							<div key={ruleIndex} className="flex items-start gap-2">
 								<div className="flex-1 space-y-2">
-									<Select
+									<FieldPicker
+										objectType={objectType}
+										fields={fields}
+										relationFieldGroups={relationFieldGroups}
+										variableOptions={variableOptions}
 										value={
 											variableLeft ? `${VAR_PREFIX}${variableLeft.path}` : rule.field
 										}
-										onValueChange={(next) => {
+										onSelect={(next) => {
 											if (!next) return;
 											if (next.startsWith(VAR_PREFIX)) {
 												updateRule(
@@ -280,41 +418,7 @@ export function FilterGroupsEditor({
 													: { kind: "static", value: "" },
 											});
 										}}
-									>
-										<SelectTrigger>
-											<SelectValue placeholder="Field" />
-										</SelectTrigger>
-										<SelectContent>
-											{fields.map((f) => (
-												<SelectItem key={f.key} value={f.key}>
-													{f.label}
-												</SelectItem>
-											))}
-											{relationFieldGroups.map(({ relation, label, fields: relFields }) =>
-												relFields.length > 0 ? (
-													<SelectGroup key={relation}>
-														<SelectLabel>{label}</SelectLabel>
-														{relFields.map((f) => (
-															<SelectItem
-																key={`${relation}.${f.key}`}
-																value={`${relation}.${f.key}`}
-															>
-																{`${label} → ${f.label}`}
-															</SelectItem>
-														))}
-													</SelectGroup>
-												) : null
-											)}
-											{variableOptions.map((o) => (
-												<SelectItem
-													key={o.path}
-													value={`${VAR_PREFIX}${o.path}`}
-												>
-													{o.label}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
+									/>
 
 									<Select
 										value={rule.operator}

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/filter-groups-editor.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/filter-groups-editor.tsx
@@ -6,16 +6,20 @@ import { Button } from "@/components/ui/button";
 import {
 	Select,
 	SelectContent,
+	SelectGroup,
 	SelectItem,
+	SelectLabel,
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
 import {
 	MAX_CONDITION_GROUPS,
 	MAX_RULES_PER_GROUP,
+	RELATED_OBJECTS,
 	VALUELESS_OPERATORS,
 	VARIABLE_LEFT_OPERATORS,
-	getFieldDefinition,
+	OBJECT_TYPE_LABELS,
+	getFieldDefinitionForKey,
 	getFilterableFields,
 	operatorsForField,
 	type AutomationObjectType,
@@ -100,6 +104,15 @@ export function FilterGroupsEditor({
 	formulas,
 }: FilterGroupsEditorProps) {
 	const fields = objectType ? getFilterableFields(objectType) : [];
+	// One-hop related fields (C6): "<relation>.<fieldKey>" values, grouped per
+	// relation ("Client → Company name") alongside the flat field group.
+	const relationFieldGroups = objectType
+		? (RELATED_OBJECTS[objectType] ?? []).map((relation) => ({
+				relation,
+				label: OBJECT_TYPE_LABELS[relation],
+				fields: getFilterableFields(relation),
+			}))
+		: [];
 	const variableOptions = variableLeftOptions ?? [];
 	const canAddRule = fields.length > 0 || variableOptions.length > 0;
 
@@ -226,7 +239,7 @@ export function FilterGroupsEditor({
 							: undefined;
 						const fieldDef =
 							!variableLeft && objectType
-								? getFieldDefinition(objectType, rule.field)
+								? getFieldDefinitionForKey(objectType, rule.field)
 								: undefined;
 						const operators = variableLeft
 							? [...VARIABLE_LEFT_OPERATORS]
@@ -277,6 +290,21 @@ export function FilterGroupsEditor({
 													{f.label}
 												</SelectItem>
 											))}
+											{relationFieldGroups.map(({ relation, label, fields: relFields }) =>
+												relFields.length > 0 ? (
+													<SelectGroup key={relation}>
+														<SelectLabel>{label}</SelectLabel>
+														{relFields.map((f) => (
+															<SelectItem
+																key={`${relation}.${f.key}`}
+																value={`${relation}.${f.key}`}
+															>
+																{`${label} → ${f.label}`}
+															</SelectItem>
+														))}
+													</SelectGroup>
+												) : null
+											)}
 											{variableOptions.map((o) => (
 												<SelectItem
 													key={o.path}

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/picker-chip.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/picker-chip.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * The chip a resource picker (a record/relation field, or a variable) renders
+ * inside its trigger to show the current selection — the Salesforce-style
+ * outlined pill shared by filter-groups-editor's FieldPicker and the flat
+ * field-picker Selects across the config panels.
+ */
+export function PickerChip({
+	label,
+	icon: Icon,
+	className,
+}: {
+	label: React.ReactNode;
+	/** Optional leading icon (e.g. Braces for a variable). */
+	icon?: React.ComponentType<{ className?: string }>;
+	className?: string;
+}) {
+	return (
+		<span
+			className={cn(
+				"flex min-w-0 items-center gap-1 rounded-md border border-border bg-muted/40 px-1.5 py-0.5 text-xs",
+				className
+			)}
+		>
+			{Icon && <Icon className="h-3 w-3 shrink-0 text-muted-foreground" />}
+			<span className="truncate">{label}</span>
+		</span>
+	);
+}

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/value-input.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/value-input.tsx
@@ -32,7 +32,18 @@ import {
 	CommandItem,
 	CommandList,
 } from "@/components/ui/command";
-import { getAvailableVariables, type VariableOption } from "../../../lib/variables";
+import {
+	getAvailableVariables,
+	partitionVariableGroups,
+	type VariableOption,
+} from "../../../lib/variables";
+import {
+	VariableDrillList,
+	type DrillGroup,
+	type DrillItem,
+	type DrillPage,
+} from "./variable-drill-list";
+import { PickerChip } from "./picker-chip";
 import type {
 	AutomationTrigger,
 	FieldDefinition,
@@ -43,29 +54,58 @@ import type {
 	WorkflowNode,
 } from "../../../lib/node-types";
 
-/** Shared variable lookup + grouping for the popover used by ValueInput and VariableInsertButton. */
-function useGroupedVariables(
+/** Shared variable lookup for the popover used by ValueInput and VariableInsertButton. */
+function useAvailableVariables(
 	nodes: WorkflowNode[],
 	trigger: TriggerConfig | AutomationTrigger | null,
 	targetNodeId: string,
 	formulas?: FormulaResource[]
-): { variables: VariableOption[]; groups: [string, VariableOption[]][] } {
-	const variables = useMemo(
+): VariableOption[] {
+	return useMemo(
 		() => (trigger ? getAvailableVariables(nodes, trigger, targetNodeId, formulas) : []),
 		[nodes, trigger, targetNodeId, formulas]
 	);
+}
 
-	const groups = useMemo(() => {
-		const map = new Map<string, VariableOption[]>();
-		for (const option of variables) {
-			const list = map.get(option.group) ?? [];
-			list.push(option);
-			map.set(option.group, list);
-		}
-		return Array.from(map.entries());
-	}, [variables]);
-
-	return { variables, groups };
+/**
+ * Builds the drill-down model (root groups + relation pages) from variable
+ * options. `decorate` adds per-row styling/hints; `sortWithin` orders a group's
+ * rows (used to float compatible-type options first).
+ */
+function buildVariableDrill(
+	variables: VariableOption[],
+	onPick: (option: VariableOption) => void,
+	decorate?: (
+		option: VariableOption
+	) => { className?: string; trailing?: React.ReactNode },
+	sortWithin?: (options: VariableOption[]) => VariableOption[]
+): { rootGroups: DrillGroup[]; pages: DrillPage[] } {
+	const { rootGroups, relationPages } = partitionVariableGroups(variables);
+	const toItem = (option: VariableOption): DrillItem => {
+		const decoration = decorate?.(option);
+		return {
+			id: option.path,
+			value: `${option.group} ${option.label}`,
+			label: option.label,
+			className: decoration?.className,
+			trailing: decoration?.trailing,
+			onSelect: () => onPick(option),
+		};
+	};
+	const order = (options: VariableOption[]) =>
+		(sortWithin ? sortWithin(options) : options).map(toItem);
+	return {
+		rootGroups: rootGroups.map(([group, options]) => ({
+			id: group,
+			heading: group,
+			items: order(options),
+		})),
+		pages: relationPages.map((page) => ({
+			id: page.id,
+			navLabel: page.navLabel,
+			items: order(page.options),
+		})),
+	};
 }
 
 /** The subset of FieldDefinition ValueInput needs to pick a static control. */
@@ -536,7 +576,7 @@ export function ValueInput({
 	arrayResolution = "first",
 }: ValueInputProps) {
 	const [open, setOpen] = useState(false);
-	const { variables, groups } = useGroupedVariables(nodes, trigger, targetNodeId, formulas);
+	const variables = useAvailableVariables(nodes, trigger, targetNodeId, formulas);
 
 	if (value?.kind === "var") {
 		const selected = variables.find((v) => v.path === value.path);
@@ -544,9 +584,8 @@ export function ValueInput({
 
 		return (
 			<div className={cn("space-y-2", className)}>
-				<div className="flex items-center gap-1.5 rounded-md border border-border bg-muted/40 px-2.5 py-1.5 text-sm">
-					<Braces className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-					<span className="flex-1 truncate">{selected?.label ?? value.path}</span>
+				<div className="flex min-h-9 items-center justify-between gap-1.5 rounded-md border border-input px-2 py-1 text-sm">
+					<PickerChip icon={Braces} label={selected?.label ?? value.path} />
 					<button
 						type="button"
 						aria-label="Remove variable"
@@ -604,15 +643,48 @@ export function ValueInput({
 					>
 						<Braces className="h-4 w-4" />
 					</PopoverTrigger>
-					<PopoverContent align="end" className="w-72 p-0">
-						<Command>
-							<CommandInput placeholder="Search variables..." />
-							<CommandList>
-								<CommandEmpty>No variables available yet.</CommandEmpty>
-								{groups.map(([group, options]) => {
-									// Compatible-type variables first; incompatible ones stay
-									// selectable but sort last and render greyed with a hint.
-									const sorted = [...options].sort(
+					<PopoverContent align="end" className="w-80 p-0">
+						{(() => {
+							const { rootGroups, pages } = buildVariableDrill(
+								variables,
+								(option) => {
+									onChange({ kind: "var", path: option.path });
+									setOpen(false);
+								},
+								(option) => {
+									const needsConversion = variableNeedsConversion(
+										field.type,
+										option.fieldType,
+										field.refType,
+										option.refType
+									);
+									// An array feeding this single-valued field resolves per
+									// arrayResolution — say so rather than let the author assume
+									// all of them land.
+									const arrayHint =
+										option.isArray &&
+										!needsConversion &&
+										arrayResolution !== "none"
+											? arrayResolution === "first"
+												? "uses first"
+												: "matches any"
+											: null;
+									return {
+										// Incompatible-type options stay selectable but render greyed.
+										className: needsConversion
+											? "text-muted-foreground"
+											: undefined,
+										trailing:
+											needsConversion || arrayHint ? (
+												<span className="ml-2 shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">
+													{needsConversion ? "needs conversion" : arrayHint}
+												</span>
+											) : undefined,
+									};
+								},
+								// Compatible-type options first within each group/page.
+								(options) =>
+									[...options].sort(
 										(a, b) =>
 											Number(
 												variableNeedsConversion(
@@ -630,63 +702,18 @@ export function ValueInput({
 													b.refType
 												)
 											)
-									);
-									return (
-										<CommandGroup key={group} heading={group}>
-											{sorted.map((option) => {
-												const needsConversion = variableNeedsConversion(
-													field.type,
-													option.fieldType,
-													field.refType,
-													option.refType
-												);
-												// An array feeding this single-valued field resolves
-												// per arrayResolution — say so rather than let the
-												// author assume all of them land.
-												const arrayHint =
-													option.isArray &&
-													!needsConversion &&
-													arrayResolution !== "none"
-														? arrayResolution === "first"
-															? "uses first"
-															: "matches any"
-														: null;
-												return (
-													<CommandItem
-														key={option.path}
-														value={`${option.group} ${option.label}`}
-														onSelect={() => {
-															onChange({ kind: "var", path: option.path });
-															setOpen(false);
-														}}
-														className="cursor-pointer"
-													>
-														<span
-															className={cn(
-																"flex-1 truncate",
-																needsConversion && "text-muted-foreground"
-															)}
-														>
-															{option.label}
-														</span>
-														{needsConversion && (
-															<span className="ml-2 shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">
-																needs conversion
-															</span>
-														)}
-														{arrayHint && (
-															<span className="ml-2 shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">
-																{arrayHint}
-															</span>
-														)}
-													</CommandItem>
-												);
-											})}
-										</CommandGroup>
-									);
-								})}
-							</CommandList>
-						</Command>
+									)
+							);
+							return (
+								<VariableDrillList
+									rootGroups={rootGroups}
+									pages={pages}
+									open={open}
+									emptyText="No variables available yet."
+									placeholder="Search variables..."
+								/>
+							);
+						})()}
 					</PopoverContent>
 				</Popover>
 			</div>
@@ -717,7 +744,11 @@ export function VariableInsertButton({
 	className?: string;
 }) {
 	const [open, setOpen] = useState(false);
-	const { groups } = useGroupedVariables(nodes, trigger, targetNodeId, formulas);
+	const variables = useAvailableVariables(nodes, trigger, targetNodeId, formulas);
+	const { rootGroups, pages } = buildVariableDrill(variables, (option) => {
+		onInsert(option.path);
+		setOpen(false);
+	});
 
 	return (
 		<Popover open={open} onOpenChange={setOpen}>
@@ -734,30 +765,14 @@ export function VariableInsertButton({
 				<Braces className="h-3.5 w-3.5" />
 				Insert variable
 			</PopoverTrigger>
-			<PopoverContent align="start" className="w-72 p-0">
-				<Command>
-					<CommandInput placeholder="Search variables..." />
-					<CommandList>
-						<CommandEmpty>No variables available yet.</CommandEmpty>
-						{groups.map(([group, options]) => (
-							<CommandGroup key={group} heading={group}>
-								{options.map((option) => (
-									<CommandItem
-										key={option.path}
-										value={`${option.group} ${option.label}`}
-										onSelect={() => {
-											onInsert(option.path);
-											setOpen(false);
-										}}
-										className="cursor-pointer"
-									>
-										{option.label}
-									</CommandItem>
-								))}
-							</CommandGroup>
-						))}
-					</CommandList>
-				</Command>
+			<PopoverContent align="start" className="w-80 p-0">
+				<VariableDrillList
+					rootGroups={rootGroups}
+					pages={pages}
+					open={open}
+					emptyText="No variables available yet."
+					placeholder="Search variables..."
+				/>
 			</PopoverContent>
 		</Popover>
 	);

--- a/apps/web/src/app/(workspace)/automations/components/sidebar/panels/variable-drill-list.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/sidebar/panels/variable-drill-list.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/command";
+
+/**
+ * One selectable row. `value` is the cmdk search string (include the full
+ * "Group → Field" path so flat search matches across levels); `label` is what
+ * renders.
+ */
+export type DrillItem = {
+	id: string;
+	value: string;
+	label: React.ReactNode;
+	className?: string;
+	trailing?: React.ReactNode;
+	onSelect: () => void;
+};
+
+/** A root-level group of rows (rendered with a heading when search is empty). */
+export type DrillGroup = {
+	id: string;
+	heading?: string;
+	items: DrillItem[];
+};
+
+/** A navigable relation page: its nav-row/back label and its own rows. */
+export type DrillPage = {
+	id: string;
+	navLabel: string;
+	items: DrillItem[];
+};
+
+/**
+ * The cmdk "pages" drill-down shared by every relation-aware picker: root shows
+ * `rootGroups` plus one nav row per relation `page`; selecting a nav row
+ * descends. Typing flattens across all levels (cmdk filters each row by its
+ * `value`), ignoring the current page. Resets to root when `open` goes false.
+ */
+export function VariableDrillList({
+	rootGroups,
+	pages,
+	open,
+	emptyText,
+	placeholder,
+}: {
+	rootGroups: DrillGroup[];
+	pages: DrillPage[];
+	open: boolean;
+	emptyText: string;
+	placeholder: string;
+}) {
+	const [search, setSearch] = useState("");
+	const [page, setPage] = useState<string | null>(null);
+
+	// Reopen at the root: clear navigation + search when the popover closes.
+	// Render-time derivation (not an effect) so no cascading-render lint error.
+	const [prevOpen, setPrevOpen] = useState(open);
+	if (prevOpen !== open) {
+		setPrevOpen(open);
+		if (!open) {
+			setSearch("");
+			setPage(null);
+		}
+	}
+
+	const searching = search.trim().length > 0;
+
+	const flatItems = useMemo(
+		() => [
+			...rootGroups.flatMap((g) => g.items),
+			...pages.flatMap((p) => p.items),
+		],
+		[rootGroups, pages]
+	);
+
+	// A stale page id (options changed) resolves to null -> falls back to root.
+	const activePage = page ? (pages.find((p) => p.id === page) ?? null) : null;
+
+	// cmdk keys rows by `value`; append the id so rows with identical display
+	// text (an own ref field "Client" vs the "Client" nav row) don't highlight
+	// together on hover.
+	const renderItem = (item: DrillItem) => (
+		<CommandItem
+			key={item.id}
+			value={`${item.value} ${item.id}`}
+			onSelect={item.onSelect}
+			className={cn("cursor-pointer", item.className)}
+		>
+			<span className="flex-1 truncate">{item.label}</span>
+			{item.trailing}
+		</CommandItem>
+	);
+
+	return (
+		<Command
+			onKeyDown={(e) => {
+				// Backspace on an empty search steps back out of a relation page
+				// rather than dismissing the popover.
+				if (e.key === "Backspace" && !search && activePage) {
+					e.preventDefault();
+					setPage(null);
+				}
+			}}
+		>
+			<CommandInput
+				placeholder={placeholder}
+				value={search}
+				onValueChange={setSearch}
+			/>
+			<CommandList>
+				<CommandEmpty>{emptyText}</CommandEmpty>
+				{searching ? (
+					<CommandGroup>{flatItems.map(renderItem)}</CommandGroup>
+				) : activePage ? (
+					<>
+						<CommandGroup>
+							<CommandItem
+								value={`__back__ ${activePage.navLabel}`}
+								onSelect={() => setPage(null)}
+								className="cursor-pointer text-muted-foreground"
+							>
+								<ChevronLeft className="h-4 w-4 shrink-0" />
+								<span className="flex-1 truncate">{activePage.navLabel}</span>
+							</CommandItem>
+						</CommandGroup>
+						<CommandGroup>{activePage.items.map(renderItem)}</CommandGroup>
+					</>
+				) : (
+					<>
+						{rootGroups.map((g) => (
+							<CommandGroup key={g.id} heading={g.heading}>
+								{g.items.map(renderItem)}
+							</CommandGroup>
+						))}
+						{pages.length > 0 && (
+							<CommandGroup heading="Related records">
+								{pages.map((p) => (
+									<CommandItem
+										key={p.id}
+										value={`__nav__ ${p.navLabel} ${p.id}`}
+										onSelect={() => setPage(p.id)}
+										className="cursor-pointer"
+									>
+										<span className="flex-1 truncate">{p.navLabel}</span>
+										<span className="ml-2 shrink-0 text-[10px] tabular-nums text-muted-foreground">
+											{p.items.length}
+										</span>
+										<ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+									</CommandItem>
+								))}
+							</CommandGroup>
+						)}
+					</>
+				)}
+			</CommandList>
+		</Command>
+	);
+}

--- a/apps/web/src/app/(workspace)/automations/lib/condition-sentence.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/condition-sentence.ts
@@ -5,13 +5,27 @@
 
 import {
 	VALUELESS_OPERATORS,
-	getFieldDefinition,
+	OBJECT_TYPE_LABELS,
+	getFieldDefinitionForKey,
+	parseRelationKey,
 	type AutomationObjectType,
 	type ConditionGroup,
 	type ConditionOperator,
 	type ConditionRule,
 	type ValueRef,
 } from "./node-types";
+
+/** Field label for a flat or one-hop relation-qualified key ("client.companyName" -> "Client → Company name"). */
+function fieldLabelForKey(
+	objectType: AutomationObjectType,
+	key: string
+): string | undefined {
+	const relation = parseRelationKey(objectType, key);
+	if (relation) {
+		return `${OBJECT_TYPE_LABELS[relation.relation]} → ${relation.field.label}`;
+	}
+	return getFieldDefinitionForKey(objectType, key)?.label;
+}
 
 export const OPERATOR_LABELS: Record<ConditionOperator, string> = {
 	equals: "equals",
@@ -82,7 +96,7 @@ export function describeVarPath(
 	if (path.startsWith(prefix)) {
 		const field = path.slice(prefix.length);
 		if (field === "_id") return "Trigger record ID"; // not in the field registry
-		const label = objectType ? getFieldDefinition(objectType, field)?.label : undefined;
+		const label = objectType ? fieldLabelForKey(objectType, field) : undefined;
 		// With no record in scope there is no field to name it after. Say so
 		// rather than leaking a raw path that reads like it resolves.
 		if (!label) return objectType ? field : "the triggering record";
@@ -110,7 +124,7 @@ function describeValue(
 ): string {
 	if (value.kind === "var") return describeVarPath(value.path, objectType, varLabels);
 
-	const fieldDef = objectType ? getFieldDefinition(objectType, field) : undefined;
+	const fieldDef = objectType ? getFieldDefinitionForKey(objectType, field) : undefined;
 	if (fieldDef?.type === "select") {
 		const option = fieldDef.options?.find((o) => o.value === value.value);
 		return option?.label ?? String(value.value ?? "");
@@ -124,14 +138,13 @@ function ruleText(
 	objectType: AutomationObjectType | null,
 	varLabels?: VarLabelMap
 ): string {
-	const fieldDef = objectType ? getFieldDefinition(objectType, rule.field) : undefined;
 	const fieldLabel = rule.left
 		? describeVarPath(
 				rule.left.kind === "var" ? rule.left.path : String(rule.left.value),
 				objectType,
 				varLabels
 			)
-		: (fieldDef?.label ?? rule.field);
+		: ((objectType && fieldLabelForKey(objectType, rule.field)) ?? rule.field);
 	const opLabel = OPERATOR_LABELS[rule.operator] ?? rule.operator;
 
 	if (isValueless(rule.operator) || rule.value === undefined) {

--- a/apps/web/src/app/(workspace)/automations/lib/node-types.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/node-types.ts
@@ -90,6 +90,8 @@ export {
 	isCreatableObjectType,
 	operatorsForField,
 	getStatusOptions,
+	parseRelationKey,
+	getFieldDefinitionForKey,
 } from "@onetool/backend/convex/lib/fieldRegistry";
 
 export type {

--- a/apps/web/src/app/(workspace)/automations/lib/variables.test.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/variables.test.ts
@@ -222,6 +222,56 @@ describe("getAvailableVariables", () => {
 		}
 	});
 
+	// C6: one-hop related-field traversal.
+	it("offers trigger.record.<relation>.<field> for the trigger object type's related objects", () => {
+		const target = actionNode("a1");
+		const projectTrigger: TriggerConfig = { type: "record_created", objectType: "project" };
+		const options = getAvailableVariables([target], projectTrigger, "a1");
+		const relationField = options.find(
+			(o) => o.path === "trigger.record.client.companyName"
+		);
+		expect(relationField).toEqual({
+			path: "trigger.record.client.companyName",
+			label: "Trigger → Client → Company Name",
+			group: "Trigger · Client",
+			fieldType: "text",
+			refType: undefined,
+			isArray: undefined,
+		});
+	});
+
+	it("does not offer a second hop through a related object's own relations", () => {
+		const target = actionNode("a1");
+		// invoice -> quote -> client is two hops from invoice; only the direct
+		// client/project/quote relations off invoice should appear.
+		const invoiceTrigger: TriggerConfig = { type: "record_created", objectType: "invoice" };
+		const options = getAvailableVariables([target], invoiceTrigger, "a1");
+		expect(
+			options.some((o) => o.path === "trigger.record.quote.client.companyName")
+		).toBe(false);
+		expect(options.some((o) => o.path === "trigger.record.quote.status")).toBe(true);
+	});
+
+	it("offers loop.<loopNodeId>.item.<relation>.<field> for the loop source's related objects", () => {
+		const fetch = fetchNode("f1", "task");
+		const loop = loopNode("loop1", "f1", { bodyStartNodeId: "body1" });
+		const bodyAction = actionNode("body1");
+		const nodes = [fetch, loop, bodyAction];
+
+		const options = getAvailableVariables(nodes, statusChangedTrigger, "body1");
+		const relationField = options.find(
+			(o) => o.path === "loop.loop1.item.client.companyName"
+		);
+		expect(relationField).toEqual({
+			path: "loop.loop1.item.client.companyName",
+			label: "Loop item → Client → Company Name",
+			group: "Loop item · Client",
+			fieldType: "text",
+			refType: undefined,
+			isArray: undefined,
+		});
+	});
+
 	it("offers a formula referencing only trigger fields anywhere, but not one referencing a loop item outside the loop", () => {
 		const fetch = fetchNode("f1", "project");
 		const loop = loopNode("loop1", "f1", { bodyStartNodeId: "body1" });

--- a/apps/web/src/app/(workspace)/automations/lib/variables.test.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/variables.test.ts
@@ -4,6 +4,7 @@ import {
 	getAvailableVariables,
 	getScopeObjectType,
 	getUpstreamFetchNodes,
+	partitionVariableGroups,
 } from "./variables";
 import type {
 	FetchNodeConfig,
@@ -237,7 +238,11 @@ describe("getAvailableVariables", () => {
 			fieldType: "text",
 			refType: undefined,
 			isArray: undefined,
+			relation: { key: "client", label: "Client" },
 		});
+		// Non-relation options carry no `relation` marker.
+		const ownField = options.find((o) => o.path === "trigger.record.title");
+		expect(ownField?.relation).toBeUndefined();
 	});
 
 	it("does not offer a second hop through a related object's own relations", () => {
@@ -269,6 +274,7 @@ describe("getAvailableVariables", () => {
 			fieldType: "text",
 			refType: undefined,
 			isArray: undefined,
+			relation: { key: "client", label: "Client" },
 		});
 	});
 
@@ -348,6 +354,34 @@ describe("getAllVariableOptions", () => {
 
 		const all = getAllVariableOptions([target], statusChangedTrigger, formulas);
 		expect(all.some((o) => o.path === "formula.loopItem")).toBe(true);
+	});
+});
+
+describe("partitionVariableGroups", () => {
+	it("splits own-field groups from one navigable page per relation", () => {
+		const target = actionNode("a1");
+		const projectTrigger: TriggerConfig = {
+			type: "record_created",
+			objectType: "project",
+		};
+		const options = getAvailableVariables([target], projectTrigger, "a1");
+		const { rootGroups, relationPages } = partitionVariableGroups(options);
+
+		// Relation options never leak into the root groups.
+		expect(rootGroups.every(([, opts]) => opts.every((o) => !o.relation))).toBe(
+			true
+		);
+		// The trigger's own fields stay at root.
+		expect(rootGroups.some(([group]) => group === "Trigger")).toBe(true);
+
+		const clientPage = relationPages.find((p) => p.id === "Trigger · Client");
+		expect(clientPage?.navLabel).toBe("Trigger → Client");
+		expect(clientPage?.options.length).toBeGreaterThan(0);
+		expect(
+			clientPage?.options.some(
+				(o) => o.path === "trigger.record.client.companyName"
+			)
+		).toBe(true);
 	});
 });
 

--- a/apps/web/src/app/(workspace)/automations/lib/variables.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/variables.ts
@@ -5,6 +5,7 @@ import {
 import { collectLoopBody } from "./graph-utils";
 import {
 	OBJECT_TYPE_LABELS,
+	RELATED_OBJECTS,
 	getFilterableFields,
 	isFetchOnlyObjectType,
 	type AutomationObjectType,
@@ -211,6 +212,36 @@ function fieldOptionLabel(
 }
 
 /**
+ * One-hop related-field options (C6): for every relation in
+ * RELATED_OBJECTS[objectType], its filterable fields as
+ * `<pathPrefix>.<relation>.<fieldKey>`. Grouped per relation ("Trigger ·
+ * Client" / "Loop item · Client") so the picker's groups stay scannable
+ * alongside the flat "Trigger"/"Loop item" group. Cap at one hop — never
+ * recurse into RELATED_OBJECTS[relation].
+ */
+function relationVariableOptions(
+	objectType: AutomationObjectType,
+	pathPrefix: string,
+	labelPrefix: string
+): VariableOption[] {
+	const options: VariableOption[] = [];
+	for (const relation of RELATED_OBJECTS[objectType] ?? []) {
+		const relationLabel = OBJECT_TYPE_LABELS[relation];
+		for (const field of getFilterableFields(relation)) {
+			options.push({
+				path: `${pathPrefix}.${relation}.${field.key}`,
+				label: fieldOptionLabel(`${labelPrefix} → ${relationLabel}`, field),
+				group: `${labelPrefix} · ${relationLabel}`,
+				fieldType: field.type,
+				refType: field.refType,
+				isArray: field.isArray,
+			});
+		}
+	}
+	return options;
+}
+
+/**
  * A record's own `_id` option is refType-compatible with a destination `id`
  * field pointing at the same object type — but `task` and the line-item types
  * aren't valid `refType` values (no id field ever points at one), so those fall
@@ -263,6 +294,9 @@ function triggerVariableOptions(
 				isArray: field.isArray,
 			});
 		}
+		options.push(
+			...relationVariableOptions(triggerObjectType, "trigger.record", "Trigger")
+		);
 	}
 
 	if (effectiveTriggerType(trigger) === "status_changed") {
@@ -399,6 +433,13 @@ export function getAvailableVariables(
 				isArray: field.isArray,
 			});
 		}
+		options.push(
+			...relationVariableOptions(
+				sourceObjectType,
+				`loop.${node.id}.item`,
+				"Loop item"
+			)
+		);
 		options.push({
 			path: `loop.${node.id}.index`,
 			label: "Loop item → Index (0-based)",
@@ -517,6 +558,13 @@ export function getAllVariableOptions(
 				isArray: field.isArray,
 			});
 		}
+		options.push(
+			...relationVariableOptions(
+				sourceObjectType,
+				`loop.${node.id}.item`,
+				"Loop item"
+			)
+		);
 		options.push({
 			path: `loop.${node.id}.index`,
 			label: "Loop item → Index (0-based)",

--- a/apps/web/src/app/(workspace)/automations/lib/variables.ts
+++ b/apps/web/src/app/(workspace)/automations/lib/variables.ts
@@ -40,6 +40,11 @@ export type VariableOption = {
 	refType?: FieldDefinition["refType"];
 	/** The option holds an array — feeding it a single-valued field uses the first element. */
 	isArray?: boolean;
+	/**
+	 * Set on one-hop relation options — drives the picker's drill-down page.
+	 * key = the relation objectType (e.g. "client"), label = its display name.
+	 */
+	relation?: { key: string; label: string };
 };
 
 function childrenOf(node: WorkflowNode): string[] {
@@ -235,6 +240,7 @@ function relationVariableOptions(
 				fieldType: field.type,
 				refType: field.refType,
 				isArray: field.isArray,
+				relation: { key: relation, label: relationLabel },
 			});
 		}
 	}
@@ -484,6 +490,52 @@ export function getAvailableVariables(
 	}
 
 	return options;
+}
+
+/** A relation drill-down page: its group id, nav label ("Trigger → Client"), and fields. */
+export type VariableRelationPage = {
+	/** The option `group` this page collects (also the drill-down page id). */
+	id: string;
+	/** Nav-row + back-header label, e.g. "Trigger → Client". */
+	navLabel: string;
+	options: VariableOption[];
+};
+
+/**
+ * Splits variable options into the drill-down root (non-relation groups, in
+ * insertion order) and one navigable page per relation group. Pure, so the
+ * picker's page structure is testable without a DOM. Nav label derives from the
+ * group ("Trigger · Client") + the relation's own label.
+ */
+export function partitionVariableGroups(options: VariableOption[]): {
+	rootGroups: [string, VariableOption[]][];
+	relationPages: VariableRelationPage[];
+} {
+	const rootMap = new Map<string, VariableOption[]>();
+	const relMap = new Map<string, VariableRelationPage>();
+	for (const option of options) {
+		if (option.relation) {
+			let page = relMap.get(option.group);
+			if (!page) {
+				const prefix = option.group.split(" · ")[0];
+				page = {
+					id: option.group,
+					navLabel: `${prefix} → ${option.relation.label}`,
+					options: [],
+				};
+				relMap.set(option.group, page);
+			}
+			page.options.push(option);
+		} else {
+			const list = rootMap.get(option.group) ?? [];
+			list.push(option);
+			rootMap.set(option.group, list);
+		}
+	}
+	return {
+		rootGroups: Array.from(rootMap.entries()),
+		relationPages: Array.from(relMap.values()),
+	};
 }
 
 /**

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -76,6 +76,7 @@ import type * as lib_permissions from "../lib/permissions.js";
 import type * as lib_planLimits from "../lib/planLimits.js";
 import type * as lib_queries from "../lib/queries.js";
 import type * as lib_quoteTotals from "../lib/quoteTotals.js";
+import type * as lib_relationRefs from "../lib/relationRefs.js";
 import type * as lib_reportFields from "../lib/reportFields.js";
 import type * as lib_reportFilters from "../lib/reportFilters.js";
 import type * as lib_reportPresets from "../lib/reportPresets.js";
@@ -217,6 +218,7 @@ declare const fullApi: ApiFromModules<{
   "lib/planLimits": typeof lib_planLimits;
   "lib/queries": typeof lib_queries;
   "lib/quoteTotals": typeof lib_quoteTotals;
+  "lib/relationRefs": typeof lib_relationRefs;
   "lib/reportFields": typeof lib_reportFields;
   "lib/reportFilters": typeof lib_reportFilters;
   "lib/reportPresets": typeof lib_reportPresets;

--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -6610,4 +6610,364 @@ describe("automationExecutor (v2 engine)", () => {
 			});
 		});
 	});
+	describe("Phase C6 — one-hop related-field traversal", () => {
+		/** update_field writing from a var path with a fallback. */
+		function updateFromVarWithFallback(
+			id: string,
+			field: string,
+			path: string,
+			fallback: string
+		) {
+			return {
+				id,
+				type: "action" as const,
+				config: {
+					kind: "action" as const,
+					action: {
+						type: "update_field" as const,
+						target: "self" as const,
+						field,
+						value: { kind: "var" as const, path, fallback },
+					},
+				},
+			};
+		}
+
+		function fetchNode(
+			id: string,
+			objectType: "project",
+			filters: {
+				logic: "and";
+				rules: {
+					field: string;
+					operator: "equals";
+					value: { kind: "static"; value: string };
+				}[];
+			}[],
+			opts: { nextNodeId?: string } = {}
+		) {
+			return {
+				id,
+				type: "fetch_records" as const,
+				config: { kind: "fetch_records" as const, objectType, filters },
+				nextNodeId: opts.nextNodeId,
+			};
+		}
+
+		async function createClientWithProject(
+			asUser: ReturnType<typeof t.withIdentity>,
+			companyName: string,
+			clientStatus: "lead" | "active" = "active"
+		) {
+			const clientId = await asUser.mutation(api.clients.create, {
+				portalAccessId: crypto.randomUUID(),
+				companyName,
+				status: clientStatus,
+			});
+			const projectId = await asUser.mutation(api.projects.create, {
+				clientId,
+				title: `${companyName} project`,
+				status: "planned",
+				projectType: "one-off",
+			});
+			return { clientId, projectId };
+		}
+
+		it("interpolates trigger.record.<relation>.<field> in notification messages", async () => {
+			const { asUser } = await setupUser();
+			const { projectId } = await createClientWithProject(asUser, "Acme Co");
+
+			await asUser.mutation(api.automations.create, {
+				name: "Notify with client name",
+				trigger: {
+					type: "record_updated",
+					objectType: "project",
+					fields: ["title"],
+				},
+				nodes: [
+					notifyNode("act-1", "Client: {{trigger.record.client.companyName}}"),
+				],
+				isActive: true,
+			});
+
+			await asUser.mutation(api.projects.update, {
+				id: projectId,
+				title: "Renamed project",
+			});
+			await drainEvents();
+
+			const notifications = await t.run(async (ctx) =>
+				ctx.db.query("notifications").collect()
+			);
+			expect(
+				notifications.some((n) => n.message === "Client: Acme Co")
+			).toBe(true);
+		});
+
+		it("condition nodes branch on dotted relation fields", async () => {
+			const { asUser } = await setupUser();
+			const acme = await createClientWithProject(asUser, "Acme Co", "active");
+			const other = await createClientWithProject(asUser, "Dormant Co", "lead");
+
+			await asUser.mutation(api.automations.create, {
+				name: "Only active clients",
+				trigger: {
+					type: "record_updated",
+					objectType: "project",
+					fields: ["title"],
+				},
+				nodes: [
+					conditionNode("cond-1", "client.status", "equals", "active", {
+						nextNodeId: "act-1",
+					}),
+					updateFieldActionNode("act-1", "description", "client active"),
+				],
+				isActive: true,
+			});
+
+			await asUser.mutation(api.projects.update, {
+				id: acme.projectId,
+				title: "Acme renamed",
+			});
+			await asUser.mutation(api.projects.update, {
+				id: other.projectId,
+				title: "Dormant renamed",
+			});
+			await drainEvents();
+
+			const acmeProject = await t.run(async (ctx) =>
+				ctx.db.get(acme.projectId)
+			);
+			const otherProject = await t.run(async (ctx) =>
+				ctx.db.get(other.projectId)
+			);
+			expect(acmeProject?.description).toBe("client active");
+			expect(otherProject?.description).toBeUndefined();
+		});
+
+		it("entry criteria filter on dotted relation fields before dispatch", async () => {
+			const { asUser } = await setupUser();
+			const acme = await createClientWithProject(asUser, "Acme Co");
+			const other = await createClientWithProject(asUser, "Other Co");
+
+			await asUser.mutation(api.automations.create, {
+				name: "Acme projects only",
+				trigger: {
+					type: "record_updated",
+					objectType: "project",
+					fields: ["title"],
+					entryCriteria: {
+						logic: "and" as const,
+						groups: [
+							{
+								logic: "and" as const,
+								rules: [
+									{
+										field: "client.companyName",
+										operator: "contains" as const,
+										value: { kind: "static" as const, value: "Acme" },
+									},
+								],
+							},
+						],
+					},
+				},
+				nodes: [updateFieldActionNode("act-1", "description", "matched")],
+				isActive: true,
+			});
+
+			await asUser.mutation(api.projects.update, {
+				id: acme.projectId,
+				title: "Acme renamed",
+			});
+			await asUser.mutation(api.projects.update, {
+				id: other.projectId,
+				title: "Other renamed",
+			});
+			await drainEvents();
+
+			const acmeProject = await t.run(async (ctx) =>
+				ctx.db.get(acme.projectId)
+			);
+			const otherProject = await t.run(async (ctx) =>
+				ctx.db.get(other.projectId)
+			);
+			expect(acmeProject?.description).toBe("matched");
+			expect(otherProject?.description).toBeUndefined();
+		});
+
+		it("fetch filters match rows via dotted relation fields", async () => {
+			const { asUser } = await setupUser();
+			const acme = await createClientWithProject(asUser, "Acme Co");
+			// Second Acme project + one project under another client.
+			await asUser.mutation(api.projects.create, {
+				clientId: acme.clientId,
+				title: "Acme second project",
+				status: "planned",
+				projectType: "one-off",
+			});
+			await createClientWithProject(asUser, "Other Co");
+
+			await asUser.mutation(api.automations.create, {
+				name: "Count Acme projects",
+				trigger: {
+					type: "record_updated",
+					objectType: "client",
+					fields: ["notes"],
+				},
+				nodes: [
+					fetchNode(
+						"fetch-1",
+						"project",
+						[
+							{
+								logic: "and",
+								rules: [
+									{
+										field: "client.companyName",
+										operator: "equals",
+										value: { kind: "static", value: "Acme Co" },
+									},
+								],
+							},
+						],
+						{ nextNodeId: "act-1" }
+					),
+					notifyNode("act-1", "Found {{node.fetch-1.count}}"),
+				],
+				isActive: true,
+			});
+
+			await asUser.mutation(api.clients.update, {
+				id: acme.clientId,
+				notes: "poke",
+			});
+			await drainEvents();
+
+			const notifications = await t.run(async (ctx) =>
+				ctx.db.query("notifications").collect()
+			);
+			expect(notifications.some((n) => n.message === "Found 2")).toBe(true);
+		});
+
+		it("loop items resolve loop.<id>.item.<relation>.<field>", async () => {
+			const { asUser } = await setupUser();
+			const acme = await createClientWithProject(asUser, "Acme Co");
+			await createClientWithProject(asUser, "Beta LLC");
+
+			await asUser.mutation(api.automations.create, {
+				name: "Notify per project with client",
+				trigger: {
+					type: "record_updated",
+					objectType: "client",
+					fields: ["notes"],
+				},
+				nodes: [
+					fetchNode("fetch-1", "project", [], { nextNodeId: "loop-1" }),
+					{
+						id: "loop-1",
+						type: "loop" as const,
+						config: { kind: "loop" as const, sourceNodeId: "fetch-1" },
+						bodyStartNodeId: "body-1",
+					},
+					notifyNode(
+						"body-1",
+						"Owner: {{loop.loop-1.item.client.companyName}}"
+					),
+				],
+				isActive: true,
+			});
+
+			await asUser.mutation(api.clients.update, {
+				id: acme.clientId,
+				notes: "poke",
+			});
+			await drainEvents();
+
+			const messages = (
+				await t.run(async (ctx) => ctx.db.query("notifications").collect())
+			).map((n) => n.message);
+			expect(messages).toContain("Owner: Acme Co");
+			expect(messages).toContain("Owner: Beta LLC");
+		});
+
+		it("resolves client indirectly via the project when the record has no clientId", async () => {
+			const { asUser } = await setupUser();
+			const { projectId } = await createClientWithProject(asUser, "Acme Co");
+			const taskId = await asUser.mutation(api.tasks.create, {
+				projectId,
+				type: "internal",
+				title: "Site visit",
+				date: Date.now(),
+				status: "pending",
+			});
+
+			await asUser.mutation(api.automations.create, {
+				name: "Task client via project",
+				trigger: {
+					type: "record_updated",
+					objectType: "task",
+					fields: ["title"],
+				},
+				nodes: [
+					notifyNode(
+						"act-1",
+						"Task for {{trigger.record.client.companyName}}"
+					),
+				],
+				isActive: true,
+			});
+
+			await asUser.mutation(api.tasks.update, {
+				id: taskId,
+				title: "Site visit v2",
+			});
+			await drainEvents();
+
+			const notifications = await t.run(async (ctx) =>
+				ctx.db.query("notifications").collect()
+			);
+			expect(
+				notifications.some((n) => n.message === "Task for Acme Co")
+			).toBe(true);
+		});
+
+		it("a missing relation resolves to the ref fallback", async () => {
+			const { asUser } = await setupUser();
+			// Task with neither client nor project: the relation cannot resolve.
+			const taskId = await asUser.mutation(api.tasks.create, {
+				type: "internal",
+				title: "Orphan task",
+				date: Date.now(),
+				status: "pending",
+			});
+
+			await asUser.mutation(api.automations.create, {
+				name: "Fallback on missing client",
+				trigger: {
+					type: "record_updated",
+					objectType: "task",
+					fields: ["title"],
+				},
+				nodes: [
+					updateFromVarWithFallback(
+						"act-1",
+						"description",
+						"trigger.record.client.companyName",
+						"(no client)"
+					),
+				],
+				isActive: true,
+			});
+
+			await asUser.mutation(api.tasks.update, {
+				id: taskId,
+				title: "Orphan task v2",
+			});
+			await drainEvents();
+
+			const task = await t.run(async (ctx) => ctx.db.get(taskId));
+			expect(task?.description).toBe("(no client)");
+		});
+	});
 });

--- a/packages/backend/convex/automationExecutor.test.ts
+++ b/packages/backend/convex/automationExecutor.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { setupConvexTest } from "./test.setup";
 import { createTestOrg, createTestIdentity, addMemberToOrg } from "./test.helpers";
 import { api, internal } from "./_generated/api";
-import { isFatalExecutionError, scanOrgRows } from "./automationExecutor";
+import {
+	hydrateRelations,
+	isFatalExecutionError,
+	scanOrgRows,
+} from "./automationExecutor";
 import { projectCountsAggregate } from "./aggregates";
 import { LOOP_FETCH_ONLY_ERROR } from "./lib/workflowTypes";
 import type { Id } from "./_generated/dataModel";
@@ -6672,6 +6676,50 @@ describe("automationExecutor (v2 engine)", () => {
 			});
 			return { clientId, projectId };
 		}
+
+		it("hydration cache keeps later rows free once the fetch budget gate would trip", async () => {
+			const { asUser } = await setupUser();
+			const { projectId } = await createClientWithProject(asUser, "Shared Co");
+
+			await t.run(async (ctx) => {
+				const project = await ctx.db.get(projectId);
+				if (!project) throw new Error("project missing");
+				const cache = new Map<string, Record<string, unknown> | null>();
+				let fetches = 0;
+				const first = await hydrateRelations(
+					ctx,
+					project.orgId,
+					"project",
+					project as unknown as Record<string, unknown>,
+					["client"],
+					cache,
+					() => {
+						fetches += 1;
+					}
+				);
+				expect(
+					(first?.client as Record<string, unknown> | null)?.companyName
+				).toBe("Shared Co");
+				expect(fetches).toBe(1);
+
+				// A later row referencing the same client: the shared-pool gate
+				// would throw on any real read, but a cache hit never invokes it.
+				const second = await hydrateRelations(
+					ctx,
+					project.orgId,
+					"project",
+					project as unknown as Record<string, unknown>,
+					["client"],
+					cache,
+					() => {
+						throw new Error("budget exhausted");
+					}
+				);
+				expect(
+					(second?.client as Record<string, unknown> | null)?.companyName
+				).toBe("Shared Co");
+			});
+		});
 
 		it("interpolates trigger.record.<relation>.<field> in notification messages", async () => {
 			const { asUser } = await setupUser();

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -2409,10 +2409,14 @@ async function runFetchNode(
 			MAX_FETCH_LIMIT
 		);
 		// Relation-qualified filter fields ("client.companyName") hydrate the
-		// related doc per row (memoized per run); each hydration read consumes
-		// the same scan budget as a scanned row.
+		// related doc per row (memoized per run). Rows and hydrations draw from
+		// ONE read pool: each scanned row and each hydration cache miss costs a
+		// unit. A miss past the pool fails loudly instead of brushing Convex's
+		// per-transaction read limits; cache hits stay free even after the pool
+		// is spent, so late rows sharing an already-hydrated relation still match.
 		const dottedRelations = dottedRuleFieldCandidates(config.filters);
 		let hydrationReads = 0;
+		let rowsSeen = 0;
 		const scanAllowance = Math.min(
 			FETCH_SCAN_CEILING,
 			Math.max(env.fetchScanBudget, 0)
@@ -2423,14 +2427,7 @@ async function runFetchNode(
 			env.orgId,
 			{
 				predicate: async (row) => {
-					// Hydration reads get their own allowance equal to the row scan's;
-					// past it the fetch fails loudly instead of brushing Convex's
-					// per-transaction read limits mid-scan.
-					if (hydrationReads >= scanAllowance) {
-						throw new Error(
-							"This filter reads too many related records — narrow the filter or add more specific conditions"
-						);
-					}
+					rowsSeen += 1;
 					const related =
 						dottedRelations.size > 0
 							? await hydrateRelations(
@@ -2441,6 +2438,11 @@ async function runFetchNode(
 									dottedRelations,
 									env.relationCache,
 									() => {
+										if (rowsSeen + hydrationReads >= scanAllowance) {
+											throw new Error(
+												"This filter reads too many related records — narrow the filter or add more specific conditions"
+											);
+										}
 										hydrationReads += 1;
 									}
 								)
@@ -2706,7 +2708,7 @@ async function getObject(
  * once. `onFetch` fires per cache miss (fetch-filter scan-budget accounting).
  * The indirect client-via-project resolution matches resolveTargetV2.
  */
-async function hydrateRelations(
+export async function hydrateRelations(
 	ctx: { db: QueryCtx["db"] },
 	orgId: Id<"organizations">,
 	objectType: AutomationObjectType,

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -25,8 +25,14 @@ import {
 	evaluateConditionGroups,
 	interpolateTemplate,
 	resolveValueRef,
+	type RelatedRecords,
 	type VariableScope,
 } from "./lib/conditionEval";
+import {
+	collectRelationRefs,
+	dottedRuleFieldCandidates,
+	type RelationRefs,
+} from "./lib/relationRefs";
 import {
 	calendarDayEpoch,
 	getZonedParts,
@@ -39,6 +45,7 @@ import {
 	FREE_MAX_CLIENTS,
 } from "./lib/planLimits";
 import {
+	RELATED_OBJECTS,
 	RELATION_FIELD,
 	getCreatableFields,
 	getFieldDefinition,
@@ -66,6 +73,7 @@ import {
 	type TeamMessageMention,
 	type ValueRef,
 	type AutomationObjectType,
+	type ConditionGroup,
 	type TriggerableObjectType,
 	type AutomationTrigger,
 	type ExecutedNode,
@@ -277,20 +285,23 @@ export const findMatchingAutomations = internalQuery({
 				: null;
 		const actor = actorId ? await ctx.db.get(actorId) : null;
 
-		return automations.filter((automation) => {
+		const relationCache: Map<string, Record<string, unknown> | null> =
+			new Map();
+		const matched: typeof automations = [];
+		for (const automation of automations) {
 			const definition = executableDefinition(automation);
 			const trigger = definition.trigger;
 			const triggerType =
 				"type" in trigger ? trigger.type : "status_changed";
 
 			if (triggerType !== args.triggerType) {
-				return false;
+				continue;
 			}
 			if (
 				"objectType" in trigger &&
 				trigger.objectType !== args.objectType
 			) {
-				return false;
+				continue;
 			}
 
 			const shapeMatches = ((): boolean => {
@@ -331,15 +342,36 @@ export const findMatchingAutomations = internalQuery({
 						return false;
 				}
 			})();
-			if (!shapeMatches) return false;
+			if (!shapeMatches) continue;
 
 			// Entry criteria (A5-2): evaluated against the actual record before
 			// anything is scheduled, with condition-node semantics
 			// (evaluateConditionGroups) scoped to trigger + globals.
 			const criteria =
 				"entryCriteria" in trigger ? trigger.entryCriteria : undefined;
-			if (!criteria || criteria.groups.length === 0) return true;
-			if (!record) return false;
+			if (!criteria || criteria.groups.length === 0) {
+				matched.push(automation);
+				continue;
+			}
+			if (!record) continue;
+			// One-hop relations the criteria reference (value refs and formulas via
+			// the static scan; dotted rule fields directly), hydrated against the
+			// trigger record. The cache is shared across candidates — same record.
+			const refs = collectRelationRefs([], trigger, definition.formulas);
+			for (const candidate of dottedRuleFieldCandidates(criteria.groups)) {
+				refs.trigger.add(candidate);
+			}
+			const related =
+				refs.trigger.size > 0
+					? await hydrateRelations(
+							ctx,
+							args.orgId,
+							args.objectType,
+							record,
+							refs.trigger,
+							relationCache
+						)
+					: undefined;
 			const scope: VariableScope = {
 				trigger: {
 					record,
@@ -347,6 +379,7 @@ export const findMatchingAutomations = internalQuery({
 						args.fromStatus !== undefined || args.toStatus !== undefined
 							? { oldValue: args.fromStatus, newValue: args.toStatus }
 							: undefined,
+					related,
 				},
 				workflow: {
 					now: Date.now(),
@@ -358,14 +391,20 @@ export const findMatchingAutomations = internalQuery({
 					: undefined,
 				formulas: definition.formulas,
 			};
-			return evaluateConditionGroups(
-				criteria.logic,
-				criteria.groups,
-				record,
-				scope,
-				args.objectType
-			);
-		});
+			if (
+				evaluateConditionGroups(
+					criteria.logic,
+					criteria.groups,
+					record,
+					scope,
+					args.objectType,
+					related
+				)
+			) {
+				matched.push(automation);
+			}
+		}
+		return matched;
 	},
 });
 
@@ -856,6 +895,10 @@ type WalkEnv = {
 	dataTruncated: boolean;
 	/** Rows this walk may still scan across all its fetches (WALK_SCAN_BUDGET). */
 	fetchScanBudget: number;
+	/** One-hop relation references statically collected from the definition. */
+	relationRefs: RelationRefs;
+	/** Per-run memo of hydrated related docs, keyed `type:id`. */
+	relationCache: Map<string, Record<string, unknown> | null>;
 	/** Original trigger reference, persisted into resumeState for delays. */
 	trigger: { objectType?: ObjectType; objectId?: string };
 	/** Wall-clock start of the node currently executing; stamped onto each entry. */
@@ -1169,10 +1212,18 @@ export const executeAutomation = systemMutation({
 			dataTruncated: false,
 			loopSummaries: [],
 			fetchScanBudget: WALK_SCAN_BUDGET,
+			relationRefs: collectRelationRefs(
+				definition.nodes,
+				definition.trigger,
+				definition.formulas
+			),
+			relationCache: new Map(),
 			trigger: { objectType: args.objectType, objectId: args.objectId },
 			nodeStartedAt: Date.now(),
 			isProduction,
 		};
+
+		await hydrateTriggerRelations(ctx, env, scopeRecord);
 
 		try {
 			if (definition.nodes.length === 0) {
@@ -1371,6 +1422,12 @@ export const resumeExecution = systemMutation({
 				errors: [...l.errors],
 			})),
 			fetchScanBudget: WALK_SCAN_BUDGET,
+			relationRefs: collectRelationRefs(
+				definition.nodes,
+				definition.trigger,
+				definition.formulas
+			),
+			relationCache: new Map(),
 			trigger: { objectType: resume.objectType, objectId: resume.objectId },
 			nodeStartedAt: Date.now(),
 			isProduction,
@@ -1428,6 +1485,8 @@ export const resumeExecution = systemMutation({
 			}
 			return;
 		}
+
+		await hydrateTriggerRelations(ctx, env, scopeRecord);
 
 		try {
 			let outcome: WalkOutcome;
@@ -1971,7 +2030,23 @@ async function runLoopNode(
 			const label = sampleRecordLabel(source.objectType, item);
 			// summary.total is the authoritative loop size (set on the first chunk,
 			// restored on resume) so loop.<id>.count is stable across chunk boundaries.
-			env.scope.loops[node.id] = { item, index, count: summary.total };
+			const loopRelations = env.relationRefs.loops.get(node.id);
+			env.scope.loops[node.id] = {
+				item,
+				index,
+				count: summary.total,
+				objectType: source.objectType,
+				related: loopRelations?.size
+					? await hydrateRelations(
+							ctx,
+							env.orgId,
+							source.objectType,
+							item,
+							loopRelations,
+							env.relationCache
+						)
+					: undefined,
+			};
 			env.currentLoop = { nodeId: node.id, index, itemId, label };
 			const itemScope: ScopeRecord = {
 				type: source.objectType,
@@ -2268,7 +2343,7 @@ export async function scanOrgRows(
 	objectType: AutomationObjectType,
 	orgId: Id<"organizations">,
 	opts: {
-		predicate?: (row: Record<string, unknown>) => boolean;
+		predicate?: (row: Record<string, unknown>) => boolean | Promise<boolean>;
 		stopAfterMatches?: number;
 		maxScan?: number;
 		batchSize?: number;
@@ -2291,7 +2366,7 @@ export async function scanOrgRows(
 		if (page.length > 0) cursor = page[page.length - 1]._creationTime;
 		scanned += page.length;
 		for (const row of page) {
-			if (!predicate(row)) continue;
+			if (!(await predicate(row))) continue;
 			matches.push(row);
 			if (
 				opts.stopAfterMatches !== undefined &&
@@ -2314,7 +2389,7 @@ export async function scanOrgRows(
 /** The subset of walk state fetch_records needs; shared by real + dry walks. */
 type FetchEnv = Pick<
 	WalkEnv,
-	"orgId" | "scope" | "fetchOutputs" | "fetchScanBudget"
+	"orgId" | "scope" | "fetchOutputs" | "fetchScanBudget" | "relationCache"
 >;
 
 /**
@@ -2333,26 +2408,59 @@ async function runFetchNode(
 			Math.max(config.limit ?? DEFAULT_FETCH_LIMIT, 1),
 			MAX_FETCH_LIMIT
 		);
+		// Relation-qualified filter fields ("client.companyName") hydrate the
+		// related doc per row (memoized per run); each hydration read consumes
+		// the same scan budget as a scanned row.
+		const dottedRelations = dottedRuleFieldCandidates(config.filters);
+		let hydrationReads = 0;
+		const scanAllowance = Math.min(
+			FETCH_SCAN_CEILING,
+			Math.max(env.fetchScanBudget, 0)
+		);
 		const { matches, scanned, truncated } = await scanOrgRows(
 			ctx,
 			config.objectType,
 			env.orgId,
 			{
-				predicate: (row) =>
-					evaluateConditionGroups(
+				predicate: async (row) => {
+					// Hydration reads get their own allowance equal to the row scan's;
+					// past it the fetch fails loudly instead of brushing Convex's
+					// per-transaction read limits mid-scan.
+					if (hydrationReads >= scanAllowance) {
+						throw new Error(
+							"This filter reads too many related records — narrow the filter or add more specific conditions"
+						);
+					}
+					const related =
+						dottedRelations.size > 0
+							? await hydrateRelations(
+									ctx,
+									env.orgId,
+									config.objectType,
+									row,
+									dottedRelations,
+									env.relationCache,
+									() => {
+										hydrationReads += 1;
+									}
+								)
+							: undefined;
+					return evaluateConditionGroups(
 						"and",
 						config.filters,
 						row,
 						env.scope,
-						config.objectType
-					),
+						config.objectType,
+						related
+					);
+				},
 				// Sorting needs every match in range; without one, rows already
 				// arrive newest-first so the scan can stop at the node's limit.
 				stopAfterMatches: config.sortBy ? undefined : limit,
-				maxScan: Math.min(FETCH_SCAN_CEILING, Math.max(env.fetchScanBudget, 0)),
+				maxScan: scanAllowance,
 			}
 		);
-		env.fetchScanBudget -= scanned;
+		env.fetchScanBudget -= scanned + hydrationReads;
 		let records = matches;
 
 		if (config.sortBy) {
@@ -2590,6 +2698,108 @@ async function getObject(
 }
 
 /**
+ * One-hop related records for `record`, keyed by relation name. Candidate
+ * names not in RELATED_OBJECTS[objectType] are skipped (flat field keys may
+ * contain dots); a missing FK / deleted / cross-org target stores `null` so
+ * resolution degrades to undefined + the ref's fallback. Reads memoize per
+ * run in `cache` (`type:id`) — a 200-item loop sharing one client reads it
+ * once. `onFetch` fires per cache miss (fetch-filter scan-budget accounting).
+ * The indirect client-via-project resolution matches resolveTargetV2.
+ */
+async function hydrateRelations(
+	ctx: { db: QueryCtx["db"] },
+	orgId: Id<"organizations">,
+	objectType: AutomationObjectType,
+	record: Record<string, unknown>,
+	relations: Iterable<string>,
+	cache: Map<string, Record<string, unknown> | null>,
+	onFetch?: () => void
+): Promise<RelatedRecords | undefined> {
+	const fetchCached = async (
+		type: AutomationObjectType,
+		id: string
+	): Promise<Record<string, unknown> | null> => {
+		const key = `${type}:${id}`;
+		const hit = cache.get(key);
+		if (hit !== undefined) return hit;
+		onFetch?.();
+		const doc = await getObject(ctx, type, id, orgId);
+		cache.set(key, doc);
+		return doc;
+	};
+
+	let related: RelatedRecords | undefined;
+	for (const name of relations) {
+		const relatedType = name as TriggerableObjectType;
+		if (!RELATED_OBJECTS[objectType]?.includes(relatedType)) continue;
+		related ??= {};
+		const fkField = RELATION_FIELD[objectType]?.[relatedType];
+		let relatedId = fkField
+			? (record[fkField] as string | undefined)
+			: undefined;
+		if (!relatedId && relatedType === "client") {
+			const projectFk = RELATION_FIELD[objectType]?.project;
+			const projectId = projectFk
+				? (record[projectFk] as string | undefined)
+				: undefined;
+			if (projectId) {
+				relatedId = (await fetchCached("project", projectId))?.clientId as
+					| string
+					| undefined;
+			}
+		}
+		related[name] = relatedId ? await fetchCached(relatedType, relatedId) : null;
+	}
+	return related;
+}
+
+/** Hydrate trigger-record relations referenced anywhere in the definition. */
+async function hydrateTriggerRelations(
+	ctx: { db: QueryCtx["db"] },
+	env: Pick<WalkEnv, "orgId" | "scope" | "relationRefs" | "relationCache">,
+	scopeRecord: ScopeRecord | undefined
+): Promise<void> {
+	if (!scopeRecord || !env.scope.trigger) return;
+	if (env.relationRefs.trigger.size === 0) return;
+	env.scope.trigger.related = await hydrateRelations(
+		ctx,
+		env.orgId,
+		scopeRecord.type,
+		scopeRecord.record,
+		env.relationRefs.trigger,
+		env.relationCache
+	);
+}
+
+/**
+ * Relations named by dotted rule fields ("client.companyName"), hydrated for
+ * the record under evaluation and merged over `related` (names already
+ * hydrated are skipped).
+ */
+async function withLazyRuleRelations(
+	ctx: { db: QueryCtx["db"] },
+	env: Pick<WalkEnv, "orgId" | "relationCache">,
+	groups: ConditionGroup[],
+	record: Record<string, unknown>,
+	recordType: AutomationObjectType | undefined,
+	related: RelatedRecords | undefined
+): Promise<RelatedRecords | undefined> {
+	if (!recordType) return related;
+	const candidates = dottedRuleFieldCandidates(groups);
+	for (const name of Object.keys(related ?? {})) candidates.delete(name);
+	if (candidates.size === 0) return related;
+	const lazy = await hydrateRelations(
+		ctx,
+		env.orgId,
+		recordType,
+		record,
+		candidates,
+		env.relationCache
+	);
+	return lazy ? { ...related, ...lazy } : related;
+}
+
+/**
  * Execute a per-record node (condition/action) via its v2 `config`.
  * Structural kinds (fetch/loop/delay/end) are handled by the walk engine
  * before this is reached.
@@ -2628,6 +2838,7 @@ async function executeNodeV2(
 		case "condition": {
 			let record: Record<string, unknown>;
 			let recordType: AutomationObjectType | undefined;
+			let related: RelatedRecords | undefined;
 			if (config.source && typeof config.source === "object") {
 				const loopScope = env.scope.loops?.[config.source.loopNodeId];
 				if (!loopScope) {
@@ -2638,16 +2849,30 @@ async function executeNodeV2(
 				}
 				record = loopScope.item;
 				recordType = loopScope.objectType;
+				related = loopScope.related;
 			} else {
 				record = scopeRecord?.record ?? {};
 				recordType = scopeRecord?.type;
+				// Inside a loop the scope record IS the current item.
+				related = env.currentLoop
+					? env.scope.loops?.[env.currentLoop.nodeId]?.related
+					: env.scope.trigger?.related;
 			}
+			related = await withLazyRuleRelations(
+				ctx,
+				env,
+				config.groups,
+				record,
+				recordType,
+				related
+			);
 			const conditionMet = evaluateConditionGroups(
 				config.logic,
 				config.groups,
 				record,
 				env.scope,
-				recordType
+				recordType,
+				related
 			);
 			return { success: true, conditionMet };
 		}
@@ -4469,6 +4694,10 @@ type DryEnv = {
 	dataTruncated: boolean;
 	/** Rows this dry run may still scan across all its fetches. */
 	fetchScanBudget: number;
+	/** One-hop relation references statically collected from the working copy. */
+	relationRefs: RelationRefs;
+	/** Per-run memo of hydrated related docs, keyed `type:id`. */
+	relationCache: Map<string, Record<string, unknown> | null>;
 	/** Wall-clock start of the node currently executing; stamped onto each entry. */
 	nodeStartedAt: number;
 	/** Per-loop item tallies, same shape production records. */
@@ -4958,6 +5187,7 @@ async function dryExecuteNode(
 	if (config?.kind === "condition") {
 		let record: Record<string, unknown>;
 		let recordType: AutomationObjectType | undefined;
+		let related: RelatedRecords | undefined;
 		if (config.source && typeof config.source === "object") {
 			const loopScope = env.scope.loops?.[config.source.loopNodeId];
 			if (!loopScope) {
@@ -4968,16 +5198,30 @@ async function dryExecuteNode(
 			}
 			record = loopScope.item;
 			recordType = loopScope.objectType;
+			related = loopScope.related;
 		} else {
 			record = scopeRecord?.record ?? {};
 			recordType = scopeRecord?.type;
+			// Inside a loop the scope record IS the current item.
+			related = env.currentLoop
+				? env.scope.loops?.[env.currentLoop.nodeId]?.related
+				: env.scope.trigger?.related;
 		}
+		related = await withLazyRuleRelations(
+			ctx,
+			env,
+			config.groups,
+			record,
+			recordType,
+			related
+		);
 		const conditionMet = evaluateConditionGroups(
 			config.logic,
 			config.groups,
 			record,
 			env.scope,
-			recordType
+			recordType,
+			related
 		);
 		return {
 			success: true,
@@ -5071,7 +5315,23 @@ async function dryRunLoopNode(
 			const label = sampleRecordLabel(source.objectType, item);
 			// `total` (full match), not `sampled`: loop.<id>.count is a data value —
 			// the count production would iterate, matching the real loop.index shown.
-			env.scope.loops[node.id] = { item, index, count: total };
+			const loopRelations = env.relationRefs.loops.get(node.id);
+			env.scope.loops[node.id] = {
+				item,
+				index,
+				count: total,
+				objectType: source.objectType,
+				related: loopRelations?.size
+					? await hydrateRelations(
+							ctx,
+							env.orgId,
+							source.objectType,
+							item,
+							loopRelations,
+							env.relationCache
+						)
+					: undefined,
+			};
 			env.currentLoop = { nodeId: node.id, index, itemId, label };
 			const itemScope: ScopeRecord = {
 				type: source.objectType,
@@ -5345,9 +5605,17 @@ async function buildDryPlan(
 		truncated: false,
 		dataTruncated: false,
 		fetchScanBudget: WALK_SCAN_BUDGET,
+		relationRefs: collectRelationRefs(
+			automation.nodes,
+			automation.trigger,
+			automation.formulas
+		),
+		relationCache: new Map(),
 		nodeStartedAt: Date.now(),
 		loopSummaries: [],
 	};
+
+	await hydrateTriggerRelations(ctx, env, scopeRecord);
 
 	let outcome: DryWalkOutcome = "chain_done";
 	if (automation.nodes.length > 0) {

--- a/packages/backend/convex/automations.ts
+++ b/packages/backend/convex/automations.ts
@@ -30,6 +30,7 @@ import {
 	type AutomationTrigger,
 	type ConditionGroup,
 	type FormulaResource,
+	type TriggerableObjectType,
 	type ValueRef,
 	type WorkflowNodeConfig,
 } from "./lib/workflowTypes";
@@ -38,11 +39,13 @@ import {
 	parseFormula,
 	FormulaError,
 } from "./lib/formula";
+import { ENTITY_PERMISSION_OBJECT } from "./activities";
 import {
 	RELATED_OBJECTS,
 	RELATION_FIELD,
 	USER_REF_RECIPIENT_FIELDS,
 	getFieldDefinition,
+	getFieldDefinitionForKey,
 	getRequiredCreateFields,
 	getStatusOptions,
 	isCreatableObjectType,
@@ -370,7 +373,9 @@ function validateConditionGroups(
 					throw new Error(`Node ${nodeId}: rule is missing a field`);
 				}
 				if (objectType) {
-					const def = getFieldDefinition(objectType, rule.field);
+					// Relation-qualified keys ("client.companyName") are valid rule
+					// fields (C6); writes elsewhere stay flat-key only.
+					const def = getFieldDefinitionForKey(objectType, rule.field);
 					if (!def) {
 						throw new Error(
 							`Node ${nodeId}: unknown field "${rule.field}" for ${objectType}`
@@ -2035,3 +2040,93 @@ export const getRecentFailures = userQuery({
 		return rows;
 	},
 });
+
+/** TriggerableObjectType -> its Convex table. Mirrors resolveCreateFk's map (automationExecutor.ts). */
+const OBJECT_TYPE_TABLE: Record<
+	TriggerableObjectType,
+	"clients" | "projects" | "quotes" | "invoices" | "tasks"
+> = {
+	client: "clients",
+	project: "projects",
+	quote: "quotes",
+	invoice: "invoices",
+	task: "tasks",
+};
+
+/**
+ * One-hop related-record fields for the formula editor's live preview (C6).
+ * Additive alongside the individual per-type `.get` queries the modal already
+ * calls for `trigger.record.<field>` — this supplies
+ * `trigger.record.<relation>.<field>`. Read-only preview data already gated by
+ * automations:view, so it stays permission-light: org-checked `ctx.db.get`
+ * rather than the full per-entity RBAC scoping those `.get` queries do.
+ * Capped at one hop via RELATED_OBJECTS (source record + up to
+ * RELATED_OBJECTS[entityType].length relations — at most 3 gets total).
+ */
+export const getSampleRelatedFields = userQuery({
+	args: {
+		entityType: v.union(
+			v.literal("client"),
+			v.literal("project"),
+			v.literal("quote"),
+			v.literal("invoice"),
+			v.literal("task")
+		),
+		entityId: v.string(),
+	},
+	handler: async (
+		ctx,
+		args
+	): Promise<Record<string, Record<string, unknown>>> => {
+		await ctx.requireLevel("automations", "view");
+
+		const relations = RELATED_OBJECTS[args.entityType] ?? [];
+		if (relations.length === 0) return {};
+		// Per-entity read gates (shadow-aware), matching the per-type sample
+		// queries the modal already calls: a relation the caller can't view is
+		// simply omitted from the preview.
+		if (!(await ctx.gateRead(ENTITY_PERMISSION_OBJECT[args.entityType]!))) {
+			return {};
+		}
+
+		const sourceTable = OBJECT_TYPE_TABLE[args.entityType];
+		const sourceId = ctx.db.normalizeId(sourceTable, args.entityId);
+		if (!sourceId) return {};
+		const source = await ctx.db.get(sourceId);
+		if (!source || source.orgId !== ctx.orgId) return {};
+
+		const result: Record<string, Record<string, unknown>> = {};
+		for (const relation of relations) {
+			if (!(await ctx.gateRead(ENTITY_PERMISSION_OBJECT[relation]!))) continue;
+			const fk = RELATION_FIELD[args.entityType]?.[relation];
+			if (!fk) continue;
+			let relatedRaw = (source as Record<string, unknown>)[fk];
+			// Same indirect client-via-project resolution the runtime uses
+			// (hydrateRelations/resolveTargetV2) so the preview matches the run.
+			if (typeof relatedRaw !== "string" && relation === "client") {
+				const projectFk = RELATION_FIELD[args.entityType]?.project;
+				const projectRaw = projectFk
+					? (source as Record<string, unknown>)[projectFk]
+					: undefined;
+				const projectId =
+					typeof projectRaw === "string"
+						? ctx.db.normalizeId("projects", projectRaw)
+						: null;
+				const project = projectId ? await ctx.db.get(projectId) : null;
+				if (project && project.orgId === ctx.orgId) {
+					relatedRaw = project.clientId;
+				}
+			}
+			if (typeof relatedRaw !== "string") continue;
+			const relatedTable = OBJECT_TYPE_TABLE[relation];
+			const relatedId = ctx.db.normalizeId(relatedTable, relatedRaw);
+			if (!relatedId) continue;
+			const doc = await ctx.db.get(relatedId);
+			if (doc && doc.orgId === ctx.orgId) {
+				result[relation] = doc as unknown as Record<string, unknown>;
+			}
+		}
+		return result;
+	},
+});
+

--- a/packages/backend/convex/automations.ts
+++ b/packages/backend/convex/automations.ts
@@ -2057,11 +2057,11 @@ const OBJECT_TYPE_TABLE: Record<
  * One-hop related-record fields for the formula editor's live preview (C6).
  * Additive alongside the individual per-type `.get` queries the modal already
  * calls for `trigger.record.<field>` — this supplies
- * `trigger.record.<relation>.<field>`. Read-only preview data already gated by
- * automations:view, so it stays permission-light: org-checked `ctx.db.get`
- * rather than the full per-entity RBAC scoping those `.get` queries do.
- * Capped at one hop via RELATED_OBJECTS (source record + up to
- * RELATED_OBJECTS[entityType].length relations — at most 3 gets total).
+ * `trigger.record.<relation>.<field>`. Mirrors those queries' full RBAC:
+ * per-entity read gates plus each entity's record-scope predicate, and returns
+ * only registry fields rather than whole docs. Capped at one hop via
+ * RELATED_OBJECTS (source record + up to RELATED_OBJECTS[entityType].length
+ * relations — at most 3 gets total).
  */
 export const getSampleRelatedFields = userQuery({
 	args: {
@@ -2085,19 +2085,68 @@ export const getSampleRelatedFields = userQuery({
 		// Per-entity read gates (shadow-aware), matching the per-type sample
 		// queries the modal already calls: a relation the caller can't view is
 		// simply omitted from the preview.
-		if (!(await ctx.gateRead(ENTITY_PERMISSION_OBJECT[args.entityType]!))) {
+		const sourcePermObj = ENTITY_PERMISSION_OBJECT[args.entityType];
+		if (!sourcePermObj || !(await ctx.gateRead(sourcePermObj))) {
 			return {};
 		}
+
+		// Record-scope mirror of each entity's own `.get` query, so the preview
+		// can't show a doc the caller couldn't open directly. requireRecordScope
+		// throws only when enforcement is on (shadow mode logs) — catch => omit.
+		const inRecordScope = async (
+			type: TriggerableObjectType,
+			doc: Record<string, unknown>
+		): Promise<boolean> => {
+			const permObj = ENTITY_PERMISSION_OBJECT[type];
+			if (!permObj) return false;
+			try {
+				await ctx.requireRecordScope(permObj, async () => {
+					switch (type) {
+						case "client":
+							return (await ctx.actorScope()).clientIds.has(
+								doc._id as Id<"clients">
+							);
+						case "project":
+							return (
+								(doc.assignedUserIds as Id<"users">[] | undefined)?.includes(
+									ctx.user._id
+								) ?? false
+							);
+						case "quote":
+						case "invoice": {
+							const s = await ctx.actorScope();
+							return doc.projectId
+								? s.projectIds.has(doc.projectId as Id<"projects">)
+								: s.clientIds.has(doc.clientId as Id<"clients">);
+						}
+						case "task":
+							return doc.assigneeUserId === ctx.user._id;
+					}
+				});
+				return true;
+			} catch {
+				return false;
+			}
+		};
 
 		const sourceTable = OBJECT_TYPE_TABLE[args.entityType];
 		const sourceId = ctx.db.normalizeId(sourceTable, args.entityId);
 		if (!sourceId) return {};
 		const source = await ctx.db.get(sourceId);
 		if (!source || source.orgId !== ctx.orgId) return {};
+		if (
+			!(await inRecordScope(
+				args.entityType,
+				source as unknown as Record<string, unknown>
+			))
+		) {
+			return {};
+		}
 
 		const result: Record<string, Record<string, unknown>> = {};
 		for (const relation of relations) {
-			if (!(await ctx.gateRead(ENTITY_PERMISSION_OBJECT[relation]!))) continue;
+			const relPermObj = ENTITY_PERMISSION_OBJECT[relation];
+			if (!relPermObj || !(await ctx.gateRead(relPermObj))) continue;
 			const fk = RELATION_FIELD[args.entityType]?.[relation];
 			if (!fk) continue;
 			let relatedRaw = (source as Record<string, unknown>)[fk];
@@ -2122,9 +2171,16 @@ export const getSampleRelatedFields = userQuery({
 			const relatedId = ctx.db.normalizeId(relatedTable, relatedRaw);
 			if (!relatedId) continue;
 			const doc = await ctx.db.get(relatedId);
-			if (doc && doc.orgId === ctx.orgId) {
-				result[relation] = doc as unknown as Record<string, unknown>;
+			if (!doc || doc.orgId !== ctx.orgId) continue;
+			const docRecord = doc as unknown as Record<string, unknown>;
+			if (!(await inRecordScope(relation, docRecord))) continue;
+			// Registry fields only — the preview resolves nothing else, and the
+			// raw doc can hold columns outside the automation surface.
+			const fields: Record<string, unknown> = {};
+			for (const key of Object.keys(docRecord)) {
+				if (getFieldDefinition(relation, key)) fields[key] = docRecord[key];
 			}
+			result[relation] = fields;
 		}
 		return result;
 	},

--- a/packages/backend/convex/lib/conditionEval.test.ts
+++ b/packages/backend/convex/lib/conditionEval.test.ts
@@ -1172,3 +1172,137 @@ describe("formula resolution (formula.<id>)", () => {
 		expect(parseSpy).toHaveBeenCalledTimes(1);
 	});
 });
+
+describe("one-hop relation resolution (C6)", () => {
+	const scope: VariableScope = {
+		trigger: {
+			record: {
+				title: "Kitchen remodel",
+				clientId: "client123",
+				"weird.key": "flat wins",
+			},
+			related: {
+				client: { companyName: "Acme Co", status: "active" },
+				// A relation the hydrator looked up but found nothing for.
+				weird: null,
+			},
+		},
+		loops: {
+			loop1: {
+				item: { title: "Task A", projectId: "proj123" },
+				index: 0,
+				count: 2,
+				related: { project: { title: "Kitchen remodel" } },
+			},
+		},
+	};
+
+	it("resolves trigger.record.<relation>.<field> from hydrated related docs", () => {
+		expect(
+			resolveValueRef(
+				{ kind: "var", path: "trigger.record.client.companyName" },
+				scope
+			)
+		).toBe("Acme Co");
+	});
+
+	it("a flat field key containing a dot still wins over relation parsing", () => {
+		expect(
+			resolveValueRef({ kind: "var", path: "trigger.record.weird.key" }, scope)
+		).toBe("flat wins");
+	});
+
+	it("a null related record resolves undefined and takes the fallback", () => {
+		expect(
+			resolveValueRef(
+				{
+					kind: "var",
+					path: "trigger.record.weird.companyName",
+					fallback: "(none)",
+				},
+				scope
+			)
+		).toBe("(none)");
+	});
+
+	it("without hydrated relations the path resolves undefined (old snapshots)", () => {
+		const bare: VariableScope = {
+			trigger: { record: { title: "T" } },
+		};
+		expect(
+			resolveValueRef(
+				{ kind: "var", path: "trigger.record.client.companyName" },
+				bare
+			)
+		).toBeUndefined();
+	});
+
+	it("resolves loop.<id>.item.<relation>.<field>", () => {
+		expect(
+			resolveValueRef(
+				{ kind: "var", path: "loop.loop1.item.project.title" },
+				scope
+			)
+		).toBe("Kitchen remodel");
+	});
+
+	it("interpolates relation tokens in templates", () => {
+		expect(
+			interpolateTemplate("Client: {{trigger.record.client.companyName}}", scope)
+		).toBe("Client: Acme Co");
+	});
+
+	it("evaluateRule resolves a dotted rule.field via the related map", () => {
+		const record = { title: "Kitchen remodel", clientId: "client123" };
+		const related = { client: { companyName: "Acme Co" } };
+		expect(
+			evaluateRule(
+				rule("client.companyName", "equals", staticRef("Acme Co")),
+				record,
+				emptyScope,
+				"project",
+				related
+			)
+		).toBe(true);
+		expect(
+			evaluateRule(
+				rule("client.companyName", "equals", staticRef("Other Co")),
+				record,
+				emptyScope,
+				"project",
+				related
+			)
+		).toBe(false);
+	});
+
+	it("evaluateRule without a related map treats the dotted field as empty", () => {
+		const record = { title: "Kitchen remodel" };
+		expect(
+			evaluateRule(
+				rule("client.companyName", "is_empty"),
+				record,
+				emptyScope,
+				"project"
+			)
+		).toBe(true);
+	});
+
+	it("evaluateGroup threads related through to its rules", () => {
+		const group: ConditionGroup = {
+			logic: "and",
+			rules: [
+				rule("status", "equals", staticRef("planned")),
+				rule("client.companyName", "contains", staticRef("acme")),
+			],
+		};
+		expect(
+			evaluateGroup(
+				group,
+				{ status: "planned" },
+				emptyScope,
+				"project",
+				{ client: { companyName: "Acme Co" } }
+			)
+		).toBe(true);
+	});
+});

--- a/packages/backend/convex/lib/conditionEval.ts
+++ b/packages/backend/convex/lib/conditionEval.ts
@@ -6,7 +6,7 @@ import type {
 	FormulaReturnType,
 	ValueRef,
 } from "./workflowTypes";
-import { getFieldDefinition } from "./fieldRegistry";
+import { getFieldDefinitionForKey } from "./fieldRegistry";
 import {
 	calendarDayEpoch,
 	evaluateFormula,
@@ -28,10 +28,18 @@ import { roundCents } from "./money";
  * (and from the web app via @onetool/backend).
  */
 
+/**
+ * One-hop related records pre-hydrated by the executor, keyed by relation name
+ * (RELATED_OBJECTS). `null` records a relation that was looked up but had no
+ * FK / a deleted target, so resolution stays a clean `undefined` → fallback.
+ */
+export type RelatedRecords = Record<string, Record<string, unknown> | null>;
+
 export type VariableScope = {
 	trigger?: {
 		record: Record<string, unknown>;
 		event?: { oldValue?: unknown; newValue?: unknown };
+		related?: RelatedRecords;
 	};
 	loops?: Record<
 		string,
@@ -40,6 +48,7 @@ export type VariableScope = {
 			index: number;
 			count?: number;
 			objectType?: AutomationObjectType;
+			related?: RelatedRecords;
 		}
 	>;
 	/** Per-node outputs: fetch → count; aggregate/adjust-time → result. */
@@ -74,8 +83,10 @@ export type VariableScope = {
  *
  * Var paths (matched by prefix so field keys containing dots still resolve):
  *   trigger.record.<field>
+ *   trigger.record.<relation>.<field>   (one hop, via pre-hydrated related docs)
  *   trigger.event.oldValue | trigger.event.newValue
  *   loop.<loopNodeId>.item.<field>
+ *   loop.<loopNodeId>.item.<relation>.<field>
  *   loop.<loopNodeId>.index | loop.<loopNodeId>.position | loop.<loopNodeId>.count
  *   node.<nodeId>.count
  *   node.<nodeId>.result
@@ -99,6 +110,25 @@ export function resolveValueRef(ref: ValueRef, scope: VariableScope): unknown {
 	return resolved;
 }
 
+/**
+ * Flat-first field lookup with a one-hop relation fallback: an existing flat
+ * key always wins (field keys may contain dots — long-standing behavior);
+ * otherwise `client.companyName` reads the pre-hydrated related record. A
+ * relation that wasn't hydrated (old snapshot, unknown name) or resolved to
+ * null yields undefined, feeding the normal fallback machinery.
+ */
+function resolveRecordField(
+	field: string,
+	record: Record<string, unknown> | undefined,
+	related: RelatedRecords | undefined
+): unknown {
+	if (record && field in record) return record[field];
+	if (!related) return undefined;
+	const dot = field.indexOf(".");
+	if (dot === -1) return undefined;
+	return related[field.slice(0, dot)]?.[field.slice(dot + 1)];
+}
+
 function resolvePath(
 	path: string,
 	scope: VariableScope,
@@ -109,7 +139,7 @@ function resolvePath(
 	if (path.startsWith(TRIGGER_RECORD)) {
 		const field = path.slice(TRIGGER_RECORD.length);
 		if (field === "") return undefined;
-		return scope.trigger?.record?.[field];
+		return resolveRecordField(field, scope.trigger?.record, scope.trigger?.related);
 	}
 	if (path === "trigger.event.oldValue") return scope.trigger?.event?.oldValue;
 	if (path === "trigger.event.newValue") return scope.trigger?.event?.newValue;
@@ -144,7 +174,7 @@ function resolvePath(
 		if (tail.startsWith(ITEM)) {
 			const field = tail.slice(ITEM.length);
 			if (field === "") return undefined;
-			return loop.item?.[field];
+			return resolveRecordField(field, loop.item, loop.related);
 		}
 		return undefined;
 	}
@@ -420,14 +450,15 @@ export function evaluateRule(
 	rule: ConditionRule,
 	record: Record<string, unknown>,
 	scope: VariableScope,
-	objectType?: AutomationObjectType
+	objectType?: AutomationObjectType,
+	related?: RelatedRecords
 ): boolean {
 	// A rule with an explicit `left` compares a scope value (aggregate result,
 	// fetch count) and never touches the record — that is how a record-less run
 	// branches at all.
 	const fieldValue = rule.left
 		? resolveValueRef(rule.left, scope)
-		: record[rule.field];
+		: resolveRecordField(rule.field, record, related);
 	const compareValue = rule.value
 		? resolveValueRef(rule.value, scope)
 		: undefined;
@@ -437,7 +468,7 @@ export function evaluateRule(
 	// rule (rule.left) or unknown objectType falls back to raw comparison.
 	const fieldDateKind =
 		objectType && !rule.left
-			? getFieldDefinition(objectType, rule.field)?.type
+			? getFieldDefinitionForKey(objectType, rule.field)?.type
 			: undefined;
 	const isDateField = fieldDateKind === "date" || fieldDateKind === "datetime";
 
@@ -490,12 +521,17 @@ export function evaluateGroup(
 	group: ConditionGroup,
 	record: Record<string, unknown>,
 	scope: VariableScope,
-	objectType?: AutomationObjectType
+	objectType?: AutomationObjectType,
+	related?: RelatedRecords
 ): boolean {
 	if (group.rules.length === 0) return true;
 	return group.logic === "and"
-		? group.rules.every((rule) => evaluateRule(rule, record, scope, objectType))
-		: group.rules.some((rule) => evaluateRule(rule, record, scope, objectType));
+		? group.rules.every((rule) =>
+				evaluateRule(rule, record, scope, objectType, related)
+			)
+		: group.rules.some((rule) =>
+				evaluateRule(rule, record, scope, objectType, related)
+			);
 }
 
 /** Evaluate groups combined with top-level logic; empty groups => true. */
@@ -504,10 +540,15 @@ export function evaluateConditionGroups(
 	groups: ConditionGroup[],
 	record: Record<string, unknown>,
 	scope: VariableScope,
-	objectType?: AutomationObjectType
+	objectType?: AutomationObjectType,
+	related?: RelatedRecords
 ): boolean {
 	if (groups.length === 0) return true;
 	return logic === "and"
-		? groups.every((group) => evaluateGroup(group, record, scope, objectType))
-		: groups.some((group) => evaluateGroup(group, record, scope, objectType));
+		? groups.every((group) =>
+				evaluateGroup(group, record, scope, objectType, related)
+			)
+		: groups.some((group) =>
+				evaluateGroup(group, record, scope, objectType, related)
+			);
 }

--- a/packages/backend/convex/lib/fieldRegistry.test.ts
+++ b/packages/backend/convex/lib/fieldRegistry.test.ts
@@ -5,6 +5,8 @@ import {
 	RELATED_OBJECTS,
 	RELATION_FIELD,
 	getFieldDefinition,
+	getFieldDefinitionForKey,
+	parseRelationKey,
 	getWritableFields,
 	getCreatableFields,
 	getFilterableFields,
@@ -421,5 +423,51 @@ describe("date/datetime split (C2-1)", () => {
 		expect(OPERATORS_BY_TYPE.datetime).toContain("on");
 		expect(operatorsForField("invoice", "paidAt")).toContain("on");
 		expect(operatorsForField("invoice", "dueDate")).toContain("on");
+	});
+});
+
+describe("relation-qualified field keys (C6)", () => {
+	it("parses a valid one-hop key into relation + related field", () => {
+		const parsed = parseRelationKey("project", "client.companyName");
+		expect(parsed?.relation).toBe("client");
+		expect(parsed?.fieldKey).toBe("companyName");
+		expect(parsed?.field.type).toBe("text");
+	});
+
+	it("an existing flat key never parses as a relation", () => {
+		expect(parseRelationKey("project", "clientId")).toBeUndefined();
+	});
+
+	it("rejects relations the object type does not have", () => {
+		// client has no outgoing relations at all.
+		expect(parseRelationKey("client", "project.title")).toBeUndefined();
+		// project has no quote relation.
+		expect(parseRelationKey("project", "quote.status")).toBeUndefined();
+	});
+
+	it("rejects unknown fields on the related type", () => {
+		expect(parseRelationKey("project", "client.notAField")).toBeUndefined();
+	});
+
+	it("line items reach only their direct parent", () => {
+		expect(parseRelationKey("quote_line_item", "quote.status")).toBeDefined();
+		expect(
+			parseRelationKey("quote_line_item", "client.companyName")
+		).toBeUndefined();
+	});
+
+	it("getFieldDefinitionForKey covers flat and relation forms", () => {
+		expect(getFieldDefinitionForKey("task", "title")?.key).toBe("title");
+		expect(getFieldDefinitionForKey("task", "client.companyName")?.type).toBe(
+			"text"
+		);
+		expect(getFieldDefinitionForKey("task", "client.nope")).toBeUndefined();
+	});
+
+	it("operatorsForField returns the related field's operators for dotted keys", () => {
+		expect(operatorsForField("project", "client.companyName")).toContain(
+			"contains"
+		);
+		expect(operatorsForField("project", "client.nope")).toEqual([]);
 	});
 });

--- a/packages/backend/convex/lib/fieldRegistry.ts
+++ b/packages/backend/convex/lib/fieldRegistry.ts
@@ -695,9 +695,43 @@ export function operatorsForField(
 	objectType: AutomationObjectType,
 	key: string
 ): ConditionOperator[] {
-	const field = getFieldDefinition(objectType, key);
+	const field = getFieldDefinitionForKey(objectType, key);
 	if (!field) return [];
 	return OPERATORS_BY_TYPE[field.type];
+}
+
+/**
+ * Split a relation-qualified field key ("client.companyName") into its
+ * relation + related-type field, validated against RELATED_OBJECTS and the
+ * related type's registry. Returns undefined for flat keys: an existing flat
+ * key always wins (field keys may themselves contain dots), and an unknown
+ * relation segment stays a flat key rather than erroring.
+ */
+export function parseRelationKey(
+	objectType: AutomationObjectType,
+	key: string
+):
+	| { relation: TriggerableObjectType; fieldKey: string; field: FieldDefinition }
+	| undefined {
+	if (getFieldDefinition(objectType, key)) return undefined;
+	const dot = key.indexOf(".");
+	if (dot === -1) return undefined;
+	const relation = key.slice(0, dot) as TriggerableObjectType;
+	if (!RELATED_OBJECTS[objectType]?.includes(relation)) return undefined;
+	const fieldKey = key.slice(dot + 1);
+	const field = getFieldDefinition(relation, fieldKey);
+	if (!field) return undefined;
+	return { relation, fieldKey, field };
+}
+
+/** Field definition for a flat OR one-hop relation-qualified key. */
+export function getFieldDefinitionForKey(
+	objectType: AutomationObjectType,
+	key: string
+): FieldDefinition | undefined {
+	return (
+		getFieldDefinition(objectType, key) ?? parseRelationKey(objectType, key)?.field
+	);
 }
 
 export function getStatusOptions(

--- a/packages/backend/convex/lib/relationRefs.test.ts
+++ b/packages/backend/convex/lib/relationRefs.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import {
+	collectRelationRefs,
+	dottedRuleFieldCandidates,
+} from "./relationRefs";
+import type { ConditionGroup, FormulaResource } from "./workflowTypes";
+
+describe("collectRelationRefs (C6)", () => {
+	it("collects trigger relations from ValueRef paths and templates", () => {
+		const nodes = [
+			{
+				id: "act-1",
+				type: "action",
+				config: {
+					kind: "action",
+					action: {
+						type: "update_field",
+						target: "self",
+						field: "description",
+						value: {
+							kind: "var",
+							path: "trigger.record.client.companyName",
+						},
+					},
+				},
+			},
+			{
+				id: "act-2",
+				type: "action",
+				config: {
+					kind: "action",
+					action: {
+						type: "send_notification",
+						recipient: "org_admins",
+						message:
+							"Project {{trigger.record.title}} for {{trigger.record.client.companyName}}",
+					},
+				},
+			},
+		];
+		const refs = collectRelationRefs(nodes, undefined, undefined);
+		expect([...refs.trigger]).toEqual(["client"]);
+		expect(refs.loops.size).toBe(0);
+	});
+
+	it("collects loop-item relations keyed by loop node id", () => {
+		const nodes = [
+			{
+				id: "act-1",
+				type: "action",
+				config: {
+					kind: "action",
+					action: {
+						type: "send_notification",
+						recipient: "org_admins",
+						message: "{{loop.loop-1.item.client.companyName}}",
+					},
+				},
+			},
+		];
+		const refs = collectRelationRefs(nodes, undefined, undefined);
+		expect(refs.trigger.size).toBe(0);
+		expect([...(refs.loops.get("loop-1") ?? [])]).toEqual(["client"]);
+	});
+
+	it("collects relations referenced from trigger entry criteria value refs", () => {
+		const trigger = {
+			type: "record_updated",
+			objectType: "project",
+			entryCriteria: {
+				logic: "and",
+				groups: [
+					{
+						logic: "and",
+						rules: [
+							{
+								field: "title",
+								operator: "equals",
+								value: {
+									kind: "var",
+									path: "trigger.record.client.companyName",
+								},
+							},
+						],
+					},
+				],
+			},
+		};
+		const refs = collectRelationRefs([], trigger, undefined);
+		expect([...refs.trigger]).toEqual(["client"]);
+	});
+
+	it("collects relations referenced inside formula expressions", () => {
+		const formulas: FormulaResource[] = [
+			{
+				id: "f1",
+				name: "Client name",
+				expression: "{trigger.record.client.companyName}",
+				returnType: "text",
+			},
+		];
+		const refs = collectRelationRefs([], undefined, formulas);
+		expect([...refs.trigger]).toEqual(["client"]);
+	});
+
+	it("ignores flat paths, globals, and unparseable formulas", () => {
+		const nodes = [
+			{
+				id: "act-1",
+				config: {
+					kind: "action",
+					action: {
+						message: "{{trigger.record.title}} at {{workflow.now}}",
+						value: { kind: "var", path: "node.fetch-1.count" },
+					},
+				},
+			},
+		];
+		const formulas: FormulaResource[] = [
+			{
+				id: "f1",
+				name: "Broken",
+				expression: "{{{not a formula",
+				returnType: "number",
+			},
+		];
+		const refs = collectRelationRefs(nodes, undefined, formulas);
+		expect(refs.trigger.size).toBe(0);
+		expect(refs.loops.size).toBe(0);
+	});
+});
+
+describe("dottedRuleFieldCandidates (C6)", () => {
+	it("returns the first segment of dotted rule fields only", () => {
+		const groups: ConditionGroup[] = [
+			{
+				logic: "and",
+				rules: [
+					{ field: "status", operator: "equals" },
+					{ field: "client.companyName", operator: "contains" },
+					{ field: "project.title", operator: "is_not_empty" },
+				] as ConditionGroup["rules"],
+			},
+		];
+		expect([...dottedRuleFieldCandidates(groups)].sort()).toEqual([
+			"client",
+			"project",
+		]);
+	});
+
+	it("returns empty for flat-only groups", () => {
+		const groups: ConditionGroup[] = [
+			{
+				logic: "or",
+				rules: [{ field: "status", operator: "is_empty" }] as ConditionGroup["rules"],
+			},
+		];
+		expect(dottedRuleFieldCandidates(groups).size).toBe(0);
+	});
+});

--- a/packages/backend/convex/lib/relationRefs.ts
+++ b/packages/backend/convex/lib/relationRefs.ts
@@ -1,0 +1,120 @@
+import type { ConditionGroup, FormulaResource } from "./workflowTypes";
+import { collectReferencedPaths, parseFormula } from "./formula";
+
+/**
+ * Static scan of an automation definition for one-hop relation references
+ * (`trigger.record.client.companyName`, `loop.<id>.item.project.title`), so
+ * the executor hydrates only the relations a run actually mentions —
+ * definitions without relation paths pay zero extra reads.
+ *
+ * Names collected here are CANDIDATES: the first path segment after
+ * `record.`/`item.` when one more segment follows. Validation against
+ * RELATED_OBJECTS happens at hydration (where the record's type is known), so
+ * flat field keys that happen to contain dots are simply skipped there.
+ */
+export type RelationRefs = {
+	/** Relation candidates referenced off trigger.record.* */
+	trigger: Set<string>;
+	/** Relation candidates referenced off loop.<loopNodeId>.item.*, per loop. */
+	loops: Map<string, Set<string>>;
+};
+
+const TEMPLATE_TOKEN = /\{\{\s*([^{}]+?)\s*\}\}/g;
+
+/**
+ * Collect every variable path a config value can carry: ValueRef `var` paths
+ * and `{{...}}` tokens inside any string, walked generically so new config
+ * shapes are covered without registration.
+ */
+function collectPathsFromValue(value: unknown, paths: Set<string>): void {
+	if (typeof value === "string") {
+		for (const match of value.matchAll(TEMPLATE_TOKEN)) paths.add(match[1]);
+		return;
+	}
+	if (Array.isArray(value)) {
+		for (const entry of value) collectPathsFromValue(entry, paths);
+		return;
+	}
+	if (value && typeof value === "object") {
+		const obj = value as Record<string, unknown>;
+		if (obj.kind === "var" && typeof obj.path === "string") paths.add(obj.path);
+		for (const entry of Object.values(obj)) collectPathsFromValue(entry, paths);
+	}
+}
+
+function collectFormulaPaths(
+	formulas: FormulaResource[] | undefined,
+	paths: Set<string>
+): void {
+	for (const formula of formulas ?? []) {
+		try {
+			for (const path of collectReferencedPaths(parseFormula(formula.expression))) {
+				paths.add(path);
+			}
+		} catch {
+			// An unparseable formula never evaluates, so it references nothing.
+		}
+	}
+}
+
+function relationCandidate(fieldPath: string): string | undefined {
+	const dot = fieldPath.indexOf(".");
+	return dot > 0 ? fieldPath.slice(0, dot) : undefined;
+}
+
+// nodes/trigger are walked generically (any config shape), so they stay
+// untyped here and the executor passes its own node/trigger types.
+export function collectRelationRefs(
+	nodes: unknown,
+	trigger: unknown,
+	formulas: FormulaResource[] | undefined
+): RelationRefs {
+	const paths = new Set<string>();
+	collectPathsFromValue(nodes, paths);
+	if (trigger) collectPathsFromValue(trigger, paths);
+	collectFormulaPaths(formulas, paths);
+
+	const refs: RelationRefs = { trigger: new Set(), loops: new Map() };
+	const TRIGGER_RECORD = "trigger.record.";
+	const LOOP = "loop.";
+	const ITEM = "item.";
+	for (const path of paths) {
+		if (path.startsWith(TRIGGER_RECORD)) {
+			const candidate = relationCandidate(path.slice(TRIGGER_RECORD.length));
+			if (candidate) refs.trigger.add(candidate);
+			continue;
+		}
+		if (!path.startsWith(LOOP)) continue;
+		const rest = path.slice(LOOP.length);
+		const dot = rest.indexOf(".");
+		if (dot <= 0) continue;
+		const loopNodeId = rest.slice(0, dot);
+		const tail = rest.slice(dot + 1);
+		if (!tail.startsWith(ITEM)) continue;
+		const candidate = relationCandidate(tail.slice(ITEM.length));
+		if (!candidate) continue;
+		let set = refs.loops.get(loopNodeId);
+		if (!set) refs.loops.set(loopNodeId, (set = new Set()));
+		set.add(candidate);
+	}
+	return refs;
+}
+
+/**
+ * Relation candidates from dotted `rule.field` keys ("client.companyName") in
+ * condition groups. Dotted rule fields name relations of whatever record the
+ * rules evaluate against, so callers hydrate these lazily at the eval site
+ * where that record and its type are known.
+ */
+export function dottedRuleFieldCandidates(
+	groups: ConditionGroup[]
+): Set<string> {
+	const out = new Set<string>();
+	for (const group of groups) {
+		for (const rule of group.rules) {
+			const candidate = relationCandidate(rule.field);
+			if (candidate) out.add(candidate);
+		}
+	}
+	return out;
+}

--- a/packages/backend/convex/permissionsGating.test.ts
+++ b/packages/backend/convex/permissionsGating.test.ts
@@ -755,4 +755,68 @@ describe("granular RBAC domain-function gating", () => {
 			asMember.query(api.homeStats.getJourneyProgress, {})
 		).resolves.toMatchObject({ hasClient: false });
 	});
+
+	// ── getSampleRelatedFields: record scope + registry-field filtering ──
+
+	it("enforced: related-fields preview omits relations outside the member's record scope", async () => {
+		process.env.PERMISSIONS_ENFORCE = "true";
+		const { org, member, asAdmin, asMember } = await seedOrgWithMember(
+			"org_srf_1",
+			"user_srf_1"
+		);
+		await grantMemberPermissions(org.orgId, member.userId, {
+			automations: { level: "view" },
+			tasks: { level: "view" },
+			clients: { level: "view" },
+		});
+
+		const clientId = await asAdmin.mutation(api.clients.create, {
+			portalAccessId: crypto.randomUUID(),
+			companyName: "Scoped Co",
+			status: "active",
+		});
+		// Assigned to the member (source task in scope), but the client hangs
+		// off no project the member is assigned to — outside their derived scope.
+		const taskId = await asAdmin.mutation(api.tasks.create, {
+			title: "External visit",
+			type: "external",
+			clientId,
+			assigneeUserId: member.userId,
+			date: Date.now(),
+			status: "pending",
+		});
+
+		const result = await asMember.query(api.automations.getSampleRelatedFields, {
+			entityType: "task",
+			entityId: taskId,
+		});
+		expect(result.client).toBeUndefined();
+	});
+
+	it("related-fields preview returns registry fields only, not whole docs", async () => {
+		const { asAdmin } = await seedOrgWithMember("org_srf_2", "user_srf_2");
+
+		const clientId = await asAdmin.mutation(api.clients.create, {
+			portalAccessId: crypto.randomUUID(),
+			companyName: "Registry Co",
+			status: "active",
+		});
+		const taskId = await asAdmin.mutation(api.tasks.create, {
+			title: "External visit",
+			type: "external",
+			clientId,
+			date: Date.now(),
+			status: "pending",
+		});
+
+		const result = await asAdmin.query(api.automations.getSampleRelatedFields, {
+			entityType: "task",
+			entityId: taskId,
+		});
+		expect(result.client?.companyName).toBe("Registry Co");
+		// Non-registry columns must not leak into the preview payload.
+		expect(result.client?.portalAccessId).toBeUndefined();
+		expect(result.client?._id).toBeUndefined();
+	});
 });
+


### PR DESCRIPTION
This pull request adds support for referencing one-hop related fields in automation formulas and filters, enhancing the flexibility and expressiveness of the automation builder. Users can now select and resolve fields like `trigger.record.<relation>.<field>` and `loop.<loopNodeId>.item.<relation>.<field>`, with appropriate UI grouping and label improvements. The changes also ensure that only direct (one-hop) relations are supported, preventing deeper nested traversals.

**One-hop related field support in automations:**

- Added support for resolving and previewing one-hop related fields (e.g., `trigger.record.client.companyName`) in the formula editor by querying related fields and updating the path resolver logic. [[1]](diffhunk://#diff-d7bbb6dbc6a767dc9d487a12bdcf2da9877e299d3681af8f12756f5c525525f1R218-R229) [[2]](diffhunk://#diff-d7bbb6dbc6a767dc9d487a12bdcf2da9877e299d3681af8f12756f5c525525f1R257-R266) [[3]](diffhunk://#diff-d7bbb6dbc6a767dc9d487a12bdcf2da9877e299d3681af8f12756f5c525525f1L269-R291)
- Updated variable option generation to include one-hop related fields for both trigger records and loop items, with clear grouping and labeling in the variable picker. [[1]](diffhunk://#diff-943e238b49652cf32b0f1fea7f772589251afd15000869263659637b2fb8a9d6R214-R243) [[2]](diffhunk://#diff-943e238b49652cf32b0f1fea7f772589251afd15000869263659637b2fb8a9d6R297-R299) [[3]](diffhunk://#diff-943e238b49652cf32b0f1fea7f772589251afd15000869263659637b2fb8a9d6R436-R442) [[4]](diffhunk://#diff-943e238b49652cf32b0f1fea7f772589251afd15000869263659637b2fb8a9d6R561-R567)

**UI and display improvements:**

- Enhanced filter group editors and selectors to present one-hop related fields in grouped dropdowns, using improved labels (e.g., "Client → Company name") and grouping under the related object’s name. [[1]](diffhunk://#diff-f646d49d19a0c1599de715e23d0b560e5dc4624b97900fdac1f386451ad05fd7R107-R115) [[2]](diffhunk://#diff-f646d49d19a0c1599de715e23d0b560e5dc4624b97900fdac1f386451ad05fd7R293-R307)
- Improved field label resolution throughout the UI and condition sentence generation to use relation-qualified labels for related fields. [[1]](diffhunk://#diff-722b0b4feeb80c3d6421ce5de73b32bd4fa40a36f0dd3201884de7e54e88edf7L8-R29) [[2]](diffhunk://#diff-722b0b4feeb80c3d6421ce5de73b32bd4fa40a36f0dd3201884de7e54e88edf7L85-R99) [[3]](diffhunk://#diff-722b0b4feeb80c3d6421ce5de73b32bd4fa40a36f0dd3201884de7e54e88edf7L113-R127) [[4]](diffhunk://#diff-722b0b4feeb80c3d6421ce5de73b32bd4fa40a36f0dd3201884de7e54e88edf7L127-R147)

**Testing and validation:**

- Added comprehensive tests to verify that one-hop related fields are offered as variable options and that deeper (multi-hop) traversals are not allowed.

**Refactoring and utility updates:**

- Centralized logic for parsing relation keys and fetching field definitions for both flat and related fields, ensuring consistent behavior across the codebase. [[1]](diffhunk://#diff-f646d49d19a0c1599de715e23d0b560e5dc4624b97900fdac1f386451ad05fd7R9-R22) [[2]](diffhunk://#diff-0f753071641ca98373d2d153eb30abe04e10fd5bfdf79b2044d57d6daf159228R93-R94)

These changes make automations more powerful and user-friendly by allowing direct access to related object fields in both formulas and filter conditions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added one-hop related-record field support across automation conditions, formulas, entry criteria, notifications, loop item variables, and dotted record-field filtering.
  * Enhanced variable picker with relation-aware drill-down browsing and clearer “Related” navigation/labels.
  * Formula editor live preview now resolves related fields for sample data.
* **Bug Fixes**
  * Improved relation-qualified key labeling and operator selection; dotted “flat” keys take precedence.
  * Added safer fallback behavior when relationships are missing.
  * Fetch/condition evaluation now hydrates related data with caching; predicates support async.
* **Tests**
  * Expanded coverage for relation traversal, rule evaluation, previewing, permissions/scope gating, and one-hop traversal boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces one-hop related-field traversal for automation formulas and filters, letting users reference `trigger.record.<relation>.<field>` and `loop.<id>.item.<relation>.<field>` in conditions, actions, and the formula editor preview. The implementation is carefully layered: a static scan at definition startup (`collectRelationRefs`) pre-hydrates only the relations actually referenced, per-run memoization via `relationCache` keeps repeated reads cheap, and a budget guard prevents runaway hydration inside fetch-filter predicates.

- **Backend**: New `hydrateRelations` / `hydrateTriggerRelations` / `withLazyRuleRelations` helpers in `automationExecutor.ts`; `resolveRecordField` in `conditionEval.ts` with flat-key-wins semantics; `parseRelationKey` / `getFieldDefinitionForKey` in `fieldRegistry.ts`; `getSampleRelatedFields` query for formula-editor live preview; new `relationRefs.ts` module for static path scanning.
- **Frontend**: Variable-picker additions in `variables.ts`, grouped `SelectGroup` rendering in `filter-groups-editor.tsx`, relation-aware label resolution in `condition-sentence.ts`, and preview integration in `formula-editor-modal.tsx`.
- **Tests**: Phase C6 test suites across executor, conditionEval, fieldRegistry, and variable-picker layers, plus the new `relationRefs.test.ts`; indirect client-via-project resolution and missing-relation fallback are both covered.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge. Org-isolation, relation validation against RELATED_OBJECTS, and per-run relation-cache memoization are all in place across every execution path.

The implementation is thorough: static pre-scanning avoids unnecessary reads, a flat-key-wins rule preserves backward compat with existing dotted field keys, and the fetch-filter budget guard prevents runaway hydration reads. The only rough edge is the non-null assertion on ENTITY_PERMISSION_OBJECT in getSampleRelatedFields — the map is currently complete but is typed Partial, so TypeScript cannot catch a future addition gap. Everything else, including the indirect client-via-project resolution parity between preview and runtime, tests out correctly.

packages/backend/convex/automations.ts around getSampleRelatedFields — the non-null assertions on ENTITY_PERMISSION_OBJECT are the one place worth a quick look before any future entity-type additions.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/lib/relationRefs.ts | New file: static scanner for one-hop relation references in automation definitions. Collects var-path and template-token candidates to drive lazy hydration. Logic is clean and well-tested. |
| packages/backend/convex/lib/conditionEval.ts | Adds RelatedRecords type, resolveRecordField helper (flat-key-wins-over-relation), and threads related through evaluateRule/evaluateGroup/evaluateConditionGroups. Backward-compatible: callers without related get undefined for dotted fields. |
| packages/backend/convex/lib/fieldRegistry.ts | Adds parseRelationKey and getFieldDefinitionForKey utilities; updates operatorsForField to support relation-qualified keys. Validation correctly rejects unknown relations and unknown fields on the related type. |
| packages/backend/convex/automationExecutor.ts | Core executor changes: adds hydrateRelations (with relation-cache memoization), hydrateTriggerRelations, withLazyRuleRelations; integrates relation hydration into loop items, condition nodes, fetch-filter predicates, and dry-run paths. |
| packages/backend/convex/automations.ts | Adds getSampleRelatedFields query for preview; uses non-null assertions on ENTITY_PERMISSION_OBJECT (a Partial record) that are safe today but fragile to future type additions. |
| apps/web/src/app/(workspace)/automations/lib/variables.ts | Adds relationVariableOptions helper that generates one-hop paths for trigger and loop-item pickers; caps at one hop by design (no recursion into RELATED_OBJECTS[relation]). |
| apps/web/src/app/(workspace)/automations/components/sidebar/panels/filter-groups-editor.tsx | Adds SelectGroup/SelectLabel rendering for one-hop relation fields in grouped dropdowns; correctly delegates field definition lookup to getFieldDefinitionForKey for relation-qualified keys. |
| apps/web/src/app/(workspace)/automations/lib/condition-sentence.ts | Adds fieldLabelForKey helper and updates three call sites to use it, so relation-qualified keys render as 'Client → Company Name' instead of raw keys in condition sentence descriptions. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Trigger as Trigger Event
    participant FMA as findMatchingAutomations
    participant EA as executeAutomation
    participant RR as collectRelationRefs
    participant HR as hydrateRelations
    participant Cache as relationCache
    participant DB as Convex DB
    participant CE as conditionEval

    Trigger->>FMA: record_updated(project, id)
    FMA->>RR: scan([], trigger, formulas)
    RR-->>FMA: "refs.trigger = {client}"
    FMA->>HR: "hydrateRelations(project, record, {client})"
    HR->>Cache: get(client:id)
    Cache-->>HR: miss
    HR->>DB: getObject(client, id, orgId)
    DB-->>HR: clientDoc (org-checked)
    HR->>Cache: set(client:id, clientDoc)
    HR-->>FMA: "related = {client: clientDoc}"
    FMA->>CE: evaluateConditionGroups(entryCriteria, record, scope, related)
    CE-->>FMA: true/false

    Trigger->>EA: executeAutomation(project, id)
    EA->>RR: collectRelationRefs(nodes, trigger, formulas)
    RR-->>EA: relationRefs
    EA->>HR: hydrateTriggerRelations(env, scopeRecord)
    HR->>Cache: get (miss then DB)
    DB-->>HR: related docs
    EA->>CE: evaluateConditionGroups(groups, record, scope, related)
    Note over EA,CE: withLazyRuleRelations fills dotted rule-field gaps at eval site
    CE-->>EA: conditionMet
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Trigger as Trigger Event
    participant FMA as findMatchingAutomations
    participant EA as executeAutomation
    participant RR as collectRelationRefs
    participant HR as hydrateRelations
    participant Cache as relationCache
    participant DB as Convex DB
    participant CE as conditionEval

    Trigger->>FMA: record_updated(project, id)
    FMA->>RR: scan([], trigger, formulas)
    RR-->>FMA: "refs.trigger = {client}"
    FMA->>HR: "hydrateRelations(project, record, {client})"
    HR->>Cache: get(client:id)
    Cache-->>HR: miss
    HR->>DB: getObject(client, id, orgId)
    DB-->>HR: clientDoc (org-checked)
    HR->>Cache: set(client:id, clientDoc)
    HR-->>FMA: "related = {client: clientDoc}"
    FMA->>CE: evaluateConditionGroups(entryCriteria, record, scope, related)
    CE-->>FMA: true/false

    Trigger->>EA: executeAutomation(project, id)
    EA->>RR: collectRelationRefs(nodes, trigger, formulas)
    RR-->>EA: relationRefs
    EA->>HR: hydrateTriggerRelations(env, scopeRecord)
    HR->>Cache: get (miss then DB)
    DB-->>HR: related docs
    EA->>CE: evaluateConditionGroups(groups, record, scope, related)
    Note over EA,CE: withLazyRuleRelations fills dotted rule-field gaps at eval site
    CE-->>EA: conditionMet
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/backend/convex/automations.ts:2088-2100
`ENTITY_PERMISSION_OBJECT` is typed as `Partial<Record<string, PermissionObject>>`, so the non-null assertions (`!`) silently bypass TypeScript's undefined check. If `RELATED_OBJECTS` is ever extended to include a relation type not yet added to `ENTITY_PERMISSION_OBJECT`, the expression `ctx.gateRead(undefined!)` would throw at runtime. The existing `getSampleRecords` query avoids this by checking for `undefined` first — doing the same here is safer and consistent.

```suggestion
		const entityPermObj = ENTITY_PERMISSION_OBJECT[args.entityType];
		if (!entityPermObj || !(await ctx.gateRead(entityPermObj))) {
			return {};
		}

		const sourceTable = OBJECT_TYPE_TABLE[args.entityType];
		const sourceId = ctx.db.normalizeId(sourceTable, args.entityId);
		if (!sourceId) return {};
		const source = await ctx.db.get(sourceId);
		if (!source || source.orgId !== ctx.orgId) return {};

		const result: Record<string, Record<string, unknown>> = {};
		for (const relation of relations) {
			const relPermObj = ENTITY_PERMISSION_OBJECT[relation];
			if (!relPermObj || !(await ctx.gateRead(relPermObj))) continue;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(automations): C6 — one-hop related-..."](https://github.com/xcarter93/onetool/commit/50e24645de2111a33d50853869d7a4694e54b7bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45384145)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->