### PR TITLE
feat(tasks): paginate task group tables at 10 rows

### DIFF
--- a/apps/web/src/app/(workspace)/tasks/page.tsx
+++ b/apps/web/src/app/(workspace)/tasks/page.tsx
@@ -26,9 +26,11 @@ import {
   DataGridContainer,
 } from "@/components/reui/data-grid/data-grid";
 import { DataGridTable } from "@/components/reui/data-grid/data-grid-table";
+import { DataGridPagination } from "@/components/reui/data-grid/data-grid-pagination";
 import {
   ColumnDef,
   getCoreRowModel,
+  getPaginationRowModel,
   useReactTable,
 } from "@tanstack/react-table";
 import {
@@ -317,10 +319,14 @@ function GroupTable({
   group: TaskGroup;
   columns: ColumnDef<Task>[];
 }) {
+  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
   const table = useReactTable({
     data: group.tasks,
     columns,
+    state: { pagination },
+    onPaginationChange: setPagination,
     getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
   });
 
   return (
@@ -347,6 +353,11 @@ function GroupTable({
         <DataGridContainer className="rounded-lg border">
           <DataGridTable />
         </DataGridContainer>
+        {group.tasks.length > pagination.pageSize && (
+          <div className="px-1 py-2">
+            <DataGridPagination />
+          </div>
+        )}
       </DataGrid>
     </div>
   );


### PR DESCRIPTION
Each status group's table on /tasks now uses TanStack pagination with a 10-row default; DataGridPagination controls render only when a group exceeds the page size, so short groups stay compact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination controls to task tables with more items than the configured page size.
  * Pagination is managed independently for each task group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds client-side TanStack pagination to each task status group.
- Defaults each group to ten rows per page.
- Displays DataGridPagination only for groups exceeding the current page size.

<h3>Confidence Score: 3/5</h3>

This PR should not merge until task-group pagination resets when the visible group data shrinks.

A status group preserves its controlled page index across searches, filters, and mutations, allowing the table to remain on a now-invalid page and hide existing tasks without recovery controls.

**Files Needing Attention:** apps/web/src/app/(workspace)/tasks/page.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/(workspace)/tasks/page.tsx | Adds per-group controlled pagination, but stale page indices can hide tasks after filtering, searching, or mutations shrink a group. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/app/(workspace)/tasks/page.tsx:322
**Stale page index hides tasks**

When a user opens a later page and then a search, filter, deletion, or completion reduces that status group, the controlled `pageIndex` remains outside the available page range, causing existing tasks to disappear. Once the group has ten or fewer tasks, the pagination controls are also removed, so the user cannot return to the first page without changing the visible task set again.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(tasks): paginate task group tables ..."](https://github.com/xcarter93/onetool/commit/44d25bf99190db464761c4559db4e141e0f18d70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47424480)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->