### PR TITLE
Fix audio context issues by muting Remotion players on load

### DIFF
--- a/apps/web/src/app/components/landing/feature-animation.tsx
+++ b/apps/web/src/app/components/landing/feature-animation.tsx
@@ -68,12 +68,9 @@ export function FeatureAnimation({
 		 * playing, so one dropped start strands an ambient embed on a still frame
 		 * with no control a visitor could use to recover it.
 		 *
-		 * isPlaying() is a trustworthy signal here *specifically* because nothing
-		 * in these compositions can reach Remotion's buffering gate — the one state
-		 * that freezes frames while isPlaying() stays true. That gate is only fed
-		 * by <Audio>/<Video> elements and by <Img> when passed `pauseWhenLoading`;
-		 * our scenes use plain <Img> and no media. If a scene ever gains audio or
-		 * video, this check stops being sufficient on its own.
+		 * NOTE: isPlaying() only reports that play() was called — it can stay true
+		 * while frames are frozen (see the `initiallyMuted` comment on <Player>).
+		 * This loop guards a dropped play(), not a stalled frame loop.
 		 */
 		let raf = 0;
 		const ensurePlaying = () => {
@@ -101,6 +98,26 @@ export function FeatureAnimation({
 
 	const video = FEATURE_VIDEOS[feature];
 
+	/*
+	 * initiallyMuted / numberOfSharedAudioTags / showVolumeControls are what
+	 * actually make autoplay work. No scene here contains <Audio> or <Video>, so
+	 * Remotion's audio path is dead weight that only ever breaks playback:
+	 *
+	 * Unmuted, the Player builds an AudioContext, and usePlayback parks the whole
+	 * frame loop on `getIsResumingAudioContext()` *before* it queues a rAF.
+	 * Without a user gesture Chrome leaves resume() pending forever rather than
+	 * rejecting it, and Remotion's waitUntilActuallyResumed() polls a clock that
+	 * never advances — so the promise never settles, no frame is ever queued, and
+	 * the scene sits on frame 0 while isPlaying() still reports true. Any click
+	 * anywhere on the page releases it, which is why clicking a rail button
+	 * looked like the trigger.
+	 *
+	 * initiallyMuted makes shouldCreateAudioContext false, so no context is built
+	 * and that branch is unreachable. numberOfSharedAudioTags drops the 5 warm-up
+	 * <audio> tags Remotion mounts for <Html5Audio>. The volume control goes with
+	 * them — it would flip the audio path back on, and there is no audio for it
+	 * to control.
+	 */
 	return (
 		<div ref={ref} className={className}>
 			<Player
@@ -119,6 +136,9 @@ export function FeatureAnimation({
 				controls={controls}
 				clickToPlay={controls}
 				spaceKeyToPlayOrPause={controls}
+				initiallyMuted
+				numberOfSharedAudioTags={0}
+				showVolumeControls={false}
 				acknowledgeRemotionLicense
 			/>
 		</div>


### PR DESCRIPTION
This pull request updates the `FeatureAnimation` component to improve playback reliability and prevent issues related to Remotion's audio handling. The changes clarify how autoplay works for scenes without audio or video, and update the `<Player>` configuration to avoid unnecessary audio context creation, which previously caused playback to stall on some browsers.

**Playback and Audio Handling Improvements:**

* Added a comment explaining why `initiallyMuted`, `numberOfSharedAudioTags`, and `showVolumeControls` are necessary for autoplay to work correctly when there is no audio or video in the scene. This prevents Remotion from creating an `AudioContext` that could block playback on browsers like Chrome.
* Updated the `<Player>` component to set `initiallyMuted`, `numberOfSharedAudioTags={0}`, and `showVolumeControls={false}` to disable Remotion’s audio path and volume controls, ensuring smooth playback.

**Documentation and Comments:**

* Clarified the comment above the playback guard loop to explain the limitations of `isPlaying()` and why the loop is necessary to guard against dropped `play()` calls rather than stalled frame loops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Video previews now start muted for a quieter, more predictable experience.
  - Audio and volume controls are hidden when sound is unavailable.

- **Documentation**
  - Clarified playback behavior during frozen frames and recovery from dropped play actions.
  - Added guidance for configuring audio playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR configures landing-page Remotion players to avoid unnecessary audio initialization and clarifies the playback recovery behavior.
- Starts every feature animation muted and disables shared audio tags and volume controls.
- Updates comments to distinguish dropped `play()` calls from stalled frame loops.
- Preserves existing autoplay, viewport, reduced-motion, and interactive-control behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The changed audio settings match the current compositions, which contain no audio or video, while existing play, pause, visibility, and reduced-motion handling remains intact.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/components/landing/feature-animation.tsx | Disables Remotion’s unused audio path for media-free feature compositions and documents why the playback guard remains necessary. |

<sub>Reviews (1): Last reviewed commit: ["fix(landing): mute Remotion players so t..."](https://github.com/xcarter93/onetool/commit/fa4a53eeb94ab04114fa33a027f489e92591e352) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49704478)</sub>

<!-- /greptile_comment -->