### PR TITLE
Implement email tracking, server-side flag enforcement, and error logging

### DIFF
--- a/apps/web/src/providers/PostHogProvider.tsx
+++ b/apps/web/src/providers/PostHogProvider.tsx
@@ -22,6 +22,8 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
 				// which double-counted on ?tab= query-param changes.
 				capture_pageview: "history_change",
 				capture_pageleave: true,
+				// Privacy policy promises we honor Do-Not-Track — this makes it true.
+				respect_dnt: true,
 				capture_performance: true, // Web vitals & performance metrics
 				autocapture: {
 					dom_event_allowlist: ["click", "change", "submit"],

--- a/packages/backend/convex/automationExecutor.ts
+++ b/packages/backend/convex/automationExecutor.ts
@@ -7,6 +7,7 @@ import {
 import { v } from "convex/values";
 import { Doc, Id } from "./_generated/dataModel";
 import { internal } from "./_generated/api";
+import { trackServerException } from "./lib/posthog";
 import { AggregateHelpers } from "./lib/aggregates";
 import { roundCents, sumMoney } from "./lib/money";
 import { ActivityHelpers } from "./lib/activities";
@@ -4072,11 +4073,26 @@ async function notifyAutomationFailure(
 	ctx: MutationCtx,
 	automation: AutomationDoc,
 	error: string,
-	// Reserved for future per-run deep-linking; the alert links to /automations.
 	executionId: Id<"workflowExecutions">
 ): Promise<void> {
-	void executionId;
 	try {
+		// Production-run failures also land in PostHog error tracking.
+		const org = await ctx.db.get(automation.orgId);
+		await trackServerException(ctx, {
+			error,
+			source: "automation",
+			...(org
+				? {
+						distinctId: `org:${org.clerkOrganizationId}`,
+						groups: { organization: org.clerkOrganizationId },
+					}
+				: {}),
+			properties: {
+				automation_id: automation._id,
+				execution_id: executionId,
+			},
+		});
+
 		const adminIds = await resolveMemberUserIds(ctx, automation.orgId, true);
 		if (adminIds.length === 0) return;
 

--- a/packages/backend/convex/automations.ts
+++ b/packages/backend/convex/automations.ts
@@ -4,6 +4,7 @@ import { v } from "convex/values";
 import { paginationOptsValidator, type PaginationResult } from "convex/server";
 import { Doc, Id } from "./_generated/dataModel";
 import { getCurrentUserOrgId, getCurrentUserOrThrow } from "./lib/auth";
+import { FEATURE_FLAGS, isServerFlagEnabled } from "./lib/posthog";
 import { userMutation, userQuery } from "./lib/factories";
 import {
 	AUTOMATION_OBJECT_TYPES,
@@ -53,6 +54,22 @@ import {
 	type FieldType,
 } from "./lib/fieldRegistry";
 import { computeNextRunAt, validateSchedule } from "./lib/schedule";
+
+/** PostHog rollout gate for creating/activating automations (fail-open). */
+async function requireAutomationAccess(
+	ctx: MutationCtx,
+	orgId: Id<"organizations">,
+	userId: Id<"users">
+): Promise<void> {
+	const enabled = await isServerFlagEnabled(ctx, {
+		key: FEATURE_FLAGS.WORKFLOW_AUTOMATIONS,
+		orgId,
+		userId,
+	});
+	if (!enabled) {
+		throw new Error("Workflow automations are not enabled for your organization");
+	}
+}
 
 /**
  * Workflow Automation operations with embedded CRUD helpers
@@ -1378,6 +1395,7 @@ export const create = userMutation({
 
 		const userOrgId = await getCurrentUserOrgId(ctx);
 		const user = await getCurrentUserOrThrow(ctx);
+		await requireAutomationAccess(ctx, userOrgId, user._id);
 		const now = Date.now();
 		const trigger = sanitizeTrigger(args.trigger);
 
@@ -1481,6 +1499,8 @@ export const publish = userMutation({
 	handler: async (ctx, args): Promise<AutomationId> => {
 		await ctx.requireLevel("automations", "modify");
 		const automation = await getAutomationOrThrow(ctx, args.id);
+		const user = await getCurrentUserOrThrow(ctx);
+		await requireAutomationAccess(ctx, automation.orgId, user._id);
 
 		validateForActivation(automation.trigger, automation.nodes as NodeArg[]);
 		validateFormulas(automation.formulas, automation.trigger);
@@ -1521,6 +1541,10 @@ export const toggleActive = userMutation({
 			});
 			return args.id;
 		}
+
+		// Activation paths only — pausing above stays allowed when the flag is off.
+		const user = await getCurrentUserOrThrow(ctx);
+		await requireAutomationAccess(ctx, automation.orgId, user._id);
 
 		if (automation.publishedSnapshot) {
 			// Resume a previously-published automation on its published version.

--- a/packages/backend/convex/communityPages.ts
+++ b/packages/backend/convex/communityPages.ts
@@ -10,6 +10,23 @@ import { rateLimiter } from "./rateLimits";
 import { optionalUserQuery, userMutation } from "./lib/factories";
 import { emitRecordCreatedEvent } from "./eventBus";
 import { isAdminRole } from "./lib/permissions";
+import { FEATURE_FLAGS, isServerFlagEnabled } from "./lib/posthog";
+
+/** PostHog rollout gate for editing/publishing community pages (fail-open). */
+async function requireCommunityPagesAccess(
+	ctx: MutationCtx,
+	orgId: Id<"organizations">,
+	userId: Id<"users">
+): Promise<void> {
+	const enabled = await isServerFlagEnabled(ctx, {
+		key: FEATURE_FLAGS.COMMUNITY_PAGES,
+		orgId,
+		userId,
+	});
+	if (!enabled) {
+		throw new Error("Community pages are not enabled for your organization");
+	}
+}
 
 // Type definitions
 type CommunityPageDocument = Doc<"communityPages">;
@@ -119,8 +136,9 @@ export const upsert = userMutation({
 	},
 	handler: async (ctx, args): Promise<CommunityPageId> => {
 		await ctx.requireLevel("community", "modify");
-		await getCurrentUserOrThrow(ctx);
+		const user = await getCurrentUserOrThrow(ctx);
 		const userOrgId = await getCurrentUserOrgId(ctx);
+		await requireCommunityPagesAccess(ctx, userOrgId, user._id);
 		if (args.draftPricingTiers !== undefined) {
 			validatePricingTiers(args.draftPricingTiers);
 		}
@@ -243,8 +261,9 @@ export const publish = userMutation({
 	args: {},
 	handler: async (ctx): Promise<void> => {
 		await ctx.requireLevel("community", "modify");
-		await getCurrentUserOrThrow(ctx);
+		const user = await getCurrentUserOrThrow(ctx);
 		const userOrgId = await getCurrentUserOrgId(ctx);
+		await requireCommunityPagesAccess(ctx, userOrgId, user._id);
 
 		const page = await ctx.db
 			.query("communityPages")

--- a/packages/backend/convex/eventBus.ts
+++ b/packages/backend/convex/eventBus.ts
@@ -11,7 +11,9 @@ import {
 	triggerableObjectTypeValidator,
 	type TriggerableObjectType,
 } from "./lib/workflowTypes";
-import { trackServerEvent, statusChangeEvent, createdEvent } from "./lib/posthog";
+import { trackServerEvent, statusChangeEvent, createdEvent,
+	trackServerException,
+} from "./lib/posthog";
 
 /**
  * Emitters accept any MutationCtx; when called from a userMutation the
@@ -366,6 +368,23 @@ export const processEvents = internalMutation({
 						failedAt: Date.now(),
 					});
 					failed++;
+
+					// Dead-letter is terminal — surface it in PostHog error tracking.
+					const org = await ctx.db.get(event.orgId);
+					await trackServerException(ctx, {
+						error,
+						source: "event_bus",
+						...(org
+							? {
+									distinctId: `org:${org.clerkOrganizationId}`,
+									groups: { organization: org.clerkOrganizationId },
+								}
+							: {}),
+						properties: {
+							event_type: event.eventType,
+							attempt_count: attemptCount,
+						},
+					});
 				} else {
 					// Schedule retry
 					await ctx.db.patch(event._id, {

--- a/packages/backend/convex/http.ts
+++ b/packages/backend/convex/http.ts
@@ -101,7 +101,7 @@ http.route({
 					});
 					logWebhookSuccess("Clerk", "organization.created", orgData.id);
 				} catch (error) {
-					logWebhookError("Clerk", "organization.created", error, orgData.id);
+					await logWebhookError("Clerk", "organization.created", error, orgData.id, ctx);
 					// Don't throw - let webhook succeed but log the error
 				}
 				break;
@@ -130,7 +130,7 @@ http.route({
 					});
 					logWebhookSuccess("Clerk", "organization.updated", orgData.id);
 				} catch (error) {
-					logWebhookError("Clerk", "organization.updated", error, orgData.id);
+					await logWebhookError("Clerk", "organization.updated", error, orgData.id, ctx);
 				}
 				break;
 			}
@@ -150,7 +150,7 @@ http.route({
 					});
 					logWebhookSuccess("Clerk", "organization.deleted", orgData.id);
 				} catch (error) {
-					logWebhookError("Clerk", "organization.deleted", error, orgData.id);
+					await logWebhookError("Clerk", "organization.deleted", error, orgData.id, ctx);
 				}
 				break;
 			}
@@ -187,11 +187,12 @@ http.route({
 						`user:${userId} org:${orgId}`
 					);
 				} catch (error) {
-					logWebhookError(
+					await logWebhookError(
 						"Clerk",
 						"organizationMembership.created",
 						error,
-						`user:${userId} org:${orgId}`
+						`user:${userId} org:${orgId}`,
+						ctx
 					);
 				}
 				break;
@@ -229,11 +230,12 @@ http.route({
 						`user:${userId} org:${orgId}`
 					);
 				} catch (error) {
-					logWebhookError(
+					await logWebhookError(
 						"Clerk",
 						"organizationMembership.updated",
 						error,
-						`user:${userId} org:${orgId}`
+						`user:${userId} org:${orgId}`,
+						ctx
 					);
 				}
 				break;
@@ -277,11 +279,12 @@ http.route({
 						`user:${userId}`
 					);
 				} catch (error) {
-					logWebhookError(
+					await logWebhookError(
 						"Clerk",
 						"organizationMembership.deleted",
 						error,
-						`user:${userId}`
+						`user:${userId}`,
+						ctx
 					);
 				}
 				break;
@@ -687,7 +690,13 @@ http.route({
 						});
 						logWebhookSuccess("Resend", "email.received (inbound)", emailId);
 					} catch (error) {
-						logWebhookError("Resend", "email.received (inbound)", error, emailId);
+						await logWebhookError(
+							"Resend",
+							"email.received (inbound)",
+							error,
+							emailId,
+							ctx
+						);
 						// Return 200 anyway to prevent Resend from retrying
 					}
 					break;
@@ -698,7 +707,7 @@ http.route({
 
 			return webhookSuccess("OK");
 		} catch (error) {
-			console.error("Error processing Resend webhook:", error);
+			await logWebhookError("Resend", "webhook", error, undefined, ctx);
 			return webhookError(500, "Internal Server Error");
 		}
 	}),
@@ -757,7 +766,7 @@ http.route({
 				}
 			);
 		} catch (error) {
-			logWebhookError("Stripe", event.type, error, event.id);
+			await logWebhookError("Stripe", event.type, error, event.id, ctx);
 			// Return 500 so Stripe retries transient processing failures.
 			return webhookError(500, "Internal error processing webhook");
 		}

--- a/packages/backend/convex/lib/posthog.ts
+++ b/packages/backend/convex/lib/posthog.ts
@@ -1,7 +1,11 @@
 import { PostHog } from "@posthog/convex";
+import type { Scheduler } from "convex/server";
 import { components } from "../_generated/api";
 import { MutationCtx } from "../_generated/server";
 import { Id } from "../_generated/dataModel";
+
+/** Minimal ctx for capture — satisfied by MutationCtx and (http)ActionCtx. */
+export type SchedulerCtx = { scheduler: Scheduler };
 
 /**
  * Server-side PostHog bridge. Mirrors the business events defined (but never
@@ -34,6 +38,7 @@ export const SERVER_EVENTS = {
 	// lifecycle
 	STRIPE_CONNECTED: "stripe_connected",
 	ONBOARDING_COMPLETED: "onboarding_completed",
+	EMAIL_SENT: "email_sent",
 	// TODO: report_generated — generation is a reactive query
 	// (reportData.executeReport); no scheduler ctx to capture from.
 	REPORT_GENERATED: "report_generated",
@@ -41,6 +46,48 @@ export const SERVER_EVENTS = {
 
 export type ServerEventName =
 	(typeof SERVER_EVENTS)[keyof typeof SERVER_EVENTS];
+
+/** PostHog feature-flag keys enforced server-side (same keys the sidebar gates on). */
+export const FEATURE_FLAGS = {
+	WORKFLOW_AUTOMATIONS: "workflow-automation-access",
+	COMMUNITY_PAGES: "community-pages-access",
+} as const;
+
+export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS];
+
+/**
+ * Locally-evaluated PostHog flag check (no network call — reads the component's
+ * polled flag-definition cache). Fail-open: flags are rollout gates, not
+ * entitlements (plan limits in lib/permissions.ts are the hard gate), so an
+ * unevaluable flag (cache cold after deploy, key deleted, POSTHOG_PERSONAL_API_KEY
+ * unset) must not lock users out. Only an explicit `false` denies.
+ */
+export async function isServerFlagEnabled(
+	ctx: MutationCtx,
+	args: {
+		key: FeatureFlagKey;
+		orgId: Id<"organizations">;
+		userId?: Id<"users">;
+	}
+): Promise<boolean> {
+	if (process.env.VITEST) return true;
+
+	try {
+		const org = await ctx.db.get(args.orgId);
+		if (!org) return true;
+		const user = args.userId ? await ctx.db.get(args.userId) : null;
+
+		const enabled = await posthog.isFeatureEnabled(ctx, {
+			key: args.key,
+			distinctId: user?.externalId ?? `org:${org.clerkOrganizationId}`,
+			groups: { organization: org.clerkOrganizationId },
+		});
+		return enabled !== false;
+	} catch (error) {
+		console.warn(`PostHog flag "${args.key}" evaluation failed; allowing`, error);
+		return true;
+	}
+}
 
 /**
  * Map an entity status change to its analytics event, or null when the
@@ -143,6 +190,36 @@ export async function trackAiGeneration(
 		},
 		groups: { organization: org.clerkOrganizationId },
 	});
+}
+
+/**
+ * Server-side $exception capture (PostHog error tracking). Needs only a
+ * scheduler, so it works from mutations and httpActions alike. Never throws.
+ */
+export async function trackServerException(
+	ctx: SchedulerCtx,
+	args: {
+		error: unknown;
+		source: string;
+		distinctId?: string;
+		groups?: Record<string, string>;
+		properties?: Record<string, unknown>;
+	}
+): Promise<void> {
+	if (process.env.VITEST) return;
+	try {
+		await posthog.captureException(ctx, {
+			error: args.error,
+			distinctId: args.distinctId,
+			additionalProperties: {
+				source: args.source,
+				...(args.groups ? { $groups: args.groups } : {}),
+				...args.properties,
+			},
+		});
+	} catch (captureError) {
+		console.warn("PostHog captureException failed", captureError);
+	}
 }
 
 export async function trackServerEvent(

--- a/packages/backend/convex/lib/webhooks.ts
+++ b/packages/backend/convex/lib/webhooks.ts
@@ -7,6 +7,7 @@
 
 import type { WebhookEvent } from "@clerk/backend";
 import { Webhook } from "svix";
+import { trackServerException, type SchedulerCtx } from "./posthog";
 
 // ============================================================================
 // Types
@@ -308,16 +309,27 @@ export function logWebhookSuccess(
 /**
  * Log webhook processing error
  */
-export function logWebhookError(
+export async function logWebhookError(
 	service: string,
 	eventType: string,
 	error: unknown,
-	identifier?: string
-): void {
+	identifier?: string,
+	// When provided, also captures to PostHog error tracking. Pass only at
+	// terminal catch sites (route-level / swallowed errors) — rethrown errors
+	// are captured upstream, so passing ctx on both would double-count.
+	ctx?: SchedulerCtx
+): Promise<void> {
 	console.error(
 		`${service} webhook error: ${eventType}${identifier ? ` for ${identifier}` : ""}`,
 		error instanceof Error ? error.message : String(error)
 	);
+	if (ctx) {
+		await trackServerException(ctx, {
+			error,
+			source: "webhook",
+			properties: { service, event_type: eventType, identifier },
+		});
+	}
 }
 
 // ============================================================================

--- a/packages/backend/convex/resend.ts
+++ b/packages/backend/convex/resend.ts
@@ -8,6 +8,7 @@ import {
 	bumpThread,
 	plusTagAddress,
 } from "./email/threads";
+import { SERVER_EVENTS, trackServerEvent } from "./lib/posthog";
 
 // Re-export the durable component instance so existing callers (portal/email.ts)
 // keep importing `resend` from here; the instance itself lives in the seam.
@@ -144,6 +145,18 @@ export const sendClientEmail = userMutation({
 			subject: args.subject,
 			preview: messagePreview,
 			direction: "outbound",
+		});
+
+		await trackServerEvent(ctx, {
+			event: SERVER_EVENTS.EMAIL_SENT,
+			orgId,
+			actorUserId: user._id,
+			properties: {
+				email_message_id: emailMessageId,
+				thread_id: threadDocId,
+				client_id: args.clientId,
+				is_reply: false,
+			},
 		});
 
 		// Log activity
@@ -316,6 +329,18 @@ export const replyToEmail = userMutation({
 			subject,
 			preview: messagePreview,
 			direction: "outbound",
+		});
+
+		await trackServerEvent(ctx, {
+			event: SERVER_EVENTS.EMAIL_SENT,
+			orgId,
+			actorUserId: user._id,
+			properties: {
+				email_message_id: emailMessageId,
+				thread_id: threadDocId,
+				client_id: clientId,
+				is_reply: true,
+			},
 		});
 
 		// Log activity


### PR DESCRIPTION
This pull request introduces server-side enforcement of PostHog feature flags for key workflow automation and community pages features, adds robust error tracking via PostHog for backend exceptions, and ensures privacy compliance with Do-Not-Track. It also improves error logging for webhooks by reporting terminal errors to PostHog, and adds related infrastructure and helpers. These changes ensure that feature rollouts are controlled, errors are surfaced for observability, and privacy promises are upheld.

**Feature flag enforcement (server-side):**
* Added `isServerFlagEnabled` and related helpers in `lib/posthog.ts` to enforce PostHog feature flags for workflow automations and community pages, with fail-open semantics.
* Updated automation and community page mutations to call new `requireAutomationAccess` and `requireCommunityPagesAccess` functions, restricting creation and activation based on feature flags. [[1]](diffhunk://#diff-28949ff315bcde2457f348b147064a31c662bd41ee55f784d7290da45f1ba4b2R58-R73) [[2]](diffhunk://#diff-28949ff315bcde2457f348b147064a31c662bd41ee55f784d7290da45f1ba4b2R1398) [[3]](diffhunk://#diff-28949ff315bcde2457f348b147064a31c662bd41ee55f784d7290da45f1ba4b2R1502-R1503) [[4]](diffhunk://#diff-28949ff315bcde2457f348b147064a31c662bd41ee55f784d7290da45f1ba4b2R1545-R1548) [[5]](diffhunk://#diff-bce525048beca1d435996809e83b2db62aea917f20d38b6312c321f7d50079eeR13-R29) [[6]](diffhunk://#diff-bce525048beca1d435996809e83b2db62aea917f20d38b6312c321f7d50079eeL122-R141) [[7]](diffhunk://#diff-bce525048beca1d435996809e83b2db62aea917f20d38b6312c321f7d50079eeL246-R266)

**Error and exception tracking:**
* Added `trackServerException` helper to `lib/posthog.ts` for capturing backend exceptions in PostHog; integrated into automation executor and event bus for production failures and dead-letter events. [[1]](diffhunk://#diff-2ef7a757b751833b34d395602b2b0dcba55f92e312823f15d26d8fdb98951e6dR195-R224) [[2]](diffhunk://#diff-74bb3a617199583fb16225745117cd7177598a19e1c289a41c22938ceca14eb7L4075-R4095) [[3]](diffhunk://#diff-1b5b60fa8e77992db1fb9e19ae23ebc6edf43c23a28cd49cfddcb51091e27b16R371-R387)
* Enhanced `logWebhookError` in `lib/webhooks.ts` to optionally report terminal webhook errors to PostHog, and updated all webhook routes to use this for improved error observability. [[1]](diffhunk://#diff-b6f72faa1743302cd0d4322db7e6666c69523821bbb8c3ebdb277c330c018907L311-R332) [[2]](diffhunk://#diff-881eea027252bff733b67f395e73bbd4d4cc19e92148f961eaa29b47a54ddc51L104-R104) [[3]](diffhunk://#diff-881eea027252bff733b67f395e73bbd4d4cc19e92148f961eaa29b47a54ddc51L133-R133) [[4]](diffhunk://#diff-881eea027252bff733b67f395e73bbd4d4cc19e92148f961eaa29b47a54ddc51L153-R153) [[5]](diffhunk://#diff-881eea027252bff733b67f395e73bbd4d4cc19e92148f961eaa29b47a54ddc51L190-R195) [[6]](diffhunk://#diff-881eea027252bff733b67f395e73bbd4d4cc19e92148f961eaa29b47a54ddc51L232-R238) [[7]](diffhunk://#diff-881eea027252bff733b67f395e73bbd4d4cc19e92148f961eaa29b47a54ddc51L280-R287) [[8]](diffhunk://#diff-881eea027252bff733b67f395e73bbd4d4cc19e92148f961eaa29b47a54ddc51L690-R699) [[9]](diffhunk://#diff-881eea027252bff733b67f395e73bbd4d4cc19e92148f961eaa29b47a54ddc51L701-R710) [[10]](diffhunk://#diff-881eea027252bff733b67f395e73bbd4d4cc19e92148f961eaa29b47a54ddc51L760-R769)

**Privacy compliance:**
* Set `respect_dnt: true` in the PostHog provider to honor browser Do-Not-Track settings, aligning with the privacy policy.

**Infrastructure and event tracking:**
* Added new server event (`EMAIL_SENT`) to PostHog event definitions and imported PostHog helpers in `resend.ts`. [[1]](diffhunk://#diff-2ef7a757b751833b34d395602b2b0dcba55f92e312823f15d26d8fdb98951e6dR41) [[2]](diffhunk://#diff-87c3eab7239b550f9bdb5bbaf144554b9e6c0342572e9cb1100036978fa1dae3R11)

**Code organization and imports:**
* Updated imports to include new helpers and types where required (e.g., `trackServerException`, feature flag helpers). [[1]](diffhunk://#diff-74bb3a617199583fb16225745117cd7177598a19e1c289a41c22938ceca14eb7R10) [[2]](diffhunk://#diff-1b5b60fa8e77992db1fb9e19ae23ebc6edf43c23a28cd49cfddcb51091e27b16L14-R16) [[3]](diffhunk://#diff-28949ff315bcde2457f348b147064a31c662bd41ee55f784d7290da45f1ba4b2R7) [[4]](diffhunk://#diff-b6f72faa1743302cd0d4322db7e6666c69523821bbb8c3ebdb277c330c018907R10)

These changes collectively improve feature rollout safety, backend observability, and user privacy compliance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Privacy**
  * Do-Not-Track preferences are now honored for analytics collection.

* **New Features**
  * Added feature controls for workflow automations and community page editing and publishing.
  * Successful client emails and replies now generate analytics events.

* **Bug Fixes**
  * Webhook, automation, and event-processing failures now receive improved error tracking and context.
  * Automation activation and community page publishing are blocked when their features are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds server-side PostHog feature-flag enforcement for workflow automations and community pages (fail-open), integrates `trackServerException` for backend error observability in the automation executor and event bus, upgrades webhook error logging to optionally report to PostHog, adds `EMAIL_SENT` tracking in `resend.ts`, and sets `respect_dnt: true` for privacy compliance.

- **Feature-flag gates** (`requireAutomationAccess`, `requireCommunityPagesAccess`) are correctly placed after existing permission level checks; deactivation is intentionally excluded from the automation gate so users can still pause automations when a flag is off.
- **Exception tracking** uses `posthog.captureException` (not raw `$exception` capture), which is correct — however, the automation failure path passes a `string` rather than an `Error` object, reducing the quality of PostHog exception metadata for that source.
- **Webhook logging** was cleanly migrated to `async`; all call sites in `http.ts` are properly awaited with `ctx` passed for PostHog reporting.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The flag gates are intentionally fail-open and backed by hard plan-limit checks in `lib/permissions.ts`, so a PostHog outage cannot lock users out.

The change is well-structured: flag checks, exception tracking, webhook logging, and the DNT privacy flag all integrate cleanly with existing patterns. One minor gap is that `notifyAutomationFailure` forwards a pre-serialized `string` rather than an `Error` object to `captureException`, which means PostHog will receive exception events without stack-trace or type metadata for that code path — reducing the observability value compared to the event-bus path that forwards the raw caught error.

`automationExecutor.ts` around the `trackServerException` call in `notifyAutomationFailure` — the string-vs-Error distinction affects exception metadata quality in PostHog.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/lib/posthog.ts | Adds `isServerFlagEnabled`, `FEATURE_FLAGS`, `trackServerException`, `SchedulerCtx`, and `EMAIL_SENT` event. Fail-open semantics are correctly implemented; the function correctly treats `undefined` flag values as not-false. Exception capture wraps a try/catch so callers are not affected. |
| packages/backend/convex/automationExecutor.ts | Integrates `trackServerException` into `notifyAutomationFailure`. The call is inside the existing try-catch so it can't roll back the terminal failure patch. However, the `error` parameter is a `string`, not an `Error` object, so PostHog captures the event without stack-trace or type metadata. |
| packages/backend/convex/automations.ts | Adds `requireAutomationAccess` gate on `create`, `publish`, and the activation branch of `toggleActive`. Deactivation correctly bypasses the flag check. Permission level check runs before the flag check. |
| packages/backend/convex/communityPages.ts | Adds `requireCommunityPagesAccess` gate on `upsert` and `publish`. Access check follows the existing `requireLevel` call, preserving correct order. |
| packages/backend/convex/eventBus.ts | Calls `trackServerException` only on the dead-letter path (max retries exceeded). `error` comes directly from the `catch` block as `unknown`, so PostHog will receive a proper Error object with stack trace where available. |
| packages/backend/convex/http.ts | All `logWebhookError` call sites correctly updated to `await` the now-async signature and pass `ctx` for PostHog reporting. No unawaited calls remain in the diff. |
| packages/backend/convex/lib/webhooks.ts | `logWebhookError` changed from sync to async; PostHog reporting is opt-in via `ctx` param. The `console.error` still runs synchronously so legacy callers without `await` would still log. |
| packages/backend/convex/resend.ts | Adds `EMAIL_SENT` tracking to both `sendClientEmail` (is_reply: false) and `replyToEmail` (is_reply: true). Correct identity stitching via `orgId` and `user._id`. |
| apps/web/src/providers/PostHogProvider.tsx | Adds `respect_dnt: true` to honor browser Do-Not-Track. Straightforward config addition; aligns with privacy policy commitment. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User mutation: create/publish/toggleActive] --> B{ctx.requireLevel check}
    B -->|authorized| C{isServerFlagEnabled}
    C -->|PostHog API available| D{Flag result}
    D -->|true| E[Proceed with mutation]
    D -->|false| F[Throw: feature not enabled]
    C -->|PostHog error / cache cold| G[Fail-open: allow access]
    G --> E

    H[Automation run fails] --> I[notifyAutomationFailure]
    I --> J[trackServerException with string error]
    J --> K[posthog.captureException no stack trace]
    I --> L[Notify admin users]

    M[Event bus dead-letter] --> N[trackServerException with Error object]
    N --> O[posthog.captureException with full metadata]

    P[Webhook error] --> Q[logWebhookError + ctx]
    Q --> R[trackServerException]
    R --> S[PostHog error tracking]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User mutation: create/publish/toggleActive] --> B{ctx.requireLevel check}
    B -->|authorized| C{isServerFlagEnabled}
    C -->|PostHog API available| D{Flag result}
    D -->|true| E[Proceed with mutation]
    D -->|false| F[Throw: feature not enabled]
    C -->|PostHog error / cache cold| G[Fail-open: allow access]
    G --> E

    H[Automation run fails] --> I[notifyAutomationFailure]
    I --> J[trackServerException with string error]
    J --> K[posthog.captureException no stack trace]
    I --> L[Notify admin users]

    M[Event bus dead-letter] --> N[trackServerException with Error object]
    N --> O[posthog.captureException with full metadata]

    P[Webhook error] --> Q[logWebhookError + ctx]
    Q --> R[trackServerException]
    R --> S[PostHog error tracking]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/backend/convex/automationExecutor.ts:4081-4094
**String passed to `captureException` loses exception metadata**

`notifyAutomationFailure` receives `error: string` (already serialized upstream), which is forwarded directly to `posthog.captureException`. PostHog's exception capture API extracts `$exception_type`, `$exception_stack_trace_raw`, and similar fields from an actual `Error` object; a plain string produces none of those. The exception is still ingested, but it won't appear correctly in PostHog's error-grouping or stack-trace views, which is the main value of error tracking. Consider wrapping the string before passing it: `new Error(error)` would let PostHog attach at least a type and a synthetic trace to the captured event.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(analytics): email\_sent + server-sid..."](https://github.com/xcarter93/onetool/commit/06a6d41caabdcb5d6351f25c413daac6b1a547ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45437291)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->