### PR TITLE
Enhance org management and onboarding experience

### DIFF
--- a/apps/web/src/app/(onboarding)/organization/complete/complete-organization.tsx
+++ b/apps/web/src/app/(onboarding)/organization/complete/complete-organization.tsx
@@ -183,7 +183,11 @@ export function CompleteOrganizationMetadata() {
 		createOrganization,
 		setActive,
 		userMemberships,
-	} = useOrganizationList({ userMemberships: { infinite: true } });
+	} = useOrganizationList({
+		// Clerk defaults to 10/page; bump it so the escape hatch shows every org
+		// for all but extreme cases, with Load more covering the rest.
+		userMemberships: { infinite: true, pageSize: 50 },
+	});
 	const { signOut } = useClerk();
 	const [switchingOrgId, setSwitchingOrgId] = useState<string | null>(null);
 	const [orgName, setOrgName] = useState("");
@@ -720,6 +724,24 @@ export function CompleteOrganizationMetadata() {
 										</li>
 									))}
 								</ul>
+								{userMemberships?.hasNextPage && (
+									<Button
+										type="button"
+										variant="ghost"
+										size="sm"
+										className="mt-2 w-full text-muted-foreground"
+										disabled={userMemberships.isFetching}
+										onClick={() => userMemberships.fetchNext?.()}
+									>
+										{userMemberships.isFetching ? (
+											<Loader2
+												className="h-4 w-4 animate-spin"
+												aria-hidden="true"
+											/>
+										) : null}
+										Load more organizations
+									</Button>
+								)}
 							</div>
 							<div className="flex items-center gap-3">
 								<div className="h-px flex-1 bg-border/60" />

--- a/apps/web/src/app/(onboarding)/organization/complete/complete-organization.tsx
+++ b/apps/web/src/app/(onboarding)/organization/complete/complete-organization.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import React, { useMemo, useState, useEffect, useSyncExternalStore } from "react";
-import { useUser, useOrganization, useOrganizationList } from "@clerk/nextjs";
+import {
+	useUser,
+	useOrganization,
+	useOrganizationList,
+	useClerk,
+} from "@clerk/nextjs";
 import { PricingTable } from "@clerk/nextjs";
 import { useTheme } from "next-themes";
 import { useMutation, useQuery } from "convex/react";
@@ -79,6 +84,13 @@ const ONBOARDING_STEPS: OnboardingStep[] = [
 ];
 
 const TOTAL_STEPS = ONBOARDING_STEPS.length;
+
+// Formats Clerk's setLogo accepts (SVG is not one of them).
+const SUPPORTED_LOGO_TYPES = new Set([
+	"image/png",
+	"image/jpeg",
+	"image/webp",
+]);
 
 // Inner content column per step; the card itself is one fixed generous size.
 const STEP_WIDTHS: Record<number, string> = {
@@ -164,11 +176,16 @@ export function CompleteOrganizationMetadata() {
 	} | null>(null);
 
 	// Step 1: custom create-org form state (replaces Clerk's <CreateOrganization>)
+	// userMemberships powers the "switch to an existing organization" escape
+	// hatch — without it, a user with orgs but no active org is trapped here.
 	const {
 		isLoaded: orgListLoaded,
 		createOrganization,
 		setActive,
-	} = useOrganizationList();
+		userMemberships,
+	} = useOrganizationList({ userMemberships: { infinite: true } });
+	const { signOut } = useClerk();
+	const [switchingOrgId, setSwitchingOrgId] = useState<string | null>(null);
 	const [orgName, setOrgName] = useState("");
 	// First/last name are required HERE, not at the Clerk sign-up step: the Clerk
 	// instance keeps name optional so Sign in with Apple completes on returning
