### PR TITLE
fix(landing): assert Remotion playback instead of firing a single play()

### DIFF
--- a/apps/web/src/app/components/landing/feature-animation.tsx
+++ b/apps/web/src/app/components/landing/feature-animation.tsx
@@ -54,12 +54,50 @@ export function FeatureAnimation({
 	const reduced = usePrefersReducedMotion();
 
 	useEffect(() => {
-		if (inView && !reduced) {
-			playerRef.current?.play();
-		} else {
-			playerRef.current?.pause();
+		const player = playerRef.current;
+		if (!player) return;
+
+		if (!inView || reduced) {
+			player.pause();
+			return;
 		}
-	}, [inView, reduced]);
+
+		/*
+		 * Assert playback rather than firing a single play(). Remotion's play() is
+		 * a void one-shot that early-returns when the player already believes it is
+		 * playing, so one dropped start strands an ambient embed on a still frame
+		 * with no control a visitor could use to recover it.
+		 *
+		 * isPlaying() is a trustworthy signal here *specifically* because nothing
+		 * in these compositions can reach Remotion's buffering gate — the one state
+		 * that freezes frames while isPlaying() stays true. That gate is only fed
+		 * by <Audio>/<Video> elements and by <Img> when passed `pauseWhenLoading`;
+		 * our scenes use plain <Img> and no media. If a scene ever gains audio or
+		 * video, this check stops being sufficient on its own.
+		 */
+		let raf = 0;
+		const ensurePlaying = () => {
+			cancelAnimationFrame(raf);
+			// Next frame, so re-asserting can never recurse inside a pause dispatch.
+			raf = requestAnimationFrame(() => {
+				if (!document.hidden && !player.isPlaying()) player.play();
+			});
+		};
+
+		ensurePlaying();
+
+		// Controls embeds opt out: there, a pause is the visitor's own choice.
+		if (controls) return () => cancelAnimationFrame(raf);
+
+		player.addEventListener("pause", ensurePlaying);
+		// Backgrounding stops the rAF loop; returning shouldn't need a scroll.
+		document.addEventListener("visibilitychange", ensurePlaying);
+		return () => {
+			cancelAnimationFrame(raf);
+			player.removeEventListener("pause", ensurePlaying);
+			document.removeEventListener("visibilitychange", ensurePlaying);
+		};
+	}, [inView, reduced, controls]);
 
 	const video = FEATURE_VIDEOS[feature];
 


### PR DESCRIPTION
On a fresh production load, scrolling to the scene rail sometimes left the animation on a still frame until a rail click remounted the Player.

The embed called playerRef.current?.play() once per in-view transition and never checked whether it took. Remotion's play() is a void one-shot that early-returns on imperativePlaying.current, and the rail embeds run with controls={false} and clickToPlay={false} — so a single dropped start was unrecoverable, with no control a visitor could use to start the scene by hand.

ensurePlaying() now re-checks isPlaying() and re-issues play(), re-armed on the player's own pause event and on visibilitychange, deferred one animation frame so re-asserting cannot recurse inside a pause dispatch. Embeds with controls opt out, since a pause there is the visitor's own choice.

isPlaying() is a sound liveness signal here because nothing in these compositions can reach Remotion's buffering gate — the one state that freezes frames while isPlaying() stays true. That gate is fed only by <Audio>/<Video> elements and by <Img> when passed pauseWhenLoading; the scenes use plain <Img> and no media. The comment records this so a future scene gaining audio does not silently invalidate the check.

Verified against @remotion/player 4.0.504: the AudioContext warnings in the console are not the cause — play() ignores the resume() rejection and sets playing unconditionally, and the frame loop clocks off performance.now().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feature animation playback reliability when scrolling, switching tabs, or returning to the page.
  * Animations now respect reduced-motion settings and pause when off-screen.
  * Preserved user-initiated pauses for controlled embeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes chromeless landing-page animations recover from dropped playback starts.
- Rechecks Remotion playback state on the next animation frame before calling `play()`.
- Reasserts playback after player pause and document visibility events.
- Preserves user-controlled pauses for embeds with playback controls.
- Documents why `isPlaying()` is currently a valid liveness signal for these media-free compositions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The playback assertion is limited to visible, non-reduced-motion players, cleans up its animation frame and event listeners, preserves intentional pauses when controls are enabled, and relies on a liveness assumption supported by the current composition implementations.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/components/landing/feature-animation.tsx | Adds lifecycle-safe playback recovery for ambient Remotion players while preserving reduced-motion, off-screen, hidden-document, and controlled-player behavior. |

<sub>Reviews (1): Last reviewed commit: ["fix(landing): assert Remotion playback i..."](https://github.com/xcarter93/onetool/commit/f9047b9a962810aa5e2e87f75f01cc12a18094f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49697043)</sub>

<!-- /greptile_comment -->