### PR TITLE
Enhance landing page with particle mark and restore hero copy

### DIFF
--- a/apps/web/src/app/components/faq-section.tsx
+++ b/apps/web/src/app/components/faq-section.tsx
@@ -172,11 +172,13 @@ function FaqRow({
 						{faq.question}
 					</span>
 				</span>
+				{/* Opaque plate on --border, not a --bp-* hairline: this is a control
+				    boundary, so it owes 3:1 non-text contrast in both themes. */}
 				<m.span
 					aria-hidden="true"
 					animate={{ rotate: isOpen ? 180 : 0 }}
 					transition={{ duration: reduced ? 0 : 0.3 }}
-					className="inline-flex h-8 w-8 shrink-0 items-center justify-center border border-bp-line text-foreground"
+					className="inline-flex h-8 w-8 shrink-0 items-center justify-center border border-border bg-card text-foreground"
 				>
 					<ChevronDown className="h-4 w-4" />
 				</m.span>

--- a/apps/web/src/app/components/landing/hero/hero.tsx
+++ b/apps/web/src/app/components/landing/hero/hero.tsx
@@ -58,12 +58,28 @@ export default function Hero() {
 						G-001 · Cover
 					</p>
 
+					{/*
+					 * Three explicit lines, not one wrapping block. "Manage with
+					 * Confidence" never fits the copy column at this scale, so the break
+					 * is authored rather than discovered — and the framed word then gets
+					 * a real margin instead of relying on line-height, which can't clear
+					 * KeywordMark's 0.12em frame overhang plus the descenders above it.
+					 * Margins are em so they track the responsive type sizes.
+					 */}
 					<h1
 						style={delay(380)}
-						className="enter mt-6 text-4xl font-medium leading-[1.05] tracking-tighter text-foreground sm:text-5xl lg:text-[4rem] xl:text-[5rem]"
+						className="enter mt-6 text-balance text-4xl font-medium leading-[1.08] tracking-tighter text-foreground sm:text-5xl lg:text-[3.5rem] xl:text-[4.25rem]"
 					>
-						Run the whole <KeywordMark>job</KeywordMark>{" "}
-						<span className="text-muted-foreground">from your phone.</span>
+						<span className="block">Simplify Your Business</span>
+						<span className="mt-[0.12em] block text-muted-foreground">
+							Manage with
+						</span>
+						{/* -ml cancels KeywordMark's 0.3em side margin less the frame's
+						    0.12em overhang, landing the dashed rectangle flush with the
+						    text column instead of a hair inside it. */}
+						<span className="mt-[0.4em] block">
+							<KeywordMark className="-ml-[0.18em]">Confidence</KeywordMark>
+						</span>
 					</h1>
 
 					<div
@@ -154,7 +170,8 @@ export default function Hero() {
 						style={delay(680)}
 						className="enter max-w-md text-base leading-relaxed text-muted-foreground sm:text-lg"
 					>
-						Quote it, schedule it, invoice it, get paid — one tool, one price.
+						OneTool brings together quotes, projects, clients, and invoices —
+						everything you need to keep work moving.
 					</p>
 				</div>
 				<div className="grid grid-cols-3 px-6 py-10 sm:px-10 lg:px-14">

--- a/apps/web/src/app/components/landing/hero/particle-mark.tsx
+++ b/apps/web/src/app/components/landing/hero/particle-mark.tsx
@@ -5,26 +5,39 @@ import { usePrefersReducedMotion } from "../use-reduced-motion";
 import { LOGO_CHECK, LOGO_WRENCH } from "./logo-mark-data";
 
 /**
- * The hero mark as particles: the real OneTool logo rasterized from its own
- * path data, each particle keeping the pixel's true brand color. Particles
- * assemble on load, scatter under the pointer, and settle back into the mark.
+ * The hero mark as particles: the real OneTool logo traced from its own path
+ * data, each particle keeping the pixel's true brand color. The particles are
+ * the *outline* only — the interior is painted with the same diagonal-stripe
+ * fill the report charts use (ChartStripeDefs), and that fill only shows while
+ * the mark is settled. Disturb the particles and the fill drops out; hold still
+ * and it eases back in once they've been home for SETTLE_DELAY.
  *
  * No CAD layer — this replaced the drafted-part treatment (construction
  * geometry, centrelines, dimensions, QA stamp) at Patrick's direction.
  *
- * Reduced motion: the paths are painted once, statically, on the same canvas.
- * The rAF loop runs only while the plate is on screen.
+ * Reduced motion: outline + fill are painted once, statically, on the same
+ * canvas. The rAF loop runs only while the plate is on screen.
  */
 
 const VIEWBOX = 296;
 /** Fraction of the canvas left as margin around the 296-space artwork. */
 const PADDING = 0.04;
-const STEP = 3; // sample stride in CSS px — density knob
-const SIZE = 2.4; // particle edge in CSS px
+const STEP = 2; // sample stride in CSS px — density knob
+const SIZE = 2; // particle edge in CSS px
+const OUTLINE_WIDTH = 3.4; // traced stroke in CSS px — the particle band
 const EASE = 0.06;
 const FRICTION = 0.84;
 const MOUSE_RADIUS = 120;
 const MOUSE_STRENGTH = 4.2;
+/** Largest particle offset (CSS px) still counted as "in place". */
+const SETTLE_EPS = 2;
+/** How long the mark must hold still before the stripe fill returns. */
+const SETTLE_DELAY = 650;
+/** Per-frame lerp rates — fill leaves fast, comes back slowly. */
+const FILL_IN = 0.05;
+const FILL_OUT = 0.22;
+
+const SHAPES = [LOGO_WRENCH, LOGO_CHECK];
 
 interface Particle {
 	x: number;
@@ -36,20 +49,128 @@ interface Particle {
 	color: string;
 }
 
-function paintMark(
+/** Runs `draw` with the 296-space artwork mapped onto the canvas, then resets. */
+function withMarkTransform(
 	ctx: CanvasRenderingContext2D,
 	width: number,
 	height: number,
+	draw: (scale: number) => void,
 ) {
 	const scale = (Math.min(width, height) * (1 - PADDING * 2)) / VIEWBOX;
 	const dx = (width - VIEWBOX * scale) / 2;
 	const dy = (height - VIEWBOX * scale) / 2;
 	ctx.setTransform(scale, 0, 0, scale, dx, dy);
-	for (const shape of [LOGO_WRENCH, LOGO_CHECK]) {
-		ctx.fillStyle = shape.fill;
-		ctx.fill(new Path2D(shape.d));
-	}
+	draw(scale);
 	ctx.setTransform(1, 0, 0, 1, 0, 0);
+}
+
+function paintOutline(
+	ctx: CanvasRenderingContext2D,
+	width: number,
+	height: number,
+	dpr: number,
+) {
+	withMarkTransform(ctx, width, height, (scale) => {
+		ctx.lineJoin = "round";
+		ctx.lineCap = "round";
+		for (const shape of SHAPES) {
+			ctx.strokeStyle = shape.fill;
+			// Divide by scale so the band is OUTLINE_WIDTH CSS px at any plate size.
+			ctx.lineWidth = (OUTLINE_WIDTH * dpr) / scale;
+			ctx.stroke(new Path2D(shape.d));
+		}
+	});
+}
+
+function line(
+	ctx: CanvasRenderingContext2D,
+	x1: number,
+	y1: number,
+	x2: number,
+	y2: number,
+) {
+	ctx.beginPath();
+	ctx.moveTo(x1, y1);
+	ctx.lineTo(x2, y2);
+	ctx.stroke();
+}
+
+/**
+ * The reports diagonal-stripe fill as a canvas pattern — same 8-unit tile,
+ * opacities and stroke widths as `ChartStripeDefs`, so the hero and the report
+ * charts print the same texture.
+ */
+function stripePattern(
+	ctx: CanvasRenderingContext2D,
+	color: string,
+	dpr: number,
+): CanvasPattern | null {
+	const tile = document.createElement("canvas");
+	const size = Math.max(8, Math.round(8 * dpr));
+	tile.width = size;
+	tile.height = size;
+	const t = tile.getContext("2d");
+	if (!t) return null;
+
+	t.scale(size / 8, size / 8);
+	t.fillStyle = color;
+	t.strokeStyle = color;
+
+	t.globalAlpha = 0.1;
+	t.fillRect(0, 0, 8, 8);
+
+	t.globalAlpha = 0.6;
+	t.lineWidth = 1.5;
+	line(t, 0, 8, 8, 0);
+	line(t, 4, 12, 12, 4);
+	line(t, -4, 4, 4, -4);
+
+	t.globalAlpha = 0.3;
+	t.lineWidth = 1;
+	line(t, 2, 10, 10, 2);
+	line(t, 6, 14, 14, 6);
+	line(t, -2, 6, 6, -2);
+
+	return ctx.createPattern(tile, "repeat");
+}
+
+/**
+ * Both shapes' interiors, striped in their own brand color, baked once into an
+ * offscreen canvas — the loop then costs a single drawImage per frame.
+ */
+function buildFillLayer(
+	width: number,
+	height: number,
+	dpr: number,
+): HTMLCanvasElement | null {
+	const layer = document.createElement("canvas");
+	layer.width = width;
+	layer.height = height;
+	const lc = layer.getContext("2d");
+	const scratch = document.createElement("canvas");
+	scratch.width = width;
+	scratch.height = height;
+	const sc = scratch.getContext("2d");
+	if (!lc || !sc) return null;
+
+	for (const shape of SHAPES) {
+		const pattern = stripePattern(sc, shape.fill, dpr);
+		if (!pattern) continue;
+		sc.setTransform(1, 0, 0, 1, 0, 0);
+		sc.clearRect(0, 0, width, height);
+		// Stripes are laid down untransformed so their pitch stays constant on
+		// screen instead of scaling with the mark.
+		sc.fillStyle = pattern;
+		sc.fillRect(0, 0, width, height);
+		sc.globalCompositeOperation = "destination-in";
+		withMarkTransform(sc, width, height, () => {
+			sc.fillStyle = "#000";
+			sc.fill(new Path2D(shape.d));
+		});
+		sc.globalCompositeOperation = "source-over";
+		lc.drawImage(scratch, 0, 0);
+	}
+	return layer;
 }
 
 export function ParticleMark({ className }: { className?: string }) {
@@ -66,6 +187,10 @@ export function ParticleMark({ className }: { className?: string }) {
 
 		const dpr = Math.min(window.devicePixelRatio || 1, 2);
 		let particles: Particle[] = [];
+		let fillLayer: HTMLCanvasElement | null = null;
+		let fillAlpha = 0;
+		let settledMs = 0;
+		let lastTime = 0;
 		let frame = 0;
 		let running = false;
 		const mouse = { x: -1e4, y: -1e4, active: false };
@@ -75,18 +200,27 @@ export function ParticleMark({ className }: { className?: string }) {
 			canvas.height = container.clientHeight * dpr;
 			if (canvas.width === 0 || canvas.height === 0) return;
 
+			fillLayer = buildFillLayer(canvas.width, canvas.height, dpr);
+
 			if (reduced) {
-				// Terminal state: the mark itself, no particles, no loop.
-				paintMark(ctx, canvas.width, canvas.height);
+				// Terminal state: settled mark, fill shown, no particles, no loop.
+				ctx.setTransform(1, 0, 0, 1, 0, 0);
+				ctx.clearRect(0, 0, canvas.width, canvas.height);
+				if (fillLayer) ctx.drawImage(fillLayer, 0, 0);
+				paintOutline(ctx, canvas.width, canvas.height, dpr);
 				return;
 			}
+
+			fillAlpha = 0;
+			settledMs = 0;
+			lastTime = 0;
 
 			const off = document.createElement("canvas");
 			off.width = canvas.width;
 			off.height = canvas.height;
 			const offCtx = off.getContext("2d");
 			if (!offCtx) return;
-			paintMark(offCtx, off.width, off.height);
+			paintOutline(offCtx, off.width, off.height, dpr);
 
 			const data = offCtx.getImageData(0, 0, off.width, off.height).data;
 			const step = Math.max(1, Math.round(STEP * dpr));
@@ -94,7 +228,8 @@ export function ParticleMark({ className }: { className?: string }) {
 			for (let y = 0; y < off.height; y += step) {
 				for (let x = 0; x < off.width; x += step) {
 					const i = (y * off.width + x) * 4;
-					if (data[i + 3] > 128) {
+					// Above the antialiased skirt, so particles keep the true brand hue.
+					if (data[i + 3] > 200) {
 						next.push({
 							x: Math.random() * off.width,
 							y: Math.random() * off.height,
@@ -110,10 +245,14 @@ export function ParticleMark({ className }: { className?: string }) {
 			particles = next;
 		};
 
-		const tick = () => {
-			ctx.clearRect(0, 0, canvas.width, canvas.height);
+		const tick = (time: number) => {
+			const delta = lastTime ? Math.min(time - lastTime, 64) : 16;
+			lastTime = time;
+
 			const size = SIZE * dpr;
 			const radius = MOUSE_RADIUS * dpr;
+			let maxOffset = 0;
+
 			for (const p of particles) {
 				let fx = 0;
 				let fy = 0;
@@ -131,9 +270,27 @@ export function ParticleMark({ className }: { className?: string }) {
 				p.vy = (p.vy + (p.oy - p.y) * EASE + fy) * FRICTION;
 				p.x += p.vx;
 				p.y += p.vy;
+				const offset = Math.hypot(p.x - p.ox, p.y - p.oy);
+				if (offset > maxOffset) maxOffset = offset;
+			}
+
+			// One particle knocked out of place is enough to pull the fill: the
+			// mark reads as "in hand" the moment anything moves.
+			settledMs = maxOffset < SETTLE_EPS * dpr ? settledMs + delta : 0;
+			const target = settledMs >= SETTLE_DELAY ? 1 : 0;
+			fillAlpha += (target - fillAlpha) * (target > fillAlpha ? FILL_IN : FILL_OUT);
+
+			ctx.clearRect(0, 0, canvas.width, canvas.height);
+			if (fillLayer && fillAlpha > 0.01) {
+				ctx.globalAlpha = Math.min(fillAlpha, 1);
+				ctx.drawImage(fillLayer, 0, 0);
+				ctx.globalAlpha = 1;
+			}
+			for (const p of particles) {
 				ctx.fillStyle = p.color;
 				ctx.fillRect(Math.round(p.x), Math.round(p.y), size, size);
 			}
+
 			frame = requestAnimationFrame(tick);
 		};
 
@@ -144,6 +301,9 @@ export function ParticleMark({ className }: { className?: string }) {
 		};
 		const stop = () => {
 			running = false;
+			// Drop the stale timestamp so re-entering the viewport doesn't bank a
+			// multi-second delta into the settle timer.
+			lastTime = 0;
 			cancelAnimationFrame(frame);
 		};
 


### PR DESCRIPTION
This pull request updates the landing page's hero section and the FAQ UI, focusing on improved accessibility, visual polish, and a major redesign of the hero logo animation. The hero logo is now rendered as animated particle outlines with a dynamic brand-colored stripe fill that reacts to user interaction, and the hero heading and copy have been rewritten for clarity and visual balance.

**Hero Section Redesign**

* The hero heading (`hero.tsx`) is now split into three explicit lines for better layout and readability, with the keyword "Confidence" visually framed and aligned precisely. The copy has been rewritten for clarity, and responsive typography improvements were made.
* The supporting paragraph under the hero heading has been updated to more clearly describe the product’s value proposition.

**Hero Logo Animation Overhaul**

* The hero logo (`particle-mark.tsx`) is now rendered as animated particle outlines, with a dynamic diagonal-stripe fill that matches the report charts. The fill fades in only when the particles are settled, and fades out when disturbed, creating a tactile, interactive effect. This includes new logic for tracking particle state, fill animation, and accessibility improvements for reduced motion. [[1]](diffhunk://#diff-6eabc23757ecb3a671466bbeb7632d4d25a9a57c3f7f2a94e08b2af2d35f5e63L8-R40) [[2]](diffhunk://#diff-6eabc23757ecb3a671466bbeb7632d4d25a9a57c3f7f2a94e08b2af2d35f5e63L39-R175) [[3]](diffhunk://#diff-6eabc23757ecb3a671466bbeb7632d4d25a9a57c3f7f2a94e08b2af2d35f5e63R190-R193) [[4]](diffhunk://#diff-6eabc23757ecb3a671466bbeb7632d4d25a9a57c3f7f2a94e08b2af2d35f5e63R203-R232) [[5]](diffhunk://#diff-6eabc23757ecb3a671466bbeb7632d4d25a9a57c3f7f2a94e08b2af2d35f5e63L113-R255) [[6]](diffhunk://#diff-6eabc23757ecb3a671466bbeb7632d4d25a9a57c3f7f2a94e08b2af2d35f5e63R273-R293) [[7]](diffhunk://#diff-6eabc23757ecb3a671466bbeb7632d4d25a9a57c3f7f2a94e08b2af2d35f5e63R304-R306)

**FAQ UI Accessibility**

* The FAQ row expand/collapse control now uses an opaque background plate with a 3:1 contrast ratio for improved accessibility in both light and dark themes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the landing page hero messaging to highlight business management and confidence.
  * Refined hero copy to mention quotes, projects, clients, and invoices.
  * Enhanced the particle logo with a traced outline, animated stripe effects, and improved reduced-motion support.

* **Style**
  * Improved FAQ expand/collapse control contrast with an opaque background and updated border styling.
  * Adjusted hero spacing and responsive typography for a clearer presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the landing page presentation:
- Rewrites and restructures the hero heading and supporting copy.
- Reworks the OneTool logo into an interactive particle outline with striped fills and reduced-motion behavior.
- Improves the FAQ expand/collapse control’s visual contrast.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete changed-code defects identified.

The responsive hero changes remain within the supported layout constraints, while the canvas lifecycle, compositing, interaction, visibility, resizing, and reduced-motion paths preserve coherent rendering behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/components/faq-section.tsx | Replaces the FAQ toggle’s hairline styling with an opaque, higher-contrast control boundary. |
| apps/web/src/app/components/landing/hero/hero.tsx | Introduces an explicitly arranged three-line heading, revised responsive typography, and updated supporting copy. |
| apps/web/src/app/components/landing/hero/particle-mark.tsx | Adds outlined particle sampling, per-shape striped fill layers, settlement-driven fill animation, and a static reduced-motion rendering path. |

<sub>Reviews (1): Last reviewed commit: ["feat(landing): outline particle mark wit..."](https://github.com/xcarter93/onetool/commit/5030bbb523741ba4869a1af4677e7888c9ce7722) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49634509)</sub>

<!-- /greptile_comment -->