### PR TITLE
Fix tour wrapper positioning to maintain assistant notch flow

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -302,13 +302,16 @@
 		background: rgba(0, 0, 0, 0.65);
 	}
 
-	/* Tour element wrapper - floats above the overlay when active */
-	.tour-element-wrapper {
+	/* Tour element wrapper - floats above the overlay when active.
+	   :where() keeps this at zero specificity so a target that hands its own
+	   positioning to the wrapper (see TourElement's className prop) isn't
+	   forced back into flow — a plain .tour-element-wrapper rule would beat
+	   Tailwind's .fixed on source order. */
+	:where(.tour-element-wrapper) {
 		position: relative;
 	}
 
 	.tour-element-wrapper[data-tour-active="true"] {
-		position: relative;
 		z-index: 9999;
 		border-radius: 8px;
 		/* Provide solid background so semi-transparent children render correctly */


### PR DESCRIPTION
This pull request makes a small but important change to the CSS for the tour element wrapper. The selector for `.tour-element-wrapper` is updated to use the `:where()` pseudo-class, ensuring that it does not override more specific utility classes (like Tailwind's `.fixed`) due to CSS specificity rules.

- CSS specificity improvement:
  * Changed the `.tour-element-wrapper` selector to `:where(.tour-element-wrapper)` in `globals.css` to keep specificity at zero, preventing it from overriding utility classes used for positioning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Product Tour styling behavior by simplifying selector priority.
  * Preserved active tour element positioning while streamlining its visual state styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a CSS specificity conflict where `.tour-element-wrapper`'s `position: relative` declaration (specificity `0,1,0`) was silently overriding Tailwind's `.fixed` utility (`0,1,0`) based on source order, breaking elements that relied on fixed positioning during the product tour.

- Wraps the base selector in `:where()` to drop its specificity to zero, letting any Tailwind positioning utility win without needing `!important`.
- Removes the now-redundant `position: relative` from the `.tour-element-wrapper[data-tour-active="true"]` rule, which previously (at specificity `0,2,0`) would also have beaten `.fixed` when a tour step was active.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a minimal, targeted CSS fix with no logic changes and a clear, correct rationale in the accompanying comment.

The change is two CSS edits: replacing a class selector with its :where() equivalent and removing a redundant position declaration. Both edits are mechanically correct — :where() is well-supported, the specificity analysis in the comment is accurate, and removing position: relative from the active-state rule is the right companion change to prevent that higher-specificity rule from reintroducing the same override. No logic, API, or data-flow changes are involved.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/globals.css | Wraps `.tour-element-wrapper` in `:where()` for zero specificity, allowing Tailwind positioning utilities (e.g. `.fixed`) to win; also removes the now-redundant `position: relative` from the active-state rule. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Tour element with .fixed + .tour-element-wrapper"]
    B{CSS specificity contest for position}
    C["OLD: .tour-element-wrapper (0,1,0) wins → position: relative — breaks .fixed layout"]
    D["NEW: :where(.tour-element-wrapper) (0,0,0) loses to Tailwind .fixed (0,1,0) → position: fixed preserved"]
    E["Active state .tour-element-wrapper[data-tour-active=true] (0,2,0)"]
    F["Sets z-index: 9999 — no longer forces position: relative"]
    G["Element floats above overlay while keeping its own positioning"]
    A --> B
    B --> C
    B --> D
    D --> E
    E --> F
    F --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Tour element with .fixed + .tour-element-wrapper"]
    B{CSS specificity contest for position}
    C["OLD: .tour-element-wrapper (0,1,0) wins → position: relative — breaks .fixed layout"]
    D["NEW: :where(.tour-element-wrapper) (0,0,0) loses to Tailwind .fixed (0,1,0) → position: fixed preserved"]
    E["Active state .tour-element-wrapper[data-tour-active=true] (0,2,0)"]
    F["Sets z-index: 9999 — no longer forces position: relative"]
    G["Element floats above overlay while keeping its own positioning"]
    A --> B
    B --> C
    B --> D
    D --> E
    E --> F
    F --> G
```

</a>

<sub>Reviews (1): Last reviewed commit: [04535c2](https://github.com/xcarter93/onetool/commit/04535c2c2b8a6e682063e447e2421c1e97ff343d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45526527)</sub>

<!-- /greptile_comment -->