### PR TITLE
fix(web): keep the beta badge out of the collapsed sidebar

### DIFF
--- a/apps/web/src/components/layout/nav-main.tsx
+++ b/apps/web/src/components/layout/nav-main.tsx
@@ -512,18 +512,28 @@ export function NavMain({
 							return (
 								<SidebarMenuItem key={item.title}>
 									<SidebarMenuButton
-										tooltip={item.title}
+										// Collapsed mode drops the badge, so the tooltip carries it.
+										tooltip={
+											item.badgeLabel
+												? `${item.title} · ${item.badgeLabel}`
+												: item.title
+										}
 										isActive={item.isActive}
 										onClick={() => router.push(item.url)}
 									>
 										{item.icon && <item.icon />}
 										<span>{item.title}</span>
-										{item.badgeLabel && (
+										{/* Must be absent from the DOM when collapsed, not just
+										    hidden: the button truncates its label via
+										    [&>span:last-child], so a trailing sibling would strip
+										    that and let the untruncated label shove the icon out
+										    of the 36px icon-mode button. */}
+										{item.badgeLabel && !isCollapsed && (
 											<Badge
 												variant="primary-light"
 												size="xs"
 												radius="full"
-												className="ml-auto group-data-[collapsible=icon]:hidden"
+												className="ml-auto"
 											>
 												{item.badgeLabel}
 											</Badge>


### PR DESCRIPTION
The badge broke icon mode: SidebarMenuButton truncates its label with [&>span:last-child]:truncate, so appending the badge after the label span stripped that rule. With justify-center and a 36px button in icon mode, the untruncated label centred itself and pushed the icon out of view — the Automations item rendered as a clipped "utomc" with no icon.

group-data-[collapsible=icon]:hidden can't fix this: a hidden element is still :last-child. The badge has to leave the DOM, so it now renders only when the sidebar is expanded, reusing the existing isCollapsed.

Collapsed mode would then lose the beta signal entirely, so the button's hover tooltip carries it instead — "Automations · Beta".

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a visual regression in icon-mode sidebar where the beta badge was left in the DOM, causing the `[&>span:last-child]:truncate` CSS selector to miss the label `<span>` and allow the untruncated text to push the icon out of the 36px collapsed button. The fix conditionally removes the badge from the DOM (`!isCollapsed`) rather than just hiding it, and promotes the beta signal into the hover tooltip for collapsed mode.

- **Badge DOM removal**: `item.badgeLabel && !isCollapsed` gates the `<Badge>` render on the existing `isCollapsed` derived from `useSidebar()`, ensuring the `:last-child` selector always targets the label `<span>`.
- **Tooltip fallback**: The `tooltip` prop now conditionally formats as `"${title} · ${badgeLabel}"` so the beta indicator is still communicated in icon mode.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is confined to a single conditional render and a tooltip string update with no impact on data or routing.

The root cause (badge as DOM sibling stealing the `:last-child` truncation selector) is correctly diagnosed, the fix (removing from DOM via `!isCollapsed`) is targeted, and `isCollapsed` is already used elsewhere in the same component. The tooltip fallback covers the collapsed-mode UX gap cleanly. shadcn's `SidebarMenuButton` only shows its `tooltip` prop in icon/collapsed state, so the richer tooltip string is a no-op in expanded mode — no redundant label appears alongside the visible badge.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/layout/nav-main.tsx | Fixes icon-mode sidebar layout break caused by badge being `:last-child` of SidebarMenuButton; badge is now conditionally excluded from the DOM when sidebar is collapsed, and the tooltip carries the beta signal instead. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Render NavMain item] --> B{item.badgeLabel?}
    B -- No --> C[Render icon + label only]
    B -- Yes --> D{isCollapsed?}

    D -- No / Expanded --> E[Render icon + label + Badge in DOM\ntooltip = title · badgeLabel]
    D -- Yes / Icon mode --> F[Render icon only\ntooltip = title · badgeLabel\nBadge absent from DOM]

    E --> G[span:last-child = Badge → truncate not applied to label]
    F --> H[span:last-child = label span → truncate applied correctly\nBeta signal carried by tooltip]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Render NavMain item] --> B{item.badgeLabel?}
    B -- No --> C[Render icon + label only]
    B -- Yes --> D{isCollapsed?}

    D -- No / Expanded --> E[Render icon + label + Badge in DOM\ntooltip = title · badgeLabel]
    D -- Yes / Icon mode --> F[Render icon only\ntooltip = title · badgeLabel\nBadge absent from DOM]

    E --> G[span:last-child = Badge → truncate not applied to label]
    F --> H[span:last-child = label span → truncate applied correctly\nBeta signal carried by tooltip]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(web): keep the beta badge out of the..."](https://github.com/xcarter93/onetool/commit/56aaa1bf9c6b0dca11f32a6472f538fbfec19490) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45531844)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collapsed navigation tooltips to include badge labels when available.
  * Prevented hidden navigation badges from remaining in the page structure when the sidebar is collapsed.
  * Ensured badges appear only when supported and when the sidebar is expanded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->