### PR TITLE
docs(help): drop the QuickBooks and Community availability gates

### DIFF
--- a/apps/web/src/lib/feature-flags.ts
+++ b/apps/web/src/lib/feature-flags.ts
@@ -8,7 +8,8 @@
 
 /**
  * Gates the whole QuickBooks Online integration: connecting, syncing, and the
- * customer import. Held off while Intuit production approval is pending.
+ * customer import. Rolled out to 100% of users on 2026-08-10; kept as a kill
+ * switch, so the off-state UI below it is still reachable.
  * Flag: https://us.posthog.com/project/265773/feature_flags/808384
  */
 export const FLAG_QUICKBOOKS = "quickbooks-integration";

--- a/packages/help-content/articles/community.ts
+++ b/packages/help-content/articles/community.ts
@@ -36,10 +36,6 @@ export const communityArticles: HelpArticle[] = [
 						type: "paragraph",
 						text: "Your community page is a free public landing page for your business, hosted by OneTool at onetool.biz/communities/your-page-url. It can show a banner, your logo, a bio, a photo gallery, your services and pricing, business hours, credentials, and social links, and it includes a built-in form visitors use to request a quote.",
 					},
-					{
-						type: "note",
-						text: "If **Community** appears grayed out in your sidebar with a coming soon message, the feature is not enabled for your organization yet.",
-					},
 				],
 			},
 			{

--- a/packages/help-content/articles/settings-and-team.ts
+++ b/packages/help-content/articles/settings-and-team.ts
@@ -124,10 +124,6 @@ export const settingsAndTeamArticles: HelpArticle[] = [
 				heading: "Integrations",
 				blocks: [
 					{
-						type: "note",
-						text: "QuickBooks Online is not open to everyone yet. While we finish certification with Intuit, the QuickBooks card shows a **Coming soon** badge and the **Connect** button is inactive. Everything below describes how it works once it is switched on for your organization.",
-					},
-					{
 						type: "paragraph",
 						text: "The **Integrations** tab is available on the Business plan to organization admins. It lists one card per integration, and it is where the organization owner connects a QuickBooks Online company, which prepares your account for QuickBooks sync of clients, invoices, and payments from OneTool.",
 					},
@@ -618,10 +614,6 @@ export const settingsAndTeamArticles: HelpArticle[] = [
 			{
 				heading: "OneTool is the source of truth",
 				blocks: [
-					{
-						type: "note",
-						text: "QuickBooks sync is still being certified with Intuit and is not available to connect yet. This article describes how it behaves once it is switched on for your organization.",
-					},
 					{
 						type: "paragraph",
 						text: "The QuickBooks integration syncs one way: from OneTool to QuickBooks. Records you create and update in OneTool are pushed to QuickBooks automatically, usually within a couple of minutes. Changes made inside QuickBooks are never pulled back into OneTool, and the next time a synced record changes in OneTool it is pushed again, replacing edits made on the QuickBooks side.",


### PR DESCRIPTION
Both features are now rolled out to 100% of users in PostHog (quickbooks-integration 808384, community-pages-access 392738), so the help center notes explaining their locked states are wrong.

Removes three notes rather than rewording them — each existed only to explain a gate that no longer exists, and the surrounding articles already describe both features in the present tense:

- settings-and-team: "not open to everyone yet ... finish certification with Intuit" on the Integrations section
- settings-and-team: "still being certified with Intuit and is not available to connect yet" on the QuickBooks sync article
- community: "grayed out in your sidebar with a coming soon message"

Also corrects the now-stale FLAG_QUICKBOOKS comment.

The in-app "Coming soon" states are flag-conditioned, not hardcoded, so they resolve on their own. Their copy is left alone deliberately: both flags are kept as kill switches, so that fallback UI stays reachable and still claims certification is in progress — tracked for a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated QuickBooks documentation to reflect full rollout while retaining an emergency disable option.
  * Removed temporary QuickBooks availability and certification notices.
  * Removed outdated messaging about Community feature availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes stale help-center availability notices now that the QuickBooks and Community features are fully rolled out.
- Removes the Community gated-availability note.
- Removes two QuickBooks certification and availability notes.
- Updates the QuickBooks feature-flag comment to document its continued use as a kill switch.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only updates comments and help content, with the remaining kill-switch fallback discrepancy explicitly acknowledged for follow-up.

No actionable defect remains beyond the deliberately retained and documented fallback behavior when either feature flag is disabled.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/feature-flags.ts | Updates documentation for the unchanged QuickBooks feature flag to reflect full rollout and its retained kill-switch role. |
| packages/help-content/articles/community.ts | Removes the obsolete Community availability-gate note without changing article structure or runtime behavior. |
| packages/help-content/articles/settings-and-team.ts | Removes two obsolete QuickBooks certification and availability notes while preserving current plan and role prerequisites. |

<sub>Reviews (1): Last reviewed commit: ["docs(help): drop the QuickBooks and Comm..."](https://github.com/xcarter93/onetool/commit/f3157766da2dbf39e278d48c56078f95e24c9dc0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51970597)</sub>

<!-- /greptile_comment -->