### PR TITLE
Align PostHog config and revive crash-on-import test

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -23,7 +23,7 @@ const cspReportOnly = [
 	"style-src 'self' 'unsafe-inline'",
 	"img-src 'self' https: data: blob:",
 	"font-src 'self' data:",
-	`connect-src 'self'${convexHostname ? ` https://${convexHostname} wss://${convexHostname}` : ""}`,
+	`connect-src 'self'${convexHostname ? ` https://${convexHostname} wss://${convexHostname}` : ""}${process.env.NEXT_PUBLIC_POSTHOG_HOST ? ` ${process.env.NEXT_PUBLIC_POSTHOG_HOST}` : ""}`, 
 	"frame-src https://js.stripe.com https://hooks.stripe.com",
 	"frame-ancestors 'none'",
 	"base-uri 'self'",
@@ -60,8 +60,12 @@ const nextConfig: NextConfig = {
 				destination: "https://us-assets.i.posthog.com/static/:path*",
 			},
 			{
+				source: "/ingest/array/:path*",
+				destination: "https://us-assets.i.posthog.com/array/:path*",
+			},
+			{
 				source: "/ingest/:path*",
-				destination: "https://us.i.posthog.com/:path*",
+				destination: `${process.env.NEXT_PUBLIC_POSTHOG_HOST}/:path*`,
 			},
 		];
 	},

--- a/apps/web/src/app/components/landing/schedule-demo-modal.tsx
+++ b/apps/web/src/app/components/landing/schedule-demo-modal.tsx
@@ -8,6 +8,8 @@ import { Input } from "@/components/ui/input";
 import { PhoneInput } from "@/components/reui/phone-input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { trackEvent } from "@/lib/analytics";
