### PR TITLE
feat(assistant): border beam attention cue on collapsed dock

### DIFF
--- a/apps/web/components.json
+++ b/apps/web/components.json
@@ -36,6 +36,7 @@
 			"headers": {
 				"Authorization": "Bearer ${REACTBITS_LICENSE_KEY}"
 			}
-		}
+		},
+		"@magicui": "https://magicui.design/r/{name}"
 	}
 }

--- a/apps/web/src/components/assistant/assistant-dock.tsx
+++ b/apps/web/src/components/assistant/assistant-dock.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { MessageCircle, Sparkles } from "lucide-react";
+import { BorderBeam } from "@/components/ui/border-beam";
 import { cn } from "@/lib/utils";
 
 /**
@@ -12,9 +13,11 @@ import { cn } from "@/lib/utils";
  */
 export function AssistantDock({
 	open,
+	pinned = false,
 	onOpen,
 }: {
 	open: boolean;
+	pinned?: boolean;
 	onOpen: () => void;
 }) {
 	return (
@@ -24,7 +27,7 @@ export function AssistantDock({
 			disabled={open}
 			aria-label="Open assistant chat"
 			className={cn(
-				"pointer-events-auto flex w-full max-w-sm cursor-pointer items-center gap-3 rounded-2xl border border-border bg-popover p-2 pr-2.5 text-left shadow-lg transition-[transform,opacity,box-shadow] duration-300 ease-out",
+				"pointer-events-auto relative flex w-full max-w-sm cursor-pointer items-center gap-3 rounded-2xl border border-border bg-popover p-2 pr-2.5 text-left shadow-lg transition-[transform,opacity,box-shadow] duration-300 ease-out",
 				"hover:-translate-y-0.5 hover:shadow-xl focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
 				open && "pointer-events-none opacity-0 duration-150"
 			)}
@@ -44,6 +47,22 @@ export function AssistantDock({
 				<MessageCircle className="size-3.5" />
 				Chat
 			</span>
+			{/* Subtle attention cue for the collapsed dock only; pinned users
+			    already know where the assistant lives. Radial (rotationally
+			    symmetric) glow instead of the default linear tail — the beam
+			    auto-rotates through corners, and a directional gradient makes
+			    that read as a snap. */}
+			{!open && !pinned && (
+				<BorderBeam
+					size={90}
+					duration={6}
+					pathRadius={16}
+					borderWidth={2}
+					colorFrom="var(--primary)"
+					colorTo="var(--primary)"
+					className="motion-reduce:hidden bg-[radial-gradient(circle_at_center,var(--color-from)_0%,var(--color-from)_20%,transparent_60%)]"
+				/>
+			)}
 		</button>
 	);
 }

--- a/apps/web/src/components/layout/sidebar-with-header.tsx
+++ b/apps/web/src/components/layout/sidebar-with-header.tsx
@@ -52,7 +52,7 @@ interface SidebarWithHeaderProps {
  * wrapper carries the width so its highlight ring (a ::after) hugs the dock.
  */
 function AssistantDockHost() {
-	const { open, setOpen, setDockAnchor } = useAssistantSurface();
+	const { open, pinned, setOpen, setDockAnchor } = useAssistantSurface();
 	return (
 		<>
 			<div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 flex justify-center px-4 pb-3 md:absolute">
@@ -68,7 +68,11 @@ function AssistantDockHost() {
 						HOME_TOUR_CONTENT[HomeTour.ASSISTANT_NOTCH].tooltipPosition
 					}
 				>
-					<AssistantDock open={open} onOpen={() => setOpen(true)} />
+					<AssistantDock
+							open={open}
+							pinned={pinned}
+							onOpen={() => setOpen(true)}
+						/>
 				</TourElement>
 			</div>
 			{/* Floating-panel anchor: AssistantPanel portals its unpinned overlay

--- a/apps/web/src/components/ui/border-beam.tsx
+++ b/apps/web/src/components/ui/border-beam.tsx
@@ -1,0 +1,114 @@
+"use client"
+
+import { motion, type MotionStyle, type Transition } from "motion/react"
+
+import { cn } from "@/lib/utils"
+
+interface BorderBeamProps {
+  /**
+   * The size of the border beam.
+   */
+  size?: number
+  /**
+   * The duration of the border beam.
+   */
+  duration?: number
+  /**
+   * The delay of the border beam.
+   */
+  delay?: number
+  /**
+   * The color of the border beam from.
+   */
+  colorFrom?: string
+  /**
+   * The color of the border beam to.
+   */
+  colorTo?: string
+  /**
+   * The motion transition of the border beam.
+   */
+  transition?: Transition
+  /**
+   * The class name of the border beam.
+   */
+  className?: string
+  /**
+   * The style of the border beam.
+   */
+  style?: React.CSSProperties
+  /**
+   * Whether to reverse the animation direction.
+   */
+  reverse?: boolean
+  /**
+   * The initial offset position (0-100).
+   */
+  initialOffset?: number
+  /**
+   * The border width of the beam.
+   */
+  borderWidth?: number
+  /**
+   * Corner radius of the travel path in px. Should match the host's
+   * border-radius; defaults to `size` (upstream magicui behavior), which
+   * distorts the path into a capsule on short hosts.
+   */
+  pathRadius?: number
+}
+
+export const BorderBeam = ({
+  className,
+  size = 50,
+  delay = 0,
+  duration = 6,
+  colorFrom = "#ffaa40",
+  colorTo = "#9c40ff",
+  transition,
+  style,
+  reverse = false,
+  initialOffset = 0,
+  borderWidth = 1,
+  pathRadius,
+}: BorderBeamProps) => {
+  return (
+    <div
+      className="pointer-events-none absolute inset-0 rounded-[inherit] border-(length:--border-beam-width) border-transparent mask-[linear-gradient(transparent,transparent),linear-gradient(#000,#000)] mask-intersect [mask-clip:padding-box,border-box]"
+      style={
+        {
+          "--border-beam-width": `${borderWidth}px`,
+        } as React.CSSProperties
+      }
+    >
+      <motion.div
+        className={cn(
+          "absolute aspect-square",
+          "bg-linear-to-l from-(--color-from) via-(--color-to) to-transparent",
+          className
+        )}
+        style={
+          {
+            width: size,
+            offsetPath: `rect(0 auto auto 0 round ${pathRadius ?? size}px)`,
+            "--color-from": colorFrom,
+            "--color-to": colorTo,
+            ...style,
+          } as MotionStyle
+        }
+        initial={{ offsetDistance: `${initialOffset}%` }}
+        animate={{
+          offsetDistance: reverse
+            ? [`${100 - initialOffset}%`, `${-initialOffset}%`]
+            : [`${initialOffset}%`, `${100 + initialOffset}%`],
+        }}
+        transition={{
+          repeat: Infinity,
+          ease: "linear",
+          duration,
+          delay: -delay,
+          ...transition,
+        }}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
Vendored magicui border-beam (with a pathRadius prop so the travel path matches the host's border-radius instead of capsule-warping on short hosts) and a rotationally symmetric radial glow so corners don't snap. Shown only while the dock is collapsed and unpinned; hidden under reduced motion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual glow animation to the assistant button when it is available but closed.
  * The attention effect automatically respects reduced-motion accessibility preferences.
  * Added support for keeping the assistant button pinned while preserving its open and closed states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a vendored, radius-aware BorderBeam animation to draw attention to the collapsed assistant dock while leaving pinned, open, and reduced-motion states unaffected.
- Adds the Magic UI registry to the web component configuration.
- Introduces a reusable BorderBeam component with configurable path radius, colors, timing, and direction.
- Passes assistant pin state into the dock and renders the cue only when the assistant is closed and unpinned.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The cue is restricted to the intended collapsed and unpinned state, respects reduced-motion preferences, and the existing pin state is passed through without altering assistant lifecycle behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/assistant/assistant-dock.tsx | Adds the animated attention cue with explicit open, pinned, and reduced-motion visibility controls. |
| apps/web/src/components/layout/sidebar-with-header.tsx | Threads the existing assistant pin state into AssistantDock without changing panel state management. |
| apps/web/src/components/ui/border-beam.tsx | Adds a configurable motion-path border animation whose path radius can match the host component. |
| apps/web/components.json | Registers the Magic UI component source alongside the existing registries. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  S[Assistant dock state] --> O{Open?}
  O -->|Yes| H[Dock fades; no border beam]
  O -->|No| P{Pinned?}
  P -->|Yes| N[Collapsed dock without cue]
  P -->|No| R{Reduced motion?}
  R -->|Yes| M[Collapsed dock; beam hidden]
  R -->|No| B[Collapsed dock with animated border beam]
```

<sub>Reviews (1): Last reviewed commit: ["feat(assistant): border beam attention c..."](https://github.com/xcarter93/onetool/commit/23367cef308fb656e2c152aa095bb4ea15b98675) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51364178)</sub>

<!-- /greptile_comment -->