### PR TITLE
Fix phone mock aspect ratio and update SiteHeader behavior

### DIFF
--- a/apps/web/src/app/(workspace)/community/edit/live-preview-pane.tsx
+++ b/apps/web/src/app/(workspace)/community/edit/live-preview-pane.tsx
@@ -3,7 +3,7 @@
 import { useDeferredValue, useState } from "react";
 import { Monitor, Smartphone } from "lucide-react";
 import { SegmentedControl } from "@/components/domain/segmented-control";
-import { Iphone } from "@/components/ui/iphone";
+import { IPHONE_FRAME, Iphone } from "@/components/ui/iphone";
 import type { CommunitySectionId } from "@/lib/community-sections";
 import {
 	CommunityPageView,
@@ -112,10 +112,15 @@ export function LivePreviewPane({
 					</div>
 				</div>
 			) : (
-				<div className="flex min-h-0 flex-1 items-center justify-center">
+				<div className="@container flex min-h-0 flex-1 items-center justify-center">
+					{/* Contain-fit by capping height at what the column width can carry;
+					    a max-width clamp would break the ratio — see IPHONE_FRAME. */}
 					<Iphone
 						className="shrink-0"
-						style={{ height: "100%", width: "auto", maxWidth: "100%" }}
+						style={{
+							height: `min(100%, 100cqw * ${IPHONE_FRAME.height} / ${IPHONE_FRAME.width})`,
+							width: "auto",
+						}}
 					>
 						<PreviewFrame
 							width={DEVICE_WIDTH.mobile}

--- a/apps/web/src/app/communities/[slug]/components/site-header.tsx
+++ b/apps/web/src/app/communities/[slug]/components/site-header.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useRef } from "react";
 import Image from "next/image";
-import { cn } from "@/lib/utils";
 
 interface NavAnchor {
 	id: string;
@@ -17,8 +16,10 @@ interface SiteHeaderProps {
 }
 
 /**
- * Sticky page header for the public community page. Goes opaque once the hero
- * scrolls past so the business name and CTA stay legible over any content.
+ * Sticky page header for the public community page. The bar is always drawn —
+ * it sits in flow rather than over a hero, so a transparent resting state just
+ * reads as a logo floating in a gap. Content passes under the frosted fill on
+ * scroll. Opacity stays high enough to hold AA over a bright banner photo.
  * The CTA is desktop-only — on phones MobileActionBar carries it.
  */
 export function SiteHeader({
@@ -27,28 +28,20 @@ export function SiteHeader({
 	anchors,
 	contactFormId,
 }: SiteHeaderProps) {
-	const [scrolled, setScrolled] = useState(false);
+	const headerRef = useRef<HTMLElement>(null);
 
-	useEffect(() => {
-		const onScroll = () => setScrolled(window.scrollY > 24);
-		onScroll();
-		window.addEventListener("scroll", onScroll, { passive: true });
-		return () => window.removeEventListener("scroll", onScroll);
-	}, []);
-
+	// The editor previews this page inside an iframe, so the component runs in the
+	// host realm while its DOM lives in another document — a bare `document` would
+	// search the editor page instead of the previewed one.
 	const scrollToForm = () =>
-		document
+		headerRef.current?.ownerDocument
 			.getElementById(contactFormId)
 			?.scrollIntoView({ behavior: "smooth", block: "start" });
 
 	return (
 		<header
-			className={cn(
-				"sticky top-0 z-30 transition-colors duration-200",
-				scrolled
-					? "bg-background/95 supports-[backdrop-filter]:bg-background/80 backdrop-blur border-b border-border"
-					: "bg-transparent border-b border-transparent"
-			)}
+			ref={headerRef}
+			className="sticky top-0 z-30 border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/90"
 		>
 			<div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center gap-4">
 				<a

--- a/apps/web/src/components/ui/iphone.tsx
+++ b/apps/web/src/components/ui/iphone.tsx
@@ -2,6 +2,14 @@ import type { HTMLAttributes, ReactNode } from "react"
 
 const PHONE_WIDTH = 433
 const PHONE_HEIGHT = 882
+
+/**
+ * Frame dimensions, exported so callers can size the shell from the same ratio.
+ * Size exactly one axis: clamping both (a `height` plus a `max-width` that
+ * bites) drops the aspect ratio, and the bezel SVG then letterboxes away from
+ * the percentage-positioned screen slot, spilling the page past the phone.
+ */
+export const IPHONE_FRAME = { width: PHONE_WIDTH, height: PHONE_HEIGHT } as const
 const SCREEN_X = 21.25
 const SCREEN_Y = 19.25
 const SCREEN_WIDTH = 389.5


### PR DESCRIPTION
This pull request makes targeted improvements to the live preview pane and the site header components, focusing on better device frame rendering and simplifying header behavior. The changes ensure correct aspect ratio handling for the iPhone frame in previews and streamline the header's logic and appearance, particularly for embedded/iframe contexts.

**Device frame rendering improvements:**

* Exported the `IPHONE_FRAME` dimensions from `iphone.tsx` so that callers can use the same aspect ratio logic, preventing layout issues and letterboxing in the live preview pane. (`apps/web/src/components/ui/iphone.tsx`)
* Updated the preview pane to use the `IPHONE_FRAME` dimensions and container queries for responsive sizing, ensuring the iPhone frame maintains the correct aspect ratio regardless of container width. (`apps/web/src/app/(workspace)/community/edit/live-preview-pane.tsx`) [[1]](diffhunk://#diff-f225945dedc28b11d8c0988cc749bc100404a7e23ab856eb048ac370ff6978a1L6-R6) [[2]](diffhunk://#diff-f225945dedc28b11d8c0988cc749bc100404a7e23ab856eb048ac370ff6978a1L115-R123)

**Site header simplification and robustness:**

* Refactored the site header to remove scroll-based opacity changes, making the header always visible and styled for accessibility over varied backgrounds. The header now uses a consistent frosted fill and border. (`apps/web/src/app/communities/[slug]/components/site-header.tsx`) ([apps/web/src/app/communities/[slug]/components/site-header.tsxL20-R22](diffhunk://#diff-1558195387e2ea159af89d085e6e0a597b5782f877eae286077131326ff4862cL20-R22), [apps/web/src/app/communities/[slug]/components/site-header.tsxL30-R44](diffhunk://#diff-1558195387e2ea159af89d085e6e0a597b5782f877eae286077131326ff4862cL30-R44))
* Replaced `useState`/`useEffect` scroll tracking with a `useRef` to the header element, and updated the smooth scroll-to-form logic to work correctly when the header is rendered in an iframe (e.g., in the editor preview). (`apps/web/src/app/communities/[slug]/components/site-header.tsx`) ([apps/web/src/app/communities/[slug]/components/site-header.tsxL3-L5](diffhunk://#diff-1558195387e2ea159af89d085e6e0a597b5782f877eae286077131326ff4862cL3-L5), [apps/web/src/app/communities/[slug]/components/site-header.tsxL30-R44](diffhunk://#diff-1558195387e2ea159af89d085e6e0a597b5782f877eae286077131326ff4862cL30-R44))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved the mobile preview so the iPhone frame scales proportionally and fits the available space more reliably.
  - Updated site headers with a consistent frosted background and border for clearer visual stability.
  - Improved contact navigation so selecting the contact option smoothly scrolls to the form in the current page context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects mobile preview frame sizing by sharing the iPhone aspect ratio and simplifies the public community header while making its CTA lookup iframe-aware.
- Exports reusable iPhone frame dimensions and contain-fits the mobile preview with container-relative sizing.
- Replaces scroll-dependent header transparency with a consistent frosted header.
- Resolves the contact form through the header element’s owning document so preview iframe navigation works.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete changed-code failures identified.

The new frame sizing remains bounded by the preview container, and the header CTA resolves its synchronously rendered target in both the public document and iframe preview document.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/(workspace)/community/edit/live-preview-pane.tsx | Uses the exported frame ratio and container width to keep the mobile preview bounded without distorting the phone shell. |
| apps/web/src/app/communities/[slug]/components/site-header.tsx | Removes scroll-state styling and scopes contact-form lookup to the document containing the rendered header. |
| apps/web/src/components/ui/iphone.tsx | Exports the existing frame dimensions as a shared immutable aspect-ratio contract. |

<sub>Reviews (1): Last reviewed commit: ["fix(community): keep the phone mock in r..."](https://github.com/xcarter93/onetool/commit/57e8d9b4442ccb1d5182e3000c34c736a99b947c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51959730)</sub>

**Context used:**

- Knowledge Base — [Notifications and Community Pages](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/notifications-and-community.md)

<!-- /greptile_comment -->