+import { AnalyticsEvents } from "@/lib/analytics-events";
 
 interface ScheduleDemoModalProps {
 	isOpen: boolean;
@@ -64,6 +66,12 @@ export default function ScheduleDemoModal({
 			if (!response.ok) {
 				throw new Error(data.error || "Failed to send demo request");
 			}
+
+			trackEvent(AnalyticsEvents.DEMO_REQUEST_SUBMITTED, {
+				has_company: Boolean(formData.company.trim()),
+				has_phone: Boolean(formData.phone.trim()),
+				has_message: Boolean(formData.message.trim()),
+			});
 
 			setFormStatus({
 				type: "success",

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -58,6 +58,7 @@ export const env = createEnv({
 		NEXT_PUBLIC_CLERK_FRONTEND_API_URL: z.string().min(1),
 		NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().min(1),
 		NEXT_PUBLIC_POSTHOG_KEY: z.string().min(1),
+		NEXT_PUBLIC_POSTHOG_HOST: z.string().url(),
 		NEXT_PUBLIC_MAPBOX_API_KEY: z.string().min(1),
 	},
 	experimental__runtimeEnv: {
@@ -69,6 +70,7 @@ export const env = createEnv({
 		NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:
 			process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
 		NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
+		NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
 		NEXT_PUBLIC_MAPBOX_API_KEY: process.env.NEXT_PUBLIC_MAPBOX_API_KEY,
 	},
 });

--- a/apps/web/src/lib/analytics-events.ts
+++ b/apps/web/src/lib/analytics-events.ts
@@ -47,6 +47,9 @@ export const AnalyticsEvents = {
 	REPORT_GENERATED: "report_generated",
 	STRIPE_CONNECTED: "stripe_connected",
 
+	// Marketing
+	DEMO_REQUEST_SUBMITTED: "demo_request_submitted",
+
 	// Onboarding
 	ONBOARDING_STARTED: "onboarding_started",
 	ONBOARDING_COMPLETED: "onboarding_completed",

--- a/apps/web/src/lib/csv-analysis.test.ts
+++ b/apps/web/src/lib/csv-analysis.test.ts
@@ -10,6 +10,12 @@ vi.mock("@ai-sdk/openai", () => ({
 	openai: vi.fn(() => "mock-model"),
 }));
 
+// Stub the analytics dependency so importing the module under test does not
+// pull in @/env (which validates NEXT_PUBLIC_* vars absent from the test env).
+vi.mock("@/lib/posthog-server", () => ({
+	getPostHogServer: () => ({ captureImmediate: vi.fn() }),
+}));
+
 import { generateText } from "ai";
 import { mapCsvSchema } from "./csv-analysis";
 
@@ -116,6 +122,7 @@ describe("mapCsvSchema (LLM-powered)", () => {
 	it("Test 1: returns enriched mappings with dataType, isRequired, and sampleValue from schema when generateText returns valid mappings", async () => {
 		mockedGenerateText.mockResolvedValueOnce({
 			output: validLlmResponse,
+			usage: { inputTokens: 100, outputTokens: 50 },
 		} as never);
 
 		const result = await mapCsvSchema({
@@ -156,6 +163,7 @@ describe("mapCsvSchema (LLM-powered)", () => {
 	it("Test 2: moves column to unmappedColumns when LLM returns a schemaField that does not exist in CLIENT_SCHEMA_FIELDS", async () => {
 		mockedGenerateText.mockResolvedValueOnce({
 			output: responseWithInvalidField,
+			usage: { inputTokens: 100, outputTokens: 50 },
 		} as never);
 
 		const result = await mapCsvSchema({
@@ -179,6 +187,7 @@ describe("mapCsvSchema (LLM-powered)", () => {
 	it("Test 3: resolves duplicate field assignments by keeping highest confidence mapping", async () => {
 		mockedGenerateText.mockResolvedValueOnce({
 			output: responseWithDuplicateField,
+			usage: { inputTokens: 100, outputTokens: 50 },
 		} as never);
 
 		const result = await mapCsvSchema({
@@ -253,6 +262,7 @@ describe("mapCsvSchema (LLM-powered)", () => {
 	it("Test 6: prompt passed to generateText includes all schema field names and mentions dot-namespace convention", async () => {
 		mockedGenerateText.mockResolvedValueOnce({
 			output: validLlmResponse,
+			usage: { inputTokens: 100, outputTokens: 50 },
 		} as never);
 
 		await mapCsvSchema({
@@ -299,6 +309,7 @@ describe("mapCsvSchema (LLM-powered)", () => {
 
 		mockedGenerateText.mockResolvedValueOnce({
 			output: partialResponse,
+			usage: { inputTokens: 100, outputTokens: 50 },
 		} as never);
 
 		const result = await mapCsvSchema({
@@ -329,6 +340,7 @@ describe("mapCsvSchema (LLM-powered)", () => {
 	it("Test 9: returns llmFailed: false when generateText succeeds", async () => {
 		mockedGenerateText.mockResolvedValueOnce({
 			output: validLlmResponse,
+			usage: { inputTokens: 100, outputTokens: 50 },
 		} as never);
 
 		const result = await mapCsvSchema({

--- a/apps/web/src/lib/posthog-server.ts
+++ b/apps/web/src/lib/posthog-server.ts
@@ -10,7 +10,7 @@ let client: PostHog | null = null;
 export function getPostHogServer(): PostHog {
 	if (!client) {
 		client = new PostHog(env.NEXT_PUBLIC_POSTHOG_KEY, {
-			host: "https://us.i.posthog.com",
+			host: env.NEXT_PUBLIC_POSTHOG_HOST,
 			// Serverless: no long-lived process to batch in.
 			flushAt: 1,
 			flushInterval: 0,


### PR DESCRIPTION
This pull request introduces several updates to improve analytics integration, environment configuration, and security policy for the web app. The main changes include making the PostHog analytics host configurable via environment variables, updating CSP and routing to support this, and adding new analytics tracking for demo requests. The test suite and server-side analytics initialization are also updated to use the new configuration.

**Analytics & Environment Configuration:**
- Made the PostHog analytics host configurable via the `NEXT_PUBLIC_POSTHOG_HOST` environment variable, updating the `env.ts` schema and runtime environment accordingly. (`[[1]](diffhunk://#diff-59ee114dfa815444a5b21a21265fd040585b6a0e40a0af358c26806aee488892R61)`, `[[2]](diffhunk://#diff-59ee114dfa815444a5b21a21265fd040585b6a0e40a0af358c26806aee488892R73)`)
- Updated server-side analytics initialization in `posthog-server.ts` to use the environment-based host instead of a hardcoded URL. (`[apps/web/src/lib/posthog-server.tsL13-R13](diffhunk://#diff-ac0f0b321294c9fd4445b4ba3b224b11afa75595354da722099f98b090f9c796L13-R13)`)
- Updated the CSP `connect-src` directive and ingest route rewrites in `next.config.ts` to use the new PostHog host from the environment, ensuring proper analytics data flow and CSP compliance. (`[[1]](diffhunk://#diff-6b13ed47afb6968d423f855cd247d64a6bd145c369f944ddb742353b319ee2a2L26-R26)`, `[[2]](diffhunk://#diff-6b13ed47afb6968d423f855cd247d64a6bd145c369f944ddb742353b319ee2a2R62-R68)`)

**Analytics Tracking:**
- Added a new analytics event, `DEMO_REQUEST_SUBMITTED`, to track demo request submissions, and instrumented the schedule demo modal to fire this event with metadata on submission. (`[[1]](diffhunk://#diff-83e30f804f4a6c1bcb6620a59250c4593cfcd2d621c058154accf222277e6f5dR50-R52)`, `[[2]](diffhunk://#diff-16b2844e20af79aafa166c898635cae29abda0850a1ae242060396d7af961b43R11-R12)`, `[[3]](diffhunk://#diff-16b2844e20af79aafa166c898635cae29abda0850a1ae242060396d7af961b43R70-R75)`)

**Testing:**
- Stubbed analytics dependencies in `csv-analysis.test.ts` to avoid requiring environment variables during tests, and updated test mocks to include `usage` data in LLM responses. (`[[1]](diffhunk://#diff-227d4cc0a0c2050bbb4b1984c2f9a303cb50e190de44116e839f47529314f743R13-R18)`, `[[2]](diffhunk://#diff-227d4cc0a0c2050bbb4b1984c2f9a303cb50e190de44116e839f47529314f743R125)`, `[[3]](diffhunk://#diff-227d4cc0a0c2050bbb4b1984c2f9a303cb50e190de44116e839f47529314f743R166)`, `[[4]](diffhunk://#diff-227d4cc0a0c2050bbb4b1984c2f9a303cb50e190de44116e839f47529314f743R190)`, `[[5]](diffhunk://#diff-227d4cc0a0c2050bbb4b1984c2f9a303cb50e190de44116e839f47529314f743R265)`, `[[6]](diffhunk://#diff-227d4cc0a0c2050bbb4b1984c2f9a303cb50e190de44116e839f47529314f743R312)`, `[[7]](diffhunk://#diff-227d4cc0a0c2050bbb4b1984c2f9a303cb50e190de44116e839f47529314f743R343)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tracking for schedule-demo form submissions, including whether key contact fields were provided.
  - Added support for configurable analytics hosting across browser and server experiences.

- **Bug Fixes**
  - Improved analytics connectivity and ingestion routing for deployments using non-default PostHog hosting.
  - Updated test coverage and fixtures to better reflect current analytics behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the PostHog analytics host configurable via `NEXT_PUBLIC_POSTHOG_HOST`, updates the CSP `connect-src` directive and Next.js ingest rewrites to use it, switches the server-side `posthog-node` client from a hardcoded URL to the same env var, adds a `DEMO_REQUEST_SUBMITTED` analytics event fired on successful demo form submission, and stubs analytics dependencies in the CSV-analysis test suite to avoid env-var validation failures.

- **`next.config.ts`**: The ingest rewrite destination now interpolates `process.env.NEXT_PUBLIC_POSTHOG_HOST` directly without a fallback — if the variable is absent at build time the destination resolves to `"undefined/:path*"`, silently breaking all analytics ingestion. The CSP directive handles this correctly with a conditional, but the rewrite does not. The new `/ingest/array/:path*` and existing `/ingest/static/:path*` rewrites still hardcode `https://us-assets.i.posthog.com`, which would be inconsistent for EU region deployments.
- **`posthog-server.ts`**: Server-side client correctly switches to the validated env var, but the block comment still claims the server SDK bypasses the reverse proxy, which may no longer be true depending on what the env var is set to.
- **`csv-analysis.test.ts` / `schedule-demo-modal.tsx`**: Test stubs and event instrumentation look correct.

<h3>Confidence Score: 3/5</h3>

The rewrite destination in next.config.ts has no guard against a missing env var, which would silently break all analytics ingestion at build time without a visible error.

The ingest rewrite destination is constructed directly from process.env.NEXT_PUBLIC_POSTHOG_HOST without a fallback. If the build environment is missing that variable, Next.js produces a rewrite pointing at 'undefined/:path*' and the build still succeeds — analytics ingestion fails silently in production. The rest of the changes (env schema, server client, analytics event, test stubs) are straightforward and look correct.

apps/web/next.config.ts — the ingest rewrite destination and hardcoded static-asset URLs warrant a close look before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/next.config.ts | Makes PostHog ingest rewrite and CSP configurable via NEXT_PUBLIC_POSTHOG_HOST, but the rewrite destination has no guard against an undefined env var, producing a broken "undefined/:path*" destination at build time if the variable is absent. |
| apps/web/src/env.ts | Adds NEXT_PUBLIC_POSTHOG_HOST as a required, URL-validated client env var; schema and runtimeEnv wiring look correct. |
| apps/web/src/lib/posthog-server.ts | Switches server-side PostHog host from a hardcoded string to the env-validated variable; contains a stale comment claiming the server SDK bypasses the reverse proxy. |
| apps/web/src/app/components/landing/schedule-demo-modal.tsx | Adds DEMO_REQUEST_SUBMITTED analytics tracking on successful form submission with presence-only boolean metadata; placement and guards look correct. |
| apps/web/src/lib/analytics-events.ts | Adds the DEMO_REQUEST_SUBMITTED event constant under a new Marketing category; straightforward and consistent with existing conventions. |
| apps/web/src/lib/csv-analysis.test.ts | Stubs posthog-server to prevent env-var validation failures in tests and adds missing `usage` fields to LLM mock responses; changes are correct and targeted. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser as Browser (posthog-js)
    participant NextJS as Next.js App (/ingest)
    participant PostHogHost as NEXT_PUBLIC_POSTHOG_HOST
    participant PostHogAssets as us-assets.i.posthog.com (hardcoded)
    participant ServerSDK as Server SDK (posthog-node)

    Browser->>NextJS: "GET /ingest/static/:path*"
    NextJS->>PostHogAssets: "Rewrite to https://us-assets.i.posthog.com/static/:path*"

    Browser->>NextJS: "GET /ingest/array/:path*"
    NextJS->>PostHogAssets: "Rewrite to https://us-assets.i.posthog.com/array/:path* (hardcoded)"

    Browser->>NextJS: "POST /ingest/:path* (events)"
    NextJS->>PostHogHost: "Rewrite to NEXT_PUBLIC_POSTHOG_HOST/:path*"

    Note over NextJS,PostHogHost: If env var missing at build time, destination = undefined/:path*

    ServerSDK->>PostHogHost: "Direct POST (host = env.NEXT_PUBLIC_POSTHOG_HOST)"
    Note over ServerSDK,PostHogHost: Server SDK now routes through configured host (comment is stale)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser as Browser (posthog-js)
    participant NextJS as Next.js App (/ingest)
    participant PostHogHost as NEXT_PUBLIC_POSTHOG_HOST
    participant PostHogAssets as us-assets.i.posthog.com (hardcoded)
    participant ServerSDK as Server SDK (posthog-node)

    Browser->>NextJS: "GET /ingest/static/:path*"
    NextJS->>PostHogAssets: "Rewrite to https://us-assets.i.posthog.com/static/:path*"

    Browser->>NextJS: "GET /ingest/array/:path*"
    NextJS->>PostHogAssets: "Rewrite to https://us-assets.i.posthog.com/array/:path* (hardcoded)"

    Browser->>NextJS: "POST /ingest/:path* (events)"
    NextJS->>PostHogHost: "Rewrite to NEXT_PUBLIC_POSTHOG_HOST/:path*"

    Note over NextJS,PostHogHost: If env var missing at build time, destination = undefined/:path*

    ServerSDK->>PostHogHost: "Direct POST (host = env.NEXT_PUBLIC_POSTHOG_HOST)"
    Note over ServerSDK,PostHogHost: Server SDK now routes through configured host (comment is stale)
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/lib/posthog-server.ts`, line 6-9 ([link](https://github.com/xcarter93/onetool/blob/0d7bbcb33de83ef6c9816db753a6b8e3ae50bfe6/apps/web/src/lib/posthog-server.ts#L6-L9)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> <a href="#"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/partners/posthog-dark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/partners/posthog.svg?v=1"><img alt="partner" src="https://greptile-static-assets.s3.amazonaws.com/partners/posthog.svg?v=1" align="top"></picture></a> **Stale comment contradicts new behaviour**

   The block comment still says "Talks to PostHog directly (the /ingest reverse proxy is for the browser SDK only)" but `host` is now `env.NEXT_PUBLIC_POSTHOG_HOST`, which could be a managed proxy subdomain or `https://us.i.posthog.com` depending on how the variable is configured. If it points at a proxy the server SDK is no longer bypassing the proxy, so the comment is misleading for whoever maintains this in the future.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/lib/posthog-server.ts
   Line: 6-9

   Comment:
   **Stale comment contradicts new behaviour**

   The block comment still says "Talks to PostHog directly (the /ingest reverse proxy is for the browser SDK only)" but `host` is now `env.NEXT_PUBLIC_POSTHOG_HOST`, which could be a managed proxy subdomain or `https://us.i.posthog.com` depending on how the variable is configured. If it points at a proxy the server SDK is no longer bypassing the proxy, so the comment is misleading for whoever maintains this in the future.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/web/next.config.ts:68
**Unguarded `undefined` in rewrite destination**

`process.env.NEXT_PUBLIC_POSTHOG_HOST` is read directly here without a fallback, so if the variable is absent at build time the destination string becomes `"undefined/:path*"`. Next.js will accept that string and silently generate broken rewrite rules — all `/ingest/*` traffic will 404 and analytics ingestion stops entirely. Unlike the CSP line above (which uses a conditional `? … : ""`), this path has no guard. The `env.ts` validation only runs at app-runtime, not during the `next.config.ts` build phase.

### Issue 2 of 3
apps/web/src/lib/posthog-server.ts:6-9
**Stale comment contradicts new behaviour**

The block comment still says "Talks to PostHog directly (the /ingest reverse proxy is for the browser SDK only)" but `host` is now `env.NEXT_PUBLIC_POSTHOG_HOST`, which could be a managed proxy subdomain or `https://us.i.posthog.com` depending on how the variable is configured. If it points at a proxy the server SDK is no longer bypassing the proxy, so the comment is misleading for whoever maintains this in the future.

### Issue 3 of 3
apps/web/next.config.ts:59-65
**Static-asset destinations remain hardcoded to the US region**

Both `/ingest/static/:path*` and the new `/ingest/array/:path*` still resolve to `https://us-assets.i.posthog.com`, while `/ingest/:path*` is now dynamically configured. If `NEXT_PUBLIC_POSTHOG_HOST` is ever set to an EU endpoint (e.g. `https://eu.i.posthog.com`) the event ingestion path switches regions but the static/array asset fetches silently stay on the US CDN, which can cause script-load mismatches or CORS errors depending on PostHog's regional isolation.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(csv-analysis): revive crash-on-impo..."](https://github.com/xcarter93/onetool/commit/0d7bbcb33de83ef6c9816db753a6b8e3ae50bfe6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45448191)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->