### PR TITLE
Fix tour ring positioning and update workflow automation labels

### DIFF
--- a/apps/web/src/app/(workspace)/automations/components/editor/editor-top-bar.tsx
+++ b/apps/web/src/app/(workspace)/automations/components/editor/editor-top-bar.tsx
@@ -2,6 +2,12 @@
 
 import { ArrowLeft, Save } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/reui/badge";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { StatusBadge } from "@/components/domain/status-badge";
 import {
 	STATUS_BADGE_PROPS,
@@ -65,6 +71,26 @@ export function EditorTopBar({
 			>
 				{STATUS_LABEL[status]}
 			</StatusBadge>
+
+			{/* Sits inline in the top bar rather than floating over the canvas —
+			    that zone already belongs to the unpublished and undo banners. */}
+			<Tooltip>
+				<TooltipTrigger
+					render={
+						<Badge
+							variant="primary-light"
+							size="sm"
+							radius="full"
+							className="shrink-0 cursor-default"
+						>
+							Beta
+						</Badge>
+					}
+				/>
+				<TooltipContent side="bottom">
+					Automations is in beta — behaviour and available actions may change.
+				</TooltipContent>
+			</Tooltip>
 
 			<div className="ml-auto flex items-center gap-2">
 				<Button variant="outline" onClick={onSave} disabled={isSaving}>

--- a/apps/web/src/app/components/app-navbar.tsx
+++ b/apps/web/src/app/components/app-navbar.tsx
@@ -118,7 +118,6 @@ const featureItems: {
 		iconClassName: "text-teal-500",
 		label: "Workflow automations",
 		description: "Trigger actions on status changes",
-		comingSoon: true,
 	},
 	{
 		icon: Blocks,

--- a/apps/web/src/app/components/feature-section.tsx
+++ b/apps/web/src/app/components/feature-section.tsx
@@ -266,7 +266,6 @@ const highlights: HighlightProps[] = [
 		title: "Workflow automations",
 		subtitle:
 			"Trigger actions when statuses change — send emails, update projects, and more automatically.",
-		comingSoon: true,
 	},
 	{
 		Icon: Blocks,

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -347,13 +347,6 @@
 		z-index: 9999 !important;
 	}
 
-	/* The assistant notch sits at z-40, below the tour overlay — lift it (and
-	   its TourElement wrapper) so the step is actually visible. */
-	body[data-tour-step="assistant-notch"] .tour-element-wrapper:has(.assistant-notch),
-	body[data-tour-step="assistant-notch"] .assistant-notch {
-		z-index: 9999 !important;
-	}
-
 	/* Prevent overflow clipping of tour outlines in sidebar */
 	body[data-tour-step="sidebar-nav"] [data-slot="sidebar-content"],
 	body[data-tour-step="team-switcher"] [data-slot="sidebar-header"],

--- a/apps/web/src/components/assistant/assistant-notch.tsx
+++ b/apps/web/src/components/assistant/assistant-notch.tsx
@@ -20,7 +20,7 @@ export function AssistantNotch({
 	return (
 		<div
 			className={cn(
-				"fixed bottom-0 right-6 z-40 transition-transform duration-300 ease-out sm:right-12 md:right-24",
+				"transition-transform duration-300 ease-out",
 				open && "pointer-events-none translate-y-12"
 			)}
 		>

--- a/apps/web/src/components/layout/app-sidebar.tsx
+++ b/apps/web/src/components/layout/app-sidebar.tsx
@@ -427,8 +427,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 			disabledTooltip: isCommunityDisabled
 				? "Communities feature coming soon"
 				: isAutomationsDisabled
-				? "Automations feature coming soon"
+				? "Automations is temporarily unavailable"
 				: undefined,
+			// Automations is released to everyone but still stabilising.
+			badgeLabel: item.title === "Automations" ? "Beta" : undefined,
 			badgeCount:
 				item.title === "Tasks" && tasksBadgeCount > 0
 					? tasksBadgeCount

--- a/apps/web/src/components/layout/nav-getting-started.tsx
+++ b/apps/web/src/components/layout/nav-getting-started.tsx
@@ -176,13 +176,13 @@ export function NavGettingStarted() {
 						</FrameHeader>
 					</button>
 					{/* Height-animated rather than mounted/unmounted, so the checklist
-					    slides open instead of popping in. Collapsed keeps a short peek
-					    of the next steps under a fade. */}
+					    slides open instead of popping in. Collapsed is fully closed —
+					    the frame header is all that shows. */}
 					<div
 						id={checklistId}
 						className={cn(
 							"relative overflow-hidden transition-all duration-500 ease-in-out motion-reduce:transition-none",
-							isOpen ? "max-h-[32rem]" : "max-h-16"
+							isOpen ? "max-h-[32rem]" : "max-h-0"
 						)}
 					>
 						<FramePanel>

--- a/apps/web/src/components/layout/nav-main.tsx
+++ b/apps/web/src/components/layout/nav-main.tsx
@@ -30,6 +30,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Badge } from "@/components/reui/badge";
 import { useIsMobile } from "@/hooks/use-mobile";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
@@ -52,6 +53,8 @@ type NavItem = {
 	disabledTooltip?: string;
 	badgeCount?: number;
 	badgeVariant?: "alert";
+	/** Small inline label beside the title (e.g. "Beta"). */
+	badgeLabel?: string;
 	items?: {
 		title: string;
 		url: string;
@@ -515,6 +518,16 @@ export function NavMain({
 									>
 										{item.icon && <item.icon />}
 										<span>{item.title}</span>
+										{item.badgeLabel && (
+											<Badge
+												variant="primary-light"
+												size="xs"
+												radius="full"
+												className="ml-auto group-data-[collapsible=icon]:hidden"
+											>
+												{item.badgeLabel}
+											</Badge>
+										)}
 									</SidebarMenuButton>
 									{typeof item.badgeCount === "number" && item.badgeCount > 0 && (
 										<SidebarMenuBadge

--- a/apps/web/src/components/layout/sidebar-with-header.tsx
+++ b/apps/web/src/components/layout/sidebar-with-header.tsx
@@ -146,7 +146,11 @@ export function SidebarWithHeader({ children }: SidebarWithHeaderProps) {
 
 				{/* Always visible — free-plan users get an upgrade prompt inside the
 				    panel (and the backend enforces the plan gate regardless). */}
+				{/* The notch positions itself out of flow, so the fixed placement
+				    lives on the tour wrapper — otherwise it collapses to 0x0 and the
+				    highlight ring (a ::after on the wrapper) has nothing to draw. */}
 				<TourElement<HomeTour>
+					className="fixed bottom-0 right-6 z-40 sm:right-12 md:right-24"
 					TourContext={HomeTourContext}
 					stepId={HomeTour.ASSISTANT_NOTCH}
 					title={HOME_TOUR_CONTENT[HomeTour.ASSISTANT_NOTCH].title}

--- a/apps/web/src/components/tours/tour-element.tsx
+++ b/apps/web/src/components/tours/tour-element.tsx
@@ -22,6 +22,11 @@ export interface TourElementProps<T extends string> {
 	title: string;
 	description: string;
 	tooltipPosition?: "top" | "bottom" | "left" | "right";
+	/** Extra classes for the wrapper. The highlight ring is a ::after on this
+	 * wrapper, so a target that positions itself out of flow (fixed/absolute)
+	 * must hand its positioning here — otherwise the wrapper collapses to 0x0
+	 * and the ring has nothing to draw around. */
+	className?: string;
 }
 
 // ============================================================================
@@ -35,12 +40,14 @@ export function TourElement<T extends string>({
 	title,
 	description,
 	tooltipPosition = "bottom",
+	className,
 }: TourElementProps<T>) {
 	const tourContextValue = useTourContext(TourContext);
 
-	// If no context is available, just render children
+	// No context: render children bare, but keep any positioning the caller
+	// delegated to the wrapper.
 	if (!tourContextValue) {
-		return <>{children}</>;
+		return className ? <div className={className}>{children}</div> : <>{children}</>;
 	}
 
 	return (
@@ -50,6 +57,7 @@ export function TourElement<T extends string>({
 			description={description}
 			tooltipPosition={tooltipPosition}
 			tourContextValue={tourContextValue}
+			className={className}
 		>
 			{children}
 		</TourElementContent>
@@ -67,6 +75,7 @@ interface TourElementContentProps<T extends string> {
 	title: string;
 	description: string;
 	tooltipPosition: "top" | "bottom" | "left" | "right";
+	className?: string;
 }
 
 function TourElementContent<T extends string>({
@@ -76,6 +85,7 @@ function TourElementContent<T extends string>({
 	title,
 	description,
 	tooltipPosition,
+	className,
 }: TourElementContentProps<T>) {
 	const wrapperRef = useRef<HTMLDivElement>(null);
 	const [targetRect, setTargetRect] = useState<DOMRect | null>(null);
@@ -149,7 +159,7 @@ function TourElementContent<T extends string>({
 	return (
 		<div
 			ref={wrapperRef}
-			className="tour-element-wrapper"
+			className={className ? `tour-element-wrapper ${className}` : "tour-element-wrapper"}
 			data-tour-active={isActive}
 			data-tour-step={stepId}
 			aria-expanded={isActive}


### PR DESCRIPTION
This pull request introduces several UI improvements and feature flag updates, focusing on the visibility and labeling of the "Automations" feature, enhancements to the tour/assistant highlight system, and minor UX adjustments. The most notable changes are grouped below:

**Automations Feature Visibility and Labeling**

* The "Automations" feature is now marked as "Beta" in the sidebar, main navigation, and editor top bar using a consistent inline `Badge` component. This clarifies that the feature is released but still stabilizing. [[1]](diffhunk://#diff-7c341ef521836c8480c730bd34f32b8254e3fd5c9704a7e4ab7f6715d0787f0aR5-R10) [[2]](diffhunk://#diff-7c341ef521836c8480c730bd34f32b8254e3fd5c9704a7e4ab7f6715d0787f0aR75-R94) [[3]](diffhunk://#diff-fc42a78f98173d3333f5ec292dc49958978df11258a632fbf9974c045ae4f591L430-R433) [[4]](diffhunk://#diff-6a3709d3197c61b3561dc19ef1cd5c7cd111a95ad6e8b4fc5eddf2dfbdb55d67R33) [[5]](diffhunk://#diff-6a3709d3197c61b3561dc19ef1cd5c7cd111a95ad6e8b4fc5eddf2dfbdb55d67R56-R57) [[6]](diffhunk://#diff-6a3709d3197c61b3561dc19ef1cd5c7cd111a95ad6e8b4fc5eddf2dfbdb55d67R521-R530)
* The "coming soon" status for Automations is removed from the feature highlights and navbar, reflecting its general availability. [[1]](diffhunk://#diff-fcc4468162536836be95547e206dbb3b17f434b1ac3e15a8fe5e72fd4031ed92L121) [[2]](diffhunk://#diff-6e3a9afea3cc2adf6df891340f0ad32c803c5f25faafb3b05786d28794745fd2L269)
* The tooltip for disabled Automations is updated to "Automations is temporarily unavailable" for clearer messaging.

**Tour and Assistant Highlight System Improvements**

* The assistant notch's fixed positioning is moved from the notch itself to the tour wrapper, ensuring the highlight ring displays correctly and is not clipped or hidden. [[1]](diffhunk://#diff-c1cc58e9a4c589005998b1ee8585edb030fbe1e3829f225df4ebe35d4d90fbdeL23-R23) [[2]](diffhunk://#diff-7388cefef474d5707b023f9396fa362c4c76add5d552b4a363785612b6e66ddfR149-R153)
* The `TourElement` component now accepts an optional `className` prop, allowing callers to delegate positioning to the wrapper. This prevents layout issues for out-of-flow elements and ensures the highlight ring always has a visible target. [[1]](diffhunk://#diff-44adbf27c5ddbca279a5973b3715941f5d98ea05c6f984ed0d15d5e086566df1R25-R29) [[2]](diffhunk://#diff-44adbf27c5ddbca279a5973b3715941f5d98ea05c6f984ed0d15d5e086566df1R43-R50) [[3]](diffhunk://#diff-44adbf27c5ddbca279a5973b3715941f5d98ea05c6f984ed0d15d5e086566df1R60) [[4]](diffhunk://#diff-44adbf27c5ddbca279a5973b3715941f5d98ea05c6f984ed0d15d5e086566df1R78) [[5]](diffhunk://#diff-44adbf27c5ddbca279a5973b3715941f5d98ea05c6f984ed0d15d5e086566df1R88) [[6]](diffhunk://#diff-44adbf27c5ddbca279a5973b3715941f5d98ea05c6f984ed0d15d5e086566df1L152-R162)
* Obsolete z-index CSS rules for the assistant notch are removed, as positioning is now handled by the tour wrapper.

**User Experience Adjustments**

* The "Getting Started" checklist panel now fully collapses when closed (instead of leaving a visible peek), improving clarity and reducing distraction.

These changes collectively improve feature communication, polish the interactive tour experience, and address minor UX issues.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR marks Automations as "Beta" across the sidebar, editor top bar, and marketing surfaces, removes all "coming soon" gates for it, and fixes a tour highlight-ring bug where the `AssistantNotch`'s self-applied `fixed` positioning caused its `TourElement` wrapper to collapse to 0×0 — leaving the ring with nothing to draw around.

- **Tour positioning refactor**: `fixed bottom-0 right-6 z-40` is lifted from `AssistantNotch` to its parent `TourElement` via the new `className` prop; the notch retains its translate animation, and the obsolete z-index CSS overrides are removed from `globals.css`.
- **Beta badge rollout**: A `badgeLabel` field is added to `NavItem` and rendered inside `SidebarMenuButton` (hidden in icon-collapsed mode); the same badge pattern is applied in the editor top bar with an explanatory tooltip.
- **Getting Started panel**: Collapsed state switches from `max-h-16` (a visible peek) to `max-h-0` (fully hidden).

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are UI-only with no impact on data, auth, or server logic.

The tour positioning refactor is well-reasoned and cleanly implemented. The only notable imperfection is that the Beta badge is silently omitted when Automations is in its disabled state, because the disabled rendering branch in nav-main.tsx doesn't render `badgeLabel` — worth confirming whether that's intentional. The template-literal class composition in TourElement is a minor style inconsistency with the rest of the codebase.

nav-main.tsx — confirm whether the Beta badge should appear on the disabled Automations item, and consider whether `badgeLabel` and `badgeCount` should be mutually exclusive at the type level to prevent future layout issues.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/tours/tour-element.tsx | Adds optional `className` prop to propagate fixed/absolute positioning to the wrapper so the tour highlight ring has a sized target; minor: template literal used instead of `cn()` for class merging. |
| apps/web/src/components/layout/sidebar-with-header.tsx | Moves `fixed bottom-0 right-6 z-40` from `AssistantNotch` to the `TourElement` wrapper so the highlight ring has a concrete bounding box; change is logically consistent with the notch refactor. |
| apps/web/src/components/assistant/assistant-notch.tsx | Strips fixed positioning from the notch; positioning now delegated to the parent `TourElement` wrapper. Transition and translate behaviour remain intact. |
| apps/web/src/components/layout/nav-main.tsx | Adds `badgeLabel` type field and renders a Beta badge in the enabled nav-item path only; the disabled item path does not render `badgeLabel`, creating a silent inconsistency for disabled Automations. |
| apps/web/src/components/layout/app-sidebar.tsx | Updates disabled tooltip copy and unconditionally sets `badgeLabel: "Beta"` for the Automations item; straightforward change with no logic concerns. |
| apps/web/src/app/globals.css | Removes now-obsolete z-index overrides for the assistant notch since positioning is handled by the `TourElement` wrapper. |
| apps/web/src/components/layout/nav-getting-started.tsx | Changes collapsed max-height from `max-h-16` to `max-h-0` so the checklist fully hides when closed instead of peeking. |
| apps/web/src/app/(workspace)/automations/components/editor/editor-top-bar.tsx | Adds a Beta badge with a tooltip to the automation editor top bar; clean, localised change. |
| apps/web/src/app/components/app-navbar.tsx | Removes `comingSoon: true` from the Automations feature item, reflecting GA status. |
| apps/web/src/app/components/feature-section.tsx | Removes `comingSoon: true` from the Automations highlight entry; straightforward update. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SidebarWithHeader] -->|renders with className prop| B[TourElement wrapper\nfixed bottom-0 right-6 z-40]
    B -->|no tour context| C[div.className\nfixed bottom-0 right-6 z-40]
    B -->|tour context present| D[TourElementContent\ntour-element-wrapper + className]
    C --> E[AssistantNotch\ntransition-transform only]
    D --> E
    D -->|isActive| F[TourTooltip + highlight ring\n::after on sized wrapper]

    G[NavMain item] -->|item.disabled = true| H[Disabled branch\nTooltip + greyed button\nNO badgeLabel rendered]
    G -->|item.disabled = false| I[Enabled branch\nSidebarMenuButton]
    I -->|item.badgeLabel exists| J[Beta Badge\nml-auto inside button]
    I -->|item.badgeCount exists| K[SidebarMenuBadge\noutside button]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[SidebarWithHeader] -->|renders with className prop| B[TourElement wrapper\nfixed bottom-0 right-6 z-40]
    B -->|no tour context| C[div.className\nfixed bottom-0 right-6 z-40]
    B -->|tour context present| D[TourElementContent\ntour-element-wrapper + className]
    C --> E[AssistantNotch\ntransition-transform only]
    D --> E
    D -->|isActive| F[TourTooltip + highlight ring\n::after on sized wrapper]

    G[NavMain item] -->|item.disabled = true| H[Disabled branch\nTooltip + greyed button\nNO badgeLabel rendered]
    G -->|item.disabled = false| I[Enabled branch\nSidebarMenuButton]
    I -->|item.badgeLabel exists| J[Beta Badge\nml-auto inside button]
    I -->|item.badgeCount exists| K[SidebarMenuBadge\noutside button]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/components/layout/nav-main.tsx`, line 488-509 ([link](https://github.com/xcarter93/onetool/blob/f1bfeb23f7c87a518895e437b439bc58a726b467/apps/web/src/components/layout/nav-main.tsx#L488-L509)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Beta badge missing from disabled Automations item**

   The `badgeLabel` prop is unconditionally set in `app-sidebar.tsx` for every Automations item (including when `isAutomationsDisabled` is `true`), but the disabled rendering path in `nav-main.tsx` never renders it. A disabled-but-Beta Automations entry will show the greyed-out item with only the "temporarily unavailable" tooltip — the Beta label is silently dropped. If showing the badge for disabled items is intentional, no fix is needed; if it should always be visible, the disabled branch needs the same `badgeLabel` rendering added inside its `TooltipTrigger` content.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/components/layout/nav-main.tsx
   Line: 488-509

   Comment:
   **Beta badge missing from disabled Automations item**

   The `badgeLabel` prop is unconditionally set in `app-sidebar.tsx` for every Automations item (including when `isAutomationsDisabled` is `true`), but the disabled rendering path in `nav-main.tsx` never renders it. A disabled-but-Beta Automations entry will show the greyed-out item with only the "temporarily unavailable" tooltip — the Beta label is silently dropped. If showing the badge for disabled items is intentional, no fix is needed; if it should always be visible, the disabled branch needs the same `badgeLabel` rendering added inside its `TooltipTrigger` content.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/src/components/layout/nav-main.tsx:488-509
**Beta badge missing from disabled Automations item**

The `badgeLabel` prop is unconditionally set in `app-sidebar.tsx` for every Automations item (including when `isAutomationsDisabled` is `true`), but the disabled rendering path in `nav-main.tsx` never renders it. A disabled-but-Beta Automations entry will show the greyed-out item with only the "temporarily unavailable" tooltip — the Beta label is silently dropped. If showing the badge for disabled items is intentional, no fix is needed; if it should always be visible, the disabled branch needs the same `badgeLabel` rendering added inside its `TooltipTrigger` content.

### Issue 2 of 2
apps/web/src/components/tours/tour-element.tsx:159-163
The wrapper `className` is composed with a template literal rather than the `cn()` utility used everywhere else in the codebase. If `className` ever contains conflicting Tailwind utilities (or conditional classes), Tailwind Merge won't deduplicate them.

```suggestion
	return (
		<div
			ref={wrapperRef}
			className={cn("tour-element-wrapper", className)}
			data-tour-active={isActive}
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: [f1bfeb2](https://github.com/xcarter93/onetool/commit/f1bfeb23f7c87a518895e437b439bc58a726b467) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45521944)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a beta badge and explanatory tooltip to Automations.
  - Added support for text badges on sidebar navigation items.
  - Improved positioning for assistant tour elements.

- **Bug Fixes**
  - Removed “Coming Soon” labels from Automations.
  - Updated unavailable Automations messaging.
  - Fully hides the Getting Started panel when the sidebar is collapsed.
  - Improved tour highlighting and assistant notch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->