@@ -506,6 +523,14 @@ export function CompleteOrganizationMetadata() {
 		setCreateLogoError(null);
 		const file = e.target.files?.[0] ?? null;
 		if (!file) return;
+		// Clerk's setLogo rejects SVGs (and other exotic types); catch them here
+		// instead of at upload time. The accept attr filters the picker but not
+		// drag-drop or "All Files" selections.
+		if (!SUPPORTED_LOGO_TYPES.has(file.type)) {
+			setCreateLogoError("Use a PNG, JPG, or WEBP image — other formats aren't supported");
+			e.target.value = "";
+			return;
+		}
 		if (file.size > 10 * 1024 * 1024) {
 			setCreateLogoError("Logo must be 10 MB or smaller");
 			// Reset so re-selecting the same file refires onChange
@@ -516,6 +541,26 @@ export function CompleteOrganizationMetadata() {
 		setLogoFile(file);
 		setLogoPreviewUrl(URL.createObjectURL(file));
 	};
+
+	// Escape hatch: activate an org the user already belongs to (e.g. after
+	// deleting/leaving their active org) instead of forcing a new one.
+	const handleSwitchToOrg = async (orgId: string) => {
+		if (!setActive || switchingOrgId) return;
+		setSwitchingOrgId(orgId);
+		try {
+			await setActive({ organization: orgId });
+			// Middleware routes "/" by role: admins → /home, members → /projects.
+			router.push("/");
+		} catch (err) {
+			toast.error(
+				"Couldn't switch organization",
+				err instanceof Error ? err.message : "Please try again."
+			);
+			setSwitchingOrgId(null);
+		}
+	};
+
+	const existingMemberships = userMemberships?.data ?? [];
 
 	const handleCreateOrganization: React.FormEventHandler<
 		HTMLFormElement
@@ -576,9 +621,19 @@ export function CompleteOrganizationMetadata() {
 					: await createOrganization({ name: trimmedName });
 			createdOrgRef.current = { org: newOrg, name: trimmedName };
 
-			// 2. Upload logo BEFORE setActive so step 2's preview tiles see imageUrl on first render
+			// 2. Upload logo BEFORE setActive so step 2's preview tiles see imageUrl
+			// on first render. A logo failure must NOT abort the flow: bailing before
+			// setActive orphans the just-created org and a retry after remount
+			// creates a duplicate. The logo can always be set later in Settings.
 			if (logoFile) {
-				await newOrg.setLogo({ file: logoFile });
+				try {
+					await newOrg.setLogo({ file: logoFile });
+				} catch {
+					toast.warning(
+						"Couldn't upload the logo",
+						"Your organization was still created — you can add a logo later in Settings."
+					);
+				}
 			}
 
 			// 3. Mark as active session org
@@ -607,6 +662,74 @@ export function CompleteOrganizationMetadata() {
 				</div>
 			) : (
 				<div className="space-y-6">
+					{existingMemberships.length > 0 && (
+						<div className="space-y-4">
+							<div className="border border-border/60 rounded-xl bg-muted/20 p-4">
+								<p className="text-sm font-medium text-foreground mb-1">
+									Your organizations
+								</p>
+								<p className="text-xs text-muted-foreground mb-3">
+									You already belong to{" "}
+									{existingMemberships.length === 1
+										? "an organization"
+										: "these organizations"}
+									. Switch back to one, or create a new one below.
+								</p>
+								<ul className="space-y-2">
+									{existingMemberships.map((m) => (
+										<li
+											key={m.organization.id}
+											className="flex items-center gap-3 rounded-lg border border-border/60 bg-background px-3 py-2"
+										>
+											{m.organization.imageUrl ? (
+												<Image
+													src={m.organization.imageUrl}
+													alt=""
+													width={32}
+													height={32}
+													className="h-8 w-8 rounded-md border border-border object-contain bg-white"
+												/>
+											) : (
+												<div className="flex h-8 w-8 items-center justify-center rounded-md border border-border bg-muted/40 text-xs font-medium text-muted-foreground">
+													{m.organization.name.charAt(0).toUpperCase()}
+												</div>
+											)}
+											<div className="min-w-0 flex-1">
+												<p className="truncate text-sm font-medium text-foreground">
+													{m.organization.name}
+												</p>
+												<p className="text-xs text-muted-foreground capitalize">
+													{m.role.replace(/^org:/, "")}
+												</p>
+											</div>
+											<Button
+												type="button"
+												variant="outline"
+												size="sm"
+												disabled={switchingOrgId !== null}
+												onClick={() => handleSwitchToOrg(m.organization.id)}
+											>
+												{switchingOrgId === m.organization.id ? (
+													<Loader2
+														className="h-4 w-4 animate-spin"
+														aria-hidden="true"
+													/>
+												) : null}
+												Switch
+											</Button>
+										</li>
+									))}
+								</ul>
+							</div>
+							<div className="flex items-center gap-3">
+								<div className="h-px flex-1 bg-border/60" />
+								<span className="text-xs text-muted-foreground">
+									Or create a new organization
+								</span>
+								<div className="h-px flex-1 bg-border/60" />
+							</div>
+						</div>
+					)}
 					<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
 						<div>
 							<label
@@ -730,7 +853,7 @@ export function CompleteOrganizationMetadata() {
 							<input
 								id="org-logo"
 								type="file"
-								accept="image/*"
+								accept="image/png,image/jpeg,image/webp"
 								onChange={handleLogoSelect}
 								disabled={createSubmitting}
 								className="text-sm text-foreground file:mr-3 file:rounded-md file:border-0 file:bg-primary/10 file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-primary hover:file:bg-primary/20 file:cursor-pointer"
@@ -740,7 +863,7 @@ export function CompleteOrganizationMetadata() {
 							<p className="mt-2 text-sm text-destructive">{createLogoError}</p>
 						)}
 						<p className="mt-2 text-xs text-muted-foreground">
-							PNG, JPG, or SVG up to 10 MB.
+							PNG, JPG, or WEBP up to 10 MB.
 						</p>
 					</div>
 				</div>
@@ -1451,6 +1574,7 @@ export function CompleteOrganizationMetadata() {
 						<OnboardingHeader
 							canGoBack={currentStep > minStep}
 							onBack={handlePrevious}
+							onSignOut={() => void signOut({ redirectUrl: "/sign-in" })}
 						/>
 
 						<div className="flex flex-1">

--- a/apps/web/src/app/(workspace)/organization/profile/_components/overview-tab.tsx
+++ b/apps/web/src/app/(workspace)/organization/profile/_components/overview-tab.tsx
@@ -193,23 +193,36 @@ export function OverviewTab() {
 	// the create-org flow when none remain. Without this, users with other
 	// orgs get trapped on /organization/complete (no switcher, no sign-out).
 	const switchToRemainingOrg = async (deletedOrgId: string) => {
-		try {
-			// Imperative fetch so we get a fresh list; the deleted org can linger
-			// in Clerk's client cache, so filter it out explicitly.
-			const { data } = (await user?.getOrganizationMemberships({
-				pageSize: 50,
-			})) ?? { data: [] };
-			const next = data.find((m) => m.organization.id !== deletedOrgId);
-			if (next) {
+		// Imperative fetch so we get a fresh list; the deleted org can linger
+		// in Clerk's client cache, so filter it out explicitly.
+		const memberships = await user
+			?.getOrganizationMemberships({ pageSize: 50 })
+			.then((res) => res.data)
+			.catch(() => []);
+		const next = memberships?.find((m) => m.organization.id !== deletedOrgId);
+		if (next) {
+			try {
 				await setActive({ organization: next.organization.id });
 				// Middleware routes "/" by role: admins → /home, members → /projects.
 				router.push("/");
 				return;
+			} catch {
+				// Activation of a known org failed (transient) — explain before
+				// landing on the picker, where the user can retry the switch.
+				toast.warning(
+					"Couldn't switch organization",
+					`Pick ${next.organization.name} from the list to try again.`,
+				);
 			}
-		} catch {
-			// Fall through to the no-org flow.
 		}
-		await setActive({ organization: null });
+		// No org left, or fetch/activation failed. The complete screen lists any
+		// remaining memberships with a switcher, so this is recoverable.
+		try {
+			await setActive({ organization: null });
+		} catch {
+			// Ignore: navigation below still lands on the picker, and surfacing
+			// this in the caller would mislabel it as a failed delete/leave.
+		}
 		router.push("/organization/complete");
 	};
 

--- a/apps/web/src/app/(workspace)/organization/profile/_components/overview-tab.tsx
+++ b/apps/web/src/app/(workspace)/organization/profile/_components/overview-tab.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useCallback, useRef, useState } from "react";
-import { useOrganization, useClerk, useReverification } from "@clerk/nextjs";
+import {
+	useOrganization,
+	useClerk,
+	useReverification,
+	useUser,
+} from "@clerk/nextjs";
 import { isReverificationCancelledError } from "@clerk/nextjs/errors";
 import { useMutation } from "convex/react";
 import { useRouter } from "next/navigation";
@@ -34,6 +39,13 @@ import { SectionHeading } from "./settings-card";
 import { TeamMembersTable } from "./team-members-table";
 import { ADMIN_ROLE, getInitials, clerkErr } from "../_lib/org-members";
 
+// Formats Clerk's setLogo accepts (SVG is not one of them).
+const SUPPORTED_LOGO_TYPES = new Set([
+	"image/png",
+	"image/jpeg",
+	"image/webp",
+]);
+
 export function OverviewTab() {
 	const router = useRouter();
 	const toast = useToast();
@@ -43,6 +55,7 @@ export function OverviewTab() {
 	const updateOrganization = useMutation(api.organizations.update);
 
 	const { organization, membership, isLoaded } = useOrganization();
+	const { user } = useUser();
 
 	const isAdmin = membership?.role === ADMIN_ROLE;
 
@@ -138,6 +151,17 @@ export function OverviewTab() {
 			event.target.value = "";
 			return;
 		}
+		// Clerk's setLogo rejects SVGs (and other exotic types); catch them here
+		// instead of at upload time. The accept attr filters the picker but not
+		// drag-drop or "All Files" selections.
+		if (!SUPPORTED_LOGO_TYPES.has(file.type)) {
+			toast.error(
+				"Unsupported logo format",
+				"Choose a PNG, JPG, or WEBP image instead.",
+			);
+			event.target.value = "";
+			return;
+		}
 		if (file.size > 10 * 1024 * 1024) {
 			toast.error("Logo too large", "Choose an image 10 MB or smaller.");
 			event.target.value = "";
@@ -164,6 +188,31 @@ export function OverviewTab() {
 		}
 	};
 
+	// After leaving/deleting the active org, land the user somewhere sane:
+	// activate another org they belong to when one exists; only fall back to
+	// the create-org flow when none remain. Without this, users with other
+	// orgs get trapped on /organization/complete (no switcher, no sign-out).
+	const switchToRemainingOrg = async (deletedOrgId: string) => {
+		try {
+			// Imperative fetch so we get a fresh list; the deleted org can linger
+			// in Clerk's client cache, so filter it out explicitly.
+			const { data } = (await user?.getOrganizationMemberships({
+				pageSize: 50,
+			})) ?? { data: [] };
+			const next = data.find((m) => m.organization.id !== deletedOrgId);
+			if (next) {
+				await setActive({ organization: next.organization.id });
+				// Middleware routes "/" by role: admins → /home, members → /projects.
+				router.push("/");
+				return;
+			}
+		} catch {
+			// Fall through to the no-org flow.
+		}
+		await setActive({ organization: null });
+		router.push("/organization/complete");
+	};
+
 	const handleLeave = async () => {
 		const confirmed = await confirmDialog({
 			title: "Leave organization",
@@ -177,8 +226,7 @@ export function OverviewTab() {
 		setLeaving(true);
 		try {
 			await membership?.destroy();
-			await setActive({ organization: null });
-			router.push("/organization/complete");
+			await switchToRemainingOrg(organization.id);
 		} catch (error) {
 			toast.error("Couldn't leave organization", clerkErr(error));
 			setLeaving(false);
@@ -198,8 +246,7 @@ export function OverviewTab() {
 		setDeleting(true);
 		try {
 			await deleteOrganization();
-			await setActive({ organization: null });
-			router.push("/organization/complete");
+			await switchToRemainingOrg(organization.id);
 		} catch (error) {
 			// The user dismissed Clerk's step-up modal — not an error worth a toast.
 			if (isReverificationCancelledError(error)) {
@@ -254,7 +301,7 @@ export function OverviewTab() {
 							<input
 								ref={logoInputRef}
 								type="file"
-								accept="image/*"
+								accept="image/png,image/jpeg,image/webp"
 								className="hidden"
 								onChange={handleLogoSelect}
 								disabled={!isAdmin || !isOwner || uploadingLogo}
@@ -273,7 +320,7 @@ export function OverviewTab() {
 								{uploadingLogo ? "Uploading…" : "Change logo"}
 							</Button>
 							<p className="text-xs text-muted-foreground">
-								PNG, JPG, or SVG up to 10 MB.
+								PNG, JPG, or WEBP up to 10 MB.
 							</p>
 						</div>
 					</div>

--- a/apps/web/src/components/blocks/onboarding-2/components/onboarding-header.tsx
+++ b/apps/web/src/components/blocks/onboarding-2/components/onboarding-header.tsx
@@ -1,30 +1,46 @@
 import { Button } from "@/components/ui/button"
 import { OnboardingLogo } from "./onboarding-logo"
-import { ArrowLeftIcon } from "lucide-react"
+import { ArrowLeftIcon, LogOutIcon } from "lucide-react"
 
 export function OnboardingHeader({
   canGoBack,
   onBack,
+  onSignOut,
 }: {
   canGoBack: boolean
   onBack: () => void
+  onSignOut?: () => void
 }) {
   return (
     <header className="relative z-10 flex min-h-8 shrink-0 items-center justify-between gap-4">
       <OnboardingLogo />
 
-      {canGoBack ? (
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={onBack}
-          aria-label="Back to previous step"
-        >
-          <ArrowLeftIcon aria-hidden="true" data-icon="inline-start" />
-          Back
-        </Button>
-      ) : null}
+      <div className="flex items-center gap-1">
+        {canGoBack ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onBack}
+            aria-label="Back to previous step"
+          >
+            <ArrowLeftIcon aria-hidden="true" data-icon="inline-start" />
+            Back
+          </Button>
+        ) : null}
+        {onSignOut ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onSignOut}
+            className="text-muted-foreground"
+          >
+            <LogOutIcon aria-hidden="true" data-icon="inline-start" />
+            Sign out
+          </Button>
+        ) : null}
+      </div>
     </header>
   )
 }

--- a/packages/help-content/articles/getting-started.ts
+++ b/packages/help-content/articles/getting-started.ts
@@ -96,14 +96,14 @@ export const gettingStartedArticles: HelpArticle[] = [
 				blocks: [
 					{
 						type: "paragraph",
-						text: "The **Organization** step asks for your first name, last name, and organization name, plus an optional logo.",
+						text: "The **Organization** step asks for your first name, last name, and organization name, plus an optional logo. If you already belong to other organizations, they're listed at the top of this step with a **Switch** button, so you can return to one instead of creating something new.",
 					},
 					{
 						type: "steps",
 						items: [
 							"Enter your **First Name** and **Last Name**.",
 							"Enter your **Organization Name**. This is the business name your clients will see.",
-							"Upload a logo if you have one. You can add or change it later in your organization settings.",
+							"Upload a logo if you have one (PNG, JPG, or WEBP up to 10 MB — SVG isn't supported). You can add or change it later in your organization settings.",
 							"Click **Create Organization**.",
 						],
 					},

--- a/packages/help-content/articles/settings-and-team.ts
+++ b/packages/help-content/articles/settings-and-team.ts
@@ -52,7 +52,7 @@ export const settingsAndTeamArticles: HelpArticle[] = [
 						type: "steps",
 						items: [
 							"Open your organization settings and stay on the **Overview** tab.",
-							"Edit your organization name, or upload a logo image (up to 10 MB).",
+							"Edit your organization name, or upload a logo image (PNG, JPG, or WEBP up to 10 MB — SVG isn't supported).",
 							"Save your changes with the footer at the bottom of the page. It reads **Unsaved changes** until you do.",
 						],
 					},
@@ -124,7 +124,7 @@ export const settingsAndTeamArticles: HelpArticle[] = [
 				blocks: [
 					{
 						type: "paragraph",
-						text: "At the bottom of the **Overview** tab, anyone can use **Leave organization** to remove themselves. **Delete organization** is an admin action that removes the organization for everyone, and it asks you to re-verify your identity first. Deleting is permanent, so treat it as a last resort.",
+						text: "At the bottom of the **Overview** tab, anyone can use **Leave organization** to remove themselves. **Delete organization** is an admin action that removes the organization for everyone, and it asks you to re-verify your identity first. Deleting is permanent, so treat it as a last resort. After you leave or delete, OneTool switches you to another organization you belong to, or takes you to the setup screen to create a new one.",
 					},
 				],
 			},


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View existing organization memberships during setup, including roles and organization details, with an option to switch.
  * Sign out directly from the organization setup flow.
  * Automatically switch to another organization after leaving or deleting one, or return to setup when none remain.

* **Bug Fixes**
  * Organization creation now continues even if logo upload fails.
  * Logo uploads now validate PNG, JPEG, and WEBP formats with clearer guidance.

* **Documentation**
  * Updated organization setup and profile guidance with supported formats, size limits, and switching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR improves organization onboarding and post-deletion/leave navigation, adds sign-out and existing-organization controls, tightens logo format handling, and updates related help content.
- Lists existing memberships during onboarding and lets users activate one.
- Attempts to activate another membership after leaving or deleting the active organization.
- Treats onboarding logo-upload failure as non-fatal.
- Restricts organization logos to PNG, JPEG, and WEBP and documents the supported formats.

<h3>Confidence Score: 4/5</h3>

The organization-switching error path should be fixed before merging because a failed activation currently clears the active organization and misroutes the user to onboarding.

The new fallback correctly handles users with no remaining memberships, but its broad catch also treats failure to activate a known remaining organization as the no-membership case.

**Files Needing Attention:** apps/web/src/app/(workspace)/organization/profile/_components/overview-tab.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/(onboarding)/organization/complete/complete-organization.tsx | Adds existing-organization switching, sign-out access, stricter logo validation, and non-fatal handling of logo upload failures during creation. |
| apps/web/src/app/(workspace)/organization/profile/_components/overview-tab.tsx | Adds post-leave/delete organization switching, but activation errors are incorrectly converted into the no-organization fallback. |
| apps/web/src/components/blocks/onboarding-2/components/onboarding-header.tsx | Adds an optional sign-out control alongside the existing back button. |
| packages/help-content/articles/getting-started.ts | Documents existing-organization switching and supported onboarding logo formats. |
| packages/help-content/articles/settings-and-team.ts | Documents logo formats and the intended organization fallback after leaving or deleting. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Leave or delete active organization] --> B[Fetch current Clerk memberships]
  B --> C{Remaining organization found?}
  C -->|Yes| D[Activate remaining organization]
  D -->|Success| E[Route through workspace root]
  D -->|Error| F[Current implementation catches error]
  C -->|No| G[Clear active organization]
  F --> G
  G --> H[Route to organization onboarding]
  H --> I[Display all existing memberships or create a new organization]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/src/app/(workspace)/organization/profile/_components/overview-tab.tsx:209-211
**Activation failure clears organization state**

When Clerk fails to activate a remaining organization after the user leaves or deletes the active one, this broad catch treats the error as though no memberships remain, clears the active organization, and sends the user to onboarding despite the known remaining membership.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(org): unstrand users after org delet..."](https://github.com/xcarter93/onetool/commit/38b4f86f5700f9d8d6ff53fb5a7418f645850be5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51308068)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Organizations, Auth Identity, and Permission Gating](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/org-auth-permissions.md)

<!-- /greptile_comment -->