### PR TITLE
Fix BoldSign draft handling and CSP for embedded editor

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -25,7 +25,8 @@ const cspReportOnly = [
 	"font-src 'self' data:",
 	`connect-src 'self'${convexHostname ? ` https://${convexHostname} wss://${convexHostname}` : ""}${process.env.NEXT_PUBLIC_POSTHOG_HOST ? ` ${process.env.NEXT_PUBLIC_POSTHOG_HOST}` : ""}`, 
 	// app.boldsign.com: embedded e-signature editor (quotes/[quoteId]/sign).
-	"frame-src https://js.stripe.com https://hooks.stripe.com https://app.boldsign.com",
+	// Convex origin: PDF previews iframe file-storage URLs (quote/invoice sidebars).
+	`frame-src https://js.stripe.com https://hooks.stripe.com https://app.boldsign.com${convexHostname ? ` https://${convexHostname}` : ""}`,
 	"frame-ancestors 'none'",
 	"base-uri 'self'",
 	"form-action 'self' https://checkout.stripe.com",

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -24,7 +24,8 @@ const cspReportOnly = [
 	"img-src 'self' https: data: blob:",
 	"font-src 'self' data:",
 	`connect-src 'self'${convexHostname ? ` https://${convexHostname} wss://${convexHostname}` : ""}${process.env.NEXT_PUBLIC_POSTHOG_HOST ? ` ${process.env.NEXT_PUBLIC_POSTHOG_HOST}` : ""}`, 
-	"frame-src https://js.stripe.com https://hooks.stripe.com",
+	// app.boldsign.com: embedded e-signature editor (quotes/[quoteId]/sign).
+	"frame-src https://js.stripe.com https://hooks.stripe.com https://app.boldsign.com",
 	"frame-ancestors 'none'",
 	"base-uri 'self'",
 	"form-action 'self' https://checkout.stripe.com",

--- a/apps/web/src/app/(workspace)/quotes/[quoteId]/sign/page.tsx
+++ b/apps/web/src/app/(workspace)/quotes/[quoteId]/sign/page.tsx
@@ -20,6 +20,12 @@ import {
 // BoldSign only posts messages from this origin; hard-guard every event.
 const BOLDSIGN_ORIGIN = "https://app.boldsign.com";
 
+// "Save and proceed" inside the editor saves the draft and fires onDraftSuccess
+// exactly like Save & Close does. Closing must wait out this window so an
+// onPageNavigation from the same click can cancel it; only a draft-save with no
+// accompanying navigation is a real Save & Close.
+const DRAFT_CLOSE_GRACE_MS = 1500;
+
 type ViewState =
 	| { kind: "creating" }
 	| { kind: "ready"; sendUrl: string }
@@ -57,6 +63,12 @@ function QuoteSignPageContent() {
 	// In-flight create, awaited before discarding so a draft persisted after an
 	// early back-click doesn't survive as an orphan.
 	const createPromiseRef = useRef<Promise<unknown> | null>(null);
+	// Pending Save & Close teardown, cancellable by onPageNavigation (see
+	// DRAFT_CLOSE_GRACE_MS).
+	const pendingDraftCloseRef = useRef<ReturnType<typeof setTimeout> | null>(
+		null
+	);
+	const lastNavAtRef = useRef(0);
 
 	const backToQuote = useCallback(async () => {
 		// Abandoning before send: delete the BoldSign draft (best-effort) and
@@ -127,7 +139,20 @@ function QuoteSignPageContent() {
 				case "onLoadComplete":
 					setIframeLoading(false);
 					break;
+				case "onPageNavigation":
+					// User is moving between editor pages (e.g. "Save and proceed");
+					// any draft-save from the same click must not close the editor.
+					lastNavAtRef.current = Date.now();
+					if (pendingDraftCloseRef.current !== null) {
+						clearTimeout(pendingDraftCloseRef.current);
+						pendingDraftCloseRef.current = null;
+					}
+					break;
 				case "onCreateSuccess":
+					if (pendingDraftCloseRef.current !== null) {
+						clearTimeout(pendingDraftCloseRef.current);
+						pendingDraftCloseRef.current = null;
+					}
 					keepDocumentRef.current = true;
 					toast.success(
 						"Sent for signature",
@@ -136,14 +161,19 @@ function QuoteSignPageContent() {
 					void backToQuote();
 					break;
 				case "onDraftSuccess":
-					// User clicked Save & Close inside the editor: keep the draft so
-					// they can resume from the same place later.
-					keepDocumentRef.current = true;
-					toast.success(
-						"Draft saved",
-						"Resume anytime from Send for e-signature."
-					);
-					void backToQuote();
+					// Draft saved. Only a genuine Save & Close (no page navigation
+					// around it) should keep the draft and leave the editor.
+					if (Date.now() - lastNavAtRef.current < DRAFT_CLOSE_GRACE_MS) break;
+					if (pendingDraftCloseRef.current !== null) break;
+					pendingDraftCloseRef.current = setTimeout(() => {
+						pendingDraftCloseRef.current = null;
+						keepDocumentRef.current = true;
+						toast.success(
+							"Draft saved",
+							"Resume anytime from Send for e-signature."
+						);
+						void backToQuote();
+					}, DRAFT_CLOSE_GRACE_MS);
 					break;
 				case "onCreateFailed":
 					setIframeLoading(false);
@@ -157,7 +187,13 @@ function QuoteSignPageContent() {
 			}
 		}
 		window.addEventListener("message", onMessage);
-		return () => window.removeEventListener("message", onMessage);
+		return () => {
+			window.removeEventListener("message", onMessage);
+			if (pendingDraftCloseRef.current !== null) {
+				clearTimeout(pendingDraftCloseRef.current);
+				pendingDraftCloseRef.current = null;
+			}
+		};
 	}, [isReady, toast, backToQuote]);
 
 	// ---- Ready: the embedded editor ----------------------------------------

--- a/apps/web/src/app/(workspace)/quotes/[quoteId]/sign/page.tsx
+++ b/apps/web/src/app/(workspace)/quotes/[quoteId]/sign/page.tsx
@@ -70,7 +70,17 @@ function QuoteSignPageContent() {
 	);
 	const lastNavAtRef = useRef(0);
 
+	const cancelPendingDraftClose = useCallback(() => {
+		if (pendingDraftCloseRef.current !== null) {
+			clearTimeout(pendingDraftCloseRef.current);
+			pendingDraftCloseRef.current = null;
+		}
+	}, []);
+
 	const backToQuote = useCallback(async () => {
+		// Leaving now supersedes any armed draft-close: without this it could fire
+		// during the discard await and add a stray toast plus a second navigation.
+		cancelPendingDraftClose();
 		// Abandoning before send: delete the BoldSign draft (best-effort) and
 		// clear the local "Preparing" state so the Signatures tab stays truthful.
 		if (!keepDocumentRef.current) {
@@ -84,7 +94,7 @@ function QuoteSignPageContent() {
 			}
 		}
 		router.push(`/quotes/${quoteId}`);
-	}, [discardRequest, router, quoteId]);
+	}, [discardRequest, router, quoteId, cancelPendingDraftClose]);
 
 	const runCreate = useCallback(async () => {
 		setView({ kind: "creating" });
@@ -143,16 +153,10 @@ function QuoteSignPageContent() {
 					// User is moving between editor pages (e.g. "Save and proceed");
 					// any draft-save from the same click must not close the editor.
 					lastNavAtRef.current = Date.now();
-					if (pendingDraftCloseRef.current !== null) {
-						clearTimeout(pendingDraftCloseRef.current);
-						pendingDraftCloseRef.current = null;
-					}
+					cancelPendingDraftClose();
 					break;
 				case "onCreateSuccess":
-					if (pendingDraftCloseRef.current !== null) {
-						clearTimeout(pendingDraftCloseRef.current);
-						pendingDraftCloseRef.current = null;
-					}
+					cancelPendingDraftClose();
 					keepDocumentRef.current = true;
 					toast.success(
 						"Sent for signature",
@@ -163,7 +167,13 @@ function QuoteSignPageContent() {
 				case "onDraftSuccess":
 					// Draft saved. Only a genuine Save & Close (no page navigation
 					// around it) should keep the draft and leave the editor.
-					if (Date.now() - lastNavAtRef.current < DRAFT_CLOSE_GRACE_MS) break;
+					if (Date.now() - lastNavAtRef.current < DRAFT_CLOSE_GRACE_MS) {
+						// Consume the marker: it accounts for this one save, so a real
+						// Save & Close moments later on the next page still closes
+						// (and keeps) the draft rather than being silently dropped.
+						lastNavAtRef.current = 0;
+						break;
+					}
 					if (pendingDraftCloseRef.current !== null) break;
 					pendingDraftCloseRef.current = setTimeout(() => {
 						pendingDraftCloseRef.current = null;
@@ -189,12 +199,9 @@ function QuoteSignPageContent() {
 		window.addEventListener("message", onMessage);
 		return () => {
 			window.removeEventListener("message", onMessage);
-			if (pendingDraftCloseRef.current !== null) {
-				clearTimeout(pendingDraftCloseRef.current);
-				pendingDraftCloseRef.current = null;
-			}
+			cancelPendingDraftClose();
 		};
-	}, [isReady, toast, backToQuote]);
+	}, [isReady, toast, backToQuote, cancelPendingDraftClose]);
 
 	// ---- Ready: the embedded editor ----------------------------------------
 	if (view.kind === "ready") {


### PR DESCRIPTION
This pull request improves the integration of the BoldSign embedded e-signature editor by refining how the application handles draft saving and navigation events, ensuring a smoother user experience and preventing unintended closures or saves. The changes introduce a grace period to differentiate between "Save and proceed" and "Save & Close" actions, and update the Content Security Policy to allow embedding BoldSign.

**BoldSign integration improvements:**

* Added a `DRAFT_CLOSE_GRACE_MS` constant and supporting logic to distinguish between "Save and proceed" and "Save & Close" actions in the BoldSign editor, preventing accidental draft closure when navigating between pages. ([apps/web/src/app/(workspace)/quotes/[quoteId]/sign/page.tsxR23-R28](diffhunk://#diff-e80d735fc77a124239e79e188ef9f5b5cfe1736838d6beecff14eca2fea7d8feR23-R28), [apps/web/src/app/(workspace)/quotes/[quoteId]/sign/page.tsxR66-R71](diffhunk://#diff-e80d735fc77a124239e79e188ef9f5b5cfe1736838d6beecff14eca2fea7d8feR66-R71), [apps/web/src/app/(workspace)/quotes/[quoteId]/sign/page.tsxR142-R155](diffhunk://#diff-e80d735fc77a124239e79e188ef9f5b5cfe1736838d6beecff14eca2fea7d8feR142-R155), [apps/web/src/app/(workspace)/quotes/[quoteId]/sign/page.tsxL139-R176](diffhunk://#diff-e80d735fc77a124239e79e188ef9f5b5cfe1736838d6beecff14eca2fea7d8feL139-R176))
* Implemented cleanup of pending timeouts when the component unmounts or when navigation occurs, ensuring no memory leaks or unintended actions. ([apps/web/src/app/(workspace)/quotes/[quoteId]/sign/page.tsxL160-R196](diffhunk://#diff-e80d735fc77a124239e79e188ef9f5b5cfe1736838d6beecff14eca2fea7d8feL160-R196))

**Security policy update:**

* Updated the Content Security Policy in `next.config.ts` to allow embedding frames from `app.boldsign.com`, enabling the e-signature editor to function correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the embedded e-signature editor’s save-and-proceed flow.
  - Prevented users from being redirected away from the quote prematurely after saving a draft.
  - Added support for the editor’s embedded content to load correctly under the application’s security policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `DRAFT_CLOSE_GRACE_MS` (1 500 ms) grace-period mechanism in the BoldSign embedded editor page to distinguish between \"Save and proceed\" (which fires `onDraftSuccess` + `onPageNavigation` together) and a genuine \"Save & Close\" (which fires only `onDraftSuccess`), and adds `https://app.boldsign.com` to the report-only `frame-src` CSP directive.

- **Grace-period logic**: On `onDraftSuccess`, a 1 500 ms timeout is scheduled; if `onPageNavigation` arrives within that window it cancels the timeout, preventing an accidental editor close on \"Save and proceed\". Cleanup of the timeout is added for unmount and `onCreateSuccess` paths.
- **Timing edge case**: The `lastNavAtRef` guard silently drops a \"Save & Close\" that arrives within 1 500 ms of the most recent `onPageNavigation`; in that window `keepDocumentRef` remains `false`, so a subsequent back-navigation will call `discardRequest` and delete a draft the user explicitly saved.
- **CSP**: The `frame-src` addition is to the `Content-Security-Policy-Report-Only` header only, so it doesn't enforce anything today but correctly prepares for the planned enforcement promotion.

<h3>Confidence Score: 3/5</h3>

The grace-period mechanism is the right idea, but the lastNavAtRef early-exit guard can silently discard a genuine Save & Close if the user acts quickly after a page navigation, leaving the draft vulnerable to deletion on back-navigation.

The onDraftSuccess handler drops events silently when Date.now() - lastNavAtRef < 1500ms, and because keepDocumentRef stays false in that path, a back-navigation will call discardRequest and permanently delete a draft the user explicitly saved. The window is narrow, but the failure mode is data loss with no user feedback.

apps/web/src/app/(workspace)/quotes/[quoteId]/sign/page.tsx — specifically the onDraftSuccess handler around the lastNavAtRef timing guard.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/(workspace)/quotes/[quoteId]/sign/page.tsx | Adds DRAFT_CLOSE_GRACE_MS grace-period logic to distinguish "Save and proceed" from "Save & Close" BoldSign events; the timing guard can silently swallow a legitimate Save & Close if it arrives within 1500ms of an onPageNavigation, leaving keepDocumentRef false and causing the draft to be discarded on back-navigation. |
| apps/web/next.config.ts | Adds https://app.boldsign.com to the report-only frame-src CSP directive; change is additive, safe, and correctly prepares the policy for future enforcement promotion. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant BS as BoldSign iframe
    participant P as Page onMessage
    participant T as setTimeout

    Note over U,T: Save and proceed flow
    U->>BS: Click Save and proceed
    BS->>P: postMessage onDraftSuccess
    P->>T: schedule close 1500ms
    BS->>P: postMessage onPageNavigation
    P->>T: clearTimeout cancelled
    P->>P: "lastNavAtRef = now"

    Note over U,T: Genuine Save and Close flow
    U->>BS: Click Save and Close
    BS->>P: postMessage onDraftSuccess
    alt lastNavAt more than 1500ms ago
        P->>T: schedule close 1500ms
        T->>P: timeout fires
        P->>P: "keepDocumentRef = true"
        P->>U: toast Draft saved
        P->>U: navigate back to quote
    else lastNavAt less than 1500ms ago edge case
        P->>P: silent break keepDocumentRef stays false
    end

    Note over U,T: Send for signature flow
    U->>BS: Click Send
    BS->>P: postMessage onCreateSuccess
    P->>T: clearTimeout if any
    P->>P: "keepDocumentRef = true"
    P->>U: toast Sent for signature
    P->>U: navigate back to quote
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant BS as BoldSign iframe
    participant P as Page onMessage
    participant T as setTimeout

    Note over U,T: Save and proceed flow
    U->>BS: Click Save and proceed
    BS->>P: postMessage onDraftSuccess
    P->>T: schedule close 1500ms
    BS->>P: postMessage onPageNavigation
    P->>T: clearTimeout cancelled
    P->>P: "lastNavAtRef = now"

    Note over U,T: Genuine Save and Close flow
    U->>BS: Click Save and Close
    BS->>P: postMessage onDraftSuccess
    alt lastNavAt more than 1500ms ago
        P->>T: schedule close 1500ms
        T->>P: timeout fires
        P->>P: "keepDocumentRef = true"
        P->>U: toast Draft saved
        P->>U: navigate back to quote
    else lastNavAt less than 1500ms ago edge case
        P->>P: silent break keepDocumentRef stays false
    end

    Note over U,T: Send for signature flow
    U->>BS: Click Send
    BS->>P: postMessage onCreateSuccess
    P->>T: clearTimeout if any
    P->>P: "keepDocumentRef = true"
    P->>U: toast Sent for signature
    P->>U: navigate back to quote
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/next.config.ts`, line 47 ([link](https://github.com/xcarter93/onetool/blob/987272051f2a1b5abe40cdf769e238ed0b5cd65d/apps/web/next.config.ts#L47)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **CSP update is report-only, not enforced**

   The `frame-src https://app.boldsign.com` addition goes into the `Content-Security-Policy-Report-Only` header, so browsers never actually block frames from this origin — they only emit console violation reports. The embedded BoldSign editor was already loading without this change. This is fine preparation for the planned enforcement promotion, and the comments explaining the soak period are clear. The PR description's wording ("enabling the e-signature editor to function correctly") may be misleading, but the code itself is correct given the documented intent.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/next.config.ts
   Line: 47

   Comment:
   **CSP update is report-only, not enforced**

   The `frame-src https://app.boldsign.com` addition goes into the `Content-Security-Policy-Report-Only` header, so browsers never actually block frames from this origin — they only emit console violation reports. The embedded BoldSign editor was already loading without this change. This is fine preparation for the planned enforcement promotion, and the comments explaining the soak period are clear. The PR description's wording ("enabling the e-signature editor to function correctly") may be misleading, but the code itself is correct given the documented intent.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/src/app/(workspace)/quotes/[quoteId]/sign/page.tsx:166-176
**Silent draft-close drop can cause unintended orphaned draft**

If the user clicks "Save & Close" within `DRAFT_CLOSE_GRACE_MS` (1 500 ms) after any `onPageNavigation` event — for example, they hit "Save and proceed" on page 1 and immediately click "Save & Close" on page 2 — the `onDraftSuccess` handler hits `break` silently. The draft is kept on BoldSign's side, but `keepDocumentRef.current` stays `false`. If the user then clicks "Back to quote" (or `backToQuote` is called), the app calls `discardRequest`, silently deleting the draft the user explicitly intended to save. The user gets no toast and no navigation, leaving them stuck, and their saved work is later discarded on back-navigation.

### Issue 2 of 2
apps/web/next.config.ts:47
**CSP update is report-only, not enforced**

The `frame-src https://app.boldsign.com` addition goes into the `Content-Security-Policy-Report-Only` header, so browsers never actually block frames from this origin — they only emit console violation reports. The embedded BoldSign editor was already loading without this change. This is fine preparation for the planned enforcement promotion, and the comments explaining the soak period are clear. The PR description's wording ("enabling the e-signature editor to function correctly") may be misleading, but the code itself is correct given the documented intent.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(quotes): stop BoldSign &quot;Save and pro..."](https://github.com/xcarter93/onetool/commit/987272051f2a1b5abe40cdf769e238ed0b5cd65d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45634790)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->