### PR TITLE
Feature/mobile 3.0

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,5 +1,7 @@
 import { Tabs, Redirect } from "expo-router";
 import type { Href } from "expo-router";
+import { View } from "react-native";
+import { SpeedDialFab } from "@/components/speed-dial-fab";
 import { useAuth, useOrganization, useOrganizationList } from "@clerk/expo";
 import { useQuery } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
@@ -56,6 +58,7 @@ export default function TabLayout() {
   }
 
   return (
+    <View style={{ flex: 1 }}>
     <Tabs
       screenOptions={{ headerShown: false }}
       tabBar={(props) => <GlassDock {...props} />}
@@ -75,5 +78,9 @@ export default function TabLayout() {
       {/* Profile reached via the header avatar (per CONTEXT) */}
       <Tabs.Screen name="profile" options={{ href: null }} />
     </Tabs>
+    {/* Speed-dial capture fan — sibling of Tabs so its open-state backdrop
+        paints over screens AND the dock (slice 5). */}
+    <SpeedDialFab />
+    </View>
   );
 }

--- a/apps/mobile/app/(tabs)/clients/[clientId].tsx
+++ b/apps/mobile/app/(tabs)/clients/[clientId].tsx
@@ -9,7 +9,7 @@ import {
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
 import { useLocalSearchParams, useRouter, type Href } from "expo-router";
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useOrganization } from "@clerk/expo";
 import {
 	SafeAreaView,
@@ -147,15 +147,21 @@ export function ClientDetailBody({
 	const recentId = client?._id;
 	const recentTitle = client?.companyName;
 	const recentSub = client?.companyDescription?.trim() || properties[0]?.city;
+	// One-shot per visit (same guard as the projects screen): recentSub arrives
+	// late with the properties query and would otherwise re-record the visit.
+	const recordedRef = useRef<string | null>(null);
 	useEffect(() => {
-		if (!recentId || !recentTitle) return;
+		if (!recentId || !recentTitle || !orgId) return;
+		if (recordedRef.current === recentId) return;
+		recordedRef.current = recentId;
 		recordRecentView(orgId, {
 			kind: "client",
 			id: recentId,
 			title: recentTitle,
 			sub: recentSub,
 		});
-	}, [orgId, recentId, recentTitle, recentSub]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [orgId, recentId, recentTitle]);
 
 	const updateClient = useMutation(api.clients.update);
 

--- a/apps/mobile/app/(tabs)/clients/[clientId].tsx
+++ b/apps/mobile/app/(tabs)/clients/[clientId].tsx
@@ -357,7 +357,6 @@ export function ClientDetailBody({
 				<IdentityBlock
 					tint={recordTint.client}
 					monogram={client.companyName}
-					title={client.companyName}
 					statusKey={status}
 					sub={identitySub}
 					renderStatus={(statusText) => (
@@ -601,7 +600,32 @@ export function ClientDetailBody({
 
 				{/* Quotes */}
 				<View style={styles.section}>
-					<SectionHeader title={`Quotes${countSuffix(quotes.length)}`} />
+					<View style={styles.headerRow}>
+						<View style={styles.headerGrow}>
+							<SectionHeader title={`Quotes${countSuffix(quotes.length)}`} />
+						</View>
+						<Pressable
+							onPress={() =>
+								// Cast: /quote/new isn't in the generated route map yet.
+								router.push({
+									pathname: "/quote/new",
+									params: { clientId },
+								} as unknown as Href)
+							}
+							hitSlop={12}
+							accessibilityRole="button"
+							accessibilityLabel="New quote for this client"
+							style={({ pressed }) => [
+								styles.newAction,
+								pressed && styles.pressed,
+							]}
+						>
+							<Plus size={14} color={t.frostedInk} />
+							<Text style={[styles.newActionText, { color: t.frostedInk }]}>
+								New quote
+							</Text>
+						</Pressable>
+					</View>
 					{recentQuotes.length > 0 ? (
 						<View>
 							{recentQuotes.map((quote, i) => (

--- a/apps/mobile/app/(tabs)/clients/[clientId].tsx
+++ b/apps/mobile/app/(tabs)/clients/[clientId].tsx
@@ -20,25 +20,23 @@ import {
 	DOCK_CLEARANCE,
 	fontFamily,
 	radii,
+	recordTint,
 	STATUS,
 	touch,
+	type,
 	useTokens,
 } from "@/lib/theme";
 import { formatCurrency } from "@/lib/format";
+import { appleMapsAddressUrl, appleMapsUrl } from "@/lib/route-run";
 import { AppHeader } from "@/components/app-header";
 import { PaneHeader } from "@/components/ipad/pane-header";
 import { useShellNav } from "@/lib/shell-nav";
 import { EditableField } from "@/components/EditableField";
 import { FieldMenu } from "@/components/FieldMenu";
 import { MentionModal } from "@/components/MentionModal";
-import {
-	Card,
-	Avatar,
-	Badge,
-	DotGrid,
-	SectionHeader,
-	ListRow,
-} from "@/components/ui";
+import { IdentityBlock } from "@/components/identity-block";
+import { QuickActions, type QuickAction } from "@/components/quick-actions";
+import { DotGrid, SectionHeader, ListRow } from "@/components/ui";
 import {
 	Illustration,
 	type IllustrationName,
@@ -47,8 +45,8 @@ import {
 	Phone,
 	Mail,
 	MessageSquare,
-	MapPin,
-	User,
+	Navigation,
+	Plus,
 } from "lucide-react-native";
 
 type ClientStatus = "lead" | "active" | "inactive" | "archived";
@@ -62,6 +60,18 @@ const STATUS_OPTIONS = [
 	// client. The list still hides archived from its default view (Plan 03).
 	{ value: "archived", label: "Archived" },
 ];
+
+const LEAD_SOURCE_LABEL: Record<string, string> = {
+	"word-of-mouth": "Word of mouth",
+	website: "Website",
+	"social-media": "Social media",
+	referral: "Referral",
+	advertising: "Advertising",
+	"trade-show": "Trade show",
+	"cold-outreach": "Cold outreach",
+	"community-page": "Community page",
+	other: "Other",
+};
 
 // Body extracted (P26 Option B) so the iPad pane can render this without the
 // route shell. headerMode DEFAULTS to "root" → the iPhone route wrapper below is
@@ -171,49 +181,156 @@ export function ClientDetailBody({
 				) : (
 					<AppHeader mode={appHeaderMode} />
 				)}
+				{/* Skeleton is shaped like the real layout: monogram + name, the
+				    four action tiles, then list rows. */}
 				<ScrollView
 					contentContainerStyle={[
 						styles.scroll,
 						{ paddingBottom: scrollBottom },
 					]}
 				>
-					<View
-						style={[
-							styles.skeletonCard,
-							{ backgroundColor: t.card, borderColor: t.line },
-						]}
-					/>
-					<View
-						style={[
-							styles.skeletonRow,
-							{ backgroundColor: t.muted, marginTop: 14 },
-						]}
-					/>
-					<View
-						style={[
-							styles.skeletonRow,
-							{ backgroundColor: t.muted, marginTop: 10 },
-						]}
-					/>
+					<View style={styles.skeletonIdentity}>
+						<View
+							style={[
+								styles.skeletonMonogram,
+								{ backgroundColor: t.lineSoft },
+							]}
+						/>
+						<View style={styles.skeletonIdentityBody}>
+							<View
+								style={[
+									styles.skeletonBar,
+									{ width: "70%", height: 20, backgroundColor: t.lineSoft },
+								]}
+							/>
+							<View
+								style={[
+									styles.skeletonBar,
+									{
+										width: "30%",
+										height: 11,
+										marginTop: 8,
+										backgroundColor: t.lineSoft,
+									},
+								]}
+							/>
+						</View>
+					</View>
+					<View style={styles.skeletonTiles}>
+						{[0, 1, 2, 3].map((i) => (
+							<View
+								key={i}
+								style={[
+									styles.skeletonTile,
+									{ backgroundColor: t.lineSoft },
+								]}
+							/>
+						))}
+					</View>
+					{[0, 1, 2].map((i) => (
+						<View key={i} style={styles.skeletonRow}>
+							<View
+								style={[
+									styles.skeletonRowTile,
+									{ backgroundColor: t.lineSoft },
+								]}
+							/>
+							<View style={styles.skeletonIdentityBody}>
+								<View
+									style={[
+										styles.skeletonBar,
+										{ width: "55%", height: 13, backgroundColor: t.lineSoft },
+									]}
+								/>
+								<View
+									style={[
+										styles.skeletonBar,
+										{
+											width: "35%",
+											height: 11,
+											marginTop: 6,
+											backgroundColor: t.lineSoft,
+										},
+									]}
+								/>
+							</View>
+						</View>
+					))}
 				</ScrollView>
 			</SafeAreaView>
 		);
 	}
 
-	const initials = client.companyName
-		.split(" ")
-		.map((w) => w[0])
-		.join("")
-		.slice(0, 2)
-		.toUpperCase();
 	const status = optimisticStatus ?? client.status;
-	const statusLabel = STATUS[status as keyof typeof STATUS]?.label ?? status;
 
 	const primaryProperty = properties.find((p) => p.isPrimary) ?? properties[0];
+	const primaryContact = contacts.find((c) => c.isPrimary) ?? contacts[0];
+
+	const propertyAddress = primaryProperty
+		? primaryProperty.formattedAddress ||
+			[
+				primaryProperty.streetAddress,
+				primaryProperty.city,
+				primaryProperty.state,
+				primaryProperty.zipCode,
+			]
+				.filter(Boolean)
+				.join(", ")
+		: undefined;
+
+	// Identity sub line: lead source, else the primary property's city.
+	const identitySub = client.leadSource
+		? (LEAD_SOURCE_LABEL[client.leadSource] ?? client.leadSource)
+		: primaryProperty?.city || undefined;
+
+	const phone = primaryContact?.phone;
+	const email = primaryContact?.email;
+	const directionsUrl =
+		primaryProperty &&
+		primaryProperty.latitude !== undefined &&
+		primaryProperty.longitude !== undefined
+			? appleMapsUrl(primaryProperty.latitude, primaryProperty.longitude)
+			: propertyAddress
+				? appleMapsAddressUrl(propertyAddress)
+				: undefined;
+
+	// Every tile stays visible; missing data dims it rather than hiding it.
+	const quickActions: QuickAction[] = [
+		{
+			key: "call",
+			label: "Call",
+			Icon: Phone,
+			disabled: !phone,
+			onPress: () => phone && Linking.openURL(`tel:${phone}`),
+		},
+		{
+			key: "message",
+			label: "Message",
+			Icon: MessageSquare,
+			disabled: !phone,
+			onPress: () => phone && Linking.openURL(`sms:${phone}`),
+		},
+		{
+			key: "email",
+			label: "Email",
+			Icon: Mail,
+			disabled: !email,
+			onPress: () => email && Linking.openURL(`mailto:${email}`),
+		},
+		{
+			key: "directions",
+			label: "Directions",
+			Icon: Navigation,
+			disabled: !directionsUrl,
+			onPress: () => directionsUrl && Linking.openURL(directionsUrl),
+		},
+	];
 
 	const recentProjects = projects.slice(0, 3);
 	const recentQuotes = quotes.slice(0, 3);
 	const recentInvoices = invoices.slice(0, 3);
+
+	const tags = client.tags?.filter(Boolean) ?? [];
 
 	return (
 		<SafeAreaView
@@ -235,49 +352,42 @@ export function ClientDetailBody({
 					<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
 				}
 			>
-				{/* Identity */}
-				<Card>
-					<View style={styles.identityRow}>
-						<Avatar text={initials} size={56} />
-						<View style={styles.identityBody}>
-							<Text
-								style={[styles.companyName, { color: t.ink }]}
-								numberOfLines={2}
+				{/* Identity — status is TEXT; the FieldMenu hangs off it so the one
+				    place a client status can change keeps working. */}
+				<IdentityBlock
+					tint={recordTint.client}
+					monogram={client.companyName}
+					title={client.companyName}
+					statusKey={status}
+					sub={identitySub}
+					renderStatus={(statusText) => (
+						<FieldMenu
+							title="Client status"
+							value={status}
+							options={STATUS_OPTIONS}
+							onSelect={handleSelectStatus}
+						>
+							{/* A single bare child is the whole trigger — a row sibling
+							    gets squeezed by the native menu host and clips the label. */}
+							<View
+								accessibilityRole="button"
+								// Status-as-text removed the badge, so the label must still
+								// speak the CURRENT value — the trigger's label overrides the
+								// child Text for VoiceOver.
+								accessibilityLabel={`Status: ${
+									STATUS[status as keyof typeof STATUS]?.label ?? status
+								}. Tap to change`}
+								style={[styles.statusTrigger, { borderBottomColor: t.faint }]}
 							>
-								{client.companyName}
-							</Text>
-							{/* alignSelf:flex-start sizes the menu host to its content.
-							    The parent identityBody is flex:1/minWidth:0 (so the long
-							    company name wraps), which otherwise stretches the native
-							    MenuView trigger and clips the Badge label to "..". The
-							    project pill avoids this only because its parent uses
-							    alignItems:flex-end. */}
-							<View style={styles.statusWrap}>
-								<FieldMenu
-									title="Client status"
-									value={status}
-									options={STATUS_OPTIONS}
-									onSelect={handleSelectStatus}
-								>
-									{/* Bare Badge is the sole trigger child — a row sibling
-									    (e.g. a chevron) gets squeezed by the native menu host
-									    and clips the label. Underline affordance matches the
-									    project status pill. */}
-									<View
-										accessibilityRole="button"
-										accessibilityLabel={`Status: ${statusLabel}. Tap to change`}
-										style={[
-											styles.statusTrigger,
-											{ borderBottomColor: t.faint },
-										]}
-									>
-										<Badge status={status} big />
-									</View>
-								</FieldMenu>
+								{statusText}
 							</View>
-						</View>
-					</View>
-				</Card>
+						</FieldMenu>
+					)}
+				/>
+
+				<View style={styles.actionsWrap}>
+					<QuickActions actions={quickActions} />
+				</View>
 
 				{/* Team chat — relocated from the old floating FAB */}
 				<Pressable
@@ -296,16 +406,34 @@ export function ClientDetailBody({
 					</Text>
 				</Pressable>
 
-				{/* Company (inline edit) */}
+				{/* Company — quiet stacked text, no card */}
 				<View style={styles.section}>
 					<SectionHeader title="Company" />
-					<Card style={styles.fieldCard}>
+					<View style={styles.stack}>
 						<EditableField
 							label="Company name"
 							value={client.companyName}
 							onSave={(value) => handleSaveField("companyName", value)}
 							placeholder="Company name"
 						/>
+						{client.companyDescription ? (
+							<View style={styles.readField}>
+								<Text style={[styles.readLabel, { color: t.faint }]}>
+									Description
+								</Text>
+								<Text style={[styles.readValue, { color: t.ink }]}>
+									{client.companyDescription}
+								</Text>
+							</View>
+						) : null}
+						{tags.length > 0 ? (
+							<View style={styles.readField}>
+								<Text style={[styles.readLabel, { color: t.faint }]}>Tags</Text>
+								<Text style={[styles.readValue, { color: t.ink }]}>
+									{tags.join("  ·  ")}
+								</Text>
+							</View>
+						) : null}
 						<EditableField
 							label="Notes"
 							value={client.notes}
@@ -314,72 +442,40 @@ export function ClientDetailBody({
 							multiline
 							numberOfLines={4}
 						/>
-					</Card>
+					</View>
 				</View>
 
 				{/* Contacts (read-only; Call on phone) */}
 				<View style={styles.section}>
 					<SectionHeader title={`Contacts${countSuffix(contacts.length)}`} />
 					{contacts.length > 0 ? (
-						<Card style={styles.listCard}>
+						<View>
 							{contacts.map((contact, i) => {
 								const name =
 									`${contact.firstName} ${contact.lastName}`.trim() ||
 									"Unnamed contact";
-								const isLast = i === contacts.length - 1;
+								const sub =
+									[
+										contact.isPrimary ? "Primary" : null,
+										contact.jobTitle,
+										contact.email,
+									]
+										.filter(Boolean)
+										.join("  ·  ") || undefined;
 								return (
-									<View
+									<ListRow
 										key={contact._id}
-										style={[
-											styles.contactRow,
-											{
-												borderBottomColor: t.line,
-												borderBottomWidth: isLast ? 0 : 1,
-											},
-										]}
-									>
-										<View style={styles.contactHead}>
-											<View
-												style={[
-													styles.contactIcon,
-													{ backgroundColor: t.secondary },
-												]}
-											>
-												<User size={16} color={t.sub} />
-											</View>
-											<View style={styles.contactInfo}>
-												<Text
-													style={[styles.contactName, { color: t.ink }]}
-													numberOfLines={1}
-												>
-													{name}
-													{contact.isPrimary ? "  ·  Primary" : ""}
-												</Text>
-												{contact.jobTitle ? (
-													<Text
-														style={[styles.contactSub, { color: t.sub }]}
-														numberOfLines={1}
-													>
-														{contact.jobTitle}
-													</Text>
-												) : null}
-											</View>
-										</View>
-										<View style={styles.contactActions}>
-											{contact.email ? (
-												<View style={styles.contactLine}>
-													<Mail size={14} color={t.faint} />
-													<Text
-														style={[styles.contactLineText, { color: t.sub }]}
-														numberOfLines={1}
-													>
-														{contact.email}
-													</Text>
-												</View>
-											) : null}
-											{contact.phone ? (
+										icon="User"
+										title={name}
+										sub={sub}
+										showChevron={false}
+										last={i === contacts.length - 1}
+										right={
+											contact.phone ? (
 												<Pressable
-													onPress={() => Linking.openURL(`tel:${contact.phone}`)}
+													onPress={() =>
+														Linking.openURL(`tel:${contact.phone}`)
+													}
 													accessibilityRole="button"
 													accessibilityLabel={`Call ${name}`}
 													hitSlop={8}
@@ -396,31 +492,29 @@ export function ClientDetailBody({
 														{contact.phone}
 													</Text>
 												</Pressable>
-											) : null}
-										</View>
-									</View>
+											) : undefined
+										}
+									/>
 								);
 							})}
-						</Card>
+						</View>
 					) : (
 						// Web aliases client-contacts-none onto the clients art — same here.
 						<EmptyRow text="No contacts yet" illo="clients-none" />
 					)}
 				</View>
 
-				{/* Properties (the section missing today) */}
+				{/* Properties */}
 				<View style={styles.section}>
 					<SectionHeader
 						title={`Properties${countSuffix(properties.length)}`}
 					/>
 					{properties.length > 0 ? (
-						<Card style={styles.listCard}>
+						<View>
 							{properties.map((property, i) => {
 								const title =
-									property.propertyName ||
-									property.streetAddress ||
-									"Property";
-								const sub =
+									property.propertyName || property.streetAddress || "Property";
+								const address =
 									property.formattedAddress ||
 									[
 										property.streetAddress,
@@ -432,47 +526,17 @@ export function ClientDetailBody({
 										.join(", ");
 								const isPrimary = property._id === primaryProperty?._id;
 								return (
-									<View
+									<ListRow
 										key={property._id}
-										style={[
-											styles.contactRow,
-											{
-												borderBottomColor: t.line,
-												borderBottomWidth: i === properties.length - 1 ? 0 : 1,
-											},
-										]}
-									>
-										<View style={styles.contactHead}>
-											<View
-												style={[
-													styles.contactIcon,
-													{ backgroundColor: t.secondary },
-												]}
-											>
-												<MapPin size={16} color={t.sub} />
-											</View>
-											<View style={styles.contactInfo}>
-												<Text
-													style={[styles.contactName, { color: t.ink }]}
-													numberOfLines={1}
-												>
-													{title}
-													{isPrimary ? "  ·  Primary" : ""}
-												</Text>
-												{sub ? (
-													<Text
-														style={[styles.contactSub, { color: t.sub }]}
-														numberOfLines={2}
-													>
-														{sub}
-													</Text>
-												) : null}
-											</View>
-										</View>
-									</View>
+										icon="MapPin"
+										title={isPrimary ? `${title}  ·  Primary` : title}
+										sub={address || undefined}
+										showChevron={false}
+										last={i === properties.length - 1}
+									/>
 								);
 							})}
-						</Card>
+						</View>
 					) : (
 						<EmptyRow text="No properties yet" illo="client-properties-none" />
 					)}
@@ -480,16 +544,41 @@ export function ClientDetailBody({
 
 				{/* Projects */}
 				<View style={styles.section}>
-					<SectionHeader
-						title={`Projects${countSuffix(projects.length)}`}
-						action={projects.length > 0 ? "View all" : undefined}
-						onAction={() =>
-							// iPad: scope Work's chip to Projects. iPhone keeps the route.
-							shellNav ? shellNav.browse("project") : router.push("/projects")
-						}
-					/>
+					<View style={styles.headerRow}>
+						<View style={styles.headerGrow}>
+							<SectionHeader
+								title={`Projects${countSuffix(projects.length)}`}
+								action={projects.length > 0 ? "View all" : undefined}
+								onAction={() =>
+									// iPad: scope Work's chip to Projects. iPhone keeps the route.
+									shellNav ? shellNav.browse("project") : router.push("/projects")
+								}
+							/>
+						</View>
+						<Pressable
+							onPress={() =>
+								// Cast: /project/new isn't in the generated route map yet.
+								router.push({
+									pathname: "/project/new",
+									params: { clientId },
+								} as unknown as Href)
+							}
+							hitSlop={12}
+							accessibilityRole="button"
+							accessibilityLabel="New project for this client"
+							style={({ pressed }) => [
+								styles.newAction,
+								pressed && styles.pressed,
+							]}
+						>
+							<Plus size={14} color={t.frostedInk} />
+							<Text style={[styles.newActionText, { color: t.frostedInk }]}>
+								New project
+							</Text>
+						</Pressable>
+					</View>
 					{recentProjects.length > 0 ? (
-						<Card style={styles.listCard}>
+						<View>
 							{recentProjects.map((project, i) => (
 								<ListRow
 									key={project._id}
@@ -504,7 +593,7 @@ export function ClientDetailBody({
 									last={i === recentProjects.length - 1}
 								/>
 							))}
-						</Card>
+						</View>
 					) : (
 						<EmptyRow text="No projects yet" illo="projects-none" />
 					)}
@@ -514,7 +603,7 @@ export function ClientDetailBody({
 				<View style={styles.section}>
 					<SectionHeader title={`Quotes${countSuffix(quotes.length)}`} />
 					{recentQuotes.length > 0 ? (
-						<Card style={styles.listCard}>
+						<View>
 							{recentQuotes.map((quote, i) => (
 								<ListRow
 									key={quote._id}
@@ -532,7 +621,7 @@ export function ClientDetailBody({
 									last={i === recentQuotes.length - 1}
 								/>
 							))}
-						</Card>
+						</View>
 					) : (
 						<EmptyRow text="No quotes yet" illo="quotes-none" />
 					)}
@@ -542,7 +631,7 @@ export function ClientDetailBody({
 				<View style={styles.section}>
 					<SectionHeader title={`Invoices${countSuffix(invoices.length)}`} />
 					{recentInvoices.length > 0 ? (
-						<Card style={styles.listCard}>
+						<View>
 							{recentInvoices.map((invoice, i) => (
 								<ListRow
 									key={invoice._id}
@@ -560,7 +649,7 @@ export function ClientDetailBody({
 									last={i === recentInvoices.length - 1}
 								/>
 							))}
-						</Card>
+						</View>
 					) : (
 						<EmptyRow text="No invoices yet" illo="invoices-none" />
 					)}
@@ -594,14 +683,9 @@ function countSuffix(n: number) {
 function EmptyRow({ text, illo }: { text: string; illo: IllustrationName }) {
 	const t = useTokens();
 	return (
-		<View
-			style={[
-				styles.empty,
-				{ backgroundColor: t.muted, borderColor: t.line },
-			]}
-		>
-			{/* Knockout = the row's own bg, so cut-out shapes don't show card-white. */}
-			<Illustration name={illo} size="sm" knockout={t.muted} />
+		<View style={styles.empty}>
+			{/* Knockout = the page canvas, so cut-out shapes don't show card-white. */}
+			<Illustration name={illo} size="sm" knockout={t.bg} />
 			<Text style={[styles.emptyText, { color: t.sub }]}>{text}</Text>
 		</View>
 	);
@@ -612,36 +696,33 @@ const styles = StyleSheet.create({
 	scroll: { padding: 16, gap: 0 },
 	pressed: { opacity: 0.7 },
 
-	skeletonCard: {
-		height: 96,
-		borderRadius: radii.rLg,
-		borderWidth: 1,
+	skeletonIdentity: { flexDirection: "row", alignItems: "center", gap: 14 },
+	skeletonMonogram: { width: 54, height: 54, borderRadius: radii.card },
+	skeletonIdentityBody: { flex: 1, minWidth: 0 },
+	skeletonBar: { borderRadius: radii.xs },
+	skeletonTiles: { flexDirection: "row", gap: 8, marginTop: 18 },
+	skeletonTile: {
+		flex: 1,
+		height: touch.min + 16,
+		borderRadius: radii.ctrl,
 	},
 	skeletonRow: {
-		height: 60,
-		borderRadius: radii.r,
-	},
-
-	identityRow: {
 		flexDirection: "row",
 		alignItems: "center",
-		gap: 14,
+		gap: 11,
+		paddingVertical: 12,
+		paddingHorizontal: 12,
+		marginTop: 6,
 	},
-	identityBody: { flex: 1, minWidth: 0 },
-	companyName: {
-		fontFamily: fontFamily.bold,
-		fontSize: 18,
-		letterSpacing: -0.2,
-	},
-	statusWrap: {
-		marginTop: 8,
-		alignSelf: "flex-start",
-	},
+	skeletonRowTile: { width: 32, height: 32, borderRadius: 9 },
+
 	statusTrigger: {
 		alignSelf: "flex-start",
-		paddingBottom: 5,
+		paddingBottom: 4,
 		borderBottomWidth: 1,
 	},
+
+	actionsWrap: { marginTop: 18 },
 
 	teamChat: {
 		flexDirection: "row",
@@ -651,7 +732,7 @@ const styles = StyleSheet.create({
 		height: 44,
 		borderRadius: radii.rSm,
 		borderWidth: 1,
-		marginTop: 12,
+		marginTop: 10,
 	},
 	teamChatText: {
 		fontFamily: fontFamily.semibold,
@@ -659,40 +740,41 @@ const styles = StyleSheet.create({
 	},
 
 	section: { marginTop: 22, gap: 10 },
-	fieldCard: { paddingBottom: 2 },
-	listCard: { paddingVertical: 6 },
-
-	contactRow: { paddingVertical: 12, paddingHorizontal: 4, gap: 8 },
-	contactHead: { flexDirection: "row", alignItems: "center", gap: 10 },
-	contactIcon: {
-		width: 32,
-		height: 32,
-		borderRadius: radii.xl,
-		alignItems: "center",
-		justifyContent: "center",
+	stack: { gap: 2 },
+	readField: { paddingVertical: 8, paddingHorizontal: 2, gap: 3 },
+	readLabel: {
+		fontFamily: fontFamily.medium,
+		fontSize: type.eyebrow,
 	},
-	contactInfo: { flex: 1, minWidth: 0 },
-	contactName: { fontFamily: fontFamily.semibold, fontSize: 13 },
-	contactSub: { fontFamily: fontFamily.regular, fontSize: 12, marginTop: 2 },
-	contactActions: { gap: 6, paddingLeft: 42 },
-	contactLine: { flexDirection: "row", alignItems: "center", gap: 8 },
-	contactLineText: { fontFamily: fontFamily.regular, fontSize: 12, flex: 1 },
+	readValue: { fontFamily: fontFamily.regular, fontSize: type.body },
+
+	headerRow: { flexDirection: "row", alignItems: "center", gap: 12 },
+	headerGrow: { flex: 1, minWidth: 0 },
+	newAction: {
+		flexDirection: "row",
+		alignItems: "center",
+		gap: 3,
+		flexShrink: 0,
+	},
+	newActionText: {
+		fontFamily: fontFamily.semibold,
+		fontSize: type.sm,
+	},
+
 	callRow: {
 		flexDirection: "row",
 		alignItems: "center",
-		gap: 8,
-		alignSelf: "flex-start",
-		// Painted, not hitSlop — alignSelf keeps the width content-sized.
+		gap: 6,
+		maxWidth: 150,
+		// Painted, not hitSlop-only — the row keeps a tappable target.
 		minHeight: touch.min,
 	},
-	callText: { fontFamily: fontFamily.semibold, fontSize: 12 },
+	callText: { fontFamily: fontFamily.semibold, fontSize: type.meta },
 
 	empty: {
-		borderRadius: radii.r,
-		borderWidth: 1,
 		paddingVertical: 18,
 		alignItems: "center",
 		gap: 8,
 	},
-	emptyText: { fontFamily: fontFamily.regular, fontSize: 12 },
+	emptyText: { fontFamily: fontFamily.regular, fontSize: type.meta },
 });

--- a/apps/mobile/app/(tabs)/clients/[clientId].tsx
+++ b/apps/mobile/app/(tabs)/clients/[clientId].tsx
@@ -9,7 +9,8 @@ import {
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
 import { useLocalSearchParams, useRouter, type Href } from "expo-router";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
+import { useOrganization } from "@clerk/expo";
 import {
 	SafeAreaView,
 	useSafeAreaInsets,
@@ -35,6 +36,7 @@ import { FieldMenu } from "@/components/FieldMenu";
 import { MentionModal } from "@/components/MentionModal";
 import { IdentityBlock } from "@/components/identity-block";
 import { openExternal } from "@/lib/open-external";
+import { recordRecentView } from "@/lib/recents";
 import { QuickActions, type QuickAction } from "@/components/quick-actions";
 import { DotGrid, SectionHeader, ListRow } from "@/components/ui";
 import {
@@ -137,6 +139,23 @@ export function ClientDetailBody({
 			api.invoices.list,
 			clientId ? { clientId: clientId as Id<"clients"> } : "skip"
 		) ?? [];
+
+	// On-device "Recently viewed" trail for the Work tab (Slice 6). Fire-and-
+	// forget, and only once the doc has loaded so the snapshot is a real title.
+	const { organization } = useOrganization();
+	const orgId = organization?.id;
+	const recentId = client?._id;
+	const recentTitle = client?.companyName;
+	const recentSub = client?.companyDescription?.trim() || properties[0]?.city;
+	useEffect(() => {
+		if (!recentId || !recentTitle) return;
+		recordRecentView(orgId, {
+			kind: "client",
+			id: recentId,
+			title: recentTitle,
+			sub: recentSub,
+		});
+	}, [orgId, recentId, recentTitle, recentSub]);
 
 	const updateClient = useMutation(api.clients.update);
 

--- a/apps/mobile/app/(tabs)/clients/[clientId].tsx
+++ b/apps/mobile/app/(tabs)/clients/[clientId].tsx
@@ -5,7 +5,6 @@ import {
 	RefreshControl,
 	Pressable,
 	StyleSheet,
-	Linking,
 } from "react-native";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
@@ -35,6 +34,7 @@ import { EditableField } from "@/components/EditableField";
 import { FieldMenu } from "@/components/FieldMenu";
 import { MentionModal } from "@/components/MentionModal";
 import { IdentityBlock } from "@/components/identity-block";
+import { openExternal } from "@/lib/open-external";
 import { QuickActions, type QuickAction } from "@/components/quick-actions";
 import { DotGrid, SectionHeader, ListRow } from "@/components/ui";
 import {
@@ -301,28 +301,28 @@ export function ClientDetailBody({
 			label: "Call",
 			Icon: Phone,
 			disabled: !phone,
-			onPress: () => phone && Linking.openURL(`tel:${phone}`),
+			onPress: () => phone && openExternal(`tel:${phone}`, "Phone"),
 		},
 		{
 			key: "message",
 			label: "Message",
 			Icon: MessageSquare,
 			disabled: !phone,
-			onPress: () => phone && Linking.openURL(`sms:${phone}`),
+			onPress: () => phone && openExternal(`sms:${phone}`, "Messages"),
 		},
 		{
 			key: "email",
 			label: "Email",
 			Icon: Mail,
 			disabled: !email,
-			onPress: () => email && Linking.openURL(`mailto:${email}`),
+			onPress: () => email && openExternal(`mailto:${email}`, "Mail"),
 		},
 		{
 			key: "directions",
 			label: "Directions",
 			Icon: Navigation,
 			disabled: !directionsUrl,
-			onPress: () => directionsUrl && Linking.openURL(directionsUrl),
+			onPress: () => directionsUrl && openExternal(directionsUrl, "Maps"),
 		},
 	];
 
@@ -473,7 +473,7 @@ export function ClientDetailBody({
 											contact.phone ? (
 												<Pressable
 													onPress={() =>
-														Linking.openURL(`tel:${contact.phone}`)
+														openExternal(`tel:${contact.phone}`, "Phone")
 													}
 													accessibilityRole="button"
 													accessibilityLabel={`Call ${name}`}

--- a/apps/mobile/app/(tabs)/clients/index.tsx
+++ b/apps/mobile/app/(tabs)/clients/index.tsx
@@ -152,20 +152,9 @@ export default function ClientsScreen({
 
 	const ListHeader = (
 		<View style={styles.listHeader}>
-			<Pressable
-				onPress={goToNew}
-				style={({ pressed }) => [
-					styles.newBtn,
-					{ backgroundColor: t.primarySolid },
-					pressed && { opacity: 0.9 },
-				]}
-				accessibilityRole="button"
-				accessibilityLabel="New client"
-			>
-				<Plus size={18} color="#fff" />
-				<Text style={styles.newBtnLabel}>New client</Text>
-			</Pressable>
-
+			{/* No "New client" button here — the speed-dial FAB owns capture on
+			    iPhone (3.0 slice 5). The empty state keeps its CTA: a first-run
+			    primary action isn't a duplicate. */}
 			<View style={styles.searchBar}>
 				<Search size={19} color={t.faint} />
 				<TextInput

--- a/apps/mobile/app/(tabs)/clients/new.tsx
+++ b/apps/mobile/app/(tabs)/clients/new.tsx
@@ -23,6 +23,7 @@ import { AppHeader } from "@/components/app-header";
 import { PaneHeader } from "@/components/ipad/pane-header";
 import { Button, DotGrid } from "@/components/ui";
 import { useDevice } from "@/lib/use-device";
+import { describeMutationError } from "@/lib/mutation-error";
 import {
 	AddressAutocomplete,
 	type AddressValue,
@@ -176,9 +177,15 @@ export function ClientCreateBody({
 			else router.replace(`/clients/${clientId}`);
 		} catch (err) {
 			console.error("Client create failed:", err);
+			const { message, planLimit } = describeMutationError(
+				err,
+				"Couldn't save your changes. Check your connection and try again."
+			);
 			Alert.alert(
-				"Couldn't save",
-				"Couldn't save your changes. Check your connection and try again.",
+				planLimit ? "Plan limit reached" : "Couldn't save",
+				planLimit
+					? `${message} Upgrade on the web app to add more.`
+					: "Couldn't save your changes. Check your connection and try again.",
 				[{ text: "OK" }]
 			);
 		} finally {

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -371,8 +371,6 @@ export default function TodayScreen({
 					eyebrow={dateLabel}
 					greeting={firstName ? `${greeting}, ${firstName}` : greeting}
 					stats={heroStats}
-					onAdd={() => router.push(TASK_FORM)}
-					addLabel="New task"
 				>
 					<WeekStrip
 						tone="ink"

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -476,6 +476,7 @@ export default function TodayScreen({
 						<DayPlanView
 							plan={plan}
 							dayMs={anchorMs}
+							isToday={!anchoredElsewhere}
 							projects={dayProjects}
 							nowLabel={nowLabel}
 							windowEmpty={windowEmpty}

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -24,24 +24,28 @@ import {
 } from "@/components/today/attention-line";
 import { TomorrowPeek } from "@/components/today/tomorrow-peek";
 import { DayPlanView, type Assignee } from "@/components/today/day-plan";
+import { UpcomingList } from "@/components/today/upcoming-list";
+import { ScheduleSkeleton } from "@/components/today/schedule-skeleton";
 import {
 	buildDayPlan,
-	countTasksByDay,
+	buildUpcomingAgenda,
+	countScheduleByDay,
 	formatClockLabel,
 	isDoneStatus,
-	projectInScope,
 	projectsForDay,
+	scopeCalendarEvents,
 	taskInScope,
 	tomorrowPeek,
 	weekDaysFor,
-	type AgendaProject,
+	UPCOMING_DAYS,
 	type AgendaTask,
 	type DayScope,
 } from "@/lib/agenda";
-import { localDayStartMs } from "@/lib/date";
+import { localDayStartMs, utcDayStartMs } from "@/lib/date";
 import { DAY_MS } from "@/components/calendar/dateUtils";
 import { useDayScope } from "@/lib/useDayScope";
-import { Plus, User, Users } from "lucide-react-native";
+import { useScheduleView, type ScheduleView } from "@/lib/useScheduleView";
+import { CalendarDays, List, Plus, User, Users } from "lucide-react-native";
 import { PaneAction, PaneHeader } from "@/components/ipad/pane-header";
 
 const TASK_FORM: Href = "/tasks/form" as Href;
@@ -51,6 +55,22 @@ const SCOPE_SEGMENTS: readonly Segment<DayScope>[] = [
 	{ value: "me", label: "Me", Icon: User },
 	{ value: "team", label: "Team", Icon: Users },
 ];
+
+const VIEW_SEGMENTS: readonly Segment<ScheduleView>[] = [
+	{ value: "day", label: "Day", Icon: CalendarDays },
+	{ value: "list", label: "List", Icon: List },
+];
+
+/**
+ * Days of calendar events fetched past the anchored week's Sunday. The List
+ * view runs `UPCOMING_DAYS` from the anchor, and the anchor can be the week's
+ * Saturday — 6 + 13 = 19, so 20 is a safe superset.
+ *
+ * The window is quantised to the WEEK, never the anchor: query args that change
+ * on every strip tap would drop `useQuery` back to `undefined` and flash the
+ * skeleton on every day you touch.
+ */
+const WINDOW_DAYS = 20;
 
 function greetingFor(hour: number): string {
 	if (hour < 12) return "Good morning";
@@ -69,13 +89,13 @@ function initialsFor(name: string, email: string): string {
 }
 
 /**
- * Today — the action hub for the selected day. Two pinned controls: the week
- * strip picks the DATE, the Me/Team toggle picks the SCOPE. Everything else
- * (attention, all-day projects, the chronological day plan, tomorrow peek) is
- * ONE scroll — the old pinned-band layout left most of the page inert.
+ * Today — run the day. The week strip is the DATE anchor, Day | List picks the
+ * representation and Me | Team the scope; everything below the hero is one
+ * scroll. Day and List read ONE calendar-events subscription, and so do the
+ * strip's workload bars, so the strip can never disagree with the schedule.
  *
- * Task dates are UTC-midnight date-ids, so they are COMPARED in UTC — but
- * "today" is derived from the instant via the LOCAL calendar (see lib/date.ts).
+ * Task/project dates are UTC-midnight date-ids, so they are COMPARED in UTC —
+ * but "today" is derived from the instant via the LOCAL calendar (lib/date.ts).
  * Mixing those up is what made Today roll over at 5pm Pacific.
  */
 export default function TodayScreen({
@@ -92,7 +112,8 @@ export default function TodayScreen({
 	const pane = headerMode === "pane";
 	// iPad only — null on iPhone, where navigation falls back to the router.
 	const shellNav = useShellNav();
-	const { scope, setScope, hydrated } = useDayScope();
+	const { scope, setScope, hydrated: scopeHydrated } = useDayScope();
+	const { view, setView, hydrated: viewHydrated } = useScheduleView();
 
 	// Ticks once a minute so the greeting and the now separator stay honest
 	// across a long session. Async setState — not the synchronous-in-effect
@@ -110,24 +131,24 @@ export default function TodayScreen({
 	const [selectedDayMs, setSelectedDayMs] = useState(() =>
 		localDayStartMs(Date.now()),
 	);
+	const anchorMs = utcDayStartMs(selectedDayMs);
 
 	// The strip is DERIVED from the selection, so jumping to a day in another
 	// week rolls the whole strip there.
 	const days = useMemo(() => weekDaysFor(selectedDayMs), [selectedDayMs]);
+	const windowEndMs = days[0] + WINDOW_DAYS * DAY_MS;
 
-	// One task subscription covers the visible week plus a day of overflow, so a
-	// Saturday's "tomorrow" (next week's Sunday) is still in range.
-	const weekTasks = useQuery(api.tasks.list, {
-		dateFrom: days[0],
-		dateTo: days[6] + 2 * DAY_MS - 1,
+	// The one schedule subscription: the anchored week plus enough overflow for
+	// the List view's rolling window.
+	const events = useQuery(api.calendar.getCalendarEvents, {
+		startDate: days[0],
+		endDate: windowEndMs,
 	});
-	// Spillover can predate the window, so it needs its own query.
+	// Spillover predates any window, so it needs its own query.
 	const overdue = useQuery(api.tasks.getOverdue, {});
+	// Only used to name the overdue rows — getOverdue returns raw task docs, with
+	// no client name of their own.
 	const clients = useQuery(api.clients.list, {});
-	// Scheduled project work — filtered client-side: `projects` has no date
-	// index, and adding one needs a Convex deploy. Revisit if an org's project
-	// count gets large.
-	const projects = useQuery(api.projects.list, {});
 	const sentQuotes = useQuery(api.quotes.list, { status: "sent" });
 	const overdueInvoices = useQuery(api.invoices.getOverdue, {});
 	// Scope plumbing: me = current user's Convex id; org members drive both the
@@ -154,13 +175,20 @@ export default function TodayScreen({
 	// the data as team-wide so a stale persisted "me" can't hide anything.
 	const effectiveScope: DayScope = multiMember ? scope : "team";
 
-	// Merge week + overdue, de-duped (an overdue task earlier in the visible
-	// week arrives from both queries), then scope. Scoping BEFORE the derived
-	// feeds means the week-strip bars and tomorrow peek reflect what you see.
-	const tasks = useMemo<AgendaTask[]>(() => {
-		const byId = new Map<string, AgendaTask>();
-		for (const task of [...(weekTasks ?? []), ...(overdue ?? [])]) {
-			byId.set(task._id, {
+	// Adapt + scope once. Every feed below (day plan, upcoming list, strip bars,
+	// tomorrow peek) reads this, so they cannot disagree.
+	const schedule = useMemo(
+		() => scopeCalendarEvents(events, meId, effectiveScope),
+		[events, meId, effectiveScope],
+	);
+
+	// Overdue spillover joins the day plan only: it can predate the window, so it
+	// is not part of the shared schedule feed. De-duped against in-window rows.
+	const overdueTasks = useMemo<AgendaTask[]>(() => {
+		const inWindow = new Set(schedule.tasks.map((task) => task._id));
+		return (overdue ?? [])
+			.filter((task) => !inWindow.has(task._id))
+			.map((task) => ({
 				_id: task._id,
 				title: task.title,
 				date: task.date,
@@ -169,58 +197,55 @@ export default function TodayScreen({
 				status: task.status,
 				context: task.clientId ? clientNames.get(task.clientId) : undefined,
 				assigneeUserId: task.assigneeUserId,
-			});
-		}
-		return [...byId.values()].filter((task) =>
-			taskInScope(task, meId, effectiveScope),
-		);
-	}, [weekTasks, overdue, clientNames, meId, effectiveScope]);
+			}))
+			.filter((task) => taskInScope(task, meId, effectiveScope));
+	}, [overdue, schedule.tasks, clientNames, meId, effectiveScope]);
 
-	const scopedProjects = useMemo<AgendaProject[]>(
-		() =>
-			(projects ?? [])
-				.map((p) => ({
-					_id: p._id,
-					title: p.title,
-					status: p.status,
-					startDate: p.startDate,
-					endDate: p.endDate,
-					context: clientNames.get(p.clientId),
-					assignedUserIds: p.assignedUserIds,
-				}))
-				.filter((p) => projectInScope(p, meId, effectiveScope)),
-		[projects, clientNames, meId, effectiveScope],
+	const dayTasks = useMemo(
+		() => [...schedule.tasks, ...overdueTasks],
+		[schedule.tasks, overdueTasks],
 	);
-	const dayProjects = useMemo<AgendaProject[]>(
-		() => projectsForDay(scopedProjects, selectedDayMs),
-		[scopedProjects, selectedDayMs],
+
+	const dayProjects = useMemo(
+		() => projectsForDay(schedule.projects, anchorMs),
+		[schedule.projects, anchorMs],
 	);
 
 	const nowDate = new Date(nowMs);
 	const nowMinutes = nowDate.getHours() * 60 + nowDate.getMinutes();
 	const plan = useMemo(
-		() => buildDayPlan(tasks, selectedDayMs, todayMs, nowMinutes),
-		[tasks, selectedDayMs, todayMs, nowMinutes],
+		() => buildDayPlan(dayTasks, anchorMs, todayMs, nowMinutes),
+		[dayTasks, anchorMs, todayMs, nowMinutes],
 	);
-	const counts = useMemo(() => countTasksByDay(tasks), [tasks]);
+	const upcoming = useMemo(
+		() => buildUpcomingAgenda(schedule, anchorMs, UPCOMING_DAYS),
+		[schedule, anchorMs],
+	);
+	const counts = useMemo(
+		() => countScheduleByDay(schedule.tasks, schedule.projects, days),
+		[schedule, days],
+	);
+
 	// The subscription follows the SELECTED week, so browsing away puts actual
 	// tomorrow outside it — and a zero count would render a confident, false
 	// "Nothing scheduled". Only show the peek when tomorrow is really in range.
 	const tomorrowMs = todayMs + DAY_MS;
-	const peekInRange =
-		tomorrowMs >= days[0] && tomorrowMs <= days[6] + 2 * DAY_MS - 1;
-	const peek = useMemo(() => tomorrowPeek(tasks, todayMs), [tasks, todayMs]);
+	const peekInRange = tomorrowMs >= days[0] && tomorrowMs <= windowEndMs;
+	const peek = useMemo(
+		() => tomorrowPeek(schedule.tasks, todayMs),
+		[schedule.tasks, todayMs],
+	);
 
 	// Effective done state = optimistic override, else server status. Derived
 	// (not an override log) so it collapses back to the server value on its own.
 	const doneIds = useMemo(
 		() =>
 			new Set(
-				tasks
+				dayTasks
 					.filter((task) => overrides.get(task._id) ?? isDoneStatus(task.status))
 					.map((task) => task._id),
 			),
-		[tasks, overrides],
+		[dayTasks, overrides],
 	);
 
 	// Team mode labels rows with who owns them; in Me mode a chip would repeat
@@ -318,9 +343,11 @@ export default function TodayScreen({
 	// Hero stats — honest to what this screen already subscribes to. "Overdue"
 	// (not the canvas's "due this week"): due-dated aggregation isn't available
 	// client-side, and a wrong money number is worse than a narrower true one.
+	// Only rendered when the anchor IS today, which is exactly when the window
+	// is guaranteed to contain today.
 	const todayVisits = useMemo(
-		() => projectsForDay(scopedProjects, todayMs).length,
-		[scopedProjects, todayMs],
+		() => projectsForDay(schedule.projects, todayMs).length,
+		[schedule.projects, todayMs],
 	);
 	const overdueTotal = useMemo(
 		() =>
@@ -338,14 +365,28 @@ export default function TodayScreen({
 				nowDate.getMinutes(),
 			).padStart(2, "0")}`,
 		) ?? "";
-	// selectedDayMs is UTC-midnight — render in UTC or the label shows the prior
+	// anchorMs is UTC-midnight — render in UTC or the label shows the prior
 	// evening in a western timezone.
-	const dateLabel = new Date(selectedDayMs).toLocaleDateString("en-US", {
+	const dateLabel = new Date(anchorMs).toLocaleDateString("en-US", {
 		weekday: "long",
 		month: "long",
 		day: "numeric",
 		timeZone: "UTC",
 	});
+
+	const anchoredElsewhere = anchorMs !== utcDayStartMs(todayMs);
+	const hydrated = scopeHydrated && viewHydrated;
+	const loading = events === undefined;
+	const windowEmpty =
+		!loading && schedule.tasks.length === 0 && schedule.projects.length === 0;
+
+	const openTask = (id: string) =>
+		router.push(`/tasks/form?taskId=${id}` as Href);
+	const openProject = (id: string) =>
+		shellNav
+			? shellNav.open({ kind: "project", id })
+			: router.push(`/projects/${id}` as Href);
+	const newTask = () => router.push(TASK_FORM);
 
 	return (
 		<View style={[styles.screen, { backgroundColor: t.bg }]}>
@@ -367,10 +408,12 @@ export default function TodayScreen({
 			) : (
 				// 3.0 ink command hero (canvas 1a): org bar, greeting, day stats and
 				// the ink-tone week strip live in the band; the body scrolls beneath.
+				// Anchoring off today compresses it so the schedule gets the room.
 				<CommandHero
 					eyebrow={dateLabel}
 					greeting={firstName ? `${greeting}, ${firstName}` : greeting}
 					stats={heroStats}
+					compact={anchoredElsewhere}
 				>
 					<WeekStrip
 						tone="ink"
@@ -387,7 +430,8 @@ export default function TodayScreen({
 			)}
 
 			{/* Pinned controls — the iPad pane keeps the light strip here; on the
-			    phone the strip moved into the hero and only the scope toggle stays. */}
+			    phone the strip moved into the hero. Day | List sits above Me | Team:
+			    two calm rows read better at 375pt than one crowded one. */}
 			<View style={styles.controls}>
 				{pane ? (
 					<WeekStrip
@@ -401,6 +445,11 @@ export default function TodayScreen({
 						}
 					/>
 				) : null}
+				<SegmentedToggle
+					segments={VIEW_SEGMENTS}
+					value={view}
+					onChange={setView}
+				/>
 				{multiMember ? (
 					<SegmentedToggle
 						segments={SCOPE_SEGMENTS}
@@ -413,45 +462,59 @@ export default function TodayScreen({
 				<ScrollFade edge="top" />
 			</View>
 
-			{!hydrated ? null : (
-				<ScrollView
-					style={styles.scroll}
-					contentContainerStyle={[
-						styles.scrollBody,
-						// Content runs under the floating glass dock (phone only — the
-						// iPad pane has no dock).
-						!pane && { paddingBottom: DOCK_CLEARANCE + insets.bottom },
-					]}
-					showsVerticalScrollIndicator={false}
-				>
-					<AttentionLine items={attention} onPress={openAttention} />
-					<DayPlanView
-						plan={plan}
-						projects={dayProjects}
-						nowLabel={nowLabel}
+			<ScrollView
+				style={styles.scroll}
+				contentContainerStyle={[
+					styles.scrollBody,
+					// Content runs under the floating glass dock (phone only — the
+					// iPad pane has no dock).
+					!pane && { paddingBottom: DOCK_CLEARANCE + insets.bottom },
+				]}
+				showsVerticalScrollIndicator={false}
+			>
+				<AttentionLine items={attention} onPress={openAttention} />
+				{!hydrated || loading ? (
+					<ScheduleSkeleton />
+				) : view === "list" ? (
+					<UpcomingList
+						days={upcoming}
+						anchorDayMs={anchorMs}
+						todayMs={todayMs}
 						completedIds={doneIds}
 						updatingIds={updatingIds}
 						onToggleTask={handleToggle}
-						onOpenTask={(id) =>
-							router.push(`/tasks/form?taskId=${id}` as Href)
-						}
-						onOpenProject={(id) =>
-							shellNav
-								? shellNav.open({ kind: "project", id })
-								: router.push(`/projects/${id}` as Href)
-						}
-						onNewTask={() => router.push(TASK_FORM)}
+						onOpenTask={openTask}
+						onOpenProject={openProject}
+						onNewTask={newTask}
 						assigneeFor={assigneeFor}
 					/>
-					{peekInRange ? (
-						<TomorrowPeek
-							count={peek.count}
-							firstStart={peek.firstStart}
-							onPress={() => setSelectedDayMs(tomorrowMs)}
+				) : (
+					<>
+						<DayPlanView
+							plan={plan}
+							dayMs={anchorMs}
+							projects={dayProjects}
+							nowLabel={nowLabel}
+							windowEmpty={windowEmpty}
+							completedIds={doneIds}
+							updatingIds={updatingIds}
+							onToggleTask={handleToggle}
+							onOpenTask={openTask}
+							onOpenProject={openProject}
+							onNewTask={newTask}
+							assigneeFor={assigneeFor}
 						/>
-					) : null}
-				</ScrollView>
-			)}
+						{/* Day view only — in List, tomorrow is literally the next group. */}
+						{peekInRange ? (
+							<TomorrowPeek
+								count={peek.count}
+								firstStart={peek.firstStart}
+								onPress={() => setSelectedDayMs(tomorrowMs)}
+							/>
+						) : null}
+					</>
+				)}
+			</ScrollView>
 		</View>
 	);
 }

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -9,13 +9,7 @@ import { DOCK_CLEARANCE, useTokens } from "@/lib/theme";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { formatCurrency } from "@/lib/format";
 import { CommandHero, type HeroStat } from "@/components/today/command-hero";
-import {
-	DotGrid,
-	SegmentedToggle,
-	ScrollFade,
-	SCROLL_TOP_INSET,
-	type Segment,
-} from "@/components/ui";
+import { DotGrid, ScrollFade, SCROLL_TOP_INSET } from "@/components/ui";
 import { useShellNav } from "@/lib/shell-nav";
 import { WeekStrip } from "@/components/today/week-strip";
 import {
@@ -44,22 +38,13 @@ import {
 import { localDayStartMs, utcDayStartMs } from "@/lib/date";
 import { DAY_MS } from "@/components/calendar/dateUtils";
 import { useDayScope } from "@/lib/useDayScope";
-import { useScheduleView, type ScheduleView } from "@/lib/useScheduleView";
-import { CalendarDays, List, Plus, User, Users } from "lucide-react-native";
+import { useScheduleView } from "@/lib/useScheduleView";
+import { Plus } from "lucide-react-native";
+import { ScheduleControls } from "@/components/today/schedule-controls";
 import { PaneAction, PaneHeader } from "@/components/ipad/pane-header";
 
 const TASK_FORM: Href = "/tasks/form" as Href;
 const WORK: Href = "/(tabs)/work" as Href;
-
-const SCOPE_SEGMENTS: readonly Segment<DayScope>[] = [
-	{ value: "me", label: "Me", Icon: User },
-	{ value: "team", label: "Team", Icon: Users },
-];
-
-const VIEW_SEGMENTS: readonly Segment<ScheduleView>[] = [
-	{ value: "day", label: "Day", Icon: CalendarDays },
-	{ value: "list", label: "List", Icon: List },
-];
 
 /**
  * Days of calendar events fetched past the anchored week's Sunday. The List
@@ -430,8 +415,11 @@ export default function TodayScreen({
 			)}
 
 			{/* Pinned controls — the iPad pane keeps the light strip here; on the
-			    phone the strip moved into the hero. Day | List sits above Me | Team:
-			    two calm rows read better at 375pt than one crowded one. */}
+			    phone the strip moved into the hero. ONE eyebrow-level row: the two
+			    stacked full-width toggles this replaced read as chrome and pushed the
+			    schedule (the reason for the tab) below the fold. Pinned, not folded
+			    into a section header — Day | List swaps the whole body, and this block
+			    anchors the ScrollFade at the chrome/scroll boundary. */}
 			<View style={styles.controls}>
 				{pane ? (
 					<WeekStrip
@@ -445,18 +433,13 @@ export default function TodayScreen({
 						}
 					/>
 				) : null}
-				<SegmentedToggle
-					segments={VIEW_SEGMENTS}
-					value={view}
-					onChange={setView}
+				<ScheduleControls
+					view={view}
+					onChangeView={setView}
+					scope={scope}
+					onChangeScope={setScope}
+					showScope={multiMember}
 				/>
-				{multiMember ? (
-					<SegmentedToggle
-						segments={SCOPE_SEGMENTS}
-						value={scope}
-						onChange={setScope}
-					/>
-				) : null}
 				{/* At the real chrome/scroll boundary. In AppHeader it painted over
 				    the week strip, which has no inset to absorb it. */}
 				<ScrollFade edge="top" />

--- a/apps/mobile/app/(tabs)/money/index.tsx
+++ b/apps/mobile/app/(tabs)/money/index.tsx
@@ -4,17 +4,21 @@ import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context"
 import { FlashList } from "@shopify/flash-list";
 import { useQuery } from "convex/react";
 import { useRouter, type Href } from "expo-router";
+import { Search } from "lucide-react-native";
 import { api } from "@onetool/backend/convex/_generated/api";
 import { Id } from "@onetool/backend/convex/_generated/dataModel";
 import {
 	badgeTone,
 	DOCK_CLEARANCE,
 	fontFamily,
+	hero,
 	radii,
+	tracking,
 	type,
 	useTokens,
 } from "@/lib/theme";
-import { AppHeader } from "@/components/app-header";
+import { InkTabHeader } from "@/components/ink-tab-header";
+import { requestSearchFocus } from "@/lib/search-focus";
 import {
 	DotGrid,
 	Eyebrow,
@@ -29,6 +33,8 @@ import {
 	CollectedChart,
 	type MonthBucket,
 } from "@/components/money/collected-chart";
+
+const WORK_TAB: Href = "/(tabs)/work" as Href;
 
 type Tab = "invoices" | "quotes";
 
@@ -57,10 +63,11 @@ type QuoteRow = {
 type MoneySelection = { kind: "quote" | "invoice"; id: string };
 
 // headerMode/onSelect/selected default off → the iPhone path (router.push to the
-// ROOT /quote/[id] + /invoice/[id] routes, AppHeader mode="root", no selected
-// highlight) is BYTE-IDENTICAL. The iPad shell renders this as a list pane:
-// headerMode="pane" suppresses the self-mounted AppHeader (shell mounts the one
-// PaneHeader), onSelect drives the detail pane via the shell selection ({kind,id})
+// ROOT /quote/[id] + /invoice/[id] routes, the InkTabHeader band, no selected
+// highlight). The iPad shell renders this as a list pane: headerMode="pane"
+// suppresses the self-mounted band and keeps the light Hero card in the list
+// header (shell mounts the one PaneHeader above), onSelect drives the detail
+// pane via the shell selection ({kind,id})
 // instead of a route push, selected marks the row matching kind AND id.
 export default function MoneyScreen({
 	headerMode = "root",
@@ -78,6 +85,9 @@ export default function MoneyScreen({
 	// The floating dock takes no layout height — lists clear it themselves.
 	// iPad panes have no dock (the shell replaces Tabs).
 	const listBottom = isPane ? 24 : DOCK_CLEARANCE + insets.bottom;
+	// Pane keeps the fade inset below the shell's light chrome; on iPhone the ink
+	// band is a hard edge, so the list starts just under it.
+	const listTop = isPane ? SCROLL_TOP_INSET : 12;
 	const [tab, setTab] = useState<Tab>("invoices");
 	// Seed "now" once (lazy) — react-hooks/purity forbids Date.now() during render.
 	const [now] = useState(() => Date.now());
@@ -133,6 +143,17 @@ export default function MoneyScreen({
 		return { overdueAmount, draftCount, months };
 	}, [invoices, now]);
 
+	// One subline, two surfaces: the light Hero card (iPad pane) and the ink band
+	// stat line (iPhone) must never drift apart.
+	const overdueAmount = derived?.overdueAmount ?? 0;
+	const sublineText = stats
+		? `${overdueAmount > 0 ? "· " : ""}${stats.byStatus.sent} sent${
+				derived && derived.draftCount > 0
+					? ` · ${derived.draftCount} draft${derived.draftCount === 1 ? "" : "s"}`
+					: ""
+			}`
+		: "";
+
 	const Hero = (
 		<View style={[styles.hero, { backgroundColor: t.card, borderColor: t.line }]}>
 			<Eyebrow>Outstanding</Eyebrow>
@@ -149,20 +170,58 @@ export default function MoneyScreen({
 				<>
 					<MoneyAmount amount={stats.totalOutstanding} size={40} />
 					<View style={styles.heroSubRow}>
-						{derived && derived.overdueAmount > 0 ? (
+						{overdueAmount > 0 ? (
 							<>
 								<View style={[styles.overdueDot, { backgroundColor: t.danger }]} />
 								<Text style={[styles.heroOverdue, { color: badgeTone.late.fg }]}>
-									{formatCurrency(derived.overdueAmount)} overdue
+									{formatCurrency(overdueAmount)} overdue
 								</Text>
 							</>
 						) : null}
 						<Text style={[styles.heroSubline, { color: t.sub }]}>
-							{derived && derived.overdueAmount > 0 ? "· " : ""}
-							{stats.byStatus.sent} sent
-							{derived && derived.draftCount > 0
-								? ` · ${derived.draftCount} draft${derived.draftCount === 1 ? "" : "s"}`
-								: ""}
+							{sublineText}
+						</Text>
+					</View>
+				</>
+			)}
+		</View>
+	);
+
+	// The same figure on ink — a deliberately light shell for now (slice 7 fills
+	// this band with the hero-KPI work).
+	const BandStat = (
+		<View style={styles.bandStat}>
+			<Text style={styles.bandEyebrow}>OUTSTANDING</Text>
+			{stats === undefined ? (
+				<>
+					<View
+						style={[styles.heroAmountSkeleton, { backgroundColor: hero.cellBg }]}
+					/>
+					<View
+						style={[styles.heroSublineSkeleton, { backgroundColor: hero.cellBg }]}
+					/>
+				</>
+			) : (
+				<>
+					<MoneyAmount
+						amount={stats.totalOutstanding}
+						size={38}
+						color={hero.text}
+						centsColor={hero.textSub}
+					/>
+					<View style={styles.heroSubRow}>
+						{overdueAmount > 0 ? (
+							<>
+								<View
+									style={[styles.overdueDot, { backgroundColor: hero.alertDot }]}
+								/>
+								<Text style={[styles.heroOverdue, { color: hero.alertDot }]}>
+									{formatCurrency(overdueAmount)} overdue
+								</Text>
+							</>
+						) : null}
+						<Text style={[styles.heroSubline, { color: hero.textMid }]}>
+							{sublineText}
 						</Text>
 					</View>
 				</>
@@ -172,7 +231,9 @@ export default function MoneyScreen({
 
 	const ListHeader = (
 		<View style={styles.listHeader}>
-			{Hero}
+			{/* iPhone: the figure moved into the ink band. The iPad pane has no band,
+			    so it keeps the light Hero card. */}
+			{isPane ? Hero : null}
 			{derived && derived.months.some((m) => m.value > 0) ? (
 				<CollectedChart months={derived.months} />
 			) : null}
@@ -331,10 +392,30 @@ export default function MoneyScreen({
 			{/* Page canvas, matching web's .workspace-canvas. */}
 			<DotGrid style={StyleSheet.absoluteFill} />
 			{/* Pane mode: the shell mounts PaneHeader above this body (one header
-			    per pane — locked convention). iPhone: AppHeader mode="root". */}
-			{isPane ? null : <AppHeader mode="root" title="Money" />}
+			    per pane — locked convention). iPhone: the ink band, carrying the
+			    outstanding figure and the search jump the old header held. */}
+			{isPane ? null : (
+				<InkTabHeader
+					title="Money"
+					actions={[
+						{
+							key: "search",
+							label: "Search everything",
+							icon: Search,
+							onPress: () => {
+								// Latch, then navigate: Work consumes it once on focus. A
+								// ?focus= param would stick to the tab and re-fire forever.
+								requestSearchFocus();
+								router.push(WORK_TAB);
+							},
+						},
+					]}
+				>
+					{BandStat}
+				</InkTabHeader>
+			)}
 			{activeLoading ? (
-				<View style={styles.listContent}>
+				<View style={[styles.listContent, { paddingTop: listTop }]}>
 					{ListHeader}
 					{Skeleton}
 				</View>
@@ -346,6 +427,7 @@ export default function MoneyScreen({
 					ListHeaderComponent={ListHeader}
 					contentContainerStyle={{
 						...styles.listContent,
+						paddingTop: listTop,
 						paddingBottom: listBottom,
 					}}
 					ListEmptyComponent={Empty}
@@ -358,6 +440,7 @@ export default function MoneyScreen({
 					ListHeaderComponent={ListHeader}
 					contentContainerStyle={{
 						...styles.listContent,
+						paddingTop: listTop,
 						paddingBottom: listBottom,
 					}}
 					ListEmptyComponent={Empty}
@@ -371,7 +454,6 @@ const styles = StyleSheet.create({
 	listContent: {
 		paddingHorizontal: 16,
 		paddingBottom: 24,
-		paddingTop: SCROLL_TOP_INSET,
 	},
 	listHeader: {
 		gap: 16,
@@ -382,6 +464,15 @@ const styles = StyleSheet.create({
 		borderRadius: radii.r,
 		borderWidth: 1,
 		gap: 8,
+	},
+	bandStat: {
+		gap: 4,
+	},
+	bandEyebrow: {
+		fontFamily: fontFamily.semibold,
+		fontSize: type.eyebrow,
+		letterSpacing: tracking.eyebrow,
+		color: hero.textDim,
 	},
 	heroSubRow: {
 		flexDirection: "row",

--- a/apps/mobile/app/(tabs)/projects/[projectId].tsx
+++ b/apps/mobile/app/(tabs)/projects/[projectId].tsx
@@ -252,6 +252,9 @@ export function ProjectDetailBody({
 					id: projectId as Id<"projects">,
 					status: next as ProjectStatus,
 				});
+				// The query has the write by the time this resolves, so hand the
+				// display back to project.status instead of pinning it here.
+				setOptimisticStatus(null);
 			} catch (error) {
 				setOptimisticStatus(null);
 				console.error("Failed to update status:", error);
@@ -421,6 +424,10 @@ export function ProjectDetailBody({
 			key: "new-quote",
 			label: "New quote",
 			Icon: Plus,
+			// Shown straight away so the row doesn't reflow, but inert until the
+			// grant is known — otherwise a tap in that window opens a sheet the
+			// role may not be allowed to use.
+			disabled: permsLoading,
 			onPress: () =>
 				// Cast: /quote/new isn't in the generated route map yet.
 				router.push({

--- a/apps/mobile/app/(tabs)/projects/[projectId].tsx
+++ b/apps/mobile/app/(tabs)/projects/[projectId].tsx
@@ -11,33 +11,52 @@ import {
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
 import { useLocalSearchParams, useRouter, type Href } from "expo-router";
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import {
 	SafeAreaView,
 	useSafeAreaInsets,
 } from "react-native-safe-area-context";
+import { useOrganization } from "@clerk/expo";
 import { Id } from "@onetool/backend/convex/_generated/dataModel";
-import { DOCK_CLEARANCE, fontFamily, radii, touch, useTokens } from "@/lib/theme";
+import {
+	DOCK_CLEARANCE,
+	fontFamily,
+	radii,
+	recordTint,
+	STATUS,
+	touch,
+	type,
+	useTokens,
+} from "@/lib/theme";
+import { formatCurrency } from "@/lib/format";
+import { appleMapsAddressUrl, appleMapsUrl } from "@/lib/route-run";
+import { openExternal } from "@/lib/open-external";
+import { recordRecentView } from "@/lib/recents";
+import { usePermissions } from "@/lib/use-permissions";
 import { AppHeader } from "@/components/app-header";
 import { PaneHeader } from "@/components/ipad/pane-header";
 import { useShellNav } from "@/lib/shell-nav";
+import { DotGrid, ListRow, Ring, SectionHeader } from "@/components/ui";
 import {
-	Badge,
-	Card,
-	DotGrid,
-	Eyebrow,
-	ListRow,
-	Ring,
-	SectionHeader,
-} from "@/components/ui";
-import { Illustration } from "@/components/illustrations";
+	Illustration,
+	type IllustrationName,
+} from "@/components/illustrations";
+import { IdentityBlock } from "@/components/identity-block";
+import { QuickActions, type QuickAction } from "@/components/quick-actions";
 import { EditableField } from "@/components/EditableField";
 import { FieldMenu } from "@/components/FieldMenu";
 import { useOverlayTransition } from "@/components/useOverlayTransition";
 import { MentionModal } from "@/components/MentionModal";
 import { ProjectDocuments } from "@/components/ProjectDocuments";
 import { AppCalendar, toDateId, fromDateId } from "@/components/AppCalendar";
-import { Building2, MessageSquare, X } from "lucide-react-native";
+import {
+	Building2,
+	MessageSquare,
+	Navigation,
+	Phone,
+	Plus,
+	X,
+} from "lucide-react-native";
 
 const STATUS_OPTIONS = [
 	{ value: "planned", label: "Planned" },
@@ -46,6 +65,7 @@ const STATUS_OPTIONS = [
 	{ value: "cancelled", label: "Cancelled" },
 ];
 
+type ProjectStatus = "planned" | "in-progress" | "completed" | "cancelled";
 type DateField = "startDate" | "endDate";
 
 function formatDate(timestamp: number | undefined): string | null {
@@ -121,6 +141,9 @@ export function ProjectDetailBody({
 	const [refreshing, setRefreshing] = useState(false);
 	const [dateField, setDateField] = useState<DateField | null>(null);
 	const [mentionVisible, setMentionVisible] = useState(false);
+	const [optimisticStatus, setOptimisticStatus] = useState<string | null>(null);
+	const { organization } = useOrganization();
+	const { can, isLoading: permsLoading } = usePermissions();
 
 	// Animated date overlay. `shownField` is set when opening (not cleared on
 	// close) so the header/selection don't flip while the sheet slides out.
@@ -151,6 +174,18 @@ export function ProjectDetailBody({
 		api.tasks.list,
 		projectId ? { projectId: projectId as Id<"projects"> } : "skip"
 	);
+	// Quick-action data hangs off the project's client — same resolution the
+	// client detail screen uses (primary contact / primary property).
+	const contacts =
+		useQuery(
+			api.clientContacts.listByClient,
+			project ? { clientId: project.clientId } : "skip"
+		) ?? [];
+	const properties =
+		useQuery(
+			api.clientProperties.listByClient,
+			project ? { clientId: project.clientId } : "skip"
+		) ?? [];
 
 	// Single org-scoped clients query → name lookup. No per-row clients.get (N+1).
 	const clientNameById = useMemo(
@@ -160,6 +195,9 @@ export function ProjectDetailBody({
 			),
 		[clients]
 	);
+	const clientName = project
+		? clientNameById.get(project.clientId)
+		: undefined;
 
 	// Optional task progress — only render when tasks.list cleanly supplies it.
 	const taskProgress = useMemo(() => {
@@ -168,6 +206,28 @@ export function ProjectDetailBody({
 		const done = tasks.filter((tk) => tk.status === "completed").length;
 		return { done, total, pct: Math.round((done / total) * 100) };
 	}, [tasks]);
+
+	// Recents trail — once per visit, after the real title exists. A ref (not
+	// state) keeps this out of the render cycle.
+	const recordedRef = useRef<string | null>(null);
+	const orgId = organization?.id;
+	const projectTitle = project?.title;
+	useEffect(() => {
+		// orgId gates too: recordRecentView no-ops without it, and the ref below
+		// would burn the one-shot before Clerk resolves the active org.
+		if (!projectId || !projectTitle || !orgId) return;
+		if (recordedRef.current === projectId) return;
+		recordedRef.current = projectId;
+		recordRecentView(orgId, {
+			kind: "project",
+			id: projectId,
+			title: projectTitle,
+			sub: clientName,
+		});
+		// clientName is a late-arriving snapshot detail — re-running on it would
+		// double-record the same visit.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [projectId, projectTitle, orgId]);
 
 	const onRefresh = useCallback(() => {
 		setRefreshing(true);
@@ -186,16 +246,14 @@ export function ProjectDetailBody({
 	const handleStatusSelect = useCallback(
 		async (next: string) => {
 			if (!projectId) return;
+			setOptimisticStatus(next);
 			try {
 				await updateProject({
 					id: projectId as Id<"projects">,
-					status: next as
-						| "planned"
-						| "in-progress"
-						| "completed"
-						| "cancelled",
+					status: next as ProjectStatus,
 				});
 			} catch (error) {
+				setOptimisticStatus(null);
 				console.error("Failed to update status:", error);
 			}
 		},
@@ -222,121 +280,249 @@ export function ProjectDetailBody({
 
 	if (!project) {
 		return (
-			<SafeAreaView
-				style={{ flex: 1, backgroundColor: t.bg }}
-				edges={[]}
-			>
+			<SafeAreaView style={[styles.flex, { backgroundColor: t.bg }]} edges={[]}>
 				<DotGrid style={StyleSheet.absoluteFill} />
 				{isPane ? (
 					<PaneHeader onBack={onBack} />
 				) : (
 					<AppHeader mode={appHeaderMode} />
 				)}
+				{/* Skeleton is shaped like the real layout: monogram + name, the
+				    action tiles, then list rows. */}
 				<ScrollView
 					contentContainerStyle={[
 						styles.scroll,
 						{ paddingBottom: scrollBottom },
 					]}
 				>
-					<View
-						style={[
-							styles.skeletonHeader,
-							{ backgroundColor: t.card, borderColor: t.line },
-						]}
-					/>
-					<View
-						style={[
-							styles.skeletonBlock,
-							{ backgroundColor: t.card, borderColor: t.line },
-						]}
-					/>
-					<View
-						style={[
-							styles.skeletonBlock,
-							{ backgroundColor: t.card, borderColor: t.line },
-						]}
-					/>
+					<View style={styles.skeletonIdentity}>
+						<View
+							style={[styles.skeletonMonogram, { backgroundColor: t.lineSoft }]}
+						/>
+						<View style={styles.skeletonIdentityBody}>
+							<View
+								style={[
+									styles.skeletonBar,
+									{ width: "70%", height: 20, backgroundColor: t.lineSoft },
+								]}
+							/>
+							<View
+								style={[
+									styles.skeletonBar,
+									{
+										width: "30%",
+										height: 11,
+										marginTop: 8,
+										backgroundColor: t.lineSoft,
+									},
+								]}
+							/>
+						</View>
+					</View>
+					<View style={styles.skeletonTiles}>
+						{[0, 1, 2, 3].map((i) => (
+							<View
+								key={i}
+								style={[styles.skeletonTile, { backgroundColor: t.lineSoft }]}
+							/>
+						))}
+					</View>
+					{[0, 1, 2].map((i) => (
+						<View key={i} style={styles.skeletonRow}>
+							<View
+								style={[styles.skeletonRowTile, { backgroundColor: t.lineSoft }]}
+							/>
+							<View style={styles.skeletonIdentityBody}>
+								<View
+									style={[
+										styles.skeletonBar,
+										{ width: "55%", height: 13, backgroundColor: t.lineSoft },
+									]}
+								/>
+								<View
+									style={[
+										styles.skeletonBar,
+										{
+											width: "35%",
+											height: 11,
+											marginTop: 6,
+											backgroundColor: t.lineSoft,
+										},
+									]}
+								/>
+							</View>
+						</View>
+					))}
 				</ScrollView>
 			</SafeAreaView>
 		);
 	}
 
-	const clientName =
-		clientNameById.get(project.clientId) ?? "View client";
+	const status = optimisticStatus ?? project.status;
+
+	const primaryContact = contacts.find((c) => c.isPrimary) ?? contacts[0];
+	// The project's own property wins; otherwise fall back to the client's primary.
+	const directionsProperty =
+		(project.propertyId
+			? properties.find((p) => p._id === project.propertyId)
+			: undefined) ??
+		properties.find((p) => p.isPrimary) ??
+		properties[0];
+	const propertyAddress = directionsProperty
+		? directionsProperty.formattedAddress ||
+			[
+				directionsProperty.streetAddress,
+				directionsProperty.city,
+				directionsProperty.state,
+				directionsProperty.zipCode,
+			]
+				.filter(Boolean)
+				.join(", ")
+		: undefined;
+
+	const phone = primaryContact?.phone;
+	const directionsUrl =
+		directionsProperty &&
+		directionsProperty.latitude !== undefined &&
+		directionsProperty.longitude !== undefined
+			? appleMapsUrl(directionsProperty.latitude, directionsProperty.longitude)
+			: propertyAddress
+				? appleMapsAddressUrl(propertyAddress)
+				: undefined;
+
+	// Every tile stays visible; missing data dims it rather than hiding it. The
+	// quote tile is the exception — creation is permission-gated, and the FAB's
+	// convention is to hide (not dim) what the user may not do.
+	const quickActions: QuickAction[] = [
+		{
+			key: "call",
+			label: "Call",
+			Icon: Phone,
+			disabled: !phone,
+			onPress: () => phone && openExternal(`tel:${phone}`, "Phone"),
+		},
+		{
+			key: "message",
+			label: "Message",
+			Icon: MessageSquare,
+			disabled: !phone,
+			onPress: () => phone && openExternal(`sms:${phone}`, "Messages"),
+		},
+		{
+			key: "directions",
+			label: "Directions",
+			Icon: Navigation,
+			disabled: !directionsUrl,
+			onPress: () => directionsUrl && openExternal(directionsUrl, "Maps"),
+		},
+	];
+	if (permsLoading || can("quotes", "modify")) {
+		quickActions.push({
+			key: "new-quote",
+			label: "New quote",
+			Icon: Plus,
+			onPress: () =>
+				// Cast: /quote/new isn't in the generated route map yet.
+				router.push({
+					pathname: "/quote/new",
+					params: { clientId: project.clientId, projectId },
+				} as unknown as Href),
+		});
+	}
+
+	const recentQuotes = quotes?.slice(0, 3) ?? [];
+	const recentInvoices = invoices?.slice(0, 3) ?? [];
 
 	return (
-		<SafeAreaView style={{ flex: 1, backgroundColor: t.bg }} edges={[]}>
+		<SafeAreaView style={[styles.flex, { backgroundColor: t.bg }]} edges={[]}>
 			<DotGrid style={StyleSheet.absoluteFill} />
 			{isPane ? (
 				<PaneHeader title={project.title} onBack={onBack} />
 			) : (
-				<AppHeader mode={appHeaderMode} />
+				<AppHeader mode={appHeaderMode} title={project.title} />
 			)}
 			<ScrollView
-				contentContainerStyle={[
-					styles.scroll,
-					{ paddingBottom: scrollBottom },
-				]}
+				contentContainerStyle={[styles.scroll, { paddingBottom: scrollBottom }]}
 				refreshControl={
 					<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
 				}
 			>
-				{/* Header card: title, client link, status, optional progress, dates */}
-				<Card>
-					<View style={styles.headerTop}>
-						<View style={styles.headerTitleCol}>
-							<EditableField
-								label="Title"
-								value={project.title}
-								onSave={(v) => saveField("title", v)}
-								placeholder="Project title"
-								renderValue={(v) => (
-									<Text style={[styles.title, { color: t.ink }]}>
-										{v}
-									</Text>
-								)}
-							/>
-							<Pressable
-								onPress={() =>
-									shellNav
-										? shellNav.open({ kind: "client", id: project.clientId })
-										: router.push(`/clients/${project.clientId}`)
-								}
-								hitSlop={8}
-								style={({ pressed }) => [
-									styles.clientLink,
-									pressed && styles.pressed,
-								]}
+				{/* Identity — status is TEXT; the FieldMenu hangs off it so the one
+				    place a project status can change keeps working. */}
+				<IdentityBlock
+					tint={recordTint.project}
+					monogram={project.title}
+					statusKey={status}
+					sub={clientName}
+					renderStatus={(statusText) => (
+						<FieldMenu
+							title="Project status"
+							value={status}
+							options={STATUS_OPTIONS}
+							onSelect={handleStatusSelect}
+						>
+							{/* A single bare child is the whole trigger — a row sibling
+							    gets squeezed by the native menu host and clips the label. */}
+							<View
 								accessibilityRole="button"
-								accessibilityLabel="View client"
+								// Status-as-text removed the badge, so the label must still
+								// speak the CURRENT value.
+								accessibilityLabel={`Status: ${
+									STATUS[status as keyof typeof STATUS]?.label ?? status
+								}. Tap to change`}
+								style={[styles.statusTrigger, { borderBottomColor: t.faint }]}
 							>
-								<Building2 size={14} color={t.frostedInk} />
-								<Text style={[styles.clientLinkText, { color: t.frostedInk }]}>
-									{clientName}
-								</Text>
-							</Pressable>
-						</View>
-						<View style={styles.headerActions}>
-							<FieldMenu
-								title="Project status"
-								value={project.status}
-								options={STATUS_OPTIONS}
-								onSelect={handleStatusSelect}
-							>
-								<View
-									accessibilityRole="button"
-									accessibilityLabel="Change status"
-									style={[
-										styles.statusTrigger,
-										{ borderBottomColor: t.faint },
-									]}
-								>
-									<Badge status={project.status} big />
-								</View>
-							</FieldMenu>
-						</View>
-					</View>
+								{statusText}
+							</View>
+						</FieldMenu>
+					)}
+				/>
 
+				{/* Client link stays adjacent to identity — the sub line is text only. */}
+				<Pressable
+					onPress={() =>
+						shellNav
+							? shellNav.open({ kind: "client", id: project.clientId })
+							: router.push(`/clients/${project.clientId}`)
+					}
+					hitSlop={8}
+					style={({ pressed }) => [
+						styles.clientLink,
+						pressed && styles.pressed,
+					]}
+					accessibilityRole="button"
+					accessibilityLabel={`View client ${clientName ?? ""}`.trim()}
+				>
+					<Building2 size={14} color={t.frostedInk} />
+					<Text style={[styles.clientLinkText, { color: t.frostedInk }]}>
+						{clientName ?? "View client"}
+					</Text>
+				</Pressable>
+
+				<View style={styles.actionsWrap}>
+					<QuickActions actions={quickActions} />
+				</View>
+
+				{/* Team chat — relocated from the old floating FAB */}
+				<Pressable
+					onPress={() => setMentionVisible(true)}
+					accessibilityRole="button"
+					accessibilityLabel="Open team chat"
+					style={({ pressed }) => [
+						styles.teamChat,
+						{ backgroundColor: t.frostedBg, borderColor: t.frostedBorder },
+						pressed && styles.pressed,
+					]}
+				>
+					<MessageSquare size={18} color={t.frostedInk} />
+					<Text style={[styles.teamChatText, { color: t.frostedInk }]}>
+						Team chat
+					</Text>
+				</Pressable>
+
+				{/* Progress — card-free: the ring sits beside a quiet stat column. */}
+				<View style={styles.section}>
+					<SectionHeader title="Progress" />
 					{taskProgress ? (
 						<View style={styles.progressRow}>
 							<Ring
@@ -344,9 +530,7 @@ export function ProjectDetailBody({
 								size={72}
 								stroke={9}
 								track={t.secondary}
-								color={
-									project.status === "completed" ? t.success : t.primarySolid
-								}
+								color={status === "completed" ? t.success : t.primarySolid}
 							>
 								<Text style={[styles.ringText, { color: t.ink }]}>
 									{taskProgress.pct}%
@@ -383,52 +567,44 @@ export function ProjectDetailBody({
 							/>
 						</View>
 					)}
-				</Card>
+				</View>
 
-				{/* Team chat — full-width pill, matching the client detail screen */}
-				<Pressable
-					onPress={() => setMentionVisible(true)}
-					accessibilityRole="button"
-					accessibilityLabel="Open team chat"
-					style={({ pressed }) => [
-						styles.teamChat,
-						{ backgroundColor: t.frostedBg, borderColor: t.frostedBorder },
-						pressed && styles.pressed,
-					]}
-				>
-					<MessageSquare size={18} color={t.frostedInk} />
-					<Text style={[styles.teamChatText, { color: t.frostedInk }]}>
-						Team chat
-					</Text>
-				</Pressable>
-
-				{/* Description — inline editable */}
-				<Card style={styles.section}>
-					<Eyebrow>Description</Eyebrow>
-					<View style={{ marginTop: 8 }}>
+				{/* Details — the header owns the name, so title editing lives here
+				    (same idiom as the client screen's Company section). */}
+				<View style={styles.section}>
+					<SectionHeader title="Details" />
+					<View style={styles.stack}>
 						<EditableField
-							label=""
+							label="Title"
+							value={project.title}
+							onSave={(v) => saveField("title", v)}
+							placeholder="Project title"
+						/>
+						<EditableField
+							label="Description"
 							value={project.description}
 							onSave={(v) => saveField("description", v)}
 							placeholder="Add a description…"
 							multiline
-							numberOfLines={3}
+							numberOfLines={4}
 						/>
 					</View>
-				</Card>
+				</View>
 
-				{/* Related quotes */}
+				{/* Quotes */}
 				<View style={styles.section}>
-					<SectionHeader title="Quotes" />
-					{quotes && quotes.length > 0 ? (
-						<Card style={styles.listCard}>
-							{quotes.slice(0, 3).map((quote, i) => (
+					<SectionHeader
+						title={`Quotes${countSuffix(quotes?.length ?? 0)}`}
+					/>
+					{recentQuotes.length > 0 ? (
+						<View>
+							{recentQuotes.map((quote, i) => (
 								<ListRow
 									key={quote._id}
-									title={
-										quote.title || `Quote #${quote.quoteNumber}`
-									}
+									title={quote.title || `Quote #${quote.quoteNumber}`}
+									sub={formatCurrency(quote.total, { exact: true })}
 									status={quote.status}
+									showChevron={false}
 									onPress={() =>
 										// Cast: dynamic detail route isn't in the generated route map.
 										router.push({
@@ -436,35 +612,29 @@ export function ProjectDetailBody({
 											params: { id: quote._id },
 										} as unknown as Href)
 									}
-									last={i === Math.min(quotes.length, 3) - 1}
+									last={i === recentQuotes.length - 1}
 								/>
 							))}
-							{quotes.length > 3 ? (
-								<Text style={[styles.more, { color: t.faint }]}>
-									+{quotes.length - 3} more
-								</Text>
-							) : null}
-						</Card>
+						</View>
 					) : (
-						<Card style={styles.emptyCard}>
-							<Illustration name="quotes-none" size="sm" knockout={t.card} />
-							<Text style={[styles.emptyText, { color: t.faint }]}>
-								No quotes yet
-							</Text>
-						</Card>
+						<EmptyRow text="No quotes yet" illo="quotes-none" />
 					)}
 				</View>
 
-				{/* Related invoices */}
+				{/* Invoices */}
 				<View style={styles.section}>
-					<SectionHeader title="Invoices" />
-					{invoices && invoices.length > 0 ? (
-						<Card style={styles.listCard}>
-							{invoices.slice(0, 3).map((invoice, i) => (
+					<SectionHeader
+						title={`Invoices${countSuffix(invoices?.length ?? 0)}`}
+					/>
+					{recentInvoices.length > 0 ? (
+						<View>
+							{recentInvoices.map((invoice, i) => (
 								<ListRow
 									key={invoice._id}
 									title={`Invoice #${invoice.invoiceNumber}`}
+									sub={formatCurrency(invoice.total, { exact: true })}
 									status={invoice.status}
+									showChevron={false}
 									onPress={() =>
 										// Cast: dynamic detail route isn't in the generated route map.
 										router.push({
@@ -472,22 +642,12 @@ export function ProjectDetailBody({
 											params: { id: invoice._id },
 										} as unknown as Href)
 									}
-									last={i === Math.min(invoices.length, 3) - 1}
+									last={i === recentInvoices.length - 1}
 								/>
 							))}
-							{invoices.length > 3 ? (
-								<Text style={[styles.more, { color: t.faint }]}>
-									+{invoices.length - 3} more
-								</Text>
-							) : null}
-						</Card>
+						</View>
 					) : (
-						<Card style={styles.emptyCard}>
-							<Illustration name="invoices-none" size="sm" knockout={t.card} />
-							<Text style={[styles.emptyText, { color: t.faint }]}>
-								No invoices yet
-							</Text>
-						</Card>
+						<EmptyRow text="No invoices yet" illo="invoices-none" />
 					)}
 				</View>
 
@@ -573,57 +733,71 @@ export default function ProjectDetailScreen() {
 	return <ProjectDetailBody id={projectId} />;
 }
 
+function countSuffix(n: number) {
+	return n > 0 ? `  ·  ${n}` : "";
+}
+
+function EmptyRow({ text, illo }: { text: string; illo: IllustrationName }) {
+	const t = useTokens();
+	return (
+		<View style={styles.empty}>
+			{/* Knockout = the page canvas, so cut-out shapes don't show card-white. */}
+			<Illustration name={illo} size="sm" knockout={t.bg} />
+			<Text style={[styles.emptyText, { color: t.sub }]}>{text}</Text>
+		</View>
+	);
+}
+
 const styles = StyleSheet.create({
+	flex: { flex: 1 },
 	scroll: {
 		padding: 16,
 		gap: 0,
 	},
-	skeletonHeader: {
-		height: 140,
-		borderRadius: radii.rLg,
-		marginBottom: 14,
-		borderWidth: 1,
+	pressed: {
+		opacity: 0.6,
 	},
-	skeletonBlock: {
-		height: 80,
-		borderRadius: radii.rLg,
-		marginBottom: 14,
-		borderWidth: 1,
-	},
-	headerTop: {
-		flexDirection: "row",
-		alignItems: "flex-start",
-		justifyContent: "space-between",
-		gap: 10,
-	},
-	headerTitleCol: {
+
+	skeletonIdentity: { flexDirection: "row", alignItems: "center", gap: 14 },
+	skeletonMonogram: { width: 54, height: 54, borderRadius: radii.card },
+	skeletonIdentityBody: { flex: 1, minWidth: 0 },
+	skeletonBar: { borderRadius: radii.xs },
+	skeletonTiles: { flexDirection: "row", gap: 8, marginTop: 18 },
+	skeletonTile: {
 		flex: 1,
-		minWidth: 0,
+		height: touch.min + 16,
+		borderRadius: radii.ctrl,
 	},
-	title: {
-		fontFamily: fontFamily.bold,
-		fontSize: 21,
-		letterSpacing: -0.3,
+	skeletonRow: {
+		flexDirection: "row",
+		alignItems: "center",
+		gap: 11,
+		paddingVertical: 12,
+		paddingHorizontal: 12,
+		marginTop: 6,
+	},
+	skeletonRowTile: { width: 32, height: 32, borderRadius: 9 },
+
+	statusTrigger: {
+		alignSelf: "flex-start",
+		paddingBottom: 4,
+		borderBottomWidth: 1,
 	},
 	clientLink: {
 		flexDirection: "row",
 		alignItems: "center",
 		gap: 6,
-		marginTop: 6,
+		marginTop: 12,
+		alignSelf: "flex-start",
+		minHeight: touch.min - 12,
 	},
 	clientLinkText: {
 		fontFamily: fontFamily.semibold,
-		fontSize: 13,
+		fontSize: type.meta,
 	},
-	headerActions: {
-		alignItems: "flex-end",
-		gap: 10,
-	},
-	statusTrigger: {
-		alignSelf: "flex-end",
-		paddingBottom: 5,
-		borderBottomWidth: 1,
-	},
+
+	actionsWrap: { marginTop: 10 },
+
 	teamChat: {
 		flexDirection: "row",
 		alignItems: "center",
@@ -631,12 +805,17 @@ const styles = StyleSheet.create({
 		gap: 8,
 		height: 44,
 		borderRadius: radii.rSm,
-		marginTop: 12,
+		borderWidth: 1,
+		marginTop: 10,
 	},
 	teamChatText: {
 		fontFamily: fontFamily.semibold,
 		fontSize: 13,
 	},
+
+	section: { marginTop: 22, gap: 10 },
+	stack: { gap: 2 },
+
 	kvEditable: {
 		paddingBottom: 5,
 		borderBottomWidth: 1,
@@ -676,7 +855,6 @@ const styles = StyleSheet.create({
 		flexDirection: "row",
 		alignItems: "center",
 		gap: 16,
-		marginTop: 16,
 	},
 	ringText: {
 		fontFamily: fontFamily.bold,
@@ -687,7 +865,6 @@ const styles = StyleSheet.create({
 		gap: 10,
 	},
 	kvColStandalone: {
-		marginTop: 16,
 		gap: 10,
 	},
 	kvRow: {
@@ -707,37 +884,11 @@ const styles = StyleSheet.create({
 		fontFamily: fontFamily.semibold,
 		fontSize: 13,
 	},
-	section: {
-		marginTop: 14,
-	},
-	description: {
-		fontFamily: fontFamily.regular,
-		fontSize: 13,
-		lineHeight: 21,
-		marginTop: 10,
-	},
-	listCard: {
-		marginTop: 10,
-		paddingVertical: 6,
-		paddingHorizontal: 12,
-	},
-	emptyCard: {
-		marginTop: 10,
+
+	empty: {
+		paddingVertical: 18,
 		alignItems: "center",
-		paddingVertical: 20,
 		gap: 8,
 	},
-	emptyText: {
-		fontFamily: fontFamily.regular,
-		fontSize: 12,
-	},
-	more: {
-		fontFamily: fontFamily.medium,
-		fontSize: 11,
-		paddingVertical: 8,
-		paddingHorizontal: 4,
-	},
-	pressed: {
-		opacity: 0.6,
-	},
+	emptyText: { fontFamily: fontFamily.regular, fontSize: type.meta },
 });

--- a/apps/mobile/app/(tabs)/work.tsx
+++ b/apps/mobile/app/(tabs)/work.tsx
@@ -188,6 +188,16 @@ export default function WorkScreen({
 		api.search.globalSearch,
 		searching ? { query: q } : "skip",
 	);
+	// Every debounced query re-subscribes, so `results` drops to undefined between
+	// terms. Hold the last resolved set and keep rendering it: only the FIRST
+	// search of a session shows the skeleton, refinements just re-sort under the
+	// finger. (Render-time derivation — set-state-in-effect is error-level here.)
+	const [lastResults, setLastResults] = useState<typeof results>(undefined);
+	if (results !== undefined && results !== lastResults) setLastResults(results);
+	// Dropped out of search: forget the held set, or the NEXT search would open
+	// on the previous term's hits instead of its own skeleton.
+	if (!searching && lastResults !== undefined) setLastResults(undefined);
+	const shownResults = searching ? (results ?? lastResults) : undefined;
 
 	const browseKind = searching ? null : kind;
 	// Clients are also the meta line ("Acme · PRJ-7") for the other three kinds,
@@ -239,7 +249,7 @@ export default function WorkScreen({
 		task: tasks,
 	};
 	const loading = searching
-		? results === undefined
+		? shownResults === undefined
 		: browseKind !== null
 			? browseList[browseKind] === undefined ||
 				(browseKind !== "task" && clients === undefined)
@@ -248,19 +258,19 @@ export default function WorkScreen({
 	const clientNames = useMemo(() => buildClientNameMap(clients), [clients]);
 
 	const searchSections = useMemo<Section[]>(() => {
-		if (!results) return [];
+		if (!shownResults) return [];
 		const byKind: Record<WorkChipKind, WorkRecord[]> = {
-			client: results.clients.map(fromClientHit),
-			project: results.projects.map(fromProjectHit),
-			quote: results.quotes.map(fromQuoteHit),
-			invoice: results.invoices.map(fromInvoiceHit),
-			task: results.tasks.map((doc) => toTaskRecord(doc)),
+			client: shownResults.clients.map(fromClientHit),
+			project: shownResults.projects.map(fromProjectHit),
+			quote: shownResults.quotes.map(fromQuoteHit),
+			invoice: shownResults.invoices.map(fromInvoiceHit),
+			task: shownResults.tasks.map((doc) => toTaskRecord(doc)),
 		};
 		// Hits arrive relevance-ordered per bucket — never re-sort them.
 		return CHIP_ORDER.filter((k) => kind === null || kind === k)
 			.map((k) => ({ key: k, label: KIND_LABEL[k], records: byKind[k] }))
 			.filter((s) => s.records.length > 0);
-	}, [results, kind]);
+	}, [shownResults, kind]);
 
 	const browseSections = useMemo<Section[]>(() => {
 		if (browseKind === null) return [];

--- a/apps/mobile/app/(tabs)/work.tsx
+++ b/apps/mobile/app/(tabs)/work.tsx
@@ -1,9 +1,15 @@
-import { useEffect, useMemo, useState } from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { StyleSheet, Text, View, type TextInput } from "react-native";
 import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 import { FlashList } from "@shopify/flash-list";
 import { useQuery } from "convex/react";
-import { useLocalSearchParams, useRouter, type Href } from "expo-router";
+import {
+	useFocusEffect,
+	useLocalSearchParams,
+	useRouter,
+	type Href,
+} from "expo-router";
+import { useOrganization } from "@clerk/expo";
 import { api } from "@onetool/backend/convex/_generated/api";
 import type { icons } from "lucide-react-native";
 import { AppHeader } from "@/components/app-header";
@@ -17,6 +23,8 @@ import {
 } from "@/components/ui";
 import { Illustration, type IllustrationName } from "@/components/illustrations";
 import { formatCurrency } from "@/lib/format";
+import { getRecents, type RecentRecord } from "@/lib/recents";
+import { consumeSearchFocus } from "@/lib/search-focus";
 import { sameRef, type RecordRef } from "@/lib/selection-context";
 import {
 	DOCK_CLEARANCE,
@@ -30,8 +38,11 @@ import {
 } from "@/lib/theme";
 import {
 	buildClientNameMap,
-	filterRecords,
-	groupByKind,
+	CHIP_ORDER,
+	fromClientHit,
+	fromInvoiceHit,
+	fromProjectHit,
+	fromQuoteHit,
 	KIND_LABEL,
 	pathForRecord,
 	sortByRecency,
@@ -39,24 +50,36 @@ import {
 	toInvoiceRecord,
 	toProjectRecord,
 	toQuoteRecord,
-	type WorkKind,
+	toTaskRecord,
+	type WorkChipKind,
 	type WorkRecord,
 } from "@/lib/work-search";
 
-const isWorkKind = (v: unknown): v is WorkKind =>
+/** Backend floor — `search.globalSearch` returns nothing below two characters,
+ * so one typed letter must keep the resting body, not blank the screen. */
+const MIN_QUERY_LENGTH = 2;
+
+const isChipKind = (v: unknown): v is WorkChipKind =>
 	typeof v === "string" && v in KIND_LABEL;
 
 // Leading tile glyph per record kind (tints come from theme's recordTint).
-const KIND_ICON: Record<WorkKind, keyof typeof icons> = {
+const KIND_ICON: Record<WorkChipKind, keyof typeof icons> = {
 	client: "Building2",
 	project: "Folder",
 	quote: "FileText",
 	invoice: "Receipt",
+	task: "CircleCheck",
 };
 
-// "Recently active" is a peek, not a full browse — the chips are the way to see
-// everything of one kind.
-const RECENT_LIMIT = 30;
+// Per-kind fragment art previews the records about to land in an empty browse
+// list. Module scope: it never varies per render.
+const KIND_ILLO: Record<WorkChipKind, IllustrationName> = {
+	client: "clients-none",
+	project: "projects-none",
+	quote: "quotes-none",
+	invoice: "invoices-none",
+	task: "all-caught-up",
+};
 
 type Section = { key: string; label: string; records: WorkRecord[] };
 
@@ -69,6 +92,25 @@ type Row =
 			first: boolean;
 			last: boolean;
 	  };
+
+function sectionsToRows(sections: Section[]): Row[] {
+	const out: Row[] = [];
+	for (const section of sections) {
+		out.push({ type: "header", key: `h:${section.key}`, label: section.label });
+		section.records.forEach((record, i) => {
+			out.push({
+				type: "record",
+				// Bucket-scoped index, NOT `kind:id`: two contact hits on the same
+				// client both resolve to that client's id and would collide.
+				key: `${section.key}:${i}:${record.id}`,
+				record,
+				first: i === 0,
+				last: i === section.records.length - 1,
+			});
+		});
+	}
+	return out;
+}
 
 // headerMode/onSelect/selected/kind default off → the iPhone path (router.push,
 // AppHeader mode="root", no selected highlight, uncontrolled chip) is byte-
@@ -87,8 +129,8 @@ export default function WorkScreen({
 	headerMode?: "root" | "pane";
 	onSelect?: (ref: RecordRef) => void;
 	selected?: RecordRef | null;
-	kind?: WorkKind | null;
-	onKindChange?: (kind: WorkKind | null) => void;
+	kind?: WorkChipKind | null;
+	onKindChange?: (kind: WorkChipKind | null) => void;
 } = {}) {
 	const t = useTokens();
 	const router = useRouter();
@@ -98,138 +140,201 @@ export default function WorkScreen({
 	// iPad panes have no dock (the shell replaces Tabs).
 	const listBottom = isPane ? 24 : DOCK_CLEARANCE + insets.bottom;
 
-	// Raw input drives the field; `q` (debounced 250ms) drives filtering.
+	// Raw input drives the field; `q` (debounced 250ms) drives the backend query.
 	const [raw, setRaw] = useState("");
 	const [q, setQ] = useState("");
 	useEffect(() => {
 		const id = setTimeout(() => setQ(raw.trim()), 250);
 		return () => clearTimeout(id);
 	}, [raw]);
+	const searching = q.length >= MIN_QUERY_LENGTH;
 
 	// Deep-link chip seed: Today's attention line pushes ?kind=quote. Unknown
 	// values fall back to no chip rather than being cast in.
 	const { kind: kindParam } = useLocalSearchParams<{ kind?: string }>();
 	const rawParam = kindParam ?? null;
 	const [appliedParam, setAppliedParam] = useState<string | null>(rawParam);
-	const [localKind, setLocalKind] = useState<WorkKind | null>(
-		isWorkKind(rawParam) ? rawParam : null,
+	const [localKind, setLocalKind] = useState<WorkChipKind | null>(
+		isChipKind(rawParam) ? rawParam : null,
 	);
 	// Re-seed at render time (set-state-in-effect is error-level here) and only
 	// when the param VALUE changes, so a later chip tap still wins.
 	if (rawParam !== appliedParam) {
 		setAppliedParam(rawParam);
-		if (isWorkKind(rawParam)) setLocalKind(rawParam);
+		if (isChipKind(rawParam)) setLocalKind(rawParam);
 	}
 	const kind = kindProp !== undefined ? kindProp : localKind;
-	const setKind = (next: WorkKind | null) =>
+	const setKind = (next: WorkChipKind | null) =>
 		onKindChange ? onKindChange(next) : setLocalKind(next);
 	// Seed "now" once — react-hooks/purity forbids Date.now() during render.
 	const [now] = useState(() => Date.now());
 
-	// All four lists stay subscribed regardless of the active chip: the default
-	// mixed body needs them anyway, and it keeps chip switches instant.
-	const clients = useQuery(api.clients.list, { includeArchived: true });
-	const projects = useQuery(api.projects.list, {});
-	const quotes = useQuery(api.quotes.list, {});
-	const invoices = useQuery(api.invoices.list, {});
+	// ── Search field focus ──────────────────────────────────────────────────
+	// One-shot latch set by the header magnifier on the other tab roots. Never in
+	// a pane: on iPad the magnifier does not exist and Work is always mounted.
+	const inputRef = useRef<TextInput | null>(null);
+	useFocusEffect(
+		useCallback(() => {
+			if (isPane || !consumeSearchFocus()) return;
+			// One frame of slack — focusing mid-transition drops the keyboard.
+			const frame = requestAnimationFrame(() => inputRef.current?.focus());
+			return () => cancelAnimationFrame(frame);
+		}, [isPane]),
+	);
 
-	const loading =
-		clients === undefined ||
-		projects === undefined ||
-		quotes === undefined ||
-		invoices === undefined;
+	// ── Data ────────────────────────────────────────────────────────────────
+	// Search is the primary path. Browse lists are LAZY — only the active chip's
+	// list subscribes, which is what let the four always-on subscriptions go.
+	const results = useQuery(
+		api.search.globalSearch,
+		searching ? { query: q } : "skip",
+	);
+
+	const browseKind = searching ? null : kind;
+	// Clients are also the meta line ("Acme · PRJ-7") for the other three kinds,
+	// so one subscription serves both the client browse list and their names.
+	const wantsClients =
+		browseKind !== null && browseKind !== "task"
+			? { includeArchived: true }
+			: "skip";
+	const clients = useQuery(api.clients.list, wantsClients);
+	const projects = useQuery(
+		api.projects.list,
+		browseKind === "project" ? {} : "skip",
+	);
+	const quotes = useQuery(api.quotes.list, browseKind === "quote" ? {} : "skip");
+	const invoices = useQuery(
+		api.invoices.list,
+		browseKind === "invoice" ? {} : "skip",
+	);
+	const tasks = useQuery(api.tasks.list, browseKind === "task" ? {} : "skip");
+
+	// ── Recently viewed (on-device, per org) ────────────────────────────────
+	const { organization } = useOrganization();
+	const orgId = organization?.id;
+	// null = not read yet. Refreshed on focus so a record opened and dismissed
+	// this session is already at the top when the tab comes back.
+	const [recents, setRecents] = useState<RecentRecord[] | null>(null);
+	useFocusEffect(
+		useCallback(() => {
+			if (!orgId) return;
+			let alive = true;
+			getRecents(orgId).then((list) => {
+				if (alive) setRecents(list);
+			});
+			return () => {
+				alive = false;
+			};
+		}, [orgId]),
+	);
+
+	const resting = !searching && kind === null;
+
+	// Each mode waits on exactly its own subscriptions. Browse kinds other than
+	// tasks also wait on `clients`, which supplies their meta line.
+	const browseList = {
+		client: clients,
+		project: projects,
+		quote: quotes,
+		invoice: invoices,
+		task: tasks,
+	};
+	const loading = searching
+		? results === undefined
+		: browseKind !== null
+			? browseList[browseKind] === undefined ||
+				(browseKind !== "task" && clients === undefined)
+			: !!orgId && recents === null;
 
 	const clientNames = useMemo(() => buildClientNameMap(clients), [clients]);
 
-	const byKind = useMemo(
-		() => ({
-			client: (clients ?? []).map((c) => toClientRecord(c)),
-			project: (projects ?? []).map((p) =>
-				toProjectRecord(p, { clientName: clientNames.get(p.clientId) })
-			),
-			quote: (quotes ?? []).map((qt) =>
-				toQuoteRecord(qt, { clientName: clientNames.get(qt.clientId) })
-			),
-			invoice: (invoices ?? []).map((inv) =>
-				toInvoiceRecord(inv, { clientName: clientNames.get(inv.clientId), now })
-			),
-		}),
-		[clients, projects, quotes, invoices, clientNames, now]
-	);
+	const searchSections = useMemo<Section[]>(() => {
+		if (!results) return [];
+		const byKind: Record<WorkChipKind, WorkRecord[]> = {
+			client: results.clients.map(fromClientHit),
+			project: results.projects.map(fromProjectHit),
+			quote: results.quotes.map(fromQuoteHit),
+			invoice: results.invoices.map(fromInvoiceHit),
+			task: results.tasks.map((doc) => toTaskRecord(doc)),
+		};
+		// Hits arrive relevance-ordered per bucket — never re-sort them.
+		return CHIP_ORDER.filter((k) => kind === null || kind === k)
+			.map((k) => ({ key: k, label: KIND_LABEL[k], records: byKind[k] }))
+			.filter((s) => s.records.length > 0);
+	}, [results, kind]);
 
-	const counts = useMemo(
-		() => ({
-			client: byKind.client.length,
-			project: byKind.project.length,
-			quote: byKind.quote.length,
-			invoice: byKind.invoice.length,
-		}),
-		[byKind]
-	);
-
-	const sections = useMemo<Section[]>(() => {
-		// Grouped cross-type results: query, no chip.
-		if (q && kind === null) {
-			const pool = [
-				...byKind.client,
-				...byKind.project,
-				...byKind.quote,
-				...byKind.invoice,
-			];
-			return groupByKind(filterRecords(pool, q)).map((g) => ({
-				key: g.kind,
-				label: g.label,
-				records: sortByRecency(g.records),
-			}));
-		}
-
-		// Single-kind browse or scoped results.
-		if (kind !== null) {
-			const records = sortByRecency(filterRecords(byKind[kind], q));
-			return records.length
-				? [{ key: kind, label: KIND_LABEL[kind], records }]
-				: [];
-		}
-
-		// Default body — mixed, most recently active first.
-		const recent = sortByRecency([
-			...byKind.client,
-			...byKind.project,
-			...byKind.quote,
-			...byKind.invoice,
-		]).slice(0, RECENT_LIMIT);
-		return recent.length
-			? [{ key: "recent", label: "Recently active", records: recent }]
+	const browseSections = useMemo<Section[]>(() => {
+		if (browseKind === null) return [];
+		const records =
+			browseKind === "client"
+				? (clients ?? []).map((c) => toClientRecord(c))
+				: browseKind === "project"
+					? (projects ?? []).map((p) =>
+							toProjectRecord(p, { clientName: clientNames.get(p.clientId) }),
+						)
+					: browseKind === "quote"
+						? (quotes ?? []).map((qt) =>
+								toQuoteRecord(qt, {
+									clientName: clientNames.get(qt.clientId),
+								}),
+							)
+						: browseKind === "invoice"
+							? (invoices ?? []).map((inv) =>
+									toInvoiceRecord(inv, {
+										clientName: clientNames.get(inv.clientId),
+										now,
+									}),
+								)
+							: (tasks ?? []).map((task) => toTaskRecord(task));
+		const sorted = sortByRecency(records);
+		return sorted.length
+			? [{ key: browseKind, label: KIND_LABEL[browseKind], records: sorted }]
 			: [];
-	}, [byKind, kind, q]);
+	}, [browseKind, clients, projects, quotes, invoices, tasks, clientNames, now]);
 
-	const rows = useMemo<Row[]>(() => {
-		const out: Row[] = [];
-		for (const section of sections) {
-			out.push({
-				type: "header",
-				key: `h:${section.key}`,
-				label: section.label,
-			});
-			section.records.forEach((record, i) => {
-				out.push({
-					type: "record",
-					key: `${record.kind}:${record.id}`,
-					record,
-					first: i === 0,
-					last: i === section.records.length - 1,
-				});
-			});
-		}
-		return out;
-	}, [sections]);
+	const recentSections = useMemo<Section[]>(() => {
+		const list = resting ? (recents ?? []) : [];
+		if (!list.length) return [];
+		return [
+			{
+				key: "recent",
+				label: "Recently viewed",
+				records: list.map(
+					(r): WorkRecord =>
+						({
+							kind: r.kind,
+							id: r.id,
+							title: r.title,
+							meta: r.sub ?? "",
+						}) as WorkRecord,
+				),
+			},
+		];
+	}, [resting, recents]);
+
+	const rows = useMemo<Row[]>(
+		() =>
+			sectionsToRows(
+				searching
+					? searchSections
+					: browseKind !== null
+						? browseSections
+						: recentSections,
+			),
+		[searching, browseKind, searchSections, browseSections, recentSections],
+	);
 
 	// On iPad pane: row tap drives the shell selection (no route push — a push
-	// would slide the whole shell). On iPhone: push the detail route as before.
-	const open = (record: WorkRecord) =>
-		onSelect
-			? onSelect({ kind: record.kind, id: record.id })
-			: router.push(pathForRecord(record) as Href);
+	// would slide the whole shell). Tasks are the exception in BOTH modes: they
+	// have no detail body, so they always open the form sheet, exactly as
+	// Today's agenda rows do.
+	const open = (record: WorkRecord) => {
+		if (record.kind === "task" || !onSelect) {
+			router.push(pathForRecord(record) as Href);
+			return;
+		}
+		onSelect({ kind: record.kind, id: record.id });
+	};
 
 	const renderRow = ({ item }: { item: Row }) => {
 		if (item.type === "header") {
@@ -242,10 +347,16 @@ export default function WorkScreen({
 
 		const { record, first, last } = item;
 		const tint = recordTint[record.kind];
-		const sub =
+		const amount =
 			record.kind === "quote" || record.kind === "invoice"
-				? `${record.meta} · ${formatCurrency(record.amount, { exact: true })}`
-				: record.meta;
+				? record.amount
+				: undefined;
+		const sub =
+			amount === undefined
+				? record.meta
+				: record.meta
+					? `${record.meta} · ${formatCurrency(amount, { exact: true })}`
+					: formatCurrency(amount, { exact: true });
 
 		return (
 			<ListRow
@@ -253,11 +364,13 @@ export default function WorkScreen({
 				iconColor={tint.fg}
 				iconBg={tint.bg}
 				title={record.title}
-				sub={sub}
+				sub={sub || undefined}
 				status={record.status}
 				onPress={() => open(record)}
 				selected={
-					isPane && sameRef(selected, { kind: record.kind, id: record.id })
+					isPane &&
+					record.kind !== "task" &&
+					sameRef(selected, { kind: record.kind, id: record.id })
 				}
 				containerStyle={[
 					styles.rowCard,
@@ -269,38 +382,31 @@ export default function WorkScreen({
 		);
 	};
 
-	// Per-kind fragment art previews the records about to land there.
-	const KIND_ILLO: Record<WorkKind, IllustrationName> = {
-		client: "clients-none",
-		project: "projects-none",
-		quote: "quotes-none",
-		invoice: "invoices-none",
-	};
-
 	const emptyCopy = (): {
 		title: string;
 		body: string;
 		illo: IllustrationName;
 	} => {
-		if (q) {
+		if (searching) {
 			return {
 				title: "No matches",
-				body: "Try a different name or number.",
+				body: "Search matches the start of words — try a name, number or fewer letters.",
 				illo: "no-filter-match",
 			};
 		}
 		if (kind) {
 			return {
 				title: `No ${KIND_LABEL[kind].toLowerCase()} yet`,
-				body: "Records you create on the web show up here.",
+				body: "Records you create show up here.",
 				illo: KIND_ILLO[kind],
 			};
 		}
+		// First run is the COMMON state on this screen, not an edge case: the trail
+		// is on-device, so a fresh install always lands here.
 		return {
-			title: "Nothing here yet",
-			body: "Clients, projects, quotes and invoices show up here as you add them.",
-			// Generic record-rows fragment — the mixed default body is still a list.
-			illo: "clients-none",
+			title: "Nothing viewed yet",
+			body: "Records you open appear here. Search finds everything else.",
+			illo: "activity-none",
 		};
 	};
 
@@ -327,8 +433,8 @@ export default function WorkScreen({
 			{/* Controls stay pinned — a search-first surface must not scroll its
 			    own search field away. */}
 			<View style={styles.controls}>
-				<SearchField value={raw} onChangeText={setRaw} />
-				<TypeChips value={kind} onChange={setKind} counts={counts} />
+				<SearchField value={raw} onChangeText={setRaw} inputRef={inputRef} />
+				<TypeChips value={kind} onChange={setKind} />
 				{/* At the real chrome/scroll boundary. In AppHeader it painted over
 				    the search field, which has no inset to absorb it. */}
 				{isPane ? null : <ScrollFade edge="top" />}
@@ -336,6 +442,14 @@ export default function WorkScreen({
 
 			{loading ? (
 				<View style={styles.listContent}>
+					{/* Shaped like the real body: a group label, then rows. */}
+					<View
+						style={[
+							styles.skeletonBar,
+							styles.skeletonLabel,
+							{ backgroundColor: t.lineSoft },
+						]}
+					/>
 					{[0, 1, 2, 3, 4, 5].map((i) => (
 						<View
 							key={i}
@@ -379,9 +493,9 @@ export default function WorkScreen({
 						...styles.listContent,
 						paddingBottom: listBottom,
 					}}
-					// On by default in FlashList v2. Four independent subscriptions
-					// resolve at different times into a recency-sorted list, so rows
-					// land above the anchor and the offset creeps down. Not a chat.
+					// On by default in FlashList v2 — but the list re-keys wholesale
+					// between search, browse and recents, so anchoring to a vanished row
+					// creeps the offset. Not a chat.
 					maintainVisibleContentPosition={{ disabled: true }}
 					keyboardShouldPersistTaps="handled"
 					keyboardDismissMode="on-drag"
@@ -399,6 +513,15 @@ export default function WorkScreen({
 								{empty.body}
 							</Text>
 						</View>
+					}
+					ListFooterComponent={
+						// Buckets cap at five hits server-side. Saying so beats letting a
+						// user believe a truncated list is the whole answer.
+						searching && rows.length > 0 ? (
+							<Text style={[styles.footnote, { color: t.faint }]}>
+								Top matches per type. Keep typing to narrow them.
+							</Text>
+						) : null
 					}
 				/>
 			)}
@@ -462,6 +585,12 @@ const styles = StyleSheet.create({
 		height: 13,
 		borderRadius: radii.xs,
 	},
+	skeletonLabel: {
+		width: 74,
+		height: 9,
+		marginTop: 18,
+		marginBottom: 11,
+	},
 	emptyState: {
 		alignItems: "center",
 		paddingVertical: 64,
@@ -479,5 +608,11 @@ const styles = StyleSheet.create({
 		fontFamily: fontFamily.regular,
 		fontSize: type.body,
 		textAlign: "center",
+	},
+	footnote: {
+		fontFamily: fontFamily.regular,
+		fontSize: type.meta,
+		textAlign: "center",
+		paddingTop: 18,
 	},
 });

--- a/apps/mobile/app/(tabs)/work.tsx
+++ b/apps/mobile/app/(tabs)/work.tsx
@@ -12,15 +12,10 @@ import {
 import { useOrganization } from "@clerk/expo";
 import { api } from "@onetool/backend/convex/_generated/api";
 import type { icons } from "lucide-react-native";
-import { AppHeader } from "@/components/app-header";
+import { InkTabHeader } from "@/components/ink-tab-header";
 import { SearchField } from "@/components/work/search-field";
 import { TypeChips } from "@/components/work/type-chips";
-import {
-	DotGrid,
-	ListRow,
-	SCROLL_TOP_INSET,
-	ScrollFade,
-} from "@/components/ui";
+import { DotGrid, ListRow, SCROLL_TOP_INSET } from "@/components/ui";
 import { Illustration, type IllustrationName } from "@/components/illustrations";
 import { formatCurrency } from "@/lib/format";
 import { getRecents, type RecentRecord } from "@/lib/recents";
@@ -113,9 +108,10 @@ function sectionsToRows(sections: Section[]): Row[] {
 }
 
 // headerMode/onSelect/selected/kind default off → the iPhone path (router.push,
-// AppHeader mode="root", no selected highlight, uncontrolled chip) is byte-
-// identical. The iPad shell renders this as a list pane: headerMode="pane"
-// suppresses the self-mounted AppHeader (shell mounts PaneHeader), onSelect
+// the InkTabHeader band, no selected highlight, uncontrolled chip). The iPad
+// shell renders this as a list pane: headerMode="pane" suppresses the
+// self-mounted band and keeps the light controls strip (shell mounts PaneHeader
+// above it — its layout is unchanged from before the band), onSelect
 // drives the detail pane via the shell selection instead of a route push,
 // selected marks the row, and kind/onKindChange let the shell drive the chip
 // (e.g. "View all projects").
@@ -139,6 +135,9 @@ export default function WorkScreen({
 	// The floating dock takes no layout height — scroll content clears it itself.
 	// iPad panes have no dock (the shell replaces Tabs).
 	const listBottom = isPane ? 24 : DOCK_CLEARANCE + insets.bottom;
+	// Pane keeps the fade inset (the shell's light chrome dissolves into content).
+	// On iPhone the ink band is a hard edge — no fade, so no fade clearance.
+	const listTop = isPane ? SCROLL_TOP_INSET : 6;
 
 	// Raw input drives the field; `q` (debounced 250ms) drives the backend query.
 	const [raw, setRaw] = useState("");
@@ -416,32 +415,31 @@ export default function WorkScreen({
 		<SafeAreaView style={{ flex: 1, backgroundColor: t.surface }} edges={[]}>
 			{/* Page canvas, matching web's .workspace-canvas. */}
 			<DotGrid style={StyleSheet.absoluteFill} />
-			{/* Pane mode: the shell mounts PaneHeader above this body (one header
-			    per pane — locked convention); it owns the ＋, and the rail's create
-			    menu covers the rest. On iPhone the header carries no ＋: the
-			    speed-dial FAB is the single capture entry point (3.0 slice 5). */}
-			{isPane ? null : (
-				<AppHeader
-					mode="root"
-					title="Work"
-					halftone
-					// Controls below are pinned, so this screen places the fade itself.
-					fade={false}
-				/>
+			{/* Controls stay pinned either way — a search-first surface must not
+			    scroll its own search field away. On iPhone they ride INSIDE the ink
+			    band (Spotlight-style); the iPad pane keeps the light strip below the
+			    shell's PaneHeader (one header per pane — locked convention). */}
+			{isPane ? (
+				<View style={styles.controls}>
+					<SearchField value={raw} onChangeText={setRaw} inputRef={inputRef} />
+					<TypeChips value={kind} onChange={setKind} />
+				</View>
+			) : (
+				// No ＋ here: the speed-dial FAB is the single capture entry point on
+				// iPhone (3.0 slice 5).
+				<InkTabHeader title="Work">
+					<SearchField
+						value={raw}
+						onChangeText={setRaw}
+						inputRef={inputRef}
+						onInk
+					/>
+					<TypeChips value={kind} onChange={setKind} onInk />
+				</InkTabHeader>
 			)}
 
-			{/* Controls stay pinned — a search-first surface must not scroll its
-			    own search field away. */}
-			<View style={styles.controls}>
-				<SearchField value={raw} onChangeText={setRaw} inputRef={inputRef} />
-				<TypeChips value={kind} onChange={setKind} />
-				{/* At the real chrome/scroll boundary. In AppHeader it painted over
-				    the search field, which has no inset to absorb it. */}
-				{isPane ? null : <ScrollFade edge="top" />}
-			</View>
-
 			{loading ? (
-				<View style={styles.listContent}>
+				<View style={[styles.listContent, { paddingTop: listTop }]}>
 					{/* Shaped like the real body: a group label, then rows. */}
 					<View
 						style={[
@@ -491,6 +489,7 @@ export default function WorkScreen({
 					renderItem={renderRow}
 					contentContainerStyle={{
 						...styles.listContent,
+						paddingTop: listTop,
 						paddingBottom: listBottom,
 					}}
 					// On by default in FlashList v2 — but the list re-keys wholesale
@@ -535,13 +534,10 @@ const styles = StyleSheet.create({
 		paddingTop: 12,
 		paddingBottom: 12,
 		gap: 10,
-		// Anchors the ScrollFade to this block's bottom edge.
-		position: "relative",
 	},
 	listContent: {
 		paddingHorizontal: spacing.gutter,
 		paddingBottom: 24,
-		paddingTop: SCROLL_TOP_INSET,
 	},
 	sectionLabel: {
 		fontFamily: fontFamily.semibold,

--- a/apps/mobile/app/(tabs)/work.tsx
+++ b/apps/mobile/app/(tabs)/work.tsx
@@ -311,10 +311,9 @@ export default function WorkScreen({
 			{/* Page canvas, matching web's .workspace-canvas. */}
 			<DotGrid style={StyleSheet.absoluteFill} />
 			{/* Pane mode: the shell mounts PaneHeader above this body (one header
-			    per pane — locked convention); it owns the +. On iPhone the ＋ is
-			    unconditional: client is the only record type mobile can create here
-			    (quotes/invoices/projects stay web-only at 2.0), and a ＋ that
-			    disappears on some chips reads as a bug. */}
+			    per pane — locked convention); it owns the ＋, and the rail's create
+			    menu covers the rest. On iPhone the header carries no ＋: the
+			    speed-dial FAB is the single capture entry point (3.0 slice 5). */}
 			{isPane ? null : (
 				<AppHeader
 					mode="root"
@@ -322,8 +321,6 @@ export default function WorkScreen({
 					halftone
 					// Controls below are pinned, so this screen places the fade itself.
 					fade={false}
-					onAdd={() => router.push("/clients/new" as Href)}
-					addLabel="New client"
 				/>
 			)}
 

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -260,6 +260,27 @@ export default function RootLayout() {
 									sheetCornerRadius: 30,
 								})}
 							/>
+							{/* Speed-dial fast-capture creates (Slice 5) — same sheet
+							    idiom as tasks/form. Static segments, so they take
+							    precedence over the sibling [id] routes. */}
+							<Stack.Screen
+								name="project/new"
+								options={overlayOptions(device, {
+									sheetAllowedDetents: [0.9, 1.0],
+									sheetInitialDetentIndex: 0,
+									sheetGrabberVisible: false,
+									sheetCornerRadius: 30,
+								})}
+							/>
+							<Stack.Screen
+								name="quote/new"
+								options={overlayOptions(device, {
+									sheetAllowedDetents: [0.9, 1.0],
+									sheetInitialDetentIndex: 0,
+									sheetGrabberVisible: false,
+									sheetCornerRadius: 30,
+								})}
+							/>
 							{/* Assistant sheet over the current context (§4). P2 ships the neutral
 							    unavailable state; P3 adds the gated chat. */}
 							<Stack.Screen

--- a/apps/mobile/app/assistant.tsx
+++ b/apps/mobile/app/assistant.tsx
@@ -5,9 +5,10 @@ import { useTokens } from "@/lib/theme";
 import { CenteredModal } from "@/components/ipad/centered-modal";
 import { useDevice } from "@/lib/use-device";
 import { AssistantHost } from "@/components/assistant/assistant-host";
+import { AssistantInkHeader } from "@/components/assistant/ink-header";
 import { buildScreenContext } from "@/lib/screen-context";
 
-// Assistant sheet — the center tab-bar FAB's destination (P3). The FAB passes
+// Assistant sheet — the dock's assistant orb's destination (P3). The orb passes
 // the path it was pressed over as `ctx`; iPad landscape gets an in-shell right
 // panel instead (ipad-shell), this pushed route covers iPhone + iPad portrait.
 export default function AssistantSheet() {
@@ -21,6 +22,7 @@ export default function AssistantSheet() {
 		return (
 			<CenteredModal onScrimPress={() => router.back()} maxHeight="80%">
 				<View style={[styles.padCard, { backgroundColor: t.card }]}>
+					<AssistantInkHeader />
 					<AssistantHost screenContext={screenContext} />
 				</View>
 			</CenteredModal>
@@ -34,6 +36,7 @@ export default function AssistantSheet() {
 				{ backgroundColor: t.card, paddingBottom: insets.bottom },
 			]}
 		>
+			<AssistantInkHeader grabber />
 			<AssistantHost screenContext={screenContext} />
 		</View>
 	);

--- a/apps/mobile/app/invoice/[id].tsx
+++ b/apps/mobile/app/invoice/[id].tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
 	Pressable,
 	ScrollView,
@@ -51,6 +51,8 @@ import { useInvoiceCapabilities } from "@/lib/use-record-capabilities";
 import { usePermissions } from "@/lib/use-permissions";
 import { deriveInvoiceDisplayPricing } from "@onetool/backend/pdf/invoicePricing";
 import { formatCurrency, formatDocumentDate } from "@/lib/format";
+import { recordRecentView } from "@/lib/recents";
+import { useOrganization } from "@clerk/expo";
 
 const METHOD_LABEL: Record<string, string> = {
 	cash: "Cash",
@@ -135,6 +137,23 @@ export function InvoiceDetailBody({
 		clients?.forEach((c) => map.set(c._id, c.companyName));
 		return map;
 	}, [clients]);
+
+	// On-device "Recently viewed" trail for the Work tab (Slice 6). Fire-and-
+	// forget, and only once the doc has loaded so the snapshot is a real title.
+	const { organization } = useOrganization();
+	const orgId = organization?.id;
+	const recentId = invoice?._id;
+	const recentTitle = invoice?.invoiceNumber;
+	const recentSub = invoice ? clientName.get(invoice.clientId) : undefined;
+	useEffect(() => {
+		if (!recentId || !recentTitle) return;
+		recordRecentView(orgId, {
+			kind: "invoice",
+			id: recentId,
+			title: recentTitle,
+			sub: recentSub,
+		});
+	}, [orgId, recentId, recentTitle, recentSub]);
 
 	// PARENT STATE — loading: skeleton document, keep the detail header.
 	if (invoice === undefined) {

--- a/apps/mobile/app/project/new.tsx
+++ b/apps/mobile/app/project/new.tsx
@@ -58,6 +58,9 @@ export default function NewProjectSheet() {
 	const [clientId, setClientId] = useState<Id<"clients"> | "">(
 		(params.clientId as Id<"clients">) || ""
 	);
+	// Arriving with a client means the picker has nothing to ask — it renders
+	// read-only and the sheet opens on Title.
+	const clientLocked = !!params.clientId;
 	const [title, setTitle] = useState("");
 	const [startDateId, setStartDateId] = useState<string | undefined>(undefined);
 	const [datePickerOpen, setDatePickerOpen] = useState(false);
@@ -138,7 +141,8 @@ export default function NewProjectSheet() {
 				<ClientPicker
 					value={clientId}
 					onChange={setClientId}
-					allowQuickAdd={can("clients", "modify")}
+					allowQuickAdd={!clientLocked && can("clients", "modify")}
+					locked={clientLocked}
 				/>
 
 				<View style={styles.field}>

--- a/apps/mobile/app/project/new.tsx
+++ b/apps/mobile/app/project/new.tsx
@@ -1,0 +1,421 @@
+import { useState } from "react";
+import {
+	ActivityIndicator,
+	Animated,
+	Pressable,
+	ScrollView,
+	StyleSheet,
+	Text,
+	TextInput,
+	View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { router, useLocalSearchParams } from "expo-router";
+import { useMutation, useQuery } from "convex/react";
+import { api } from "@onetool/backend/convex/_generated/api";
+import type { Id } from "@onetool/backend/convex/_generated/dataModel";
+import { CalendarDays, X } from "lucide-react-native";
+import { fontFamily, radii, type, useTokens } from "@/lib/theme";
+import { Button, Eyebrow } from "@/components/ui";
+import { AppCalendar } from "@/components/AppCalendar";
+import { useOverlayTransition } from "@/components/useOverlayTransition";
+import { CenteredModal } from "@/components/ipad/centered-modal";
+import { ClientPicker } from "@/components/create/client-picker";
+import { useDevice } from "@/lib/use-device";
+import { usePermissions } from "@/lib/use-permissions";
+import { hapticSuccess } from "@/lib/haptics";
+import { describeMutationError } from "@/lib/mutation-error";
+import { utcMsFromDateId } from "@/lib/date";
+
+// Fast-capture project create (Slice 5 speed-dial). Deliberately minimal —
+// client, title, optional start date. Status and type mirror web's minimal
+// new-project path ("planned" / "one-off"); everything else is edited on the
+// detail screen the create lands on.
+const DEFAULT_STATUS = "planned" as const;
+const DEFAULT_PROJECT_TYPE = "one-off" as const;
+
+// Off-screen start distance for the calendar slide-up (>= sheet height).
+const SHEET_SLIDE = 600;
+
+function formatDateLabel(dateId: string): string {
+	return new Date(utcMsFromDateId(dateId)).toLocaleDateString("en-US", {
+		timeZone: "UTC",
+		year: "numeric",
+		month: "long",
+		day: "numeric",
+	});
+}
+
+export default function NewProjectSheet() {
+	const t = useTokens();
+	const insets = useSafeAreaInsets();
+	const { device } = useDevice();
+	const { can, isLoading: permsLoading } = usePermissions();
+	const params = useLocalSearchParams<{ clientId?: string }>();
+
+	// Preselect the client when pushed from a client detail screen
+	// ("/project/new?clientId=…") — initializer form, no setState-in-effect.
+	const [clientId, setClientId] = useState<Id<"clients"> | "">(
+		(params.clientId as Id<"clients">) || ""
+	);
+	const [title, setTitle] = useState("");
+	const [startDateId, setStartDateId] = useState<string | undefined>(undefined);
+	const [datePickerOpen, setDatePickerOpen] = useState(false);
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<{
+		message: string;
+		planLimit: boolean;
+	} | null>(null);
+
+	const createProject = useMutation(api.projects.create);
+	// Reactive and NOT gated on: a single property is a convenience, not a
+	// prerequisite. Read whatever has arrived at submit time.
+	const properties = useQuery(
+		api.clientProperties.listByClient,
+		clientId ? { clientId: clientId as Id<"clients"> } : "skip"
+	);
+
+	const canCreate = can("projects", "modify");
+	const valid = !!clientId && title.trim().length > 0;
+
+	const submit = async () => {
+		if (!valid || submitting) return;
+		setSubmitting(true);
+		setError(null);
+		try {
+			const propertyId =
+				properties && properties.length === 1 ? properties[0]._id : undefined;
+			const projectId = (await createProject({
+				clientId: clientId as Id<"clients">,
+				propertyId,
+				title: title.trim(),
+				status: DEFAULT_STATUS,
+				projectType: DEFAULT_PROJECT_TYPE,
+				startDate: startDateId ? utcMsFromDateId(startDateId) : undefined,
+			})) as Id<"projects">;
+			hapticSuccess();
+			router.replace(`/projects/${projectId}`);
+		} catch (err) {
+			setError(
+				describeMutationError(
+					err,
+					"Couldn't create that project. Check your connection and try again."
+				)
+			);
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	// `can` is false while permissions resolve, so wait before hiding — otherwise
+	// every open flashes an empty sheet.
+	if (!permsLoading && !canCreate) return null;
+
+	const content = (
+		<>
+			<View style={styles.header}>
+				<View style={{ flex: 1 }} />
+				<Text style={[styles.headerTitle, { color: t.ink }]}>New project</Text>
+				<View style={styles.headerAction}>
+					<Pressable
+						onPress={() => router.back()}
+						hitSlop={8}
+						accessibilityRole="button"
+						accessibilityLabel="Close"
+						style={styles.closeBtn}
+					>
+						<X size={22} color={t.sub} />
+					</Pressable>
+				</View>
+			</View>
+
+			<ScrollView
+				style={styles.flex}
+				contentContainerStyle={styles.body}
+				keyboardShouldPersistTaps="handled"
+			>
+				<Eyebrow>Client</Eyebrow>
+				<ClientPicker
+					value={clientId}
+					onChange={setClientId}
+					allowQuickAdd={can("clients", "modify")}
+				/>
+
+				<View style={styles.field}>
+					<Eyebrow>Project</Eyebrow>
+					<TextInput
+						value={title}
+						onChangeText={setTitle}
+						placeholder="What's the job?"
+						placeholderTextColor={t.faint}
+						style={[
+							styles.input,
+							{ borderColor: t.line, backgroundColor: t.card, color: t.ink },
+						]}
+						accessibilityLabel="Project title"
+					/>
+				</View>
+
+				<View style={styles.field}>
+					<Eyebrow>Start date</Eyebrow>
+					<Pressable
+						onPress={() => setDatePickerOpen(true)}
+						accessibilityRole="button"
+						accessibilityLabel="Choose a start date"
+						style={[
+							styles.select,
+							{ borderColor: t.line, backgroundColor: t.card },
+						]}
+					>
+						<Text
+							style={[
+								styles.selectText,
+								{ color: startDateId ? t.ink : t.faint },
+							]}
+							numberOfLines={1}
+						>
+							{startDateId ? formatDateLabel(startDateId) : "Optional"}
+						</Text>
+						{startDateId ? (
+							<Pressable
+								onPress={() => setStartDateId(undefined)}
+								hitSlop={10}
+								accessibilityRole="button"
+								accessibilityLabel="Clear start date"
+							>
+								<X size={16} color={t.sub} />
+							</Pressable>
+						) : (
+							<CalendarDays size={18} color={t.sub} />
+						)}
+					</Pressable>
+				</View>
+
+				{error ? (
+					<Text style={[styles.error, { color: t.destructive }]}>
+						{error.planLimit
+							? `${error.message} Upgrade on the web app to add more.`
+							: error.message}
+					</Text>
+				) : null}
+
+				<Button
+					title="Create project"
+					onPress={() => void submit()}
+					disabled={!valid || submitting}
+					icon={
+						submitting ? (
+							<ActivityIndicator size="small" color={t.primaryInk} />
+						) : undefined
+					}
+					style={styles.submit}
+				/>
+			</ScrollView>
+
+			<CalendarOverlay
+				visible={datePickerOpen}
+				selectedDate={startDateId}
+				onSelect={(id) => {
+					setStartDateId(id);
+					setDatePickerOpen(false);
+				}}
+				onClose={() => setDatePickerOpen(false)}
+				t={t}
+				insets={insets}
+			/>
+		</>
+	);
+
+	if (device === "ipad") {
+		return (
+			<CenteredModal onScrimPress={() => router.back()} maxHeight="92%">
+				<View style={[styles.padCard, { backgroundColor: t.card }]}>
+					{content}
+				</View>
+			</CenteredModal>
+		);
+	}
+
+	return (
+		<View
+			style={[
+				styles.container,
+				{ backgroundColor: t.card, paddingBottom: insets.bottom },
+			]}
+		>
+			<View style={[styles.grabber, { backgroundColor: t.line }]} />
+			{content}
+		</View>
+	);
+}
+
+/**
+ * In-sheet calendar overlay — a nested RN <Modal> inside an Expo Router
+ * formSheet deadlocks iOS touch handling (see tasks/form.tsx), so this stays a
+ * plain absolute overlay in the RN hierarchy.
+ */
+function CalendarOverlay({
+	visible,
+	selectedDate,
+	onSelect,
+	onClose,
+	t,
+	insets,
+}: {
+	visible: boolean;
+	selectedDate?: string;
+	onSelect: (dateId: string) => void;
+	onClose: () => void;
+	t: ReturnType<typeof useTokens>;
+	insets: { bottom: number };
+}) {
+	const { mounted, progress } = useOverlayTransition(visible);
+	if (!mounted) return null;
+	const translateY = progress.interpolate({
+		inputRange: [0, 1],
+		outputRange: [SHEET_SLIDE, 0],
+	});
+	return (
+		<View style={styles.overlay}>
+			<Animated.View
+				style={[styles.backdrop, { opacity: progress }]}
+				pointerEvents="none"
+			/>
+			<Pressable
+				style={StyleSheet.absoluteFill}
+				onPress={onClose}
+				accessibilityRole="button"
+				accessibilityLabel="Close date picker"
+			/>
+			<Animated.View
+				style={[
+					styles.calendarSheet,
+					{
+						backgroundColor: t.card,
+						paddingBottom: insets.bottom + 12,
+						transform: [{ translateY }],
+					},
+				]}
+			>
+				<View style={[styles.grabber, { backgroundColor: t.line }]} />
+				<View style={styles.header}>
+					<View style={{ flex: 1 }} />
+					<Text style={[styles.headerTitle, { color: t.ink }]}>Start date</Text>
+					<View style={styles.headerAction}>
+						<Pressable
+							onPress={onClose}
+							hitSlop={8}
+							accessibilityRole="button"
+							accessibilityLabel="Close"
+							style={styles.closeBtn}
+						>
+							<X size={22} color={t.sub} />
+						</Pressable>
+					</View>
+				</View>
+				<View style={styles.calendarWrap}>
+					<AppCalendar selectedDate={selectedDate} onDateSelect={onSelect} />
+				</View>
+			</Animated.View>
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	flex: { flex: 1 },
+	container: {
+		flex: 1,
+		borderTopLeftRadius: 30,
+		borderTopRightRadius: 30,
+		overflow: "hidden",
+	},
+	padCard: { flex: 1, paddingTop: 18 },
+	grabber: {
+		alignSelf: "center",
+		width: 44,
+		height: 5,
+		borderRadius: 999,
+		marginTop: 10,
+		marginBottom: 12,
+	},
+	header: {
+		flexDirection: "row",
+		alignItems: "center",
+		paddingHorizontal: 20,
+		paddingBottom: 12,
+	},
+	headerTitle: {
+		flex: 2,
+		textAlign: "center",
+		fontSize: type.h2,
+		lineHeight: 30,
+		fontFamily: fontFamily.bold,
+	},
+	headerAction: { flex: 1, alignItems: "flex-end" },
+	closeBtn: {
+		width: 32,
+		height: 32,
+		borderRadius: 999,
+		alignItems: "center",
+		justifyContent: "center",
+	},
+	body: { paddingHorizontal: 20, paddingBottom: 32 },
+	field: { marginTop: 20 },
+	input: {
+		borderWidth: 1,
+		borderRadius: radii.ctrl,
+		paddingHorizontal: 14,
+		paddingVertical: 12,
+		fontSize: type.h4,
+		fontFamily: fontFamily.regular,
+		marginTop: 8,
+	},
+	select: {
+		flexDirection: "row",
+		alignItems: "center",
+		justifyContent: "space-between",
+		borderWidth: 1,
+		borderRadius: radii.ctrl,
+		paddingHorizontal: 14,
+		paddingVertical: 14,
+		marginTop: 8,
+	},
+	selectText: {
+		flex: 1,
+		fontSize: type.h4,
+		fontFamily: fontFamily.regular,
+		marginRight: 8,
+	},
+	error: {
+		fontFamily: fontFamily.medium,
+		fontSize: type.meta,
+		marginTop: 16,
+	},
+	submit: { marginTop: 24 },
+	overlay: {
+		position: "absolute",
+		top: 0,
+		left: 0,
+		right: 0,
+		bottom: 0,
+		zIndex: 10,
+	},
+	backdrop: {
+		position: "absolute",
+		top: 0,
+		left: 0,
+		right: 0,
+		bottom: 0,
+		backgroundColor: "rgba(0,0,0,0.35)",
+	},
+	calendarSheet: {
+		position: "absolute",
+		left: 0,
+		right: 0,
+		bottom: 0,
+		borderTopLeftRadius: 30,
+		borderTopRightRadius: 30,
+		overflow: "hidden",
+	},
+	calendarWrap: { paddingHorizontal: 16, paddingBottom: 8 },
+});

--- a/apps/mobile/app/project/new.tsx
+++ b/apps/mobile/app/project/new.tsx
@@ -10,7 +10,7 @@ import {
 	View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { router, useLocalSearchParams } from "expo-router";
+import { Redirect, router, useLocalSearchParams } from "expo-router";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
 import type { Id } from "@onetool/backend/convex/_generated/dataModel";
@@ -111,8 +111,9 @@ export default function NewProjectSheet() {
 	};
 
 	// `can` is false while permissions resolve, so wait before hiding — otherwise
-	// every open flashes an empty sheet.
-	if (!permsLoading && !canCreate) return null;
+	// every open flashes an empty sheet. Once it resolves to "no", leave rather
+	// than sitting on a blank sheet the user can't dismiss.
+	if (!permsLoading && !canCreate) return <Redirect href="/(tabs)/projects" />;
 
 	const content = (
 		<>

--- a/apps/mobile/app/quote/[id].tsx
+++ b/apps/mobile/app/quote/[id].tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
 	Alert,
 	Image,
@@ -37,6 +37,8 @@ import {
 import { useQuoteCapabilities } from "@/lib/use-record-capabilities";
 import { usePermissions } from "@/lib/use-permissions";
 import { formatCurrency, formatDocumentDate } from "@/lib/format";
+import { recordRecentView } from "@/lib/recents";
+import { useOrganization } from "@clerk/expo";
 
 // Lifecycle track states per status (frame 1h). Declined/expired terminate
 // the track at the third node instead of pretending the path continues.
@@ -163,6 +165,24 @@ export function QuoteDetailBody({
 		clients?.forEach((c) => map.set(c._id, c.companyName));
 		return map;
 	}, [clients]);
+
+	// On-device "Recently viewed" trail for the Work tab (Slice 6). Fire-and-
+	// forget, and only once the doc has loaded so the snapshot is a real title.
+	const { organization } = useOrganization();
+	const orgId = organization?.id;
+	const recentId = quote?._id;
+	const recentTitle =
+		quote?.title?.trim() || quote?.quoteNumber?.trim() || "Quote";
+	const recentSub = quote ? clientName.get(quote.clientId) : undefined;
+	useEffect(() => {
+		if (!recentId) return;
+		recordRecentView(orgId, {
+			kind: "quote",
+			id: recentId,
+			title: recentTitle,
+			sub: recentSub,
+		});
+	}, [orgId, recentId, recentTitle, recentSub]);
 
 	// quote === undefined → loading skeleton.
 	if (quote === undefined) {

--- a/apps/mobile/app/quote/new.tsx
+++ b/apps/mobile/app/quote/new.tsx
@@ -36,14 +36,21 @@ export default function NewQuoteSheet() {
 	const insets = useSafeAreaInsets();
 	const { device } = useDevice();
 	const { can, isLoading: permsLoading } = usePermissions();
-	const params = useLocalSearchParams<{ clientId?: string }>();
+	const params = useLocalSearchParams<{
+		clientId?: string;
+		projectId?: string;
+	}>();
 
 	const [clientId, setClientId] = useState<Id<"clients"> | "">(
 		(params.clientId as Id<"clients">) || ""
 	);
 	// A client pushed in on the route is settled — show it read-only.
 	const clientLocked = !!params.clientId;
-	const [projectId, setProjectId] = useState<Id<"projects"> | "">("");
+	// A project pushed in on the route is only pre-staged, never locked — the
+	// picker below still clears it (and a client change wipes it outright).
+	const [projectId, setProjectId] = useState<Id<"projects"> | "">(
+		(params.projectId as Id<"projects">) || ""
+	);
 	const [title, setTitle] = useState("");
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<{

--- a/apps/mobile/app/quote/new.tsx
+++ b/apps/mobile/app/quote/new.tsx
@@ -9,7 +9,7 @@ import {
 	View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { router, useLocalSearchParams } from "expo-router";
+import { Redirect, router, useLocalSearchParams } from "expo-router";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
 import type { Id } from "@onetool/backend/convex/_generated/dataModel";
@@ -69,6 +69,9 @@ export default function NewQuoteSheet() {
 	];
 	const projectLabel =
 		projectOptions.find((o) => o.value === projectId)?.label ?? "No project";
+	const selectedProject = projectId
+		? (projects ?? []).find((p) => p._id === projectId)
+		: undefined;
 
 	const canCreate = can("quotes", "modify");
 	const valid = !!clientId;
@@ -80,7 +83,15 @@ export default function NewQuoteSheet() {
 		try {
 			const quoteId = (await createQuote({
 				clientId: clientId as Id<"clients">,
-				projectId: projectId ? (projectId as Id<"projects">) : undefined,
+				// Once the client's projects are loaded, only send one the list
+				// actually holds — a stale ?projectId is dropped. Before that,
+				// trust the param: submitting inside the load window must not
+				// silently strip the project the detail screen handed over (a real
+				// mismatch is rejected server-side).
+				projectId:
+					projects === undefined
+						? (projectId as Id<"projects">) || undefined
+						: selectedProject?._id,
 				title: title.trim() || undefined,
 				status: "draft",
 				subtotal: 0,
@@ -100,8 +111,10 @@ export default function NewQuoteSheet() {
 		}
 	};
 
-	// `can` is false while permissions resolve — wait before hiding.
-	if (!permsLoading && !canCreate) return null;
+	// `can` is false while permissions resolve — wait before hiding. A role that
+	// can't create quotes can still deep-link here, so leave, rather than leaving
+	// a blank sheet with no way out.
+	if (!permsLoading && !canCreate) return <Redirect href="/(tabs)/money" />;
 
 	const content = (
 		<>

--- a/apps/mobile/app/quote/new.tsx
+++ b/apps/mobile/app/quote/new.tsx
@@ -1,0 +1,235 @@
+import { useState } from "react";
+import {
+	ActivityIndicator,
+	Pressable,
+	ScrollView,
+	StyleSheet,
+	Text,
+	TextInput,
+	View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { router, useLocalSearchParams } from "expo-router";
+import { useMutation } from "convex/react";
+import { api } from "@onetool/backend/convex/_generated/api";
+import type { Id } from "@onetool/backend/convex/_generated/dataModel";
+import { X } from "lucide-react-native";
+import { fontFamily, radii, type, useTokens } from "@/lib/theme";
+import { Button, Eyebrow } from "@/components/ui";
+import { CenteredModal } from "@/components/ipad/centered-modal";
+import { ClientPicker } from "@/components/create/client-picker";
+import { useDevice } from "@/lib/use-device";
+import { usePermissions } from "@/lib/use-permissions";
+import { hapticSuccess } from "@/lib/haptics";
+import { describeMutationError } from "@/lib/mutation-error";
+
+// Fast-capture quote create (Slice 5 speed-dial). This screen only mints the
+// empty draft — the line-item sheet on the quote detail screen (Slice 4) is
+// where the money gets entered, so the sheet hands off immediately.
+export default function NewQuoteSheet() {
+	const t = useTokens();
+	const insets = useSafeAreaInsets();
+	const { device } = useDevice();
+	const { can, isLoading: permsLoading } = usePermissions();
+	const params = useLocalSearchParams<{ clientId?: string }>();
+
+	const [clientId, setClientId] = useState<Id<"clients"> | "">(
+		(params.clientId as Id<"clients">) || ""
+	);
+	const [title, setTitle] = useState("");
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<{
+		message: string;
+		planLimit: boolean;
+	} | null>(null);
+
+	const createQuote = useMutation(api.quotes.create);
+
+	const canCreate = can("quotes", "modify");
+	const valid = !!clientId;
+
+	const submit = async () => {
+		if (!valid || submitting) return;
+		setSubmitting(true);
+		setError(null);
+		try {
+			const quoteId = (await createQuote({
+				clientId: clientId as Id<"clients">,
+				title: title.trim() || undefined,
+				status: "draft",
+				subtotal: 0,
+				total: 0,
+			})) as Id<"quotes">;
+			hapticSuccess();
+			router.replace(`/quote/${quoteId}`);
+		} catch (err) {
+			setError(
+				describeMutationError(
+					err,
+					"Couldn't start that quote. Check your connection and try again."
+				)
+			);
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	// `can` is false while permissions resolve — wait before hiding.
+	if (!permsLoading && !canCreate) return null;
+
+	const content = (
+		<>
+			<View style={styles.header}>
+				<View style={{ flex: 1 }} />
+				<Text style={[styles.headerTitle, { color: t.ink }]}>New quote</Text>
+				<View style={styles.headerAction}>
+					<Pressable
+						onPress={() => router.back()}
+						hitSlop={8}
+						accessibilityRole="button"
+						accessibilityLabel="Close"
+						style={styles.closeBtn}
+					>
+						<X size={22} color={t.sub} />
+					</Pressable>
+				</View>
+			</View>
+
+			<ScrollView
+				style={styles.flex}
+				contentContainerStyle={styles.body}
+				keyboardShouldPersistTaps="handled"
+			>
+				<Eyebrow>Client</Eyebrow>
+				<ClientPicker
+					value={clientId}
+					onChange={setClientId}
+					allowQuickAdd={can("clients", "modify")}
+				/>
+
+				<View style={styles.field}>
+					<Eyebrow>Title</Eyebrow>
+					<TextInput
+						value={title}
+						onChangeText={setTitle}
+						placeholder="Optional"
+						placeholderTextColor={t.faint}
+						style={[
+							styles.input,
+							{ borderColor: t.line, backgroundColor: t.card, color: t.ink },
+						]}
+						accessibilityLabel="Quote title"
+					/>
+				</View>
+
+				{error ? (
+					<Text style={[styles.error, { color: t.destructive }]}>
+						{error.planLimit
+							? `${error.message} Upgrade on the web app to add more.`
+							: error.message}
+					</Text>
+				) : null}
+
+				<Button
+					title="Create quote"
+					onPress={() => void submit()}
+					disabled={!valid || submitting}
+					icon={
+						submitting ? (
+							<ActivityIndicator size="small" color={t.primaryInk} />
+						) : undefined
+					}
+					style={styles.submit}
+				/>
+				<Text style={[styles.footnote, { color: t.sub }]}>
+					You&rsquo;ll add line items on the next screen.
+				</Text>
+			</ScrollView>
+		</>
+	);
+
+	if (device === "ipad") {
+		return (
+			<CenteredModal onScrimPress={() => router.back()} maxHeight="92%">
+				<View style={[styles.padCard, { backgroundColor: t.card }]}>
+					{content}
+				</View>
+			</CenteredModal>
+		);
+	}
+
+	return (
+		<View
+			style={[
+				styles.container,
+				{ backgroundColor: t.card, paddingBottom: insets.bottom },
+			]}
+		>
+			<View style={[styles.grabber, { backgroundColor: t.line }]} />
+			{content}
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	flex: { flex: 1 },
+	container: {
+		flex: 1,
+		borderTopLeftRadius: 30,
+		borderTopRightRadius: 30,
+		overflow: "hidden",
+	},
+	padCard: { flex: 1, paddingTop: 18 },
+	grabber: {
+		alignSelf: "center",
+		width: 44,
+		height: 5,
+		borderRadius: 999,
+		marginTop: 10,
+		marginBottom: 12,
+	},
+	header: {
+		flexDirection: "row",
+		alignItems: "center",
+		paddingHorizontal: 20,
+		paddingBottom: 12,
+	},
+	headerTitle: {
+		flex: 2,
+		textAlign: "center",
+		fontSize: type.h2,
+		lineHeight: 30,
+		fontFamily: fontFamily.bold,
+	},
+	headerAction: { flex: 1, alignItems: "flex-end" },
+	closeBtn: {
+		width: 32,
+		height: 32,
+		borderRadius: 999,
+		alignItems: "center",
+		justifyContent: "center",
+	},
+	body: { paddingHorizontal: 20, paddingBottom: 32 },
+	field: { marginTop: 20 },
+	input: {
+		borderWidth: 1,
+		borderRadius: radii.ctrl,
+		paddingHorizontal: 14,
+		paddingVertical: 12,
+		fontSize: type.h4,
+		fontFamily: fontFamily.regular,
+		marginTop: 8,
+	},
+	error: {
+		fontFamily: fontFamily.medium,
+		fontSize: type.meta,
+		marginTop: 16,
+	},
+	submit: { marginTop: 24 },
+	footnote: {
+		fontFamily: fontFamily.regular,
+		fontSize: type.xs,
+		textAlign: "center",
+		marginTop: 10,
+	},
+});

--- a/apps/mobile/app/quote/new.tsx
+++ b/apps/mobile/app/quote/new.tsx
@@ -10,7 +10,7 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { router, useLocalSearchParams } from "expo-router";
-import { useMutation } from "convex/react";
+import { useMutation, useQuery } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
 import type { Id } from "@onetool/backend/convex/_generated/dataModel";
 import { X } from "lucide-react-native";
@@ -18,10 +18,15 @@ import { fontFamily, radii, type, useTokens } from "@/lib/theme";
 import { Button, Eyebrow } from "@/components/ui";
 import { CenteredModal } from "@/components/ipad/centered-modal";
 import { ClientPicker } from "@/components/create/client-picker";
+import { FieldMenu } from "@/components/FieldMenu";
 import { useDevice } from "@/lib/use-device";
 import { usePermissions } from "@/lib/use-permissions";
 import { hapticSuccess } from "@/lib/haptics";
 import { describeMutationError } from "@/lib/mutation-error";
+
+// FieldMenu action id for "no project" — an empty-string id is not a shape the
+// native MenuView is known to round-trip.
+const NO_PROJECT = "__none__";
 
 // Fast-capture quote create (Slice 5 speed-dial). This screen only mints the
 // empty draft — the line-item sheet on the quote detail screen (Slice 4) is
@@ -36,6 +41,9 @@ export default function NewQuoteSheet() {
 	const [clientId, setClientId] = useState<Id<"clients"> | "">(
 		(params.clientId as Id<"clients">) || ""
 	);
+	// A client pushed in on the route is settled — show it read-only.
+	const clientLocked = !!params.clientId;
+	const [projectId, setProjectId] = useState<Id<"projects"> | "">("");
 	const [title, setTitle] = useState("");
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<{
@@ -44,6 +52,16 @@ export default function NewQuoteSheet() {
 	} | null>(null);
 
 	const createQuote = useMutation(api.quotes.create);
+	const projects = useQuery(
+		api.projects.list,
+		clientId ? { clientId: clientId as Id<"clients"> } : "skip"
+	);
+	const projectOptions = [
+		{ value: NO_PROJECT, label: "No project" },
+		...(projects ?? []).map((p) => ({ value: p._id, label: p.title })),
+	];
+	const projectLabel =
+		projectOptions.find((o) => o.value === projectId)?.label ?? "No project";
 
 	const canCreate = can("quotes", "modify");
 	const valid = !!clientId;
@@ -55,6 +73,7 @@ export default function NewQuoteSheet() {
 		try {
 			const quoteId = (await createQuote({
 				clientId: clientId as Id<"clients">,
+				projectId: projectId ? (projectId as Id<"projects">) : undefined,
 				title: title.trim() || undefined,
 				status: "draft",
 				subtotal: 0,
@@ -103,9 +122,35 @@ export default function NewQuoteSheet() {
 				<Eyebrow>Client</Eyebrow>
 				<ClientPicker
 					value={clientId}
-					onChange={setClientId}
-					allowQuickAdd={can("clients", "modify")}
+					onChange={(next) => {
+						setClientId(next);
+						setProjectId(""); // a new client invalidates the staged project
+					}}
+					allowQuickAdd={!clientLocked && can("clients", "modify")}
+					locked={clientLocked}
 				/>
+
+				{/* Optional, and only when the client actually has projects — same
+				    FieldMenu idiom as the task form's client/project pair. */}
+				{clientId && projects && projects.length > 0 ? (
+					<View style={styles.field}>
+						<Eyebrow>Project</Eyebrow>
+						<View style={styles.menuWrap}>
+							<FieldMenu
+								title="Select project"
+								value={projectId || NO_PROJECT}
+								options={projectOptions}
+								label={projectLabel}
+								placeholder={!projectId}
+								onSelect={(next) =>
+									setProjectId(
+										next === NO_PROJECT ? "" : (next as Id<"projects">)
+									)
+								}
+							/>
+						</View>
+					</View>
+				) : null}
 
 				<View style={styles.field}>
 					<Eyebrow>Title</Eyebrow>
@@ -211,6 +256,8 @@ const styles = StyleSheet.create({
 	},
 	body: { paddingHorizontal: 20, paddingBottom: 32 },
 	field: { marginTop: 20 },
+	// FieldMenu has no outer margin of its own; match the TextInput's offset.
+	menuWrap: { marginTop: 8 },
 	input: {
 		borderWidth: 1,
 		borderRadius: radii.ctrl,

--- a/apps/mobile/app/tasks/form.tsx
+++ b/apps/mobile/app/tasks/form.tsx
@@ -9,7 +9,8 @@ import {
 	StyleSheet,
 	Animated,
 } from "react-native";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useOrganization } from "@clerk/expo";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { router, useLocalSearchParams } from "expo-router";
 import { useMutation, useQuery } from "convex/react";
@@ -24,6 +25,8 @@ import { useOverlayTransition } from "@/components/useOverlayTransition";
 import { utcMsFromDateId, todayDateId, dateIdFromUtcMs } from "@/lib/date";
 import { CenteredModal } from "@/components/ipad/centered-modal";
 import { useDevice } from "@/lib/use-device";
+import { recordRecentView } from "@/lib/recents";
+import { formatTaskDate } from "@/lib/work-search";
 
 const TYPE_OPTIONS = [
 	{ value: "external", label: "External" },
@@ -137,6 +140,23 @@ export default function TaskFormSheet() {
 			setAppliedKey(initKey);
 		}
 	}
+
+	// On-device "Recently viewed" trail for the Work tab (Slice 6). Edit only —
+	// a task being created has nothing to remember yet.
+	const { organization } = useOrganization();
+	const orgId = organization?.id;
+	const recentId = isEdit ? task?._id : undefined;
+	const recentTitle = task?.title;
+	const recentSub = task ? formatTaskDate(task.date) : undefined;
+	useEffect(() => {
+		if (!recentId || !recentTitle) return;
+		recordRecentView(orgId, {
+			kind: "task",
+			id: recentId,
+			title: recentTitle,
+			sub: recentSub,
+		});
+	}, [orgId, recentId, recentTitle, recentSub]);
 
 	// Queries
 	const clients = useQuery(api.clients.list, {});

--- a/apps/mobile/components/app-header.tsx
+++ b/apps/mobile/components/app-header.tsx
@@ -20,9 +20,10 @@ import { Avatar, HalftoneBg, ScrollFade } from "@/components/ui";
 
 // Tab roots that get the "jump to search" magnifier. An ALLOWLIST, not
 // "everything except Work": the Clients/Projects/Activity/Profile roots also
-// mount a root-mode header and have no business growing one. Today is absent
-// because it mounts CommandHero, not this header (3.0 slice 6).
-const SEARCH_JUMP_ROUTES = new Set(["/money", "/routes"]);
+// mount a root-mode header and have no business growing one. Today and Money
+// are absent because they mount an ink band, not this header — their magnifier
+// lives in the band's icon cluster (3.0 slice 6).
+const SEARCH_JUMP_ROUTES = new Set(["/routes"]);
 const WORK_TAB: Href = "/(tabs)/work" as Href;
 
 // mode: 'root' | 'detail' | 'pane' — P19 uses root/detail; 'pane' reserved for P26 iPad.

--- a/apps/mobile/components/app-header.tsx
+++ b/apps/mobile/components/app-header.tsx
@@ -9,13 +9,21 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { BlurView } from "expo-blur";
-import { useRouter, type Href } from "expo-router";
+import { usePathname, useRouter, type Href } from "expo-router";
 import { useOrganization, useUser } from "@clerk/expo";
 import { useQuery } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
-import { ArrowLeft, Bell, ChevronDown, Plus } from "lucide-react-native";
+import { ArrowLeft, Bell, ChevronDown, Plus, Search } from "lucide-react-native";
+import { requestSearchFocus } from "@/lib/search-focus";
 import { fontFamily, radii, tokens, tracking, type, useTokens } from "@/lib/theme";
 import { Avatar, HalftoneBg, ScrollFade } from "@/components/ui";
+
+// Tab roots that get the "jump to search" magnifier. An ALLOWLIST, not
+// "everything except Work": the Clients/Projects/Activity/Profile roots also
+// mount a root-mode header and have no business growing one. Today is absent
+// because it mounts CommandHero, not this header (3.0 slice 6).
+const SEARCH_JUMP_ROUTES = new Set(["/money", "/routes"]);
+const WORK_TAB: Href = "/(tabs)/work" as Href;
 
 // mode: 'root' | 'detail' | 'pane' — P19 uses root/detail; 'pane' reserved for P26 iPad.
 type HeaderMode = "root" | "detail" | "pane";
@@ -69,6 +77,7 @@ export function AppHeader({
 }: AppHeaderProps) {
 	const t = useTokens();
 	const router = useRouter();
+	const pathname = usePathname();
 	const insets = useSafeAreaInsets();
 	const { organization } = useOrganization();
 	const { user } = useUser();
@@ -91,6 +100,10 @@ export function AppHeader({
 		setHeaderHeight(e.nativeEvent.layout.height);
 
 	const detail = mode === "detail";
+	// Pane mode returns early below, and both call sites that qualify gate their
+	// root header on !isPane — so this can never render inside an iPad pane,
+	// where Work is already on screen as a list pane.
+	const showSearchJump = mode === "root" && SEARCH_JUMP_ROUTES.has(pathname);
 	const orgName = organization?.name ?? "Personal";
 	const orgInitials = initialsFrom(orgName);
 	const userInitials = initialsFrom(
@@ -231,6 +244,22 @@ export function AppHeader({
 				<View style={{ flex: 1 }} pointerEvents="none" />
 
 				{/* Constant right cluster (root + detail) */}
+				{showSearchJump ? (
+					<Pressable
+						onPress={() => {
+							// Latch, then navigate: Work consumes it once on focus. A
+							// ?focus= param would stick to the tab and re-fire forever.
+							requestSearchFocus();
+							router.push(WORK_TAB);
+						}}
+						style={styles.bareBtn}
+						accessibilityRole="button"
+						accessibilityLabel="Search"
+					>
+						<Search size={21} color={t.ink} strokeWidth={2} />
+					</Pressable>
+				) : null}
+
 				{onAdd ? (
 					<Pressable
 						onPress={onAdd}

--- a/apps/mobile/components/assistant/assistant-chat.tsx
+++ b/apps/mobile/components/assistant/assistant-chat.tsx
@@ -219,11 +219,9 @@ export function AssistantChat({ screenContext }: { screenContext?: string }) {
 			style={styles.flex}
 			behavior={Platform.OS === "ios" ? "padding" : undefined}
 		>
+			{/* The ink header above the chat already names the surface — this row is
+			    just the two actions, splitting the width evenly (visual-pass r1). */}
 			<View style={[styles.header, { borderBottomColor: t.lineSoft }]}>
-				<View style={styles.headerTitleRow}>
-					<Sparkles size={16} color={t.frostedInk} />
-					<Text style={[styles.headerTitle, { color: t.ink }]}>Assistant</Text>
-				</View>
 				<View style={styles.headerActions}>
 					<Pressable
 						onPress={() => setShowHistory((v) => !v)}
@@ -404,23 +402,16 @@ const styles = StyleSheet.create({
 		paddingBottom: 12,
 		borderBottomWidth: 1,
 	},
-	headerTitleRow: {
-		flexDirection: "row",
-		alignItems: "center",
-		gap: 6,
-	},
-	headerTitle: {
-		fontFamily: fontFamily.bold,
-		fontSize: type.h2,
-	},
 	headerActions: {
+		flex: 1,
 		flexDirection: "row",
 		alignItems: "center",
-		gap: 14,
 	},
 	newChatBtn: {
+		flex: 1,
 		flexDirection: "row",
 		alignItems: "center",
+		justifyContent: "center",
 		gap: 4,
 		minHeight: touch.min,
 		paddingHorizontal: 4,

--- a/apps/mobile/components/assistant/ink-header.tsx
+++ b/apps/mobile/components/assistant/ink-header.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { Sparkles } from "lucide-react-native";
+import { dock, fontFamily, hero, radii, type } from "@/lib/theme";
+
+// Ink-lite band above the assistant chat. Shared by all three surfaces so the
+// pushed sheet, the iPad centered modal and the landscape companion panel read
+// as one thing: hero.ink ground, a very low-alpha echo of the dock orb's
+// gradient, Sparkles + title. Deliberately short — the chat owns the screen.
+
+export function AssistantInkHeader({
+	/** Sheet presentations get the drag handle; docked panels don't. */
+	grabber,
+	/** Trailing slot — the panel's close button. */
+	right,
+}: {
+	grabber?: boolean;
+	right?: React.ReactNode;
+}) {
+	return (
+		<View style={styles.band}>
+			{/* Orb-gradient glow, barely there — the ink stays the ground. */}
+			<LinearGradient
+				colors={[`${dock.orbGradient[0]}26`, `${dock.orbGradient[1]}00`]}
+				start={{ x: 0.85, y: 0 }}
+				end={{ x: 0.15, y: 1 }}
+				style={StyleSheet.absoluteFill}
+				pointerEvents="none"
+			/>
+			{grabber ? <View style={styles.grabber} /> : null}
+			<View style={styles.row}>
+				<Sparkles size={18} color={hero.text} strokeWidth={2.2} />
+				<Text style={styles.title}>Assistant</Text>
+				<View style={styles.spacer} />
+				{right}
+			</View>
+		</View>
+	);
+}
+
+/** Text tier for a header-slot glyph on the ink band (e.g. the close X). */
+export const inkHeaderGlyph = hero.textMid;
+
+const styles = StyleSheet.create({
+	band: {
+		backgroundColor: hero.ink,
+		paddingHorizontal: 16,
+		paddingTop: 8,
+		paddingBottom: 12,
+		overflow: "hidden",
+	},
+	grabber: {
+		alignSelf: "center",
+		width: 36,
+		height: 4,
+		borderRadius: radii.xs,
+		backgroundColor: hero.textSub,
+		marginBottom: 10,
+	},
+	row: {
+		flexDirection: "row",
+		alignItems: "center",
+		gap: 9,
+		minHeight: 28,
+	},
+	title: {
+		fontFamily: fontFamily.semibold,
+		fontSize: type.h3,
+		color: hero.text,
+	},
+	spacer: {
+		flex: 1,
+	},
+});

--- a/apps/mobile/components/create/client-picker.tsx
+++ b/apps/mobile/components/create/client-picker.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import {
 	ActivityIndicator,
 	Pressable,
+	ScrollView,
 	StyleSheet,
 	Text,
 	TextInput,
@@ -19,6 +20,13 @@ import { describeMutationError } from "@/lib/mutation-error";
 // Above this many clients the list stops being scannable — a filter appears.
 const FILTER_THRESHOLD = 8;
 
+// A ListRow measures 12 + 12 padding + 32 icon tile + 1 hairline separator.
+// Five of them is the tallest the list can get before it pushes the rest of the
+// create sheet off-screen (visual pass: 15+ clients rendered full-height).
+const ROW_HEIGHT = 57;
+const MAX_VISIBLE_ROWS = 5;
+const LIST_MAX_HEIGHT = ROW_HEIGHT * MAX_VISIBLE_ROWS;
+
 /** Mirrors backend ValidationPatterns.isValidPhone so we never orphan a client. */
 function isValidPhone(phone: string): boolean {
 	return /^\+?[\d\s()-]+$/.test(phone) && phone.replace(/\D/g, "").length >= 10;
@@ -32,15 +40,21 @@ function isValidPhone(phone: string): boolean {
  * `allowQuickAdd` adds a "+ New client" row that expands INLINE into name +
  * phone. Confirming creates the client and its primary contact, then selects
  * it — the capture flow never navigates away.
+ *
+ * `locked` is the "pushed from client detail with ?clientId=" case: the client
+ * is already known, so the picker collapses to a read-only row and the form
+ * opens straight on its own fields.
  */
 export function ClientPicker({
 	value,
 	onChange,
 	allowQuickAdd = false,
+	locked = false,
 }: {
 	value: Id<"clients"> | "";
 	onChange: (id: Id<"clients">) => void;
 	allowQuickAdd?: boolean;
+	locked?: boolean;
 }) {
 	const t = useTokens();
 	const clients = useQuery(api.clients.list, {});
@@ -48,6 +62,9 @@ export function ClientPicker({
 	const createContact = useMutation(api.clientContacts.create);
 
 	const [filter, setFilter] = useState("");
+	// Collapse-on-select: once a client is chosen the list folds into a single
+	// row. "Change" flips this back open. Derived at render — never an effect.
+	const [reopened, setReopened] = useState(false);
 	const [quickOpen, setQuickOpen] = useState(false);
 	const [quickName, setQuickName] = useState("");
 	const [quickPhone, setQuickPhone] = useState("");
@@ -64,6 +81,13 @@ export function ClientPicker({
 
 	const quickValid =
 		quickName.trim().length > 0 && isValidPhone(quickPhone.trim());
+
+	const select = (id: Id<"clients">) => {
+		hapticSelect();
+		onChange(id);
+		setReopened(false);
+		setFilter("");
+	};
 
 	const confirmQuickAdd = async () => {
 		if (!quickValid || quickSaving) return;
@@ -90,12 +114,10 @@ export function ClientPicker({
 			} catch {
 				setQuickHint("Client saved, but the phone number didn't stick.");
 			}
-			hapticSelect();
-			onChange(clientId);
+			select(clientId);
 			setQuickOpen(false);
 			setQuickName("");
 			setQuickPhone("");
-			setFilter("");
 		} catch (err) {
 			const { message, planLimit } = describeMutationError(
 				err,
@@ -114,6 +136,43 @@ export function ClientPicker({
 			<View style={styles.loading}>
 				<ActivityIndicator size="small" color={t.sub} />
 			</View>
+		);
+	}
+
+	const selected = value ? clients.find((c) => c._id === value) : undefined;
+
+	// Preselected client (?clientId=): read-only, no search / list / quick-add.
+	// The name is resolved off the list we already have — no extra query.
+	if (locked) {
+		return (
+			<ListRow
+				icon="Building2"
+				title={selected?.companyName ?? "Selected client"}
+				showChevron={false}
+				last
+			/>
+		);
+	}
+
+	// Chosen: fold to one row so the fields below get the vertical space back.
+	if (selected && !reopened) {
+		return (
+			<ListRow
+				icon="Building2"
+				title={selected.companyName}
+				selected
+				showChevron={false}
+				last
+				onPress={() => setReopened(true)}
+				right={
+					<View style={styles.collapsedRight}>
+						<Text style={[styles.change, { color: t.primarySolid }]}>
+							Change
+						</Text>
+						<Check size={17} color={t.primarySolid} strokeWidth={2.5} />
+					</View>
+				}
+			/>
 		);
 	}
 
@@ -152,14 +211,36 @@ export function ClientPicker({
 				</View>
 			) : null}
 
-			{rows.length === 0 ? (
+			{/* Pinned above the scroll area: a trailing quick-add row would be
+			    scrolled out of reach the moment the list overflows. */}
+			{allowQuickAdd && !quickOpen ? (
+				<ListRow
+					icon="Plus"
+					iconColor={t.primarySolid}
+					title="New client"
+					showChevron={false}
+					onPress={() => {
+						setQuickError(null);
+						setQuickHint(null);
+						setQuickOpen(true);
+					}}
+				/>
+			) : null}
+
+			{/* The inline quick-add form takes over this space while it's open. */}
+			{quickOpen ? null : rows.length === 0 ? (
 				<Text style={[styles.empty, { color: t.sub }]}>
 					{clients.length === 0
 						? "No clients yet."
 						: "No clients match that search."}
 				</Text>
 			) : (
-				<View>
+				<ScrollView
+					style={{ maxHeight: LIST_MAX_HEIGHT }}
+					nestedScrollEnabled
+					keyboardShouldPersistTaps="handled"
+					showsVerticalScrollIndicator={rows.length > MAX_VISIBLE_ROWS}
+				>
 					{rows.map((c, i) => (
 						<ListRow
 							key={c._id}
@@ -172,30 +253,12 @@ export function ClientPicker({
 									<Check size={17} color={t.primarySolid} strokeWidth={2.5} />
 								) : undefined
 							}
-							last={i === lastRowIndex && !allowQuickAdd}
-							onPress={() => {
-								hapticSelect();
-								onChange(c._id);
-							}}
+							last={i === lastRowIndex}
+							onPress={() => select(c._id)}
 						/>
 					))}
-				</View>
+				</ScrollView>
 			)}
-
-			{allowQuickAdd && !quickOpen ? (
-				<ListRow
-					icon="Plus"
-					iconColor={t.primarySolid}
-					title="New client"
-					showChevron={false}
-					last
-					onPress={() => {
-						setQuickError(null);
-						setQuickHint(null);
-						setQuickOpen(true);
-					}}
-				/>
-			) : null}
 
 			{allowQuickAdd && quickOpen ? (
 				<View
@@ -274,6 +337,11 @@ export function ClientPicker({
 
 const styles = StyleSheet.create({
 	loading: { paddingVertical: 24, alignItems: "center" },
+	collapsedRight: { flexDirection: "row", alignItems: "center", gap: 8 },
+	change: {
+		fontFamily: fontFamily.semibold,
+		fontSize: type.meta,
+	},
 	searchBar: {
 		flexDirection: "row",
 		alignItems: "center",

--- a/apps/mobile/components/create/client-picker.tsx
+++ b/apps/mobile/components/create/client-picker.tsx
@@ -1,0 +1,332 @@
+import { useMemo, useState } from "react";
+import {
+	ActivityIndicator,
+	Pressable,
+	StyleSheet,
+	Text,
+	TextInput,
+	View,
+} from "react-native";
+import { useMutation, useQuery } from "convex/react";
+import { api } from "@onetool/backend/convex/_generated/api";
+import type { Id } from "@onetool/backend/convex/_generated/dataModel";
+import { Check, Search, X } from "lucide-react-native";
+import { fontFamily, radii, type, useTokens } from "@/lib/theme";
+import { Button, ListRow } from "@/components/ui";
+import { hapticSelect } from "@/lib/haptics";
+import { describeMutationError } from "@/lib/mutation-error";
+
+// Above this many clients the list stops being scannable — a filter appears.
+const FILTER_THRESHOLD = 8;
+
+/** Mirrors backend ValidationPatterns.isValidPhone so we never orphan a client. */
+function isValidPhone(phone: string): boolean {
+	return /^\+?[\d\s()-]+$/.test(phone) && phone.replace(/\D/g, "").length >= 10;
+}
+
+/**
+ * Bare-row client picker shared by the fast-capture create sheets (Slice 5).
+ * Selection idiom is sign-quote's signer list: no Card wrapper (it clips the
+ * selected row's capsule), a Check on the chosen row, `last` on the final row.
+ *
+ * `allowQuickAdd` adds a "+ New client" row that expands INLINE into name +
+ * phone. Confirming creates the client and its primary contact, then selects
+ * it — the capture flow never navigates away.
+ */
+export function ClientPicker({
+	value,
+	onChange,
+	allowQuickAdd = false,
+}: {
+	value: Id<"clients"> | "";
+	onChange: (id: Id<"clients">) => void;
+	allowQuickAdd?: boolean;
+}) {
+	const t = useTokens();
+	const clients = useQuery(api.clients.list, {});
+	const createClient = useMutation(api.clients.create);
+	const createContact = useMutation(api.clientContacts.create);
+
+	const [filter, setFilter] = useState("");
+	const [quickOpen, setQuickOpen] = useState(false);
+	const [quickName, setQuickName] = useState("");
+	const [quickPhone, setQuickPhone] = useState("");
+	const [quickSaving, setQuickSaving] = useState(false);
+	const [quickError, setQuickError] = useState<string | null>(null);
+	const [quickHint, setQuickHint] = useState<string | null>(null);
+
+	const rows = useMemo(() => {
+		const all = clients ?? [];
+		const q = filter.trim().toLowerCase();
+		if (!q) return all;
+		return all.filter((c) => c.companyName.toLowerCase().includes(q));
+	}, [clients, filter]);
+
+	const quickValid =
+		quickName.trim().length > 0 && isValidPhone(quickPhone.trim());
+
+	const confirmQuickAdd = async () => {
+		if (!quickValid || quickSaving) return;
+		setQuickSaving(true);
+		setQuickError(null);
+		setQuickHint(null);
+		const name = quickName.trim();
+		try {
+			const clientId = (await createClient({
+				companyName: name,
+				status: "active",
+			})) as Id<"clients">;
+			// The contact carries the phone so the detail screen's call/message
+			// actions work. A failure here must not strand a real client: keep it,
+			// select it, and say what's missing.
+			try {
+				await createContact({
+					clientId,
+					firstName: name,
+					lastName: "",
+					phone: quickPhone.trim(),
+					isPrimary: true,
+				});
+			} catch {
+				setQuickHint("Client saved, but the phone number didn't stick.");
+			}
+			hapticSelect();
+			onChange(clientId);
+			setQuickOpen(false);
+			setQuickName("");
+			setQuickPhone("");
+			setFilter("");
+		} catch (err) {
+			const { message, planLimit } = describeMutationError(
+				err,
+				"Couldn't add that client. Check your connection and try again."
+			);
+			setQuickError(
+				planLimit ? `${message} Upgrade on the web app to continue.` : message
+			);
+		} finally {
+			setQuickSaving(false);
+		}
+	};
+
+	if (clients === undefined) {
+		return (
+			<View style={styles.loading}>
+				<ActivityIndicator size="small" color={t.sub} />
+			</View>
+		);
+	}
+
+	const showFilter = clients.length > FILTER_THRESHOLD;
+	const lastRowIndex = rows.length - 1;
+
+	return (
+		<View>
+			{showFilter ? (
+				<View
+					style={[
+						styles.searchBar,
+						{ backgroundColor: t.card, borderColor: t.line },
+					]}
+				>
+					<Search size={18} color={t.faint} />
+					<TextInput
+						value={filter}
+						onChangeText={setFilter}
+						placeholder="Search clients…"
+						placeholderTextColor={t.faint}
+						autoCorrect={false}
+						style={[styles.searchInput, { color: t.ink }]}
+						accessibilityLabel="Search clients"
+					/>
+					{filter.length > 0 ? (
+						<Pressable
+							onPress={() => setFilter("")}
+							hitSlop={8}
+							accessibilityRole="button"
+							accessibilityLabel="Clear search"
+						>
+							<X size={16} color={t.faint} />
+						</Pressable>
+					) : null}
+				</View>
+			) : null}
+
+			{rows.length === 0 ? (
+				<Text style={[styles.empty, { color: t.sub }]}>
+					{clients.length === 0
+						? "No clients yet."
+						: "No clients match that search."}
+				</Text>
+			) : (
+				<View>
+					{rows.map((c, i) => (
+						<ListRow
+							key={c._id}
+							icon="Building2"
+							title={c.companyName}
+							selected={c._id === value}
+							showChevron={false}
+							right={
+								c._id === value ? (
+									<Check size={17} color={t.primarySolid} strokeWidth={2.5} />
+								) : undefined
+							}
+							last={i === lastRowIndex && !allowQuickAdd}
+							onPress={() => {
+								hapticSelect();
+								onChange(c._id);
+							}}
+						/>
+					))}
+				</View>
+			)}
+
+			{allowQuickAdd && !quickOpen ? (
+				<ListRow
+					icon="Plus"
+					iconColor={t.primarySolid}
+					title="New client"
+					showChevron={false}
+					last
+					onPress={() => {
+						setQuickError(null);
+						setQuickHint(null);
+						setQuickOpen(true);
+					}}
+				/>
+			) : null}
+
+			{allowQuickAdd && quickOpen ? (
+				<View
+					style={[
+						styles.quick,
+						{ backgroundColor: t.card, borderColor: t.line },
+					]}
+				>
+					<View style={styles.quickHead}>
+						<Text style={[styles.quickTitle, { color: t.ink }]}>
+							New client
+						</Text>
+						<Pressable
+							onPress={() => {
+								setQuickOpen(false);
+								setQuickError(null);
+							}}
+							hitSlop={8}
+							disabled={quickSaving}
+							accessibilityRole="button"
+							accessibilityLabel="Cancel new client"
+						>
+							<X size={16} color={t.sub} />
+						</Pressable>
+					</View>
+					<TextInput
+						value={quickName}
+						onChangeText={setQuickName}
+						placeholder="Client or company name"
+						placeholderTextColor={t.faint}
+						autoCapitalize="words"
+						style={[
+							styles.input,
+							{ borderColor: t.line, backgroundColor: t.bg, color: t.ink },
+						]}
+						accessibilityLabel="Client name"
+					/>
+					<TextInput
+						value={quickPhone}
+						onChangeText={setQuickPhone}
+						placeholder="Phone number"
+						placeholderTextColor={t.faint}
+						keyboardType="phone-pad"
+						style={[
+							styles.input,
+							{ borderColor: t.line, backgroundColor: t.bg, color: t.ink },
+						]}
+						accessibilityLabel="Client phone number"
+					/>
+					{quickPhone.trim().length > 0 && !isValidPhone(quickPhone.trim()) ? (
+						<Text style={[styles.hint, { color: t.faint }]}>
+							Enter a phone number with at least 10 digits.
+						</Text>
+					) : null}
+					{quickError ? (
+						<Text style={[styles.error, { color: t.destructive }]}>
+							{quickError}
+						</Text>
+					) : null}
+					<Button
+						title={quickSaving ? "Adding…" : "Add client"}
+						size="sm"
+						disabled={!quickValid || quickSaving}
+						onPress={() => void confirmQuickAdd()}
+						style={styles.quickCta}
+					/>
+				</View>
+			) : null}
+
+			{quickHint ? (
+				<Text style={[styles.hint, { color: t.sub }]}>{quickHint}</Text>
+			) : null}
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	loading: { paddingVertical: 24, alignItems: "center" },
+	searchBar: {
+		flexDirection: "row",
+		alignItems: "center",
+		gap: 9,
+		borderWidth: 1,
+		borderRadius: radii.ctrl,
+		paddingHorizontal: 12,
+		height: 44,
+		marginBottom: 8,
+	},
+	searchInput: {
+		flex: 1,
+		fontFamily: fontFamily.regular,
+		fontSize: type.body,
+	},
+	empty: {
+		fontFamily: fontFamily.medium,
+		fontSize: type.meta,
+		paddingVertical: 14,
+	},
+	quick: {
+		borderWidth: 1,
+		borderRadius: radii.card,
+		padding: 12,
+		gap: 8,
+		marginTop: 8,
+	},
+	quickHead: {
+		flexDirection: "row",
+		alignItems: "center",
+		justifyContent: "space-between",
+	},
+	quickTitle: {
+		fontFamily: fontFamily.semibold,
+		fontSize: type.rowTitle,
+	},
+	input: {
+		borderWidth: 1,
+		borderRadius: radii.ctrl,
+		paddingHorizontal: 12,
+		paddingVertical: 11,
+		fontFamily: fontFamily.regular,
+		fontSize: type.body,
+	},
+	quickCta: { marginTop: 2 },
+	hint: {
+		fontFamily: fontFamily.regular,
+		fontSize: type.xs,
+		marginTop: 6,
+	},
+	error: {
+		fontFamily: fontFamily.medium,
+		fontSize: type.xs,
+		marginTop: 2,
+	},
+});

--- a/apps/mobile/components/identity-block.tsx
+++ b/apps/mobile/components/identity-block.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+import {
+	fontFamily,
+	radii,
+	STATUS,
+	tracking,
+	type,
+	useTokens,
+} from "@/lib/theme";
+
+interface IdentityBlockProps {
+	/** Record tint pair — pass `recordTint.client`, `recordTint.project`, … */
+	tint: { bg: string; fg: string };
+	/** Monogram glyph. Callers pass a single letter; longer strings are clipped. */
+	monogram: string;
+	title: string;
+	/** Key into the STATUS map — rendered as TEXT, never a badge pill. */
+	statusKey?: string;
+	/** Quiet third line: lead source, city, project client, … */
+	sub?: string;
+	/**
+	 * Wraps the status text so a screen can make it interactive (the client
+	 * detail hangs a FieldMenu off it). The native MenuView host must receive a
+	 * SINGLE bare child inside a content-sized parent — hence the status line
+	 * lives on its own row with alignSelf:"flex-start", and `sub` is a separate
+	 * line rather than an inline sibling.
+	 */
+	renderStatus?: (statusText: React.ReactNode) => React.ReactNode;
+}
+
+// Daybook identity header: tinted monogram square + name + status-as-text.
+// Card-free by design — it sits directly on the page canvas.
+export function IdentityBlock({
+	tint,
+	monogram,
+	title,
+	statusKey,
+	sub,
+	renderStatus,
+}: IdentityBlockProps) {
+	const t = useTokens();
+	const entry = statusKey
+		? STATUS[statusKey as keyof typeof STATUS]
+		: undefined;
+	const statusLabel = entry?.label ?? statusKey;
+	const statusColor = entry?.c ?? t.sub;
+
+	const statusText = statusKey ? (
+		<Text style={[styles.status, { color: statusColor }]} numberOfLines={1}>
+			{statusLabel}
+		</Text>
+	) : null;
+
+	return (
+		<View style={styles.row}>
+			<View style={[styles.monogram, { backgroundColor: tint.bg }]}>
+				<Text style={[styles.monogramText, { color: tint.fg }]}>
+					{monogram.slice(0, 1).toUpperCase()}
+				</Text>
+			</View>
+			<View style={styles.body}>
+				<Text style={[styles.title, { color: t.ink }]} numberOfLines={2}>
+					{title}
+				</Text>
+				{statusText ? (
+					<View style={styles.statusWrap}>
+						{renderStatus ? renderStatus(statusText) : statusText}
+					</View>
+				) : null}
+				{sub ? (
+					<Text style={[styles.sub, { color: t.sub }]} numberOfLines={1}>
+						{sub}
+					</Text>
+				) : null}
+			</View>
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	row: {
+		flexDirection: "row",
+		alignItems: "center",
+		gap: 14,
+	},
+	monogram: {
+		width: 54,
+		height: 54,
+		borderRadius: radii.card,
+		alignItems: "center",
+		justifyContent: "center",
+		flexShrink: 0,
+	},
+	monogramText: {
+		fontFamily: fontFamily.semibold,
+		fontSize: 24,
+		letterSpacing: 0.2,
+	},
+	body: { flex: 1, minWidth: 0 },
+	title: {
+		fontFamily: fontFamily.semibold,
+		fontSize: type.h1,
+		letterSpacing: tracking.title,
+	},
+	// alignSelf sizes the (possibly menu-hosting) wrapper to its content — a
+	// stretched native MenuView trigger clips its label to "..".
+	statusWrap: { alignSelf: "flex-start", marginTop: 4 },
+	status: {
+		fontFamily: fontFamily.semibold,
+		fontSize: type.eyebrow,
+		letterSpacing: tracking.groupLabel,
+		textTransform: "uppercase",
+	},
+	sub: {
+		fontFamily: fontFamily.regular,
+		fontSize: type.meta,
+		marginTop: 4,
+	},
+});

--- a/apps/mobile/components/identity-block.tsx
+++ b/apps/mobile/components/identity-block.tsx
@@ -14,7 +14,9 @@ interface IdentityBlockProps {
 	tint: { bg: string; fg: string };
 	/** Monogram glyph. Callers pass a single letter; longer strings are clipped. */
 	monogram: string;
-	title: string;
+	/** Omit when the screen header already carries the name (visual-pass r1:
+	 * repeating it beside the monogram read as redundant). */
+	title?: string;
 	/** Key into the STATUS map — rendered as TEXT, never a badge pill. */
 	statusKey?: string;
 	/** Quiet third line: lead source, city, project client, … */
@@ -60,9 +62,11 @@ export function IdentityBlock({
 				</Text>
 			</View>
 			<View style={styles.body}>
-				<Text style={[styles.title, { color: t.ink }]} numberOfLines={2}>
-					{title}
-				</Text>
+				{title ? (
+					<Text style={[styles.title, { color: t.ink }]} numberOfLines={2}>
+						{title}
+					</Text>
+				) : null}
 				{statusText ? (
 					<View style={styles.statusWrap}>
 						{renderStatus ? renderStatus(statusText) : statusText}

--- a/apps/mobile/components/ink-tab-header.tsx
+++ b/apps/mobile/components/ink-tab-header.tsx
@@ -1,0 +1,249 @@
+import React, { useState } from "react";
+import {
+	Pressable,
+	StyleSheet,
+	Text,
+	View,
+	type LayoutChangeEvent,
+} from "react-native";
+import Svg, { Defs, Ellipse, RadialGradient, Stop } from "react-native-svg";
+import { StatusBar } from "expo-status-bar";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useIsFocused, useRouter, type Href } from "expo-router";
+import { useUser } from "@clerk/expo";
+import { useQuery } from "convex/react";
+import { api } from "@onetool/backend/convex/_generated/api";
+import { Bell, type LucideIcon } from "lucide-react-native";
+import { DotGrid } from "@/components/ui";
+import { fontFamily, hero, tokens, tracking } from "@/lib/theme";
+
+const NOTIFICATIONS: Href = "/notifications" as Href;
+
+function initialsFrom(name?: string | null, email?: string | null): string {
+	const source = name?.trim() || email || "?";
+	const words = source.split(/\s+/).filter(Boolean);
+	if (words.length >= 2) {
+		return (words[0][0] + words[words.length - 1][0]).toUpperCase();
+	}
+	return source.slice(0, 2).toUpperCase();
+}
+
+export interface InkHeaderAction {
+	key: string;
+	/** Accessibility label — these buttons are icon-only. */
+	label: string;
+	icon: LucideIcon;
+	onPress: () => void;
+}
+
+interface InkTabHeaderProps {
+	title: string;
+	/** Uppercase line above the title. */
+	eyebrow?: string;
+	/** Extra icon buttons, placed LEFT of the constant bell + avatar cluster. */
+	actions?: readonly InkHeaderAction[];
+	/** On-ink slot below the title — search field, stat line, pinned controls. */
+	children?: React.ReactNode;
+}
+
+/**
+ * The lighter sibling of today/command-hero: the same ink band language (glow,
+ * dot grid, frosted icon circles, rounded foot) for the other tab roots, minus
+ * the org chip, greeting and week strip. Screens feed it a title and whatever
+ * belongs on ink.
+ */
+export function InkTabHeader({
+	title,
+	eyebrow,
+	actions,
+	children,
+}: InkTabHeaderProps) {
+	const router = useRouter();
+	const insets = useSafeAreaInsets();
+	const isFocused = useIsFocused();
+	const { user } = useUser();
+	const notificationData = useQuery(api.notifications.listForCurrentUser, {
+		limit: 1,
+	});
+	const unread = (notificationData?.unreadCount ?? 0) > 0;
+
+	const userInitials = initialsFrom(
+		user?.fullName ?? user?.firstName,
+		user?.primaryEmailAddress?.emailAddress,
+	);
+
+	// Glow SVG needs measured pixels — Fabric escapes %-sized SVGs inside an
+	// indefinite-height parent (same pitfall as dot-grid.tsx).
+	const [size, setSize] = useState({ width: 0, height: 0 });
+	const onLayout = (e: LayoutChangeEvent) => {
+		const { width, height } = e.nativeEvent.layout;
+		setSize((prev) =>
+			prev.width === width && prev.height === height
+				? prev
+				: { width, height },
+		);
+	};
+
+	const iconButton = (
+		key: string,
+		label: string,
+		onPress: () => void,
+		child: React.ReactNode,
+		options?: { avatar?: boolean; dot?: boolean },
+	) => (
+		<Pressable
+			key={key}
+			onPress={onPress}
+			accessibilityRole="button"
+			accessibilityLabel={label}
+			style={[
+				styles.iconButton,
+				{
+					backgroundColor: options?.avatar ? hero.avatarBg : hero.buttonBg,
+					borderColor: hero.buttonBorder,
+				},
+			]}
+		>
+			{child}
+			{options?.dot ? <View style={styles.alertDot} /> : null}
+		</Pressable>
+	);
+
+	return (
+		<View
+			onLayout={onLayout}
+			style={[styles.band, { paddingTop: insets.top + 6 }]}
+		>
+			{/* The dark band needs light status-bar glyphs — but only while this
+			    screen is the focused tab, or the sibling roots inherit invisible
+			    icons. */}
+			{isFocused ? <StatusBar style="light" /> : null}
+			{size.width > 0 && (
+				<Svg
+					width={size.width}
+					height={size.height}
+					style={StyleSheet.absoluteFill}
+					pointerEvents="none"
+				>
+					<Defs>
+						<RadialGradient id="inkHeaderGlow" cx="50%" cy="50%" r="50%">
+							<Stop offset="0" stopColor={tokens.brand} stopOpacity={0.22} />
+							<Stop offset="0.6" stopColor={tokens.brand} stopOpacity={0} />
+						</RadialGradient>
+					</Defs>
+					<Ellipse
+						cx={size.width * 0.85}
+						cy={-size.height * 0.1}
+						rx={size.width * 1.2}
+						ry={size.height * 0.9}
+						fill="url(#inkHeaderGlow)"
+					/>
+				</Svg>
+			)}
+			<DotGrid style={StyleSheet.absoluteFill} color={hero.dotGrid} />
+
+			{/* Title row — the title sits inline with the icon cluster, which is what
+			    keeps this band shorter than Today's. */}
+			<View style={styles.topRow}>
+				<View style={styles.titleBlock}>
+					{eyebrow ? (
+						<Text style={styles.eyebrow}>{eyebrow.toUpperCase()}</Text>
+					) : null}
+					<Text numberOfLines={1} style={styles.title}>
+						{title}
+					</Text>
+				</View>
+				<View style={styles.spacer} />
+				{actions?.map((action) =>
+					iconButton(
+						action.key,
+						action.label,
+						action.onPress,
+						<action.icon size={18} color={hero.text} strokeWidth={2} />,
+					),
+				)}
+				{iconButton(
+					"bell",
+					unread ? "Notifications, unread" : "Notifications",
+					() => router.push(NOTIFICATIONS),
+					<Bell size={18} color={hero.text} strokeWidth={2} />,
+					{ dot: unread },
+				)}
+				{iconButton(
+					"avatar",
+					"Profile",
+					() => router.push("/(tabs)/profile"),
+					<Text style={styles.avatarText}>{userInitials}</Text>,
+					{ avatar: true },
+				)}
+			</View>
+
+			{children ? <View style={styles.slot}>{children}</View> : null}
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	band: {
+		backgroundColor: hero.ink,
+		borderBottomLeftRadius: hero.radius,
+		borderBottomRightRadius: hero.radius,
+		overflow: "hidden",
+		paddingHorizontal: 20,
+		paddingBottom: 14,
+	},
+	topRow: {
+		flexDirection: "row",
+		alignItems: "center",
+		gap: 8,
+	},
+	titleBlock: {
+		flexShrink: 1,
+		minWidth: 0,
+	},
+	eyebrow: {
+		fontFamily: fontFamily.semibold,
+		fontSize: 11,
+		letterSpacing: tracking.groupLabel,
+		color: hero.textDim,
+		marginBottom: 2,
+	},
+	title: {
+		fontFamily: fontFamily.semibold,
+		fontSize: 26,
+		lineHeight: 31,
+		letterSpacing: -0.3,
+		color: hero.text,
+	},
+	spacer: {
+		flex: 1,
+	},
+	iconButton: {
+		width: 36,
+		height: 36,
+		borderRadius: 12,
+		borderWidth: 1,
+		alignItems: "center",
+		justifyContent: "center",
+	},
+	alertDot: {
+		position: "absolute",
+		top: 7,
+		right: 7,
+		width: 7,
+		height: 7,
+		borderRadius: 4,
+		backgroundColor: hero.alertDot,
+		borderWidth: 1.5,
+		borderColor: hero.ink,
+	},
+	avatarText: {
+		fontFamily: fontFamily.semibold,
+		fontSize: 12,
+		color: hero.text,
+	},
+	slot: {
+		marginTop: 16,
+		gap: 10,
+	},
+});

--- a/apps/mobile/components/ink-tab-header.tsx
+++ b/apps/mobile/components/ink-tab-header.tsx
@@ -96,6 +96,8 @@ export function InkTabHeader({
 			onPress={onPress}
 			accessibilityRole="button"
 			accessibilityLabel={label}
+			// The circle stays 36pt; the target reaches 44 (bell, avatar, actions).
+			hitSlop={4}
 			style={[
 				styles.iconButton,
 				{

--- a/apps/mobile/components/ipad/ipad-shell.tsx
+++ b/apps/mobile/components/ipad/ipad-shell.tsx
@@ -25,7 +25,7 @@ import { DotGrid } from "@/components/ui";
 import { PaneDetailHost } from "@/components/ipad/pane-detail-host";
 import { PaneAction, PaneHeader } from "@/components/ipad/pane-header";
 import { ShellNavProvider, type ShellNav } from "@/lib/shell-nav";
-import type { WorkKind } from "@/lib/work-search";
+import type { WorkChipKind } from "@/lib/work-search";
 import TodayScreen from "@/app/(tabs)/index";
 import WorkScreen from "@/app/(tabs)/work";
 import RoutesScreen from "@/app/(tabs)/routes";
@@ -119,7 +119,9 @@ function IpadShellInner() {
 
 	// Work's chip lives here so `browse(kind)` ("View all projects" from a client
 	// detail) can scope the list without a route push.
-	const [workKind, setWorkKind] = useState<WorkKind | null>(null);
+	// Chip kinds are wider than pane kinds: Work also browses tasks, which open a
+	// form sheet rather than a detail pane (so they never reach `select`).
+	const [workKind, setWorkKind] = useState<WorkChipKind | null>(null);
 
 	// Route → selection reconciliation. On a detail route, sync the durable
 	// selection so the pane opens the target. select() dispatches to the

--- a/apps/mobile/components/ipad/ipad-shell.tsx
+++ b/apps/mobile/components/ipad/ipad-shell.tsx
@@ -1,15 +1,19 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { Pressable, StyleSheet, View } from "react-native";
 import { Plus, X } from "lucide-react-native";
 import { Slot, usePathname, useRouter, type Href } from "expo-router";
 import { useDevice } from "@/lib/use-device";
-import { fontFamily, type, useTokens } from "@/lib/theme";
+import { useTokens } from "@/lib/theme";
 import {
 	SelectionProvider,
 	useSelection,
 	type SelectionTab,
 } from "@/lib/selection-context";
-import { PadSidebar, type SidebarTab } from "@/components/ipad/pad-sidebar";
+import {
+	PadSidebar,
+	type CreateItem,
+	type SidebarTab,
+} from "@/components/ipad/pad-sidebar";
 import {
 	isOverlayRoute,
 	isStackRoute,
@@ -29,7 +33,12 @@ import ActivityScreen from "@/app/(tabs)/activity";
 import ProfileScreen from "@/app/(tabs)/profile";
 import { ClientCreateBody } from "@/app/(tabs)/clients/new";
 import { AssistantHost } from "@/components/assistant/assistant-host";
+import {
+	AssistantInkHeader,
+	inkHeaderGlyph,
+} from "@/components/assistant/ink-header";
 import { buildScreenContext } from "@/lib/screen-context";
+import { usePermissions } from "@/lib/use-permissions";
 
 // ============================================================================
 // IpadShell — top-level iPad layout (gated on device === "ipad" in (tabs)/
@@ -77,6 +86,7 @@ function IpadShellInner() {
 	const { orientation } = useDevice();
 	const { state, select, clear } = useSelection();
 	const pathname = usePathname();
+	const { can, isLoading: permissionsLoading } = usePermissions();
 
 	// activeTab is held in LOCAL STATE so a rail tap swaps only the content pane —
 	// the rail is a persistent frame, not a navigation push. A router.push() for
@@ -157,10 +167,47 @@ function IpadShellInner() {
 		[select],
 	);
 
+	// Rail create menu — the iPad counterpart of the iPhone speed-dial FAB. Same
+	// four record types, same "modify" gate; New client uses the shell-native
+	// in-pane surface rather than a route push, the rest push their stack route.
+	const createItems = useMemo<CreateItem[]>(() => {
+		const items: CreateItem[] = [];
+		if (can("projects", "modify")) {
+			items.push({
+				key: "project",
+				label: "New project",
+				run: () => router.push("/project/new" as Href),
+			});
+		}
+		if (can("tasks", "modify")) {
+			items.push({
+				key: "task",
+				label: "New task",
+				run: () => router.push("/tasks/form" as Href),
+			});
+		}
+		if (can("clients", "modify")) {
+			items.push({
+				key: "client",
+				label: "New client",
+				run: () => shellNav.startCreate(),
+			});
+		}
+		if (can("quotes", "modify")) {
+			items.push({
+				key: "quote",
+				label: "New quote",
+				run: () => router.push("/quote/new" as Href),
+			});
+		}
+		return items;
+	}, [can, router, shellNav]);
+
 	const sidebar = (
 		<PadSidebar
 			activeTab={activeTab}
 			onNavigate={onNavigate}
+			createItems={permissionsLoading ? [] : createItems}
 			onAssistant={() => {
 				if (orientation === "landscape") {
 					setAssistantOpen((open) => !open);
@@ -380,20 +427,19 @@ function AssistantPanel({
 				{ backgroundColor: t.card, borderLeftColor: t.border },
 			]}
 		>
-			<View style={[styles.assistantHeader, { borderBottomColor: t.border }]}>
-				<Text style={[styles.assistantTitle, { color: t.ink }]}>
-					Assistant
-				</Text>
-				<Pressable
-					onPress={onClose}
-					hitSlop={10}
-					accessibilityRole="button"
-					accessibilityLabel="Close assistant"
-					style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
-				>
-					<X size={18} color={t.sub} strokeWidth={2.25} />
-				</Pressable>
-			</View>
+			<AssistantInkHeader
+				right={
+					<Pressable
+						onPress={onClose}
+						hitSlop={10}
+						accessibilityRole="button"
+						accessibilityLabel="Close assistant"
+						style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+					>
+						<X size={18} color={inkHeaderGlyph} strokeWidth={2.25} />
+					</Pressable>
+				}
+			/>
 			<AssistantHost screenContext={screenContext} />
 		</View>
 	);
@@ -436,17 +482,5 @@ const styles = StyleSheet.create({
 		flexShrink: 0,
 		borderLeftWidth: 1,
 		overflow: "hidden",
-	},
-	assistantHeader: {
-		flexDirection: "row",
-		alignItems: "center",
-		justifyContent: "space-between",
-		paddingHorizontal: 16,
-		paddingVertical: 12,
-		borderBottomWidth: StyleSheet.hairlineWidth,
-	},
-	assistantTitle: {
-		fontFamily: fontFamily.semibold,
-		fontSize: type.h3,
 	},
 });

--- a/apps/mobile/components/ipad/pad-sidebar.tsx
+++ b/apps/mobile/components/ipad/pad-sidebar.tsx
@@ -1,7 +1,11 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import {
+	ActionSheetIOS,
+	Alert,
+	findNodeHandle,
 	Image,
 	type LayoutChangeEvent,
+	Platform,
 	Pressable,
 	StyleSheet,
 	Text,
@@ -15,6 +19,7 @@ import {
 	Briefcase,
 	CalendarCheck,
 	ChevronDown,
+	Plus,
 	Route as RouteIcon,
 	Sparkles,
 } from "lucide-react-native";
@@ -30,9 +35,19 @@ export type SidebarTab = "today" | "work" | "routes" | "activity";
 /** "profile" highlights NO nav row — Profile is reached via the footer. */
 export type SidebarActive = SidebarTab | "profile";
 
+/** One entry of the rail's create menu. The shell builds and permission-filters
+ *  these; the rail only renders them (same "pure chrome" split as the nav). */
+export interface CreateItem {
+	key: string;
+	label: string;
+	run: () => void;
+}
+
 interface PadSidebarProps {
 	activeTab: SidebarActive;
 	onNavigate: (tab: SidebarTab) => void;
+	/** Empty → no ＋ at all (nothing this member may create = no dead chrome). */
+	createItems?: CreateItem[];
 	onAssistant: () => void;
 	onProfile: () => void;
 	onNotifications: () => void;
@@ -66,12 +81,35 @@ function roleLabel(role?: string | null): string {
 export function PadSidebar({
 	activeTab,
 	onNavigate,
+	createItems = [],
 	onAssistant,
 	onProfile,
 	onNotifications,
 }: PadSidebarProps) {
 	const t = useTokens();
 	const router = useRouter();
+	// The sheet must be anchored to the ＋ or iOS pops it from the screen centre
+	// instead of beside the rail.
+	const createAnchor = useRef<View>(null);
+
+	const openCreateMenu = () => {
+		if (createItems.length === 0) return;
+		if (Platform.OS === "ios") {
+			ActionSheetIOS.showActionSheetWithOptions(
+				{
+					options: [...createItems.map((i) => i.label), "Cancel"],
+					cancelButtonIndex: createItems.length,
+					anchor: findNodeHandle(createAnchor.current) ?? undefined,
+				},
+				(index) => createItems[index]?.run(),
+			);
+		} else {
+			Alert.alert("Create", undefined, [
+				...createItems.map((i) => ({ text: i.label, onPress: i.run })),
+				{ text: "Cancel", style: "cancel" as const },
+			]);
+		}
+	};
 	const { organization, membership } = useOrganization();
 	const { user } = useUser();
 
@@ -182,6 +220,27 @@ export function PadSidebar({
 			{/* Assistant sits OUTSIDE the tablist — it is a button, not a fifth tab —
 			    and after the flex:1 nav, which is what pins it to the rail bottom (§6:
 			    no floating FAB on iPad). */}
+			{/* Create sits directly above the assistant — the rail's capture entry
+			    point, standing in for the phone's speed-dial FAB (§6: no FAB on
+			    iPad). Anchors its own action sheet. */}
+			{createItems.length > 0 ? (
+				<View style={styles.createWrap}>
+					<Pressable
+						ref={createAnchor}
+						onPress={openCreateMenu}
+						style={({ pressed }) => [
+							styles.createBtn,
+							{ backgroundColor: t.secondary },
+							pressed && { opacity: 0.85 },
+						]}
+						accessibilityRole="button"
+						accessibilityLabel="Create"
+					>
+						<Plus size={22} color={t.primaryInk} strokeWidth={2.2} />
+					</Pressable>
+				</View>
+			) : null}
+
 			<View style={styles.assistantWrap}>
 				<Pressable
 					onPress={onAssistant}
@@ -312,6 +371,17 @@ const styles = StyleSheet.create({
 	},
 	navLabel: {
 		fontSize: type.body,
+	},
+	createWrap: {
+		paddingHorizontal: 12,
+		paddingBottom: 8,
+	},
+	createBtn: {
+		width: touch.min,
+		height: touch.min,
+		borderRadius: radii.ctrl,
+		alignItems: "center",
+		justifyContent: "center",
 	},
 	assistantWrap: {
 		paddingHorizontal: 12,

--- a/apps/mobile/components/money/money-amount.tsx
+++ b/apps/mobile/components/money/money-amount.tsx
@@ -9,11 +9,14 @@ export function MoneyAmount({
 	amount,
 	size = 34,
 	color,
+	centsColor,
 }: {
 	amount: number;
 	/** Hero (Money hub) uses 40; document cards use 34. */
 	size?: number;
 	color?: string;
+	/** Override for on-ink surfaces — the default faint is a light-mode value. */
+	centsColor?: string;
 }) {
 	const t = useTokens();
 	const formatted = formatCurrency(amount, { exact: true });
@@ -33,7 +36,10 @@ export function MoneyAmount({
 				<Text
 					style={[
 						styles.cents,
-						{ fontSize: Math.round(size * 0.56), color: t.faintDecor },
+						{
+							fontSize: Math.round(size * 0.56),
+							color: centsColor ?? t.faintDecor,
+						},
 					]}
 				>
 					{cents}

--- a/apps/mobile/components/quick-actions.tsx
+++ b/apps/mobile/components/quick-actions.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import type { LucideIcon } from "lucide-react-native";
+import { fontFamily, radii, touch, type, useTokens } from "@/lib/theme";
+
+export interface QuickAction {
+	key: string;
+	label: string;
+	Icon: LucideIcon;
+	onPress: () => void;
+	/** Missing data (no phone, no property) — dimmed and inert, never hidden. */
+	disabled?: boolean;
+}
+
+// A row of equal frosted action tiles (Call / Message / Email / Directions).
+// Deliberately NOT components/money/quick-action-row.tsx — that one renders the
+// status→CTA resolver's union and can't take arbitrary tiles.
+export function QuickActions({ actions }: { actions: QuickAction[] }) {
+	const t = useTokens();
+	if (actions.length === 0) return null;
+
+	return (
+		<View style={styles.row}>
+			{actions.map(({ key, label, Icon, onPress, disabled }) => (
+				<Pressable
+					key={key}
+					accessibilityRole="button"
+					accessibilityLabel={label}
+					accessibilityState={{ disabled: !!disabled }}
+					disabled={disabled}
+					onPress={onPress}
+					style={({ pressed }) => [
+						styles.tile,
+						{
+							backgroundColor:
+								pressed && !disabled ? t.frostedBgPressed : t.frostedBg,
+							borderColor: t.frostedBorder,
+							opacity: disabled ? 0.45 : 1,
+						},
+					]}
+				>
+					<Icon size={18} color={t.frostedInk} />
+					<Text
+						style={[styles.label, { color: t.frostedInk }]}
+						numberOfLines={1}
+					>
+						{label}
+					</Text>
+				</Pressable>
+			))}
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	row: {
+		flexDirection: "row",
+		alignItems: "stretch",
+		gap: 8,
+	},
+	tile: {
+		flex: 1,
+		minWidth: 0,
+		minHeight: touch.min + 16,
+		borderRadius: radii.ctrl,
+		borderWidth: 1,
+		alignItems: "center",
+		justifyContent: "center",
+		gap: 6,
+		paddingHorizontal: 4,
+		paddingVertical: 10,
+	},
+	label: {
+		fontFamily: fontFamily.semibold,
+		fontSize: type.xs,
+	},
+});

--- a/apps/mobile/components/speed-dial-fab.tsx
+++ b/apps/mobile/components/speed-dial-fab.tsx
@@ -89,9 +89,10 @@ const SATELLITE_OBJECT: Record<SatelliteKey, "projects" | "tasks" | "clients" | 
 
 // Layout-animation objects built once at module scope (never in render — New
 // Architecture nativeID gotcha) and indexed by visual position bottom-up so the
-// stagger rises from the FAB.
+// stagger rises from the FAB. Timed, not sprung — the fan is a tool, not a toy
+// (visual-pass round 1: springs read too playful).
 const ENTER_BY_ROW = [0, 1, 2, 3].map((i) =>
-	FadeInDown.delay(i * 40).springify().damping(16),
+	FadeInDown.delay(i * 30).duration(150),
 );
 const EXIT = FadeOutDown.duration(110);
 const BACKDROP_IN = FadeIn.duration(150);

--- a/apps/mobile/components/speed-dial-fab.tsx
+++ b/apps/mobile/components/speed-dial-fab.tsx
@@ -1,0 +1,296 @@
+import React, { useMemo, useState } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { BlurView } from "expo-blur";
+import { usePathname, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import Animated, {
+	FadeIn,
+	FadeInDown,
+	FadeOut,
+	FadeOutDown,
+	useAnimatedStyle,
+	useReducedMotion,
+	useSharedValue,
+	withTiming,
+} from "react-native-reanimated";
+import {
+	Building2,
+	FileText,
+	Folder,
+	ClipboardCheck,
+	Plus,
+	type LucideIcon,
+} from "lucide-react-native";
+import {
+	dock,
+	fontFamily,
+	hero,
+	radii,
+	recordTint,
+	shadow,
+	type,
+	useTokens,
+} from "@/lib/theme";
+import { usePermissions } from "@/lib/use-permissions";
+import { hapticImpact, hapticSelect } from "@/lib/haptics";
+
+// Speed-dial capture fan (3.0 slice 5, Jobber-pattern: labeled satellites over
+// a washed backdrop, most-used action nearest the thumb). The dock's center orb
+// stays the ASSISTANT — this is the one create entry point, floating above the
+// dock's right end on every tab screen.
+
+type SatelliteKey = "project" | "task" | "client" | "quote";
+
+const SATELLITES: {
+	key: SatelliteKey;
+	label: string;
+	Icon: LucideIcon;
+	tint: { bg: string; fg: string };
+	href: string;
+}[] = [
+	// Rendered top-to-bottom; Project sits last = nearest the thumb.
+	{
+		key: "quote",
+		label: "New quote",
+		Icon: FileText,
+		tint: recordTint.quote,
+		href: "/quote/new",
+	},
+	{
+		key: "client",
+		label: "New client",
+		Icon: Building2,
+		tint: recordTint.client,
+		href: "/(tabs)/clients/new",
+	},
+	{
+		key: "task",
+		label: "New task",
+		Icon: ClipboardCheck,
+		tint: recordTint.task,
+		href: "/tasks/form",
+	},
+	{
+		key: "project",
+		label: "New project",
+		Icon: Folder,
+		tint: recordTint.project,
+		href: "/project/new",
+	},
+];
+
+// Which permission object each satellite needs at "modify".
+const SATELLITE_OBJECT: Record<SatelliteKey, "projects" | "tasks" | "clients" | "quotes"> = {
+	project: "projects",
+	task: "tasks",
+	client: "clients",
+	quote: "quotes",
+};
+
+// Layout-animation objects built once at module scope (never in render — New
+// Architecture nativeID gotcha) and indexed by visual position bottom-up so the
+// stagger rises from the FAB.
+const ENTER_BY_ROW = [0, 1, 2, 3].map((i) =>
+	FadeInDown.delay(i * 40).springify().damping(16),
+);
+const EXIT = FadeOutDown.duration(110);
+const BACKDROP_IN = FadeIn.duration(150);
+const BACKDROP_OUT = FadeOut.duration(110);
+
+export function SpeedDialFab() {
+	const t = useTokens();
+	const router = useRouter();
+	const pathname = usePathname();
+	const insets = useSafeAreaInsets();
+	const reducedMotion = useReducedMotion();
+	const { can, isLoading } = usePermissions();
+	const [open, setOpen] = useState(false);
+	const rotation = useSharedValue(0);
+
+	const visible = useMemo(
+		() => SATELLITES.filter((s) => can(SATELLITE_OBJECT[s.key], "modify")),
+		[can],
+	);
+
+	const plusStyle = useAnimatedStyle(() => ({
+		transform: [{ rotate: `${rotation.value * 45}deg` }],
+	}));
+
+	// Plain functions, not useCallback: listing `rotation` as a hook dep trips
+	// react-hooks/immutability when its .value is written.
+	const setRotation = (to: number) => {
+		rotation.value = withTiming(to, { duration: 160 });
+	};
+
+	const toggle = () => {
+		const next = !open;
+		setOpen(next);
+		setRotation(next ? 1 : 0);
+		hapticImpact();
+	};
+
+	const close = () => {
+		setOpen(false);
+		setRotation(0);
+	};
+
+	const onSatellite = (href: string) => {
+		hapticSelect();
+		close();
+		router.push(href as never);
+	};
+
+	// Tab ROOTS only — clients/projects/activity/profile and the create/detail
+	// screens live inside the (tabs) navigator too, and the FAB floating over a
+	// create form (or client detail's own "+ New project") is noise.
+	const onTabRoot =
+		pathname === "/" ||
+		pathname === "/work" ||
+		pathname === "/money" ||
+		pathname === "/routes";
+
+	// Nothing to create (or permissions still resolving) — no dead chrome.
+	if (!onTabRoot || isLoading || visible.length === 0) return null;
+
+	const fabBottom =
+		Math.max(insets.bottom, dock.bottomInset) + dock.height + 14;
+
+	return (
+		<>
+			{open && (
+				<Animated.View
+					style={StyleSheet.absoluteFill}
+					entering={reducedMotion ? undefined : BACKDROP_IN}
+					exiting={reducedMotion ? undefined : BACKDROP_OUT}
+				>
+					{/* Washed blur backdrop — tap anywhere to dismiss. */}
+					<Pressable
+						style={StyleSheet.absoluteFill}
+						onPress={close}
+						accessibilityRole="button"
+						accessibilityLabel="Close create menu"
+					>
+						<BlurView
+							intensity={18}
+							tint="light"
+							style={StyleSheet.absoluteFill}
+						/>
+						<View
+							style={[
+								StyleSheet.absoluteFill,
+								{ backgroundColor: "rgba(246,247,248,.72)" },
+							]}
+						/>
+					</Pressable>
+
+					<View
+						style={[styles.fan, { bottom: fabBottom + dock.orbSize + 18 }]}
+						pointerEvents="box-none"
+					>
+						{visible.map((s, i) => {
+							// Stagger rises from the FAB: last row animates first.
+							const row = visible.length - 1 - i;
+							const { Icon } = s;
+							return (
+								<Animated.View
+									key={s.key}
+									entering={reducedMotion ? undefined : ENTER_BY_ROW[row]}
+									exiting={reducedMotion ? undefined : EXIT}
+									style={styles.satRow}
+								>
+									<Pressable
+										onPress={() => onSatellite(s.href)}
+										accessibilityRole="button"
+										accessibilityLabel={s.label}
+										style={({ pressed }) => [
+											styles.satPress,
+											pressed && { opacity: 0.7 },
+										]}
+									>
+										<View style={[styles.satLabelPill, { backgroundColor: t.card }]}>
+											<Text style={[styles.satLabel, { color: t.ink }]}>
+												{s.label}
+											</Text>
+										</View>
+										<View
+											style={[styles.satCircle, { backgroundColor: s.tint.bg }]}
+										>
+											<Icon size={20} color={s.tint.fg} strokeWidth={2.1} />
+										</View>
+									</Pressable>
+								</Animated.View>
+							);
+						})}
+					</View>
+				</Animated.View>
+			)}
+
+			<View
+				style={[styles.fabWrap, { bottom: fabBottom }]}
+				pointerEvents="box-none"
+			>
+				<Pressable
+					onPress={toggle}
+					accessibilityRole="button"
+					accessibilityLabel={open ? "Close create menu" : "Create"}
+					accessibilityState={{ expanded: open }}
+					style={styles.fab}
+				>
+					<Animated.View style={plusStyle}>
+						<Plus size={24} color={hero.text} strokeWidth={2.4} />
+					</Animated.View>
+				</Pressable>
+			</View>
+		</>
+	);
+}
+
+const styles = StyleSheet.create({
+	fabWrap: {
+		position: "absolute",
+		right: dock.sideInset + 2,
+		alignItems: "flex-end",
+	},
+	fab: {
+		width: 52,
+		height: 52,
+		borderRadius: radii.fab,
+		backgroundColor: hero.ink,
+		alignItems: "center",
+		justifyContent: "center",
+		boxShadow: shadow.lg,
+	},
+	fan: {
+		position: "absolute",
+		right: dock.sideInset + 2,
+		alignItems: "flex-end",
+		gap: 14,
+	},
+	satRow: {
+		alignItems: "flex-end",
+	},
+	satPress: {
+		flexDirection: "row",
+		alignItems: "center",
+		gap: 12,
+		minHeight: 44,
+	},
+	satLabelPill: {
+		paddingVertical: 7,
+		paddingHorizontal: 14,
+		borderRadius: radii.pill,
+		boxShadow: shadow.md,
+	},
+	satLabel: {
+		fontSize: type.rowTitle,
+		fontFamily: fontFamily.semibold,
+	},
+	satCircle: {
+		width: 44,
+		height: 44,
+		borderRadius: 22,
+		alignItems: "center",
+		justifyContent: "center",
+		boxShadow: shadow.sm,
+	},
+});

--- a/apps/mobile/components/today/agenda-row.tsx
+++ b/apps/mobile/components/today/agenda-row.tsx
@@ -88,6 +88,8 @@ export function AgendaRow({
 				accessibilityLabel={[
 					task.title,
 					timeLabel,
+					endLabel && `till ${endLabel}`,
+					task.context,
 					// The chip only shows initials — the full name belongs here.
 					assignee && `assigned to ${assignee.name}`,
 				]
@@ -154,7 +156,10 @@ export function AgendaRow({
 				hitSlop={6}
 				style={styles.checkTarget}
 				accessibilityRole="checkbox"
-				accessibilityState={{ checked: done, disabled: cancelled }}
+				accessibilityState={{
+					checked: done,
+					disabled: updating || cancelled,
+				}}
 				accessibilityLabel={
 					done ? `Mark ${task.title} not done` : `Mark ${task.title} done`
 				}

--- a/apps/mobile/components/today/agenda-row.tsx
+++ b/apps/mobile/components/today/agenda-row.tsx
@@ -7,12 +7,21 @@ import {
 	View,
 } from "react-native";
 import { Check } from "lucide-react-native";
-import { fontFamily, radii, touch, type, useTokens } from "@/lib/theme";
+import {
+	fontFamily,
+	radii,
+	recordTint,
+	touch,
+	type,
+	useTokens,
+} from "@/lib/theme";
 import { formatClockLabel, type AgendaTask } from "@/lib/agenda";
 
 const BOX = 22;
-// Time column width + gap — the indent titles and context lines share.
-const TIME_COL = 65;
+/** Left time rail. Fixed so every title starts on the same column, timed or not. */
+const RAIL = 58;
+/** Record-tint spine width — a hairline bar, never a color block. */
+export const SPINE = 3;
 
 interface AgendaRowProps {
 	task: AgendaTask;
@@ -26,9 +35,27 @@ interface AgendaRowProps {
 }
 
 /**
- * One line of Today's agenda. The checkbox and the row body are SEPARATE tap
- * targets — checking off a job and opening it are different intents, and a
- * single row-wide handler makes the common one (checking off) risky.
+ * Wraps a non-task row (project `ListRow`s) in the same tinted spine, so the
+ * ALL DAY band and the timeline speak one language. Lives here rather than in
+ * `ui/list-row.tsx`, which the Today tab does not own.
+ */
+export function SpinedRow({
+	color,
+	children,
+}: {
+	color: string;
+	children: React.ReactNode;
+}) {
+	return <View style={[styles.spined, { borderLeftColor: color }]}>{children}</View>;
+}
+
+/**
+ * One line of Today's timeline: a record-tint spine and a left time rail
+ * (Timepage), then the title block, then the checkbox.
+ *
+ * The checkbox and the row body are SEPARATE tap targets — checking off a job
+ * and opening it are different intents, and a single row-wide handler makes the
+ * common one (checking off) risky.
  */
 export function AgendaRow({
 	task,
@@ -43,15 +70,84 @@ export function AgendaRow({
 	const done = completed || task.status === "completed";
 	const cancelled = task.status === "cancelled";
 	const timeLabel = formatClockLabel(task.startTime);
+	const endLabel = formatClockLabel(task.endTime);
 	const muted = done || cancelled;
 
 	return (
 		<View
 			style={[
 				styles.row,
+				{ borderLeftColor: muted ? t.line : recordTint.task.fg },
 				!last && { borderBottomWidth: 1, borderBottomColor: t.lineSoft },
 			]}
 		>
+			<Pressable
+				onPress={onOpen}
+				style={styles.body}
+				accessibilityRole="button"
+				accessibilityLabel={[
+					task.title,
+					timeLabel,
+					// The chip only shows initials — the full name belongs here.
+					assignee && `assigned to ${assignee.name}`,
+				]
+					.filter(Boolean)
+					.join(", ")}
+			>
+				<View style={styles.rail}>
+					{timeLabel ? (
+						<>
+							<Text style={[styles.time, { color: muted ? t.faint : t.ink }]}>
+								{timeLabel}
+							</Text>
+							{endLabel ? (
+								<Text style={[styles.endTime, { color: t.faint }]}>
+									{endLabel}
+								</Text>
+							) : null}
+						</>
+					) : (
+						<Text style={[styles.endTime, { color: t.faint }]}>Anytime</Text>
+					)}
+				</View>
+
+				<View style={styles.text}>
+					<Text
+						style={[
+							styles.title,
+							{
+								color: muted ? t.faint : t.ink,
+								textDecorationLine: muted ? "line-through" : "none",
+							},
+						]}
+						numberOfLines={1}
+					>
+						{task.title}
+					</Text>
+					{task.context ? (
+						<Text
+							style={[styles.context, { color: t.sub }]}
+							numberOfLines={1}
+						>
+							{task.context}
+						</Text>
+					) : null}
+				</View>
+			</Pressable>
+
+			{assignee ? (
+				// Announced via the body label; the chip itself is decoration.
+				<View
+					style={[styles.assignee, { backgroundColor: t.secondary }]}
+					accessibilityElementsHidden
+					importantForAccessibility="no-hide-descendants"
+				>
+					<Text style={[styles.assigneeText, { color: t.frostedInk }]}>
+						{assignee.initials}
+					</Text>
+				</View>
+			) : null}
+
 			<Pressable
 				onPress={onToggle}
 				disabled={updating || cancelled}
@@ -79,65 +175,6 @@ export function AgendaRow({
 					</View>
 				)}
 			</Pressable>
-
-			<Pressable
-				onPress={onOpen}
-				style={styles.body}
-				accessibilityRole="button"
-				accessibilityLabel={[
-					task.title,
-					timeLabel,
-					// The chip only shows initials — the full name belongs here.
-					assignee && `assigned to ${assignee.name}`,
-				]
-					.filter(Boolean)
-					.join(", ")}
-			>
-				<View style={styles.titleLine}>
-					{timeLabel ? (
-						<Text style={[styles.time, { color: muted ? t.faint : t.sub }]}>
-							{timeLabel}
-						</Text>
-					) : null}
-					<Text
-						style={[
-							styles.title,
-							{
-								color: muted ? t.faint : t.ink,
-								textDecorationLine: muted ? "line-through" : "none",
-							},
-						]}
-						numberOfLines={1}
-					>
-						{task.title}
-					</Text>
-				</View>
-				{task.context ? (
-					<Text
-						style={[
-							styles.context,
-							// Align under the title, which is itself offset only when timed.
-							{ color: t.sub, marginLeft: timeLabel ? TIME_COL : 0 },
-						]}
-						numberOfLines={1}
-					>
-						{task.context}
-					</Text>
-				) : null}
-			</Pressable>
-
-			{assignee ? (
-				// Announced via the body label; the chip itself is decoration.
-				<View
-					style={[styles.assignee, { backgroundColor: t.secondary }]}
-					accessibilityElementsHidden
-					importantForAccessibility="no-hide-descendants"
-				>
-					<Text style={[styles.assigneeText, { color: t.frostedInk }]}>
-						{assignee.initials}
-					</Text>
-				</View>
-			) : null}
 		</View>
 	);
 }
@@ -147,7 +184,44 @@ const styles = StyleSheet.create({
 		flexDirection: "row",
 		alignItems: "center",
 		minHeight: touch.min,
-		paddingRight: 14,
+		borderLeftWidth: SPINE,
+	},
+	spined: {
+		borderLeftWidth: SPINE,
+	},
+	body: {
+		flex: 1,
+		minWidth: 0,
+		flexDirection: "row",
+		alignItems: "center",
+		gap: 10,
+		paddingLeft: 11,
+		paddingVertical: 9,
+	},
+	rail: {
+		width: RAIL,
+	},
+	time: {
+		fontFamily: fontFamily.semibold,
+		fontSize: type.sm,
+	},
+	endTime: {
+		fontFamily: fontFamily.regular,
+		fontSize: type.xs,
+		marginTop: 1,
+	},
+	text: {
+		flex: 1,
+		minWidth: 0,
+	},
+	title: {
+		fontFamily: fontFamily.medium,
+		fontSize: type.rowTitle,
+	},
+	context: {
+		fontFamily: fontFamily.regular,
+		fontSize: type.meta,
+		marginTop: 2,
 	},
 	// 44pt tap target around a 22px glyph.
 	checkTarget: {
@@ -164,41 +238,12 @@ const styles = StyleSheet.create({
 		alignItems: "center",
 		justifyContent: "center",
 	},
-	body: {
-		flex: 1,
-		minWidth: 0,
-		justifyContent: "center",
-		paddingVertical: 9,
-	},
-	titleLine: {
-		flexDirection: "row",
-		alignItems: "baseline",
-		gap: 7,
-	},
-	time: {
-		fontFamily: fontFamily.semibold,
-		fontSize: type.meta,
-		// Keeps titles left-aligned down the column whether or not a row is timed.
-		minWidth: 58,
-	},
-	title: {
-		flex: 1,
-		minWidth: 0,
-		fontFamily: fontFamily.medium,
-		fontSize: type.rowTitle,
-	},
-	context: {
-		fontFamily: fontFamily.regular,
-		fontSize: type.meta,
-		marginTop: 2,
-	},
 	assignee: {
 		width: 26,
 		height: 26,
 		borderRadius: 13,
 		alignItems: "center",
 		justifyContent: "center",
-		marginLeft: 8,
 	},
 	assigneeText: {
 		fontFamily: fontFamily.semibold,

--- a/apps/mobile/components/today/command-hero.tsx
+++ b/apps/mobile/components/today/command-hero.tsx
@@ -19,7 +19,6 @@ import {
 	Activity as ActivityIcon,
 	Bell,
 	ChevronDown,
-	Plus,
 } from "lucide-react-native";
 import { DotGrid } from "@/components/ui";
 import { fontFamily, hero, tokens, tracking, useTokens } from "@/lib/theme";
@@ -49,9 +48,6 @@ interface CommandHeroProps {
 	eyebrow: string;
 	greeting: string;
 	stats: readonly HeroStat[];
-	/** "New task" — the hero keeps 2.0's capture affordance the canvas omits. */
-	onAdd?: () => void;
-	addLabel?: string;
 	/** The ink-tone week strip (or any pinned control) below the stats. */
 	children?: React.ReactNode;
 }
@@ -65,8 +61,6 @@ export function CommandHero({
 	eyebrow,
 	greeting,
 	stats,
-	onAdd,
-	addLabel = "New",
 	children,
 }: CommandHeroProps) {
 	const t = useTokens();
@@ -186,14 +180,8 @@ export function CommandHero({
 					<ChevronDown size={14} color={hero.textSub} />
 				</Pressable>
 				<View style={styles.spacer} />
-				{onAdd
-					? iconButton(
-							"add",
-							addLabel,
-							onAdd,
-							<Plus size={18} color={hero.text} strokeWidth={2.2} />,
-						)
-					: null}
+				{/* No ＋ here — the speed-dial FAB is the single capture entry point
+				    on iPhone (3.0 slice 5). */}
 				{iconButton(
 					"activity",
 					"Activity",

--- a/apps/mobile/components/today/command-hero.tsx
+++ b/apps/mobile/components/today/command-hero.tsx
@@ -19,13 +19,16 @@ import {
 	Activity as ActivityIcon,
 	Bell,
 	ChevronDown,
+	Search,
 } from "lucide-react-native";
 import { DotGrid } from "@/components/ui";
 import { fontFamily, hero, tokens, tracking, useTokens } from "@/lib/theme";
+import { requestSearchFocus } from "@/lib/search-focus";
 
 const ORG_SWITCH: Href = "/org-switch" as Href;
 const NOTIFICATIONS: Href = "/notifications" as Href;
 const ACTIVITY: Href = "/(tabs)/activity" as Href;
+const WORK: Href = "/(tabs)/work" as Href;
 
 function initialsFrom(name?: string | null, email?: string | null): string {
 	const source = name?.trim() || email || "?";
@@ -48,6 +51,12 @@ interface CommandHeroProps {
 	eyebrow: string;
 	greeting: string;
 	stats: readonly HeroStat[];
+	/**
+	 * Compressed band: greeting shrinks and the day stats drop out. Used when the
+	 * schedule is anchored to a day other than today — the stats describe TODAY,
+	 * so keeping them would both mislead and steal the room the schedule needs.
+	 */
+	compact?: boolean;
 	/** The ink-tone week strip (or any pinned control) below the stats. */
 	children?: React.ReactNode;
 }
@@ -61,6 +70,7 @@ export function CommandHero({
 	eyebrow,
 	greeting,
 	stats,
+	compact = false,
 	children,
 }: CommandHeroProps) {
 	const t = useTokens();
@@ -182,6 +192,17 @@ export function CommandHero({
 				<View style={styles.spacer} />
 				{/* No ＋ here — the speed-dial FAB is the single capture entry point
 				    on iPhone (3.0 slice 5). */}
+				{/* Today has no AppHeader on iPhone, so the hero carries the global
+				    search jump the other tab roots get from app-header.tsx. */}
+				{iconButton(
+					"search",
+					"Search everything",
+					() => {
+						requestSearchFocus();
+						router.push(WORK);
+					},
+					<Search size={18} color={hero.text} strokeWidth={2} />,
+				)}
 				{iconButton(
 					"activity",
 					"Activity",
@@ -205,25 +226,31 @@ export function CommandHero({
 			</View>
 
 			{/* Greeting */}
-			<Text style={styles.eyebrow}>{eyebrow.toUpperCase()}</Text>
-			<Text style={styles.greeting}>{greeting}</Text>
+			<Text style={[styles.eyebrow, compact && styles.eyebrowCompact]}>
+				{eyebrow.toUpperCase()}
+			</Text>
+			<Text style={[styles.greeting, compact && styles.greetingCompact]}>
+				{greeting}
+			</Text>
 
-			{/* Day stats */}
-			<View style={styles.statsRow}>
-				{stats.map((stat) => (
-					<View key={stat.caption} style={styles.statCard}>
-						<Text
-							style={[
-								styles.statValue,
-								stat.accent && { color: hero.statAccent },
-							]}
-						>
-							{stat.value}
-						</Text>
-						<Text style={styles.statCaption}>{stat.caption}</Text>
-					</View>
-				))}
-			</View>
+			{/* Day stats — today's numbers, so they leave with the compressed band. */}
+			{compact ? null : (
+				<View style={styles.statsRow}>
+					{stats.map((stat) => (
+						<View key={stat.caption} style={styles.statCard}>
+							<Text
+								style={[
+									styles.statValue,
+									stat.accent && { color: hero.statAccent },
+								]}
+							>
+								{stat.value}
+							</Text>
+							<Text style={styles.statCaption}>{stat.caption}</Text>
+						</View>
+					))}
+				</View>
+			)}
 
 			{children ? <View style={styles.controls}>{children}</View> : null}
 		</View>
@@ -304,6 +331,9 @@ const styles = StyleSheet.create({
 		letterSpacing: tracking.groupLabel,
 		color: hero.textDim,
 	},
+	eyebrowCompact: {
+		marginTop: 14,
+	},
 	greeting: {
 		marginTop: 4,
 		fontFamily: fontFamily.semibold,
@@ -311,6 +341,11 @@ const styles = StyleSheet.create({
 		lineHeight: 31,
 		letterSpacing: -0.3,
 		color: hero.text,
+	},
+	greetingCompact: {
+		fontSize: 19,
+		lineHeight: 23,
+		marginTop: 2,
 	},
 	statsRow: {
 		flexDirection: "row",

--- a/apps/mobile/components/today/day-plan.tsx
+++ b/apps/mobile/components/today/day-plan.tsx
@@ -1,26 +1,27 @@
 import React from "react";
 import { StyleSheet, Text, View } from "react-native";
-import {
-	fontFamily,
-	radii,
-	recordTint,
-	tracking,
-	type,
-	useTokens,
-} from "@/lib/theme";
-import { Button, ListRow } from "@/components/ui";
-import { Illustration } from "@/components/illustrations";
+import { fontFamily, recordTint, type, useTokens } from "@/lib/theme";
+import { ListRow } from "@/components/ui";
 import { AgendaRow } from "@/components/today/agenda-row";
-import type { AgendaProject, AgendaTask, DayPlan } from "@/lib/agenda";
+import { PlanSection } from "@/components/today/plan-section";
+import {
+	ScheduleEmpty,
+	type ScheduleEmptyVariant,
+} from "@/components/today/schedule-empty";
+import { isWeekend, type AgendaProject, type AgendaTask, type DayPlan } from "@/lib/agenda";
 
 export type Assignee = { initials: string; name: string };
 
 interface DayPlanViewProps {
 	plan: DayPlan;
-	/** Multi-day/all-day project work covering this day (the ALL DAY lane). */
+	/** The anchored day (UTC-midnight date-id) — drives the empty-state variant. */
+	dayMs: number;
+	/** Project spans covering this day (the ALL DAY band). */
 	projects: AgendaProject[];
 	/** "10:24 AM" — rendered on the now separator. */
 	nowLabel: string;
+	/** True when the whole rolling window is empty, not just this day. */
+	windowEmpty: boolean;
 	completedIds: Set<string>;
 	updatingIds: Set<string>;
 	onToggleTask: (id: string) => void;
@@ -32,16 +33,21 @@ interface DayPlanViewProps {
 }
 
 /**
- * The single chronological plan for a day — ALL DAY project lane on top,
- * timed tasks in start order with a now separator and a "next up" emphasis,
- * then untimed and overdue work. One representation, list-first: the pattern
- * every field-service app (and Apple's own day-view list toggle) converges on
- * for phone-width glanceability.
+ * The anchored day's timeline — an ALL DAY band on top (project spans plus
+ * untimed tasks: work that owns the day but not a slot in it), then timed rows
+ * in start order with the now separator and a "next up" emphasis, then overdue
+ * spillover. List-first: the pattern every field-service app converges on for
+ * phone-width glanceability.
+ *
+ * The now separator is placed by `buildDayPlan`, which only sets `nowIndex`
+ * when the anchored day IS today — browsing another day needs no extra guard.
  */
 export function DayPlanView({
 	plan,
+	dayMs,
 	projects,
 	nowLabel,
+	windowEmpty,
 	completedIds,
 	updatingIds,
 	onToggleTask,
@@ -52,25 +58,16 @@ export function DayPlanView({
 }: DayPlanViewProps) {
 	const t = useTokens();
 	const { timed, anytime, overdue, nextUpId, nowIndex } = plan;
-	const empty =
-		projects.length === 0 &&
-		timed.length === 0 &&
-		anytime.length === 0 &&
-		overdue.length === 0;
+	const allDayCount = projects.length + anytime.length;
+	const empty = allDayCount === 0 && timed.length === 0 && overdue.length === 0;
 
 	if (empty) {
-		return (
-			<View style={[styles.empty, { borderColor: t.line }]}>
-				<Illustration name="all-caught-up" knockout={t.bg} style={styles.emptyArt} />
-				<Text style={[styles.emptyTitle, { color: t.ink }]}>
-					Nothing scheduled
-				</Text>
-				<Text style={[styles.emptyCopy, { color: t.sub }]}>
-					This day is clear.
-				</Text>
-				<Button title="New task" onPress={onNewTask} style={styles.emptyAction} />
-			</View>
-		);
+		const variant: ScheduleEmptyVariant = windowEmpty
+			? "no-work"
+			: isWeekend(dayMs)
+				? "day-off"
+				: "clear-day";
+		return <ScheduleEmpty variant={variant} onNewTask={onNewTask} />;
 	}
 
 	const nowSeparator = (
@@ -112,88 +109,52 @@ export function DayPlanView({
 		);
 	};
 
-	const section = (label: string, children: React.ReactNode) => (
-		<View style={styles.group}>
-			<Text style={[styles.groupLabel, { color: t.faint }]}>{label}</Text>
-			<View
-				style={[
-					styles.groupCard,
-					{ backgroundColor: t.card, borderColor: t.line },
-				]}
-			>
-				{children}
-			</View>
-		</View>
-	);
-
 	return (
 		<>
-			{projects.length > 0
-				? section(
-						"ALL DAY",
-						projects.map((p, i) => (
-							<ListRow
-								key={p._id}
-								icon="Folder"
-								iconColor={recordTint.project.fg}
-								iconBg={recordTint.project.bg}
-								title={p.title}
-								sub={p.context}
-								status={p.status}
-								onPress={() => onOpenProject(p._id)}
-								last={i === projects.length - 1}
-							/>
-						)),
-					)
-				: null}
+			{allDayCount > 0 ? (
+				<PlanSection label="All day">
+					{projects.map((p, i) => (
+						<ListRow
+							key={p._id}
+							icon="Folder"
+							iconColor={recordTint.project.fg}
+							iconBg={recordTint.project.bg}
+							title={p.title}
+							sub={p.context}
+							status={p.status}
+							onPress={() => onOpenProject(p._id)}
+							last={i === allDayCount - 1}
+						/>
+					))}
+					{anytime.map((task, i) =>
+						taskRow(task, projects.length + i === allDayCount - 1),
+					)}
+				</PlanSection>
+			) : null}
 
-			{timed.length > 0
-				? section(
-						"SCHEDULE",
-						<>
-							{timed.flatMap((task, i) => [
-								...(i === nowIndex
-									? [<React.Fragment key="now">{nowSeparator}</React.Fragment>]
-									: []),
-								taskRow(task, i === timed.length - 1),
-							])}
-							{/* A finished schedule still shows where "now" stands. */}
-							{nowIndex === timed.length ? nowSeparator : null}
-						</>,
-					)
-				: null}
+			{timed.length > 0 ? (
+				<PlanSection label="Schedule">
+					{timed.flatMap((task, i) => [
+						...(i === nowIndex
+							? [<React.Fragment key="now">{nowSeparator}</React.Fragment>]
+							: []),
+						taskRow(task, i === timed.length - 1),
+					])}
+					{/* A finished schedule still shows where "now" stands. */}
+					{nowIndex === timed.length ? nowSeparator : null}
+				</PlanSection>
+			) : null}
 
-			{anytime.length > 0
-				? section(
-						"ANYTIME",
-						anytime.map((task, i) => taskRow(task, i === anytime.length - 1)),
-					)
-				: null}
-
-			{overdue.length > 0
-				? section(
-						"OVERDUE",
-						overdue.map((task, i) => taskRow(task, i === overdue.length - 1)),
-					)
-				: null}
+			{overdue.length > 0 ? (
+				<PlanSection label="Overdue">
+					{overdue.map((task, i) => taskRow(task, i === overdue.length - 1))}
+				</PlanSection>
+			) : null}
 		</>
 	);
 }
 
 const styles = StyleSheet.create({
-	group: {
-		gap: 7,
-	},
-	groupLabel: {
-		fontFamily: fontFamily.semibold,
-		fontSize: type.eyebrow,
-		letterSpacing: tracking.groupLabel,
-	},
-	groupCard: {
-		borderWidth: 1,
-		borderRadius: radii.card,
-		overflow: "hidden",
-	},
 	nowRow: {
 		flexDirection: "row",
 		alignItems: "center",
@@ -219,29 +180,5 @@ const styles = StyleSheet.create({
 	},
 	nextUp: {
 		borderLeftWidth: 3,
-	},
-	empty: {
-		alignItems: "center",
-		gap: 4,
-		borderWidth: 1,
-		borderStyle: "dashed",
-		borderRadius: radii.card,
-		paddingVertical: 30,
-		paddingHorizontal: 24,
-	},
-	emptyArt: {
-		marginBottom: 6,
-	},
-	emptyTitle: {
-		fontFamily: fontFamily.semibold,
-		fontSize: type.h3,
-	},
-	emptyCopy: {
-		fontFamily: fontFamily.regular,
-		fontSize: type.body,
-	},
-	emptyAction: {
-		marginTop: 12,
-		alignSelf: "stretch",
 	},
 });

--- a/apps/mobile/components/today/day-plan.tsx
+++ b/apps/mobile/components/today/day-plan.tsx
@@ -3,7 +3,10 @@ import { StyleSheet, Text, View } from "react-native";
 import { fontFamily, recordTint, type, useTokens } from "@/lib/theme";
 import { ListRow } from "@/components/ui";
 import { AgendaRow, SpinedRow } from "@/components/today/agenda-row";
-import { NextUpCard } from "@/components/today/next-up-card";
+import {
+	NextUpCard,
+	NextUpProjectCard,
+} from "@/components/today/next-up-card";
 import { PlanSection } from "@/components/today/plan-section";
 import {
 	ScheduleEmpty,
@@ -12,6 +15,7 @@ import {
 import {
 	isWeekend,
 	selectNextUp,
+	selectNextUpProject,
 	type AgendaProject,
 	type AgendaTask,
 	type DayPlan,
@@ -23,6 +27,8 @@ interface DayPlanViewProps {
 	plan: DayPlan;
 	/** The anchored day (UTC-midnight date-id) — drives the empty-state variant. */
 	dayMs: number;
+	/** Anchored to the real today — gates both card variants. */
+	isToday: boolean;
 	/** Project spans covering this day (the ALL DAY band). */
 	projects: AgendaProject[];
 	/** "10:24 AM" — rendered on the now separator. */
@@ -62,6 +68,7 @@ function sectionMeta(tasks: readonly AgendaTask[], done: Set<string>): string {
 export function DayPlanView({
 	plan,
 	dayMs,
+	isToday,
 	projects,
 	nowLabel,
 	windowEmpty,
@@ -76,10 +83,18 @@ export function DayPlanView({
 	const t = useTokens();
 	const { anytime, overdue } = plan;
 	const { next, timed, nowIndex } = selectNextUp(plan, completedIds);
-	const allDayCount = projects.length + anytime.length;
+	// Project-visit fallback: a timed-empty plan has nowIndex -1 even today, so
+	// the today gate comes from the screen, not from selectNextUp.
+	const nextProject =
+		!next && isToday ? selectNextUpProject(projects) : null;
+	// The lead is never duplicated below — same rule as the timed card.
+	const bandProjects = nextProject
+		? projects.filter((p) => p._id !== nextProject._id)
+		: projects;
+	const allDayCount = bandProjects.length + anytime.length;
 	// Emptiness is judged on the WHOLE day, before the lead is split off.
 	const empty =
-		allDayCount === 0 && plan.timed.length === 0 && overdue.length === 0;
+		projects.length === 0 && anytime.length === 0 && plan.timed.length === 0 && overdue.length === 0;
 
 	if (empty) {
 		const variant: ScheduleEmptyVariant = windowEmpty
@@ -123,6 +138,11 @@ export function DayPlanView({
 					onOpen={() => onOpenTask(next._id)}
 					assignee={assigneeFor?.(next)}
 				/>
+			) : nextProject ? (
+				<NextUpProjectCard
+					project={nextProject}
+					onOpen={() => onOpenProject(nextProject._id)}
+				/>
 			) : null}
 
 			{allDayCount > 0 ? (
@@ -130,7 +150,7 @@ export function DayPlanView({
 					label="All day"
 					meta={`${allDayCount} ${allDayCount === 1 ? "item" : "items"}`}
 				>
-					{projects.map((p, i) => (
+					{bandProjects.map((p, i) => (
 						<SpinedRow key={p._id} color={recordTint.project.fg}>
 							<ListRow
 								icon="Folder"
@@ -145,7 +165,7 @@ export function DayPlanView({
 						</SpinedRow>
 					))}
 					{anytime.map((task, i) =>
-						taskRow(task, projects.length + i === allDayCount - 1),
+						taskRow(task, bandProjects.length + i === allDayCount - 1),
 					)}
 				</PlanSection>
 			) : null}

--- a/apps/mobile/components/today/day-plan.tsx
+++ b/apps/mobile/components/today/day-plan.tsx
@@ -2,13 +2,20 @@ import React from "react";
 import { StyleSheet, Text, View } from "react-native";
 import { fontFamily, recordTint, type, useTokens } from "@/lib/theme";
 import { ListRow } from "@/components/ui";
-import { AgendaRow } from "@/components/today/agenda-row";
+import { AgendaRow, SpinedRow } from "@/components/today/agenda-row";
+import { NextUpCard } from "@/components/today/next-up-card";
 import { PlanSection } from "@/components/today/plan-section";
 import {
 	ScheduleEmpty,
 	type ScheduleEmptyVariant,
 } from "@/components/today/schedule-empty";
-import { isWeekend, type AgendaProject, type AgendaTask, type DayPlan } from "@/lib/agenda";
+import {
+	isWeekend,
+	selectNextUp,
+	type AgendaProject,
+	type AgendaTask,
+	type DayPlan,
+} from "@/lib/agenda";
 
 export type Assignee = { initials: string; name: string };
 
@@ -32,15 +39,25 @@ interface DayPlanViewProps {
 	assigneeFor?: (task: AgendaTask) => Assignee | undefined;
 }
 
+/** "3 jobs · 1 done" — the day's stats echo, from rows already on screen. */
+function sectionMeta(tasks: readonly AgendaTask[], done: Set<string>): string {
+	const n = tasks.length;
+	const finished = tasks.filter((task) => done.has(task._id)).length;
+	const label = `${n} ${n === 1 ? "job" : "jobs"}`;
+	return finished > 0 ? `${label} · ${finished} done` : label;
+}
+
 /**
- * The anchored day's timeline — an ALL DAY band on top (project spans plus
- * untimed tasks: work that owns the day but not a slot in it), then timed rows
- * in start order with the now separator and a "next up" emphasis, then overdue
- * spillover. List-first: the pattern every field-service app converges on for
- * phone-width glanceability.
+ * The anchored day's timeline. The first still-open timed job is lifted OUT of
+ * the list into the "Next up" card — it is the day's lead object, so it gets the
+ * moment below the hero and is never duplicated in the rows beneath. Then an ALL
+ * DAY band (project spans plus untimed tasks: work that owns the day but not a
+ * slot in it), the remaining timed rows with the now separator, then overdue
+ * spillover.
  *
- * The now separator is placed by `buildDayPlan`, which only sets `nowIndex`
- * when the anchored day IS today — browsing another day needs no extra guard.
+ * `selectNextUp` only yields a card when the anchored day IS today, and the now
+ * separator's `nowIndex` comes back re-based onto the shortened list — browsing
+ * another day needs no extra guard in here.
  */
 export function DayPlanView({
 	plan,
@@ -57,9 +74,12 @@ export function DayPlanView({
 	assigneeFor,
 }: DayPlanViewProps) {
 	const t = useTokens();
-	const { timed, anytime, overdue, nextUpId, nowIndex } = plan;
+	const { anytime, overdue } = plan;
+	const { next, timed, nowIndex } = selectNextUp(plan, completedIds);
 	const allDayCount = projects.length + anytime.length;
-	const empty = allDayCount === 0 && timed.length === 0 && overdue.length === 0;
+	// Emptiness is judged on the WHOLE day, before the lead is split off.
+	const empty =
+		allDayCount === 0 && plan.timed.length === 0 && overdue.length === 0;
 
 	if (empty) {
 		const variant: ScheduleEmptyVariant = windowEmpty
@@ -80,51 +100,49 @@ export function DayPlanView({
 		</View>
 	);
 
-	const taskRow = (task: AgendaTask, last: boolean) => {
-		const row = (
-			<AgendaRow
-				key={task._id}
-				task={task}
-				completed={completedIds.has(task._id)}
-				updating={updatingIds.has(task._id)}
-				last={last}
-				onToggle={() => onToggleTask(task._id)}
-				onOpen={() => onOpenTask(task._id)}
-				assignee={assigneeFor?.(task)}
-			/>
-		);
-		if (task._id !== nextUpId) return row;
-		// "Next up" carries its state on a SOLID rail — frosted washes composite
-		// too close to the card to indicate anything (see design notes).
-		return (
-			<View
-				key={task._id}
-				style={[
-					styles.nextUp,
-					{ borderLeftColor: t.primarySolid, backgroundColor: t.secondary },
-				]}
-			>
-				{row}
-			</View>
-		);
-	};
+	const taskRow = (task: AgendaTask, last: boolean) => (
+		<AgendaRow
+			key={task._id}
+			task={task}
+			completed={completedIds.has(task._id)}
+			updating={updatingIds.has(task._id)}
+			last={last}
+			onToggle={() => onToggleTask(task._id)}
+			onOpen={() => onOpenTask(task._id)}
+			assignee={assigneeFor?.(task)}
+		/>
+	);
 
 	return (
 		<>
+			{next ? (
+				<NextUpCard
+					task={next}
+					updating={updatingIds.has(next._id)}
+					onToggle={() => onToggleTask(next._id)}
+					onOpen={() => onOpenTask(next._id)}
+					assignee={assigneeFor?.(next)}
+				/>
+			) : null}
+
 			{allDayCount > 0 ? (
-				<PlanSection label="All day">
+				<PlanSection
+					label="All day"
+					meta={`${allDayCount} ${allDayCount === 1 ? "item" : "items"}`}
+				>
 					{projects.map((p, i) => (
-						<ListRow
-							key={p._id}
-							icon="Folder"
-							iconColor={recordTint.project.fg}
-							iconBg={recordTint.project.bg}
-							title={p.title}
-							sub={p.context}
-							status={p.status}
-							onPress={() => onOpenProject(p._id)}
-							last={i === allDayCount - 1}
-						/>
+						<SpinedRow key={p._id} color={recordTint.project.fg}>
+							<ListRow
+								icon="Folder"
+								iconColor={recordTint.project.fg}
+								iconBg={recordTint.project.bg}
+								title={p.title}
+								sub={p.context}
+								status={p.status}
+								onPress={() => onOpenProject(p._id)}
+								last={i === allDayCount - 1}
+							/>
+						</SpinedRow>
 					))}
 					{anytime.map((task, i) =>
 						taskRow(task, projects.length + i === allDayCount - 1),
@@ -133,7 +151,10 @@ export function DayPlanView({
 			) : null}
 
 			{timed.length > 0 ? (
-				<PlanSection label="Schedule">
+				<PlanSection
+					label="Schedule"
+					meta={sectionMeta(timed, completedIds)}
+				>
 					{timed.flatMap((task, i) => [
 						...(i === nowIndex
 							? [<React.Fragment key="now">{nowSeparator}</React.Fragment>]
@@ -146,7 +167,10 @@ export function DayPlanView({
 			) : null}
 
 			{overdue.length > 0 ? (
-				<PlanSection label="Overdue">
+				<PlanSection
+					label="Overdue"
+					meta={`${overdue.length} ${overdue.length === 1 ? "job" : "jobs"}`}
+				>
 					{overdue.map((task, i) => taskRow(task, i === overdue.length - 1))}
 				</PlanSection>
 			) : null}
@@ -177,8 +201,5 @@ const styles = StyleSheet.create({
 	nowLabel: {
 		fontFamily: fontFamily.semibold,
 		fontSize: type.meta,
-	},
-	nextUp: {
-		borderLeftWidth: 3,
 	},
 });

--- a/apps/mobile/components/today/next-up-card.tsx
+++ b/apps/mobile/components/today/next-up-card.tsx
@@ -16,7 +16,12 @@ import {
 	type,
 	useTokens,
 } from "@/lib/theme";
-import { formatClockLabel, type AgendaTask } from "@/lib/agenda";
+import { ChevronRight } from "lucide-react-native";
+import {
+	formatClockLabel,
+	type AgendaProject,
+	type AgendaTask,
+} from "@/lib/agenda";
 
 interface NextUpCardProps {
 	task: AgendaTask;
@@ -143,6 +148,75 @@ export function NextUpCard({
 				) : null}
 			</View>
 		</View>
+	);
+}
+
+/**
+ * Project-visit variant of the card — the fallback lead object when the day has
+ * no (remaining) timed job. Same anatomy, but "All day" replaces the clock
+ * headline and a chevron replaces the checkbox: projects aren't checkable, so
+ * the whole card is one open intent.
+ */
+export function NextUpProjectCard({
+	project,
+	onOpen,
+}: {
+	project: AgendaProject;
+	onOpen: () => void;
+}) {
+	const t = useTokens();
+	const status = STATUS[project.status as keyof typeof STATUS];
+
+	return (
+		<Pressable
+			onPress={onOpen}
+			accessibilityRole="button"
+			accessibilityLabel={[
+				"Next up",
+				"all day",
+				project.title,
+				project.context,
+				status?.label,
+			]
+				.filter(Boolean)
+				.join(", ")}
+			style={[
+				styles.card,
+				{
+					backgroundColor: t.card,
+					borderColor: t.line,
+					borderLeftColor: recordTint.project.fg,
+				},
+			]}
+		>
+			<View style={styles.body}>
+				<View style={styles.eyebrowRow}>
+					<Text style={[styles.eyebrow, { color: t.faint }]}>NEXT UP</Text>
+					{status ? (
+						<Text style={[styles.status, { color: status.c }]}>
+							{status.label}
+						</Text>
+					) : null}
+				</View>
+
+				<View style={styles.timeRow}>
+					<Text style={[styles.time, { color: t.ink }]}>All day</Text>
+				</View>
+
+				<Text style={[styles.title, { color: t.ink }]} numberOfLines={2}>
+					{project.title}
+				</Text>
+				{project.context ? (
+					<Text style={[styles.context, { color: t.sub }]} numberOfLines={1}>
+						{project.context}
+					</Text>
+				) : null}
+			</View>
+
+			<View style={styles.side}>
+				<ChevronRight size={20} color={t.faint} />
+			</View>
+		</Pressable>
 	);
 }
 

--- a/apps/mobile/components/today/next-up-card.tsx
+++ b/apps/mobile/components/today/next-up-card.tsx
@@ -1,0 +1,232 @@
+import React from "react";
+import {
+	ActivityIndicator,
+	Pressable,
+	StyleSheet,
+	Text,
+	View,
+} from "react-native";
+import {
+	fontFamily,
+	radii,
+	recordTint,
+	STATUS,
+	touch,
+	tracking,
+	type,
+	useTokens,
+} from "@/lib/theme";
+import { formatClockLabel, type AgendaTask } from "@/lib/agenda";
+
+interface NextUpCardProps {
+	task: AgendaTask;
+	updating: boolean;
+	onToggle: () => void;
+	onOpen: () => void;
+	/** Team scope initials chip; undefined in Me scope. */
+	assignee?: { initials: string; name: string };
+}
+
+/**
+ * The day's lead object — the first still-open timed job, promoted out of the
+ * timeline into a card (Jobber's next-visit card, Zocdoc's "Up next"). It owns
+ * the moment below the ink hero, so the time is the headline, not row metadata.
+ *
+ * It carries the SAME checkbox contract as `AgendaRow`: checking off the current
+ * job is the field worker's most frequent action, and a tap-to-open-only card
+ * would make the lead object harder to finish than the row it replaced.
+ *
+ * `selectNextUp` guarantees this only renders when the anchored day is today and
+ * an open timed job remains, so there is no gating to repeat here.
+ */
+export function NextUpCard({
+	task,
+	updating,
+	onToggle,
+	onOpen,
+	assignee,
+}: NextUpCardProps) {
+	const t = useTokens();
+	const timeLabel = formatClockLabel(task.startTime);
+	const endLabel = formatClockLabel(task.endTime);
+	// Status-as-text, not a pill — Daybook grammar. "Pending" is the unremarkable
+	// default and would just add a word to every card.
+	const status =
+		task.status && task.status !== "pending"
+			? STATUS[task.status as keyof typeof STATUS]
+			: undefined;
+
+	return (
+		<View
+			style={[
+				styles.card,
+				{
+					backgroundColor: t.card,
+					borderColor: t.line,
+					borderLeftColor: recordTint.task.fg,
+				},
+			]}
+		>
+			<Pressable
+				onPress={onOpen}
+				style={styles.body}
+				accessibilityRole="button"
+				accessibilityLabel={[
+					"Next up",
+					timeLabel,
+					task.title,
+					task.context,
+					status?.label,
+					assignee && `assigned to ${assignee.name}`,
+				]
+					.filter(Boolean)
+					.join(", ")}
+			>
+				<View style={styles.eyebrowRow}>
+					<Text style={[styles.eyebrow, { color: t.faint }]}>NEXT UP</Text>
+					{status ? (
+						<Text style={[styles.status, { color: status.c }]}>
+							{status.label}
+						</Text>
+					) : null}
+				</View>
+
+				<View style={styles.timeRow}>
+					<Text style={[styles.time, { color: t.ink }]}>
+						{timeLabel ?? "Anytime"}
+					</Text>
+					{endLabel ? (
+						<Text style={[styles.until, { color: t.sub }]}>till {endLabel}</Text>
+					) : null}
+				</View>
+
+				<Text
+					style={[styles.title, { color: t.ink }]}
+					numberOfLines={2}
+				>
+					{task.title}
+				</Text>
+				{task.context ? (
+					<Text style={[styles.context, { color: t.sub }]} numberOfLines={1}>
+						{task.context}
+					</Text>
+				) : null}
+			</Pressable>
+
+			{/* Sibling of the body, never nested — two intents, two targets. */}
+			<View style={styles.side}>
+				<Pressable
+					onPress={onToggle}
+					disabled={updating}
+					hitSlop={6}
+					style={styles.checkTarget}
+					accessibilityRole="checkbox"
+					accessibilityState={{ checked: false, disabled: updating }}
+					accessibilityLabel={`Mark ${task.title} done`}
+				>
+					{updating ? (
+						<ActivityIndicator size="small" color={t.sub} />
+					) : (
+						<View style={[styles.box, { borderColor: t.checkbox }]} />
+					)}
+				</Pressable>
+				{assignee ? (
+					<View
+						style={[styles.assignee, { backgroundColor: t.secondary }]}
+						accessibilityElementsHidden
+						importantForAccessibility="no-hide-descendants"
+					>
+						<Text style={[styles.assigneeText, { color: t.frostedInk }]}>
+							{assignee.initials}
+						</Text>
+					</View>
+				) : null}
+			</View>
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	card: {
+		flexDirection: "row",
+		borderWidth: 1,
+		borderLeftWidth: 3,
+		borderRadius: radii.card,
+		overflow: "hidden",
+	},
+	body: {
+		flex: 1,
+		minWidth: 0,
+		paddingVertical: 13,
+		paddingLeft: 14,
+		paddingRight: 6,
+		gap: 2,
+	},
+	eyebrowRow: {
+		flexDirection: "row",
+		alignItems: "baseline",
+		gap: 8,
+	},
+	eyebrow: {
+		fontFamily: fontFamily.semibold,
+		fontSize: type.eyebrow,
+		letterSpacing: tracking.eyebrow,
+	},
+	status: {
+		fontFamily: fontFamily.semibold,
+		fontSize: type.micro,
+	},
+	timeRow: {
+		flexDirection: "row",
+		alignItems: "baseline",
+		gap: 7,
+		marginTop: 3,
+	},
+	time: {
+		fontFamily: fontFamily.semibold,
+		fontSize: type.h1,
+		letterSpacing: tracking.title,
+	},
+	until: {
+		fontFamily: fontFamily.medium,
+		fontSize: type.meta,
+	},
+	title: {
+		fontFamily: fontFamily.semibold,
+		fontSize: type.h3,
+		marginTop: 3,
+	},
+	context: {
+		fontFamily: fontFamily.regular,
+		fontSize: type.meta,
+	},
+	side: {
+		alignItems: "center",
+		justifyContent: "center",
+		gap: 8,
+		paddingRight: 8,
+	},
+	checkTarget: {
+		width: touch.min,
+		height: touch.min,
+		alignItems: "center",
+		justifyContent: "center",
+	},
+	box: {
+		width: 24,
+		height: 24,
+		borderRadius: radii.xs,
+		borderWidth: 1.5,
+	},
+	assignee: {
+		width: 26,
+		height: 26,
+		borderRadius: 13,
+		alignItems: "center",
+		justifyContent: "center",
+	},
+	assigneeText: {
+		fontFamily: fontFamily.semibold,
+		fontSize: 10,
+	},
+});

--- a/apps/mobile/components/today/plan-section.tsx
+++ b/apps/mobile/components/today/plan-section.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { fontFamily, radii, tracking, type, useTokens } from "@/lib/theme";
+
+interface PlanSectionProps {
+	/** Group label above the rows ("ALL DAY", "SCHEDULE", "Today"). */
+	label: string;
+	/** Right-aligned count or time hint. Optional — omit for a bare label. */
+	meta?: string;
+	/** Renders the label in sentence case (List view day headers). */
+	tone?: "eyebrow" | "day";
+	children: React.ReactNode;
+}
+
+/**
+ * The one grouped-rows shell both schedule views use, so the Day timeline and
+ * the upcoming List can't drift apart on label weight, gap or row-card border.
+ */
+export function PlanSection({
+	label,
+	meta,
+	tone = "eyebrow",
+	children,
+}: PlanSectionProps) {
+	const t = useTokens();
+	const day = tone === "day";
+	return (
+		<View style={styles.group}>
+			<View style={styles.header}>
+				<Text
+					style={[
+						day ? styles.dayLabel : styles.groupLabel,
+						{ color: day ? t.ink : t.faint },
+					]}
+				>
+					{day ? label : label.toUpperCase()}
+				</Text>
+				{meta ? (
+					<Text style={[styles.meta, { color: t.faint }]}>{meta}</Text>
+				) : null}
+			</View>
+			<View
+				style={[
+					styles.groupCard,
+					{ backgroundColor: t.card, borderColor: t.line },
+				]}
+			>
+				{children}
+			</View>
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	group: {
+		gap: 7,
+	},
+	header: {
+		flexDirection: "row",
+		alignItems: "baseline",
+		gap: 8,
+	},
+	groupLabel: {
+		flex: 1,
+		fontFamily: fontFamily.semibold,
+		fontSize: type.eyebrow,
+		letterSpacing: tracking.groupLabel,
+	},
+	dayLabel: {
+		flex: 1,
+		fontFamily: fontFamily.semibold,
+		fontSize: type.body,
+	},
+	meta: {
+		fontFamily: fontFamily.medium,
+		fontSize: type.meta,
+	},
+	groupCard: {
+		borderWidth: 1,
+		borderRadius: radii.card,
+		overflow: "hidden",
+	},
+});

--- a/apps/mobile/components/today/plan-section.tsx
+++ b/apps/mobile/components/today/plan-section.tsx
@@ -28,6 +28,7 @@ export function PlanSection({
 		<View style={styles.group}>
 			<View style={styles.header}>
 				<Text
+					accessibilityRole="header"
 					style={[
 						day ? styles.dayLabel : styles.groupLabel,
 						{ color: day ? t.ink : t.faint },

--- a/apps/mobile/components/today/schedule-controls.tsx
+++ b/apps/mobile/components/today/schedule-controls.tsx
@@ -1,0 +1,156 @@
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { CalendarDays, List, User, Users } from "lucide-react-native";
+import { fontFamily, radii, touch, type, useTokens } from "@/lib/theme";
+import type { DayScope } from "@/lib/agenda";
+import type { ScheduleView } from "@/lib/useScheduleView";
+
+/**
+ * Painted height of both controls. Below `touch.min`, so every trigger keeps a
+ * 44pt hit area via hitSlop rather than growing the row — the two stacked
+ * full-width toggles this replaced ate ~98pt of the page's most valuable space.
+ */
+const H = 30;
+const HIT = { top: 7, bottom: 7, left: 6, right: 6 };
+
+interface ScheduleControlsProps {
+	view: ScheduleView;
+	onChangeView: (view: ScheduleView) => void;
+	scope: DayScope;
+	onChangeScope: (scope: DayScope) => void;
+	/** False in a solo org, where a scope toggle would be a no-op. */
+	showScope: boolean;
+}
+
+/**
+ * Today's one control row: Day | List as a small pill pair on the left, Me |
+ * Team as an icon pair on the right (Asana's rule — secondary controls sit at
+ * eyebrow level, never as stacked full-width chrome).
+ *
+ * Selected state is a SOLID `primarySolid` border plus a `card` fill: frosted
+ * tokens composite ~1.1:1 on this background and cannot carry state.
+ */
+export function ScheduleControls({
+	view,
+	onChangeView,
+	scope,
+	onChangeScope,
+	showScope,
+}: ScheduleControlsProps) {
+	const t = useTokens();
+
+	const pill = (value: ScheduleView, label: string, Icon: typeof List) => {
+		const active = view === value;
+		return (
+			<Pressable
+				key={value}
+				onPress={() => onChangeView(value)}
+				hitSlop={HIT}
+				accessibilityRole="tab"
+				accessibilityState={{ selected: active }}
+				accessibilityLabel={`${label} view`}
+				style={[
+					styles.pill,
+					active && { backgroundColor: t.card, borderColor: t.primarySolid },
+				]}
+			>
+				<Icon size={13} color={active ? t.frostedInk : t.sub} />
+				<Text
+					style={[
+						styles.pillLabel,
+						{
+							color: active ? t.ink : t.sub,
+							fontFamily: active ? fontFamily.semibold : fontFamily.medium,
+						},
+					]}
+				>
+					{label}
+				</Text>
+			</Pressable>
+		);
+	};
+
+	const scopeButton = (value: DayScope, label: string, Icon: typeof User) => {
+		const active = scope === value;
+		return (
+			<Pressable
+				key={value}
+				onPress={() => onChangeScope(value)}
+				hitSlop={HIT}
+				accessibilityRole="tab"
+				accessibilityState={{ selected: active }}
+				accessibilityLabel={`Show ${label.toLowerCase()}`}
+				style={[
+					styles.scopeButton,
+					active && { backgroundColor: t.card, borderColor: t.primarySolid },
+				]}
+			>
+				<Icon size={14} color={active ? t.frostedInk : t.sub} />
+			</Pressable>
+		);
+	};
+
+	return (
+		<View style={styles.row}>
+			<View
+				style={[styles.group, { backgroundColor: t.secondary }]}
+				accessibilityRole="tablist"
+			>
+				{pill("day", "Day", CalendarDays)}
+				{pill("list", "List", List)}
+			</View>
+			{showScope ? (
+				<View
+					style={[styles.group, { backgroundColor: t.secondary }]}
+					accessibilityRole="tablist"
+					accessibilityLabel="Schedule scope"
+				>
+					{scopeButton("me", "Me", User)}
+					{scopeButton("team", "Team", Users)}
+				</View>
+			) : null}
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	row: {
+		flexDirection: "row",
+		alignItems: "center",
+		justifyContent: "space-between",
+		// Keeps the block itself a legal 44pt band even though the pills are 30pt,
+		// so the hitSlop never reaches outside its parent (RN won't hit-test there).
+		minHeight: touch.min,
+		gap: 10,
+	},
+	group: {
+		flexDirection: "row",
+		alignItems: "center",
+		borderRadius: radii.pill,
+		padding: 2,
+		gap: 2,
+	},
+	pill: {
+		flexDirection: "row",
+		alignItems: "center",
+		justifyContent: "center",
+		gap: 5,
+		height: H,
+		paddingHorizontal: 11,
+		borderRadius: radii.pill,
+		borderWidth: 1,
+		borderColor: "transparent",
+	},
+	pillLabel: {
+		fontSize: type.sm,
+	},
+	scopeButton: {
+		alignItems: "center",
+		justifyContent: "center",
+		width: 36,
+		height: H,
+		borderRadius: radii.pill,
+		borderWidth: 1,
+		borderColor: "transparent",
+	},
+});

--- a/apps/mobile/components/today/schedule-controls.tsx
+++ b/apps/mobile/components/today/schedule-controls.tsx
@@ -79,7 +79,7 @@ export function ScheduleControls({
 				hitSlop={HIT}
 				accessibilityRole="tab"
 				accessibilityState={{ selected: active }}
-				accessibilityLabel={`Show ${label.toLowerCase()}`}
+				accessibilityLabel={`Filter to ${label.toLowerCase()}`}
 				style={[
 					styles.scopeButton,
 					active && { backgroundColor: t.card, borderColor: t.primarySolid },
@@ -95,6 +95,7 @@ export function ScheduleControls({
 			<View
 				style={[styles.group, { backgroundColor: t.secondary }]}
 				accessibilityRole="tablist"
+				accessibilityLabel="Schedule view"
 			>
 				{pill("day", "Day", CalendarDays)}
 				{pill("list", "List", List)}

--- a/apps/mobile/components/today/schedule-empty.tsx
+++ b/apps/mobile/components/today/schedule-empty.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, Text, View } from "react-native";
 import { fontFamily, radii, type, useTokens } from "@/lib/theme";
 import { Button } from "@/components/ui";
 import { Illustration } from "@/components/illustrations";
+import { UPCOMING_DAYS } from "@/lib/agenda";
 
 export type ScheduleEmptyVariant =
 	/** This day is clear, but there IS work elsewhere in the window. */
@@ -17,7 +18,7 @@ const COPY: Record<ScheduleEmptyVariant, { title: string; body: string }> = {
 	"day-off": { title: "Day off", body: "Nothing booked this weekend." },
 	"no-work": {
 		title: "Nothing on the books",
-		body: "No work scheduled for the next two weeks.",
+		body: `No work scheduled for the next ${UPCOMING_DAYS} days.`,
 	},
 };
 

--- a/apps/mobile/components/today/schedule-empty.tsx
+++ b/apps/mobile/components/today/schedule-empty.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { fontFamily, radii, type, useTokens } from "@/lib/theme";
+import { Button } from "@/components/ui";
+import { Illustration } from "@/components/illustrations";
+
+export type ScheduleEmptyVariant =
+	/** This day is clear, but there IS work elsewhere in the window. */
+	| "clear-day"
+	/** A clear weekend — worth naming, so the blank screen reads as intended. */
+	| "day-off"
+	/** Nothing at all across the whole rolling window. */
+	| "no-work";
+
+const COPY: Record<ScheduleEmptyVariant, { title: string; body: string }> = {
+	"clear-day": { title: "Nothing scheduled", body: "This day is clear." },
+	"day-off": { title: "Day off", body: "Nothing booked this weekend." },
+	"no-work": {
+		title: "Nothing on the books",
+		body: "No work scheduled for the next two weeks.",
+	},
+};
+
+interface ScheduleEmptyProps {
+	variant: ScheduleEmptyVariant;
+	onNewTask: () => void;
+}
+
+/** The schedule's composed empty state — same frame in both views. */
+export function ScheduleEmpty({ variant, onNewTask }: ScheduleEmptyProps) {
+	const t = useTokens();
+	const copy = COPY[variant];
+	return (
+		<View style={[styles.empty, { borderColor: t.line }]}>
+			<Illustration
+				name="all-caught-up"
+				knockout={t.bg}
+				style={styles.emptyArt}
+			/>
+			<Text style={[styles.emptyTitle, { color: t.ink }]}>{copy.title}</Text>
+			<Text style={[styles.emptyCopy, { color: t.sub }]}>{copy.body}</Text>
+			<Button title="New task" onPress={onNewTask} style={styles.emptyAction} />
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	empty: {
+		alignItems: "center",
+		gap: 4,
+		borderWidth: 1,
+		borderStyle: "dashed",
+		borderRadius: radii.card,
+		paddingVertical: 30,
+		paddingHorizontal: 24,
+	},
+	emptyArt: {
+		marginBottom: 6,
+	},
+	emptyTitle: {
+		fontFamily: fontFamily.semibold,
+		fontSize: type.h3,
+	},
+	emptyCopy: {
+		fontFamily: fontFamily.regular,
+		fontSize: type.body,
+	},
+	emptyAction: {
+		marginTop: 12,
+		alignSelf: "stretch",
+	},
+});

--- a/apps/mobile/components/today/schedule-skeleton.tsx
+++ b/apps/mobile/components/today/schedule-skeleton.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { radii, touch, useTokens } from "@/lib/theme";
+
+/**
+ * Shaped like the real schedule: a group label bar, a card of rows with a
+ * checkbox square and two text lines, then a shorter second group. Static —
+ * a pulse at this frequency (every Today open) is noise, not feedback.
+ */
+export function ScheduleSkeleton() {
+	const t = useTokens();
+
+	const group = (rows: number, labelWidth: number) => (
+		<View style={styles.group}>
+			<View
+				style={[styles.label, { width: labelWidth, backgroundColor: t.lineSoft }]}
+			/>
+			<View
+				style={[styles.card, { backgroundColor: t.card, borderColor: t.line }]}
+			>
+				{Array.from({ length: rows }, (_, i) => (
+					<View
+						key={i}
+						style={[
+							styles.row,
+							i < rows - 1 && {
+								borderBottomWidth: 1,
+								borderBottomColor: t.lineSoft,
+							},
+						]}
+					>
+						<View style={[styles.box, { backgroundColor: t.lineSoft }]} />
+						<View style={styles.body}>
+							<View
+								style={[
+									styles.line,
+									{ width: "58%", height: 12, backgroundColor: t.lineSoft },
+								]}
+							/>
+							<View
+								style={[
+									styles.line,
+									{ width: "34%", height: 10, backgroundColor: t.lineSoft },
+								]}
+							/>
+						</View>
+					</View>
+				))}
+			</View>
+		</View>
+	);
+
+	return (
+		<View
+			style={styles.wrap}
+			accessibilityLabel="Loading schedule"
+			accessibilityRole="progressbar"
+		>
+			{group(2, 58)}
+			{group(3, 76)}
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	wrap: {
+		gap: 18,
+	},
+	group: {
+		gap: 7,
+	},
+	label: {
+		height: 9,
+		borderRadius: radii.xs,
+	},
+	card: {
+		borderWidth: 1,
+		borderRadius: radii.card,
+		overflow: "hidden",
+	},
+	row: {
+		flexDirection: "row",
+		alignItems: "center",
+		minHeight: touch.min,
+		paddingHorizontal: 14,
+		gap: 12,
+	},
+	box: {
+		width: 22,
+		height: 22,
+		borderRadius: radii.xs,
+	},
+	body: {
+		flex: 1,
+		gap: 6,
+		paddingVertical: 11,
+	},
+	line: {
+		borderRadius: radii.xs,
+	},
+});

--- a/apps/mobile/components/today/schedule-skeleton.tsx
+++ b/apps/mobile/components/today/schedule-skeleton.tsx
@@ -1,20 +1,24 @@
 import React from "react";
 import { StyleSheet, View } from "react-native";
 import { radii, touch, useTokens } from "@/lib/theme";
+import { SPINE } from "@/components/today/agenda-row";
 
 /**
- * Shaped like the real schedule: a group label bar, a card of rows with a
- * checkbox square and two text lines, then a shorter second group. Static —
- * a pulse at this frequency (every Today open) is noise, not feedback.
+ * Shaped like the real body: the "Next up" lead card, then a group label bar and
+ * a card of timeline rows (spine, time rail, two text lines), then a shorter
+ * second group. Static — a pulse at this frequency (every Today open) is noise,
+ * not feedback.
  */
 export function ScheduleSkeleton() {
 	const t = useTokens();
 
+	const bar = (width: number | `${number}%`, height: number) => (
+		<View style={[styles.line, { width, height, backgroundColor: t.lineSoft }]} />
+	);
+
 	const group = (rows: number, labelWidth: number) => (
 		<View style={styles.group}>
-			<View
-				style={[styles.label, { width: labelWidth, backgroundColor: t.lineSoft }]}
-			/>
+			{bar(labelWidth, 9)}
 			<View
 				style={[styles.card, { backgroundColor: t.card, borderColor: t.line }]}
 			>
@@ -23,27 +27,19 @@ export function ScheduleSkeleton() {
 						key={i}
 						style={[
 							styles.row,
+							{ borderLeftColor: t.lineSoft },
 							i < rows - 1 && {
 								borderBottomWidth: 1,
 								borderBottomColor: t.lineSoft,
 							},
 						]}
 					>
-						<View style={[styles.box, { backgroundColor: t.lineSoft }]} />
+						<View style={styles.rail}>{bar(40, 11)}</View>
 						<View style={styles.body}>
-							<View
-								style={[
-									styles.line,
-									{ width: "58%", height: 12, backgroundColor: t.lineSoft },
-								]}
-							/>
-							<View
-								style={[
-									styles.line,
-									{ width: "34%", height: 10, backgroundColor: t.lineSoft },
-								]}
-							/>
+							{bar("58%", 12)}
+							{bar("34%", 10)}
 						</View>
+						<View style={[styles.box, { backgroundColor: t.lineSoft }]} />
 					</View>
 				))}
 			</View>
@@ -56,8 +52,23 @@ export function ScheduleSkeleton() {
 			accessibilityLabel="Loading schedule"
 			accessibilityRole="progressbar"
 		>
-			{group(2, 58)}
+			<View
+				style={[
+					styles.lead,
+					{
+						backgroundColor: t.card,
+						borderColor: t.line,
+						borderLeftColor: t.lineSoft,
+					},
+				]}
+			>
+				{bar(52, 9)}
+				{bar(112, 22)}
+				{bar("62%", 13)}
+				{bar("38%", 10)}
+			</View>
 			{group(3, 76)}
+			{group(2, 58)}
 		</View>
 	);
 }
@@ -66,12 +77,16 @@ const styles = StyleSheet.create({
 	wrap: {
 		gap: 18,
 	},
+	lead: {
+		gap: 7,
+		borderWidth: 1,
+		borderLeftWidth: SPINE,
+		borderRadius: radii.card,
+		paddingVertical: 15,
+		paddingHorizontal: 14,
+	},
 	group: {
 		gap: 7,
-	},
-	label: {
-		height: 9,
-		borderRadius: radii.xs,
 	},
 	card: {
 		borderWidth: 1,
@@ -82,18 +97,23 @@ const styles = StyleSheet.create({
 		flexDirection: "row",
 		alignItems: "center",
 		minHeight: touch.min,
-		paddingHorizontal: 14,
-		gap: 12,
+		borderLeftWidth: SPINE,
+		paddingLeft: 11,
+		paddingRight: 14,
+		gap: 10,
 	},
-	box: {
-		width: 22,
-		height: 22,
-		borderRadius: radii.xs,
+	rail: {
+		width: 58,
 	},
 	body: {
 		flex: 1,
 		gap: 6,
 		paddingVertical: 11,
+	},
+	box: {
+		width: 22,
+		height: 22,
+		borderRadius: radii.xs,
 	},
 	line: {
 		borderRadius: radii.xs,

--- a/apps/mobile/components/today/upcoming-list.tsx
+++ b/apps/mobile/components/today/upcoming-list.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import { StyleSheet, Text } from "react-native";
+import { fontFamily, recordTint, type, useTokens } from "@/lib/theme";
+import { ListRow } from "@/components/ui";
+import { AgendaRow } from "@/components/today/agenda-row";
+import { PlanSection } from "@/components/today/plan-section";
+import { ScheduleEmpty } from "@/components/today/schedule-empty";
+import { dayLabel, type AgendaTask, type UpcomingDay } from "@/lib/agenda";
+import { utcDayStartMs } from "@/lib/date";
+import type { Assignee } from "@/components/today/day-plan";
+
+interface UpcomingListProps {
+	/** Non-empty days only, in order (see `buildUpcomingAgenda`). */
+	days: UpcomingDay[];
+	/** The day the list starts from — used for the "nothing until…" lead line. */
+	anchorDayMs: number;
+	todayMs: number;
+	completedIds: Set<string>;
+	updatingIds: Set<string>;
+	onToggleTask: (id: string) => void;
+	onOpenTask: (id: string) => void;
+	onOpenProject: (id: string) => void;
+	onNewTask: () => void;
+	assigneeFor?: (task: AgendaTask) => Assignee | undefined;
+}
+
+/**
+ * The rolling upcoming agenda — the anchored day forward two weeks, grouped by
+ * day, empty days omitted. Day-level work (project spans, untimed tasks) leads
+ * each group; timed rows follow in start order.
+ *
+ * No now separator here: this view answers "what's coming", and a now line
+ * repeated inside a two-week scroll would be noise.
+ */
+export function UpcomingList({
+	days,
+	anchorDayMs,
+	todayMs,
+	completedIds,
+	updatingIds,
+	onToggleTask,
+	onOpenTask,
+	onOpenProject,
+	onNewTask,
+	assigneeFor,
+}: UpcomingListProps) {
+	const t = useTokens();
+
+	if (days.length === 0) {
+		return <ScheduleEmpty variant="no-work" onNewTask={onNewTask} />;
+	}
+
+	// The anchored day being empty is information — without a line, the list
+	// silently opens on a later date.
+	const firstLabel = dayLabel(days[0].dayMs, todayMs);
+	const skipsAhead =
+		utcDayStartMs(days[0].dayMs) !== utcDayStartMs(anchorDayMs);
+
+	return (
+		<>
+			{skipsAhead ? (
+				<Text style={[styles.lead, { color: t.sub }]}>
+					Nothing scheduled until{" "}
+					{firstLabel === "Tomorrow" ? "tomorrow" : firstLabel}.
+				</Text>
+			) : null}
+			{days.map((day) => {
+				const allDayCount = day.projects.length + day.anytime.length;
+				const total = allDayCount + day.timed.length;
+				return (
+					<PlanSection
+						key={day.dayMs}
+						tone="day"
+						label={dayLabel(day.dayMs, todayMs)}
+						meta={`${total} ${total === 1 ? "job" : "jobs"}`}
+					>
+						{day.projects.map((p, i) => (
+							<ListRow
+								key={p._id}
+								icon="Folder"
+								iconColor={recordTint.project.fg}
+								iconBg={recordTint.project.bg}
+								title={p.title}
+								sub={p.context}
+								status={p.status}
+								onPress={() => onOpenProject(p._id)}
+								last={i === total - 1}
+							/>
+						))}
+						{day.anytime.map((task, i) => (
+							<AgendaRow
+								key={task._id}
+								task={task}
+								completed={completedIds.has(task._id)}
+								updating={updatingIds.has(task._id)}
+								last={day.projects.length + i === total - 1}
+								onToggle={() => onToggleTask(task._id)}
+								onOpen={() => onOpenTask(task._id)}
+								assignee={assigneeFor?.(task)}
+							/>
+						))}
+						{day.timed.map((task, i) => (
+							<AgendaRow
+								key={task._id}
+								task={task}
+								completed={completedIds.has(task._id)}
+								updating={updatingIds.has(task._id)}
+								last={allDayCount + i === total - 1}
+								onToggle={() => onToggleTask(task._id)}
+								onOpen={() => onOpenTask(task._id)}
+								assignee={assigneeFor?.(task)}
+							/>
+						))}
+					</PlanSection>
+				);
+			})}
+		</>
+	);
+}
+
+const styles = StyleSheet.create({
+	lead: {
+		fontFamily: fontFamily.regular,
+		fontSize: type.sm,
+		// Sits directly above the first group; the scroll container owns the rest.
+		marginBottom: -8,
+	},
+});

--- a/apps/mobile/components/today/upcoming-list.tsx
+++ b/apps/mobile/components/today/upcoming-list.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { StyleSheet, Text } from "react-native";
 import { fontFamily, recordTint, type, useTokens } from "@/lib/theme";
 import { ListRow } from "@/components/ui";
-import { AgendaRow } from "@/components/today/agenda-row";
+import { AgendaRow, SpinedRow } from "@/components/today/agenda-row";
 import { PlanSection } from "@/components/today/plan-section";
 import { ScheduleEmpty } from "@/components/today/schedule-empty";
 import { dayLabel, type AgendaTask, type UpcomingDay } from "@/lib/agenda";
@@ -75,17 +75,18 @@ export function UpcomingList({
 						meta={`${total} ${total === 1 ? "job" : "jobs"}`}
 					>
 						{day.projects.map((p, i) => (
-							<ListRow
-								key={p._id}
-								icon="Folder"
-								iconColor={recordTint.project.fg}
-								iconBg={recordTint.project.bg}
-								title={p.title}
-								sub={p.context}
-								status={p.status}
-								onPress={() => onOpenProject(p._id)}
-								last={i === total - 1}
-							/>
+							<SpinedRow key={p._id} color={recordTint.project.fg}>
+								<ListRow
+									icon="Folder"
+									iconColor={recordTint.project.fg}
+									iconBg={recordTint.project.bg}
+									title={p.title}
+									sub={p.context}
+									status={p.status}
+									onPress={() => onOpenProject(p._id)}
+									last={i === total - 1}
+								/>
+							</SpinedRow>
 						))}
 						{day.anytime.map((task, i) => (
 							<AgendaRow

--- a/apps/mobile/components/today/week-strip.tsx
+++ b/apps/mobile/components/today/week-strip.tsx
@@ -30,7 +30,11 @@ interface WeekStripProps {
 	days: number[];
 	selectedDayMs: number;
 	todayMs: number;
-	/** Open-task counts keyed by UTC-midnight ms (see `countTasksByDay`). */
+	/**
+	 * Open-work counts keyed by UTC-midnight ms — tasks AND project spans, from
+	 * the same calendar-events feed the schedule renders (`countScheduleByDay`),
+	 * so the bars can never disagree with the timeline this strip anchors.
+	 */
 	counts: Map<number, number>;
 	/** Tapping a day scopes the agenda to it. */
 	onSelectDay: (dayMs: number) => void;
@@ -167,7 +171,7 @@ export function WeekStrip({
 						accessibilityLabel={[
 							isToday ? `Today, ${label}` : label,
 							// The bar encodes workload but is invisible to a screen reader.
-							count > 0 ? `${count} ${count === 1 ? "task" : "tasks"}` : "no tasks",
+							count > 0 ? `${count} ${count === 1 ? "job" : "jobs"}` : "nothing scheduled",
 						].join(", ")}
 						accessibilityHint="Shows this day's work"
 						onPress={() => onSelectDay(dayMs)}

--- a/apps/mobile/components/work/search-field.tsx
+++ b/apps/mobile/components/work/search-field.tsx
@@ -9,13 +9,20 @@ interface SearchFieldProps {
 	placeholder?: string;
 	/** Programmatic label — the magnifier glyph is decorative, not a label. */
 	label?: string;
+	/**
+	 * Handle on the TextInput so the owner can focus it (the header magnifier
+	 * jumps here). NOT named `ref`: a plain prop keeps this a normal component
+	 * and sidesteps the forwardRef/`ref`-prop footgun.
+	 */
+	inputRef?: React.RefObject<TextInput | null>;
 }
 
 export function SearchField({
 	value,
 	onChangeText,
-	placeholder = "Search clients, projects, quotes, invoices…",
+	placeholder = "Search everything",
 	label = "Search work",
+	inputRef,
 }: SearchFieldProps) {
 	const t = useTokens();
 
@@ -25,6 +32,7 @@ export function SearchField({
 		>
 			<Search size={18} color={t.faint} />
 			<TextInput
+				ref={inputRef}
 				value={value}
 				onChangeText={onChangeText}
 				placeholder={placeholder}

--- a/apps/mobile/components/work/search-field.tsx
+++ b/apps/mobile/components/work/search-field.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Pressable, StyleSheet, TextInput, View } from "react-native";
 import { Search, X } from "lucide-react-native";
-import { fontFamily, radii, touch, type, useTokens } from "@/lib/theme";
+import { fontFamily, hero, radii, touch, type, useTokens } from "@/lib/theme";
 
 interface SearchFieldProps {
 	value: string;
@@ -15,6 +15,8 @@ interface SearchFieldProps {
 	 * and sidesteps the forwardRef/`ref`-prop footgun.
 	 */
 	inputRef?: React.RefObject<TextInput | null>;
+	/** Frosted-on-ink palette for the tab-root ink band. */
+	onInk?: boolean;
 }
 
 export function SearchField({
@@ -23,21 +25,24 @@ export function SearchField({
 	placeholder = "Search everything",
 	label = "Search work",
 	inputRef,
+	onInk = false,
 }: SearchFieldProps) {
 	const t = useTokens();
+	const bar = onInk
+		? { backgroundColor: hero.cellBg, borderColor: hero.cellBorder }
+		: { backgroundColor: t.card, borderColor: t.line };
+	const glyph = onInk ? hero.textSub : t.faint;
 
 	return (
-		<View
-			style={[styles.bar, { backgroundColor: t.card, borderColor: t.line }]}
-		>
-			<Search size={18} color={t.faint} />
+		<View style={[styles.bar, bar]}>
+			<Search size={18} color={glyph} />
 			<TextInput
 				ref={inputRef}
 				value={value}
 				onChangeText={onChangeText}
 				placeholder={placeholder}
-				placeholderTextColor={t.faint}
-				style={[styles.input, { color: t.ink }]}
+				placeholderTextColor={glyph}
+				style={[styles.input, { color: onInk ? hero.text : t.ink }]}
 				accessibilityLabel={label}
 				accessibilityHint="Results filter as you type"
 				autoCorrect={false}
@@ -56,7 +61,7 @@ export function SearchField({
 					accessibilityRole="button"
 					accessibilityLabel="Clear search"
 				>
-					<X size={16} color={t.sub} />
+					<X size={16} color={onInk ? hero.textMid : t.sub} />
 				</Pressable>
 			) : null}
 		</View>

--- a/apps/mobile/components/work/type-chips.tsx
+++ b/apps/mobile/components/work/type-chips.tsx
@@ -1,13 +1,23 @@
 import React from "react";
 import { Pressable, ScrollView, StyleSheet, Text } from "react-native";
 import { Check } from "lucide-react-native";
-import { fontFamily, radii, spacing, touch, type, useTokens } from "@/lib/theme";
+import {
+	fontFamily,
+	hero,
+	radii,
+	spacing,
+	touch,
+	type,
+	useTokens,
+} from "@/lib/theme";
 import { CHIP_ORDER, KIND_LABEL, type WorkChipKind } from "@/lib/work-search";
 
 interface TypeChipsProps {
 	/** null = no type filter (search everything / resting view). */
 	value: WorkChipKind | null;
 	onChange: (next: WorkChipKind | null) => void;
+	/** Frosted-on-ink palette for the tab-root ink band. */
+	onInk?: boolean;
 }
 
 /**
@@ -18,8 +28,32 @@ interface TypeChipsProps {
  * subscriptions, and search buckets cap at 5 hits — any number rendered here
  * would be either a lie or four subscriptions bought back to print it.
  */
-export function TypeChips({ value, onChange }: TypeChipsProps) {
+export function TypeChips({ value, onChange, onInk = false }: TypeChipsProps) {
 	const t = useTokens();
+
+	// On ink, selection is a SOLID white chip with ink text — the frosted fills
+	// composite to ~1.1:1 there and cannot carry a state on their own.
+	const chipStyle = (selected: boolean) =>
+		onInk
+			? selected
+				? { backgroundColor: hero.text, borderColor: hero.text }
+				: { backgroundColor: hero.cellBg, borderColor: hero.cellBorder }
+			: selected
+				? {
+						backgroundColor: t.frostedBg,
+						// A 10% wash reads as "white chip" in sunlight; the border does
+						// the real work at 4.8:1 against the surface.
+						borderColor: t.primarySolid,
+					}
+				: { backgroundColor: t.card, borderColor: t.line };
+	const chipInk = (selected: boolean) =>
+		onInk
+			? selected
+				? hero.ink
+				: hero.textMid
+			: selected
+				? t.frostedInk
+				: t.sub;
 
 	return (
 		<ScrollView
@@ -43,25 +77,13 @@ export function TypeChips({ value, onChange }: TypeChipsProps) {
 						accessibilityLabel={KIND_LABEL[kind]}
 						style={({ pressed }) => [
 							styles.chip,
-							selected
-								? {
-										backgroundColor: t.frostedBg,
-										// A 10% wash reads as "white chip" in sunlight; the border does
-										// the real work at 4.8:1 against the surface.
-										borderColor: t.primarySolid,
-									}
-								: { backgroundColor: t.card, borderColor: t.line },
+							chipStyle(selected),
 							pressed && styles.pressed,
 						]}
 					>
 						{/* Glyph, not just color — selection must not be color-only. */}
-						{selected ? <Check size={13} color={t.frostedInk} /> : null}
-						<Text
-							style={[
-								styles.label,
-								{ color: selected ? t.frostedInk : t.sub },
-							]}
-						>
+						{selected ? <Check size={13} color={chipInk(true)} /> : null}
+						<Text style={[styles.label, { color: chipInk(selected) }]}>
 							{KIND_LABEL[kind]}
 						</Text>
 					</Pressable>

--- a/apps/mobile/components/work/type-chips.tsx
+++ b/apps/mobile/components/work/type-chips.tsx
@@ -2,18 +2,23 @@ import React from "react";
 import { Pressable, ScrollView, StyleSheet, Text } from "react-native";
 import { Check } from "lucide-react-native";
 import { fontFamily, radii, spacing, touch, type, useTokens } from "@/lib/theme";
-import { KIND_LABEL, KIND_ORDER, type WorkKind } from "@/lib/work-search";
+import { CHIP_ORDER, KIND_LABEL, type WorkChipKind } from "@/lib/work-search";
 
 interface TypeChipsProps {
-	/** null = no type filter (mixed view). */
-	value: WorkKind | null;
-	onChange: (next: WorkKind | null) => void;
-	/** Optional per-kind counts, shown after the label when known. */
-	counts?: Partial<Record<WorkKind, number>>;
+	/** null = no type filter (search everything / resting view). */
+	value: WorkChipKind | null;
+	onChange: (next: WorkChipKind | null) => void;
 }
 
-/** Record-type filter chips. Tapping the selected chip clears the filter. */
-export function TypeChips({ value, onChange, counts }: TypeChipsProps) {
+/**
+ * Bucket chips. With a query they scope results to one kind; without one they
+ * open that kind's full browse list.
+ *
+ * COUNTLESS by design (Slice 6): the screen no longer holds four always-on list
+ * subscriptions, and search buckets cap at 5 hits — any number rendered here
+ * would be either a lie or four subscriptions bought back to print it.
+ */
+export function TypeChips({ value, onChange }: TypeChipsProps) {
 	const t = useTokens();
 
 	return (
@@ -27,20 +32,15 @@ export function TypeChips({ value, onChange, counts }: TypeChipsProps) {
 			contentContainerStyle={styles.row}
 			keyboardShouldPersistTaps="handled"
 		>
-			{KIND_ORDER.map((kind) => {
+			{CHIP_ORDER.map((kind) => {
 				const selected = value === kind;
-				const count = counts?.[kind];
 				return (
 					<Pressable
 						key={kind}
 						onPress={() => onChange(selected ? null : kind)}
 						accessibilityRole="button"
 						accessibilityState={{ selected }}
-						accessibilityLabel={
-							count === undefined
-								? KIND_LABEL[kind]
-								: `${KIND_LABEL[kind]}, ${count}`
-						}
+						accessibilityLabel={KIND_LABEL[kind]}
 						style={({ pressed }) => [
 							styles.chip,
 							selected
@@ -64,16 +64,6 @@ export function TypeChips({ value, onChange, counts }: TypeChipsProps) {
 						>
 							{KIND_LABEL[kind]}
 						</Text>
-						{count === undefined ? null : (
-							<Text
-								style={[
-									styles.count,
-									{ color: selected ? t.frostedInk : t.faint },
-								]}
-							>
-								{count}
-							</Text>
-						)}
 					</Pressable>
 				);
 			})}
@@ -102,10 +92,6 @@ const styles = StyleSheet.create({
 	label: {
 		fontFamily: fontFamily.semibold,
 		fontSize: type.sm,
-	},
-	count: {
-		fontFamily: fontFamily.semibold,
-		fontSize: type.meta,
 	},
 	pressed: {
 		opacity: 0.75,

--- a/apps/mobile/lib/agenda.test.ts
+++ b/apps/mobile/lib/agenda.test.ts
@@ -444,6 +444,20 @@ describe("scopeCalendarEvents", () => {
 		expect(s.tasks.find((t) => t._id === "withClient")?.context).toBe("Acme");
 	});
 
+	it("ignores a placeholder client name when the task has no client", () => {
+		// The filler travels with clientId undefined, so the guard is the id, not
+		// the string — a real client called "Unknown Client" still shows.
+		const s = scopeCalendarEvents(
+			{
+				tasks: [taskEvent({ id: "filler", clientName: "Unknown Client" })],
+				projects: [],
+			},
+			"u1",
+			"team",
+		);
+		expect(s.tasks[0]?.context).toBeUndefined();
+	});
+
 	it("applies the scope helpers, keeping unassigned work in Me", () => {
 		const me = scopeCalendarEvents(events, "u1", "me");
 		expect(me.tasks.map((t) => t._id)).toEqual(["mine", "loose", "withClient"]);

--- a/apps/mobile/lib/agenda.test.ts
+++ b/apps/mobile/lib/agenda.test.ts
@@ -11,6 +11,7 @@ import {
 	projectInScope,
 	projectsForDay,
 	scopeCalendarEvents,
+	selectNextUp,
 	taskInScope,
 	tomorrowPeek,
 	weekDaysFor,
@@ -103,22 +104,10 @@ describe("buildDayPlan", () => {
 	it("puts the separator after the last row once the day is behind you", () => {
 		const plan = buildDayPlan(tasks, WED, WED, 23 * 60);
 		expect(plan.nowIndex).toBe(plan.timed.length);
-		expect(plan.nextUpId).toBeNull();
 	});
 
-	it("marks the first OPEN upcoming task as next up, skipping done rows", () => {
-		expect(buildDayPlan(tasks, WED, WED, NOON).nextUpId).toBe("deep");
-		const withDone = [
-			task({ _id: "did", date: WED, startTime: "13:00", status: "completed" }),
-			task({ _id: "next", date: WED, startTime: "15:00" }),
-		];
-		expect(buildDayPlan(withDone, WED, WED, NOON).nextUpId).toBe("next");
-	});
-
-	it("has no now separator or next-up when browsing another day", () => {
-		const plan = buildDayPlan(tasks, WED + 2 * DAY, WED, NOON);
-		expect(plan.nowIndex).toBe(-1);
-		expect(plan.nextUpId).toBeNull();
+	it("has no now separator when browsing another day", () => {
+		expect(buildDayPlan(tasks, WED + 2 * DAY, WED, NOON).nowIndex).toBe(-1);
 	});
 
 	it("has no now separator when the day has no timed work", () => {
@@ -153,6 +142,72 @@ describe("buildDayPlan", () => {
 		const plan = buildDayPlan([task({ _id: "floating" })], WED, WED, NOON);
 		expect(plan.timed).toEqual([]);
 		expect(plan.anytime).toEqual([]);
+	});
+});
+
+describe("selectNextUp", () => {
+	const NOON = 12 * 60;
+	const day: AgendaTask[] = [
+		task({ _id: "wash", date: WED, startTime: "08:00" }),
+		task({ _id: "gutter", date: WED, startTime: "13:00" }),
+		task({ _id: "deep", date: WED, startTime: "15:00" }),
+	];
+	const none = new Set<string>();
+
+	it("lifts the first open upcoming task out of the timeline", () => {
+		const split = selectNextUp(buildDayPlan(day, WED, WED, NOON), none);
+		expect(split.next?._id).toBe("gutter");
+		expect(split.timed.map((t) => t._id)).toEqual(["wash", "deep"]);
+	});
+
+	it("advances past an OPTIMISTICALLY completed row before the server agrees", () => {
+		const plan = buildDayPlan(day, WED, WED, NOON);
+		const split = selectNextUp(plan, new Set(["gutter"]));
+		expect(split.next?._id).toBe("deep");
+		expect(split.timed.map((t) => t._id)).toEqual(["wash", "gutter"]);
+	});
+
+	it("skips rows the server already calls done", () => {
+		const withDone = [
+			task({ _id: "did", date: WED, startTime: "13:00", status: "completed" }),
+			task({ _id: "next", date: WED, startTime: "15:00" }),
+		];
+		expect(selectNextUp(buildDayPlan(withDone, WED, WED, NOON), none).next?._id).toBe(
+			"next",
+		);
+	});
+
+	it("keeps the now separator's position on the shortened timeline", () => {
+		// now = 07:00, so nowIndex is 0 and the lead is the first row.
+		const split = selectNextUp(buildDayPlan(day, WED, WED, 7 * 60), none);
+		expect(split.next?._id).toBe("wash");
+		expect(split.nowIndex).toBe(0);
+		// Everything after now is done → separator clamps to the shortened end.
+		const late = selectNextUp(
+			buildDayPlan(day, WED, WED, 14 * 60),
+			new Set(["deep"]),
+		);
+		expect(late.next).toBeNull();
+		expect(late.nowIndex).toBe(2);
+	});
+
+	it("clamps the separator when the lead was the only row left", () => {
+		const one = [task({ _id: "solo", date: WED, startTime: "15:00" })];
+		const split = selectNextUp(buildDayPlan(one, WED, WED, NOON), none);
+		expect(split.next?._id).toBe("solo");
+		expect(split.timed).toEqual([]);
+		expect(split.nowIndex).toBe(0);
+	});
+
+	it("yields no card when browsing another day, or when the day is done", () => {
+		const elsewhere = selectNextUp(buildDayPlan(day, WED + DAY, WED, NOON), none);
+		expect(elsewhere.next).toBeNull();
+		expect(elsewhere.nowIndex).toBe(-1);
+
+		const finished = buildDayPlan(day, WED, WED, NOON);
+		const allDone = selectNextUp(finished, new Set(["wash", "gutter", "deep"]));
+		expect(allDone.next).toBeNull();
+		expect(allDone.timed).toBe(finished.timed);
 	});
 });
 

--- a/apps/mobile/lib/agenda.test.ts
+++ b/apps/mobile/lib/agenda.test.ts
@@ -1,18 +1,26 @@
 import { describe, expect, it } from "vitest";
 import {
 	buildDayPlan,
+	buildUpcomingAgenda,
+	countScheduleByDay,
 	countTasksByDay,
+	dayLabel,
 	formatClockLabel,
+	isWeekend,
 	minutesFromHHMM,
 	projectInScope,
 	projectsForDay,
+	scopeCalendarEvents,
 	taskInScope,
 	tomorrowPeek,
 	weekDaysFor,
 	workloadBar,
 	type AgendaProject,
 	type AgendaTask,
+	type CalendarEvents,
+	type ScopedSchedule,
 } from "./agenda";
+import type { ProjectEvent, TaskEvent } from "@/components/calendar/dateUtils";
 
 const DAY = 86_400_000;
 const utc = (y: number, m: number, d: number) => Date.UTC(y, m - 1, d);
@@ -327,5 +335,326 @@ describe("workloadBar", () => {
 		// An empty week: dividing by a zero max would be NaN and paint nothing
 		// predictable.
 		expect(workloadBar(3, 0)).toBe(0);
+	});
+});
+
+describe("scopeCalendarEvents", () => {
+	const taskEvent = (over: Partial<TaskEvent> & { id: string }): TaskEvent => ({
+		type: "task",
+		title: over.id,
+		startDate: WED,
+		status: "pending",
+		clientName: "Internal Task",
+		...over,
+	});
+	const projectEvent = (
+		over: Partial<ProjectEvent> & { id: string },
+	): ProjectEvent => ({
+		type: "project",
+		title: over.id,
+		startDate: WED,
+		status: "in-progress",
+		clientId: "c1",
+		clientName: "Acme",
+		...over,
+	});
+
+	const events: CalendarEvents = {
+		tasks: [
+			taskEvent({ id: "mine", assigneeUserId: "u1", startTime: "09:00" }),
+			taskEvent({ id: "theirs", assigneeUserId: "u2" }),
+			taskEvent({ id: "loose" }),
+			taskEvent({ id: "withClient", clientId: "c1", clientName: "Acme" }),
+		],
+		projects: [
+			projectEvent({ id: "pmine", assignedUserIds: ["u1"] }),
+			projectEvent({ id: "ptheirs", assignedUserIds: ["u2"] }),
+		],
+	};
+
+	it("adapts calendar events onto the agenda shapes", () => {
+		const s = scopeCalendarEvents(events, "u1", "team");
+		const mine = s.tasks.find((t) => t._id === "mine")!;
+		expect(mine.date).toBe(WED);
+		expect(mine.startTime).toBe("09:00");
+		expect(s.projects.find((p) => p._id === "pmine")?.context).toBe("Acme");
+	});
+
+	it("drops the backend's placeholder client name for clientless tasks", () => {
+		// "Internal Task"/"Unknown Client" are backend fillers — a row with no
+		// client must show nothing rather than a fabricated line.
+		const s = scopeCalendarEvents(events, "u1", "team");
+		expect(s.tasks.find((t) => t._id === "loose")?.context).toBeUndefined();
+		expect(s.tasks.find((t) => t._id === "withClient")?.context).toBe("Acme");
+	});
+
+	it("applies the scope helpers, keeping unassigned work in Me", () => {
+		const me = scopeCalendarEvents(events, "u1", "me");
+		expect(me.tasks.map((t) => t._id)).toEqual(["mine", "loose", "withClient"]);
+		expect(me.projects.map((p) => p._id)).toEqual(["pmine"]);
+		const team = scopeCalendarEvents(events, "u1", "team");
+		expect(team.tasks).toHaveLength(4);
+		expect(team.projects).toHaveLength(2);
+	});
+
+	it("returns an empty schedule while the query is still loading", () => {
+		expect(scopeCalendarEvents(undefined, "u1", "me")).toEqual({
+			projects: [],
+			tasks: [],
+		});
+	});
+});
+
+describe("countScheduleByDay", () => {
+	const week = weekDaysFor(WED);
+	const proj = (
+		over: Partial<AgendaProject> & { _id: string },
+	): AgendaProject => ({ title: over._id, status: "in-progress", ...over });
+
+	it("counts tasks AND project spans on each day in view", () => {
+		const counts = countScheduleByDay(
+			[task({ _id: "a", date: WED }), task({ _id: "b", date: WED })],
+			[proj({ _id: "p", startDate: WED, endDate: WED + DAY })],
+			week,
+		);
+		expect(counts.get(WED)).toBe(3);
+		expect(counts.get(WED + DAY)).toBe(1);
+	});
+
+	it("counts a multi-day project on every day it spans", () => {
+		const counts = countScheduleByDay(
+			[],
+			[proj({ _id: "p", startDate: SUN, endDate: SAT })],
+			week,
+		);
+		expect([...counts.values()]).toEqual([1, 1, 1, 1, 1, 1, 1]);
+	});
+
+	it("skips finished work of both kinds", () => {
+		const counts = countScheduleByDay(
+			[task({ _id: "a", date: WED, status: "completed" })],
+			[proj({ _id: "p", startDate: WED, status: "cancelled" })],
+			week,
+		);
+		expect(counts.size).toBe(0);
+	});
+
+	it("is bounded to the days passed — the strip's scale is its own week", () => {
+		// A task two weeks out must not set the bar scale for the visible week.
+		const counts = countScheduleByDay(
+			[task({ _id: "far", date: WED + 14 * DAY })],
+			[],
+			week,
+		);
+		expect(counts.size).toBe(0);
+	});
+});
+
+describe("buildUpcomingAgenda", () => {
+	const proj = (
+		over: Partial<AgendaProject> & { _id: string },
+	): AgendaProject => ({ title: over._id, status: "in-progress", ...over });
+	const schedule = (over: Partial<ScopedSchedule>): ScopedSchedule => ({
+		projects: [],
+		tasks: [],
+		...over,
+	});
+
+	it("groups by day, all-day work apart from timed, empty days omitted", () => {
+		const days = buildUpcomingAgenda(
+			schedule({
+				tasks: [
+					task({ _id: "late", date: WED, startTime: "15:00" }),
+					task({ _id: "early", date: WED, startTime: "08:00" }),
+					task({ _id: "zloose", date: WED }),
+					task({ _id: "aloose", date: WED }),
+					task({ _id: "far", date: WED + 3 * DAY, startTime: "10:00" }),
+				],
+				projects: [proj({ _id: "p", startDate: WED + DAY })],
+			}),
+			WED,
+			5,
+		);
+		expect(days.map((d) => d.dayMs)).toEqual([WED, WED + DAY, WED + 3 * DAY]);
+		expect(days[0].timed.map((t) => t._id)).toEqual(["early", "late"]);
+		expect(days[0].anytime.map((t) => t._id)).toEqual(["aloose", "zloose"]);
+		expect(days[1].projects.map((p) => p._id)).toEqual(["p"]);
+	});
+
+	it("includes a project that starts BEFORE the window and ends inside it", () => {
+		const days = buildUpcomingAgenda(
+			schedule({
+				projects: [proj({ _id: "p", startDate: SUN, endDate: WED })],
+			}),
+			WED,
+			3,
+		);
+		expect(days.map((d) => d.dayMs)).toEqual([WED]);
+	});
+
+	it("includes a project that runs past the end of the window", () => {
+		const days = buildUpcomingAgenda(
+			schedule({
+				projects: [proj({ _id: "p", startDate: WED, endDate: WED + 90 * DAY })],
+			}),
+			WED,
+			3,
+		);
+		expect(days).toHaveLength(3);
+		expect(days.every((d) => d.projects.length === 1)).toBe(true);
+	});
+
+	it("puts a single-day project on exactly one day", () => {
+		const days = buildUpcomingAgenda(
+			schedule({ projects: [proj({ _id: "p", startDate: WED + DAY })] }),
+			WED,
+			5,
+		);
+		expect(days.map((d) => d.dayMs)).toEqual([WED + DAY]);
+	});
+
+	it("crosses week and month boundaries by whole UTC days", () => {
+		// Anchor on a Saturday: the 14-day window rolls through two week starts
+		// and a month boundary without drifting.
+		const anchor = utc(2026, 7, 25); // Saturday
+		const days = buildUpcomingAgenda(
+			schedule({
+				tasks: [
+					task({ _id: "sun", date: utc(2026, 7, 26) }),
+					task({ _id: "aug", date: utc(2026, 8, 1) }),
+					task({ _id: "last", date: utc(2026, 8, 7) }),
+					task({ _id: "past", date: utc(2026, 8, 8) }),
+				],
+			}),
+			anchor,
+			14,
+		);
+		expect(days.map((d) => d.dayMs)).toEqual([
+			utc(2026, 7, 26),
+			utc(2026, 8, 1),
+			utc(2026, 8, 7),
+		]);
+	});
+
+	it("is DST-immune — a spring-forward span steps whole UTC days", () => {
+		// 2026-03-08 is the US spring-forward Sunday. Stepping DAY_MS on a
+		// UTC-midnight date-id must land on 03-09, not 03-08T23:00.
+		const anchor = utc(2026, 3, 7);
+		const days = buildUpcomingAgenda(
+			schedule({
+				tasks: [
+					task({ _id: "sat", date: utc(2026, 3, 7) }),
+					task({ _id: "sun", date: utc(2026, 3, 8) }),
+					task({ _id: "mon", date: utc(2026, 3, 9) }),
+				],
+			}),
+			anchor,
+			4,
+		);
+		expect(days.map((d) => d.dayMs)).toEqual([
+			utc(2026, 3, 7),
+			utc(2026, 3, 8),
+			utc(2026, 3, 9),
+		]);
+	});
+
+	it("is DST-immune across fall-back too", () => {
+		// 2026-11-01 is the US fall-back Sunday (a 25-hour local day).
+		const days = buildUpcomingAgenda(
+			schedule({
+				tasks: [
+					task({ _id: "sun", date: utc(2026, 11, 1) }),
+					task({ _id: "mon", date: utc(2026, 11, 2) }),
+				],
+			}),
+			utc(2026, 10, 31),
+			4,
+		);
+		expect(days.map((d) => d.dayMs)).toEqual([
+			utc(2026, 11, 1),
+			utc(2026, 11, 2),
+		]);
+	});
+
+	it("buckets on the UTC day when handed an instant as the anchor", () => {
+		// Callers may pass an afternoon instant; date-ids are UTC-midnight.
+		const days = buildUpcomingAgenda(
+			schedule({ tasks: [task({ _id: "a", date: WED })] }),
+			WED + 18 * 3_600_000,
+			2,
+		);
+		expect(days.map((d) => d.dayMs)).toEqual([WED]);
+	});
+
+	it("ignores work before the anchor and past the window", () => {
+		const days = buildUpcomingAgenda(
+			schedule({
+				tasks: [
+					task({ _id: "before", date: WED - DAY }),
+					task({ _id: "after", date: WED + 5 * DAY }),
+				],
+			}),
+			WED,
+			3,
+		);
+		expect(days).toEqual([]);
+	});
+
+	it("carries the scope filter through from scopeCalendarEvents", () => {
+		const scoped = scopeCalendarEvents(
+			{
+				tasks: [
+					{
+						id: "mine",
+						type: "task",
+						title: "mine",
+						startDate: WED,
+						status: "pending",
+						clientName: "Acme",
+						clientId: "c1",
+						assigneeUserId: "u1",
+					},
+					{
+						id: "theirs",
+						type: "task",
+						title: "theirs",
+						startDate: WED,
+						status: "pending",
+						clientName: "Acme",
+						clientId: "c1",
+						assigneeUserId: "u2",
+					},
+				],
+				projects: [],
+			},
+			"u1",
+			"me",
+		);
+		const days = buildUpcomingAgenda(scoped, WED, 2);
+		expect(days[0].anytime.map((t) => t._id)).toEqual(["mine"]);
+	});
+});
+
+describe("dayLabel", () => {
+	it("names today and tomorrow rather than dating them", () => {
+		expect(dayLabel(WED, WED)).toBe("Today");
+		expect(dayLabel(WED + DAY, WED)).toBe("Tomorrow");
+	});
+
+	it("dates every other day with its weekday", () => {
+		expect(dayLabel(SAT, WED)).toBe("Saturday, Jul 25");
+		expect(dayLabel(SUN, WED)).toBe("Sunday, Jul 19");
+	});
+
+	it("reads the UTC calendar, so an instant inside the day still matches", () => {
+		expect(dayLabel(WED + 20 * 3_600_000, WED)).toBe("Today");
+	});
+});
+
+describe("isWeekend", () => {
+	it("is true only for Saturday and Sunday", () => {
+		expect(isWeekend(SUN)).toBe(true);
+		expect(isWeekend(SAT)).toBe(true);
+		expect(isWeekend(WED)).toBe(false);
 	});
 });

--- a/apps/mobile/lib/agenda.test.ts
+++ b/apps/mobile/lib/agenda.test.ts
@@ -12,6 +12,7 @@ import {
 	projectsForDay,
 	scopeCalendarEvents,
 	selectNextUp,
+	selectNextUpProject,
 	taskInScope,
 	tomorrowPeek,
 	weekDaysFor,
@@ -711,5 +712,31 @@ describe("isWeekend", () => {
 		expect(isWeekend(SUN)).toBe(true);
 		expect(isWeekend(SAT)).toBe(true);
 		expect(isWeekend(WED)).toBe(false);
+	});
+});
+
+describe("selectNextUpProject", () => {
+	const proj = (id: string, status = "in-progress") => ({
+		_id: id,
+		title: `Project ${id}`,
+		status,
+	});
+
+	it("picks the first still-active project", () => {
+		expect(selectNextUpProject([proj("a"), proj("b")])?._id).toBe("a");
+	});
+
+	it("skips completed and cancelled visits", () => {
+		const picked = selectNextUpProject([
+			proj("done", "completed"),
+			proj("gone", "cancelled"),
+			proj("live", "planned"),
+		]);
+		expect(picked?._id).toBe("live");
+	});
+
+	it("returns null when every visit is finished or the day has none", () => {
+		expect(selectNextUpProject([proj("done", "completed")])).toBeNull();
+		expect(selectNextUpProject([])).toBeNull();
 	});
 });

--- a/apps/mobile/lib/agenda.ts
+++ b/apps/mobile/lib/agenda.ts
@@ -246,6 +246,19 @@ export function selectNextUp(
 }
 
 /**
+ * Fallback lead object when no timed job qualifies for the card: the first
+ * still-active project visit. A project-only day is the COMMON field-service
+ * shape ("1 visit today", nothing clocked) — without this, exactly those days
+ * lose the "what's next" moment. Caller gates on today-anchored, since a
+ * timed-empty plan carries nowIndex -1 whether or not the day is today.
+ */
+export function selectNextUpProject(
+	projects: readonly AgendaProject[],
+): AgendaProject | null {
+	return projects.find((p) => !DONE.has(p.status)) ?? null;
+}
+
+/**
  * Width fraction (0-1) for a day's workload bar, scaled against the busiest day
  * in view. Relative rather than absolute so the strip reads as a shape for any
  * shop size — 2 jobs is a full bar for someone whose peak is 2.

--- a/apps/mobile/lib/agenda.ts
+++ b/apps/mobile/lib/agenda.ts
@@ -152,8 +152,6 @@ export type DayPlan = {
 	anytime: AgendaTask[];
 	/** Open spillover from earlier days, oldest first. */
 	overdue: AgendaTask[];
-	/** Task to emphasize as "next up"; null off-today or when the day is done. */
-	nextUpId: string | null;
 	/**
 	 * `timed` index the now-separator renders BEFORE (== timed.length → after
 	 * the last row); -1 = don't render (browsing another day, or no timed work).
@@ -199,19 +197,52 @@ export function buildDayPlan(
 	// Oldest first — the thing you've ignored longest leads.
 	overdue.sort((a, b) => (a.date ?? 0) - (b.date ?? 0));
 
+	// The "next up" pick derives from nowIndex, but lives in `selectNextUp` — it
+	// has to see the screen's optimistic done state, which a pure plan cannot.
 	let nowIndex = -1;
-	let nextUpId: string | null = null;
 	if (day === today && timed.length > 0) {
 		const firstUpcoming = timed.findIndex(
 			(t) => (minutesFromHHMM(t.startTime) ?? 0) >= nowMinutes,
 		);
 		nowIndex = firstUpcoming === -1 ? timed.length : firstUpcoming;
-		// Next up = the first upcoming task still open; a done row isn't "next".
-		nextUpId =
-			timed.slice(nowIndex).find((t) => !DONE.has(t.status ?? ""))?._id ?? null;
 	}
 
-	return { timed, anytime, overdue, nextUpId, nowIndex };
+	return { timed, anytime, overdue, nowIndex };
+}
+
+/** The lead object plus the timeline that continues after it. */
+export type NextUpSplit = {
+	/** The card's task; null off-today, on an empty day, or when the day is done. */
+	next: AgendaTask | null;
+	/** `plan.timed` with `next` removed — the card is never duplicated below. */
+	timed: AgendaTask[];
+	/** `plan.nowIndex` re-based onto the shortened `timed`. */
+	nowIndex: number;
+};
+
+/**
+ * Split the day's lead job off the timeline for the "Next up" card.
+ *
+ * Re-derives the pick from `doneIds` rather than trusting `plan.nextUpId`:
+ * nextUpId reads SERVER status, so checking the card off would leave a
+ * struck-through "Next up" until the subscription round-trips. `nowIndex === -1`
+ * (browsing another day) short-circuits, which is what anchors the card to today.
+ */
+export function selectNextUp(
+	plan: DayPlan,
+	doneIds: ReadonlySet<string>,
+): NextUpSplit {
+	const { timed, nowIndex } = plan;
+	if (nowIndex < 0) return { next: null, timed, nowIndex };
+	const at = timed.findIndex(
+		(task, i) =>
+			i >= nowIndex && !doneIds.has(task._id) && !DONE.has(task.status ?? ""),
+	);
+	if (at === -1) return { next: null, timed, nowIndex };
+	const rest = timed.filter((_, i) => i !== at);
+	// The removed row is always at index >= nowIndex, so earlier indices hold;
+	// only the "after the last row" position can fall off the end.
+	return { next: timed[at], timed: rest, nowIndex: Math.min(nowIndex, rest.length) };
 }
 
 /**

--- a/apps/mobile/lib/agenda.ts
+++ b/apps/mobile/lib/agenda.ts
@@ -5,7 +5,11 @@
 // boundary here is a UTC boundary. Never use local getFullYear/getMonth/getDate
 // on a task date. `startTime`/`endTime` are "HH:MM" wall-clock strings.
 
-import { DAY_MS } from "@/components/calendar/dateUtils";
+import {
+	DAY_MS,
+	type ProjectEvent,
+	type TaskEvent,
+} from "@/components/calendar/dateUtils";
 import { utcDayStartMs } from "@/lib/date";
 
 /** Sunday-start, matching the mockup's `Sun Mon Tue Wed Thu Fri Sat` strip. */
@@ -235,6 +239,197 @@ export function countTasksByDay(tasks: AgendaTask[]): Map<number, number> {
 		counts.set(day, (counts.get(day) ?? 0) + 1);
 	}
 	return counts;
+}
+
+// ---------------------------------------------------------------------------
+// Calendar-events feed. Today's schedule (both views) and the week strip's
+// workload bars read ONE subscription — api.calendar.getCalendarEvents — so the
+// strip can never disagree with the timeline it anchors.
+// ---------------------------------------------------------------------------
+
+export type CalendarEvents = {
+	projects: readonly ProjectEvent[];
+	tasks: readonly TaskEvent[];
+};
+
+/** Calendar events adapted to agenda shapes and filtered to a scope. */
+export type ScopedSchedule = {
+	projects: AgendaProject[];
+	tasks: AgendaTask[];
+};
+
+export const EMPTY_SCHEDULE: ScopedSchedule = { projects: [], tasks: [] };
+
+function taskEventToAgenda(event: TaskEvent): AgendaTask {
+	return {
+		_id: event.id,
+		title: event.title,
+		date: event.startDate,
+		startTime: event.startTime,
+		endTime: event.endTime,
+		status: event.status,
+		// The backend substitutes "Internal Task"/"Unknown Client" when a task has
+		// no client. A clientless row should show nothing, not a placeholder.
+		context: event.clientId ? event.clientName : undefined,
+		assigneeUserId: event.assigneeUserId,
+	};
+}
+
+function projectEventToAgenda(event: ProjectEvent): AgendaProject {
+	return {
+		_id: event.id,
+		title: event.title,
+		status: event.status,
+		startDate: event.startDate,
+		endDate: event.endDate,
+		context: event.clientName,
+		assignedUserIds: event.assignedUserIds,
+	};
+}
+
+/**
+ * Adapt + scope in one place, so every downstream feed (day plan, upcoming
+ * list, strip counts, tomorrow peek) sees the same rows. Scoping reuses
+ * `taskInScope`/`projectInScope` — including their deliberate "unassigned work
+ * is still mine" rule.
+ */
+export function scopeCalendarEvents(
+	events: CalendarEvents | undefined,
+	meId: string | null,
+	scope: DayScope,
+): ScopedSchedule {
+	if (!events) return EMPTY_SCHEDULE;
+	return {
+		projects: events.projects
+			.filter((p) => projectInScope(p, meId, scope))
+			.map(projectEventToAgenda),
+		tasks: events.tasks
+			.filter((t) => taskInScope(t, meId, scope))
+			.map(taskEventToAgenda),
+	};
+}
+
+/**
+ * Per-day workload counts for the week strip, over BOTH kinds of work. Bounded
+ * to `days`: a project span is unbounded, and the strip's bar scale must be set
+ * by days it actually shows.
+ */
+export function countScheduleByDay(
+	tasks: AgendaTask[],
+	projects: readonly AgendaProject[],
+	days: readonly number[],
+): Map<number, number> {
+	const taskCounts = countTasksByDay(tasks);
+	const counts = new Map<number, number>();
+	for (const dayMs of days) {
+		const day = utcDayStartMs(dayMs);
+		const total =
+			(taskCounts.get(day) ?? 0) + projectsForDay(projects, day).length;
+		if (total > 0) counts.set(day, total);
+	}
+	return counts;
+}
+
+/** One day of the rolling upcoming agenda. */
+export type UpcomingDay = {
+	dayMs: number;
+	/** Day-level work: project spans covering the day. */
+	projects: AgendaProject[];
+	/** Untimed tasks — shown with the projects, above the timed rows. */
+	anytime: AgendaTask[];
+	/** Timed tasks in start order. */
+	timed: AgendaTask[];
+};
+
+/** Rolling window length for the List view, in days (anchor day included). */
+export const UPCOMING_DAYS = 14;
+
+/**
+ * The List view's feed: `days` calendar days starting at the anchor, grouped by
+ * day, empty days omitted. Days are stepped in whole UTC days (DAY_MS on a
+ * UTC-midnight date-id), which is DST-immune — no local calendar arithmetic.
+ */
+export function buildUpcomingAgenda(
+	schedule: ScopedSchedule,
+	anchorDayMs: number,
+	days: number = UPCOMING_DAYS,
+): UpcomingDay[] {
+	const start = utcDayStartMs(anchorDayMs);
+	const end = start + (days - 1) * DAY_MS;
+
+	// Bucket tasks once rather than re-scanning per day.
+	const byDay = new Map<number, AgendaTask[]>();
+	for (const task of schedule.tasks) {
+		if (task.date === undefined) continue;
+		const day = utcDayStartMs(task.date);
+		if (day < start || day > end) continue;
+		const bucket = byDay.get(day);
+		if (bucket) bucket.push(task);
+		else byDay.set(day, [task]);
+	}
+
+	const out: UpcomingDay[] = [];
+	for (let i = 0; i < days; i++) {
+		const dayMs = start + i * DAY_MS;
+		const dayTasks = byDay.get(dayMs) ?? [];
+		const timed = dayTasks
+			.filter((t) => minutesFromHHMM(t.startTime) !== null)
+			.sort(byStartTime);
+		const anytime = dayTasks
+			.filter((t) => minutesFromHHMM(t.startTime) === null)
+			.sort((a, b) => a.title.localeCompare(b.title));
+		const projects = projectsForDay(schedule.projects, dayMs);
+		if (projects.length === 0 && timed.length === 0 && anytime.length === 0) {
+			continue;
+		}
+		out.push({ dayMs, projects, anytime, timed });
+	}
+	return out;
+}
+
+const WEEKDAY_NAMES = [
+	"Sunday",
+	"Monday",
+	"Tuesday",
+	"Wednesday",
+	"Thursday",
+	"Friday",
+	"Saturday",
+];
+const MONTH_NAMES = [
+	"Jan",
+	"Feb",
+	"Mar",
+	"Apr",
+	"May",
+	"Jun",
+	"Jul",
+	"Aug",
+	"Sep",
+	"Oct",
+	"Nov",
+	"Dec",
+];
+
+/**
+ * Group header for a day in the List view: "Today", "Tomorrow", else
+ * "Wednesday, Jul 22". Hand-rolled rather than Intl so it is deterministic
+ * under test and never re-renders a date in the host's timezone (date-ids are
+ * UTC — see lib/date.ts).
+ */
+export function dayLabel(dayMs: number, todayMs: number): string {
+	const day = utcDayStartMs(dayMs);
+	const today = utcDayStartMs(todayMs);
+	if (day === today) return "Today";
+	if (day === today + DAY_MS) return "Tomorrow";
+	const d = new Date(day);
+	return `${WEEKDAY_NAMES[d.getUTCDay()]}, ${MONTH_NAMES[d.getUTCMonth()]} ${d.getUTCDate()}`;
+}
+
+/** Saturday or Sunday on the UTC calendar — drives the "day off" empty state. */
+export function isWeekend(dayMs: number): boolean {
+	const dow = new Date(utcDayStartMs(dayMs)).getUTCDay();
+	return dow === 0 || dow === 6;
 }
 
 /** One-line Tomorrow peek: "3 tasks · first stop 8:30 AM" style summary parts. */

--- a/apps/mobile/lib/haptics.ts
+++ b/apps/mobile/lib/haptics.ts
@@ -1,0 +1,46 @@
+// Safe haptics: expo-haptics is a native module, so a JS bundle that ships
+// before the next dev-client/TestFlight build would crash on a bare call.
+// Resolve lazily and swallow — haptics are garnish, never gate UX on them
+// (they also silently no-op in Low Power Mode / while the camera is active).
+let mod: typeof import("expo-haptics") | null | undefined;
+
+function haptics() {
+	if (mod === undefined) {
+		try {
+			// eslint-disable-next-line @typescript-eslint/no-require-imports
+			mod = require("expo-haptics") as typeof import("expo-haptics");
+		} catch {
+			mod = null;
+		}
+	}
+	return mod;
+}
+
+/** Light tick — fan satellites appearing, pickers snapping. */
+export function hapticSelect() {
+	try {
+		haptics()?.selectionAsync().catch(() => {});
+	} catch {
+		// native module absent — old client build
+	}
+}
+
+/** Soft impact — FAB open/close, sheet commit. */
+export function hapticImpact() {
+	try {
+		const h = haptics();
+		h?.impactAsync(h.ImpactFeedbackStyle.Light).catch(() => {});
+	} catch {
+		// native module absent — old client build
+	}
+}
+
+/** Success notification — record created, payment recorded. */
+export function hapticSuccess() {
+	try {
+		const h = haptics();
+		h?.notificationAsync(h.NotificationFeedbackType.Success).catch(() => {});
+	} catch {
+		// native module absent — old client build
+	}
+}

--- a/apps/mobile/lib/mutation-error.ts
+++ b/apps/mobile/lib/mutation-error.ts
@@ -1,0 +1,34 @@
+import { ConvexError } from "convex/values";
+
+/** Stable code thrown by lib/planCaps.ts when a free-plan ceiling is hit. */
+export const PLAN_LIMIT_CODE = "PLAN_LIMIT_REACHED";
+
+export type MutationError = {
+	/** Message safe to render inline under the field/CTA that failed. */
+	message: string;
+	/** True when the org hit a plan ceiling — callers add the upgrade hint. */
+	planLimit: boolean;
+};
+
+/**
+ * Normalize a thrown mutation error into inline-renderable copy. Convex sends
+ * structured `{ code, message }` payloads through ConvexError.data; anything
+ * else (network, plain Error) collapses to the caller's fallback so we never
+ * leak a stack trace into the UI.
+ */
+export function describeMutationError(
+	err: unknown,
+	fallback: string
+): MutationError {
+	const data =
+		err instanceof ConvexError && typeof err.data === "object" && err.data !== null
+			? (err.data as { code?: string; message?: string })
+			: undefined;
+	if (data?.code === PLAN_LIMIT_CODE) {
+		return {
+			message: data.message ?? "You've reached a plan limit.",
+			planLimit: true,
+		};
+	}
+	return { message: fallback, planLimit: false };
+}

--- a/apps/mobile/lib/mutation-error.ts
+++ b/apps/mobile/lib/mutation-error.ts
@@ -26,7 +26,11 @@ export function describeMutationError(
 			: undefined;
 	if (data?.code === PLAN_LIMIT_CODE) {
 		return {
-			message: data.message ?? "You've reached a plan limit.",
+			// Only a real string may reach the UI — `message` is typed, not proven.
+			message:
+				typeof data.message === "string"
+					? data.message
+					: "You've reached a plan limit.",
 			planLimit: true,
 		};
 	}

--- a/apps/mobile/lib/open-external.ts
+++ b/apps/mobile/lib/open-external.ts
@@ -1,0 +1,17 @@
+import { Alert, Linking } from "react-native";
+
+/**
+ * Open a tel:/sms:/mailto:/maps URL with a graceful fallback. Linking.openURL
+ * rejects when no app handles the scheme (simulators lack Phone and Mail
+ * entirely; real devices can have Mail unconfigured) — an uncaught rejection
+ * surfaces as a dev error toast, so every external open routes through here.
+ */
+export function openExternal(url: string, appLabel: string) {
+	Linking.openURL(url).catch(() => {
+		Alert.alert(
+			`Couldn't open ${appLabel}`,
+			`This device doesn't have an app set up for ${appLabel.toLowerCase()}.`,
+			[{ text: "OK" }]
+		);
+	});
+}

--- a/apps/mobile/lib/recents.test.ts
+++ b/apps/mobile/lib/recents.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { pushRecent, RECENTS_LIMIT, type RecentRecord } from "./recents";
+
+const rec = (id: string, at = 0): RecentRecord => ({
+	kind: "client",
+	id,
+	title: `Client ${id}`,
+	at,
+});
+
+describe("pushRecent", () => {
+	it("prepends a new entry", () => {
+		const out = pushRecent([rec("a", 1)], { kind: "client", id: "b", title: "B" }, 2);
+		expect(out.map((r) => r.id)).toEqual(["b", "a"]);
+		expect(out[0].at).toBe(2);
+	});
+
+	it("moves a re-viewed entry to the front and refreshes its snapshot", () => {
+		const out = pushRecent(
+			[rec("a", 1), rec("b", 2)],
+			{ kind: "client", id: "a", title: "Renamed", sub: "Boston" },
+			3
+		);
+		expect(out.map((r) => r.id)).toEqual(["a", "b"]);
+		expect(out[0]).toMatchObject({ title: "Renamed", sub: "Boston", at: 3 });
+		expect(out).toHaveLength(2);
+	});
+
+	it("treats the same id under a different kind as distinct", () => {
+		const out = pushRecent([rec("a")], { kind: "project", id: "a", title: "P" }, 1);
+		expect(out).toHaveLength(2);
+	});
+
+	it("caps at RECENTS_LIMIT, dropping the oldest", () => {
+		let list: RecentRecord[] = [];
+		for (let i = 0; i < RECENTS_LIMIT + 3; i++) {
+			list = pushRecent(list, { kind: "client", id: `c${i}`, title: `C${i}` }, i);
+		}
+		expect(list).toHaveLength(RECENTS_LIMIT);
+		expect(list[0].id).toBe(`c${RECENTS_LIMIT + 2}`);
+		expect(list.some((r) => r.id === "c0")).toBe(false);
+	});
+});

--- a/apps/mobile/lib/recents.ts
+++ b/apps/mobile/lib/recents.ts
@@ -1,0 +1,81 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+// On-device "Recently viewed" trail (Slice 6). Keyed BY ORG — a flat MRU would
+// surface another org's record titles after an org switch. Entries are
+// snapshots (title/sub captured at view time): rendering never queries, so a
+// renamed record shows its old label until re-viewed and a deleted one lands on
+// the target screen's existing not-found state. Deliberate.
+
+export type RecentKind = "client" | "project" | "quote" | "invoice" | "task";
+
+export interface RecentRecord {
+	kind: RecentKind;
+	/** Convex document id, stored as a plain string. */
+	id: string;
+	title: string;
+	sub?: string;
+	/** Instant of the last view (Date.now()). */
+	at: number;
+}
+
+export const RECENTS_LIMIT = 12;
+
+const keyFor = (orgId: string) => `work.recents.${orgId}`;
+
+/** Pure MRU update: move-to-front on re-view, refresh the snapshot, cap. */
+export function pushRecent(
+	list: RecentRecord[],
+	entry: Omit<RecentRecord, "at">,
+	at: number
+): RecentRecord[] {
+	const rest = list.filter((r) => !(r.kind === entry.kind && r.id === entry.id));
+	return [{ ...entry, at }, ...rest].slice(0, RECENTS_LIMIT);
+}
+
+function parse(raw: string | null): RecentRecord[] {
+	if (!raw) return [];
+	try {
+		const val = JSON.parse(raw);
+		if (!Array.isArray(val)) return [];
+		return val.filter(
+			(r): r is RecentRecord =>
+				r &&
+				typeof r.id === "string" &&
+				typeof r.title === "string" &&
+				typeof r.at === "number" &&
+				typeof r.kind === "string"
+		);
+	} catch {
+		return [];
+	}
+}
+
+export async function getRecents(orgId: string): Promise<RecentRecord[]> {
+	try {
+		return parse(await AsyncStorage.getItem(keyFor(orgId)));
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * Fire-and-forget: call from record-detail screens once the record has loaded
+ * (so the title snapshot is real, not a skeleton placeholder). Never blocks or
+ * throws — a failed persist just loses one trail entry.
+ */
+export function recordRecentView(
+	orgId: string | undefined,
+	entry: Omit<RecentRecord, "at">
+): void {
+	if (!orgId) return;
+	getRecents(orgId)
+		.then((list) =>
+			AsyncStorage.setItem(
+				keyFor(orgId),
+				JSON.stringify(pushRecent(list, entry, Date.now()))
+			)
+		)
+		.catch((e) => {
+			if (__DEV__) console.warn("recordRecentView persist failed", e);
+		});
+}

--- a/apps/mobile/lib/recents.ts
+++ b/apps/mobile/lib/recents.ts
@@ -6,7 +6,15 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 // renamed record shows its old label until re-viewed and a deleted one lands on
 // the target screen's existing not-found state. Deliberate.
 
-export type RecentKind = "client" | "project" | "quote" | "invoice" | "task";
+export const RECENT_KINDS = [
+	"client",
+	"project",
+	"quote",
+	"invoice",
+	"task",
+] as const;
+
+export type RecentKind = (typeof RECENT_KINDS)[number];
 
 export interface RecentRecord {
 	kind: RecentKind;
@@ -43,7 +51,9 @@ function parse(raw: string | null): RecentRecord[] {
 				typeof r.id === "string" &&
 				typeof r.title === "string" &&
 				typeof r.at === "number" &&
-				typeof r.kind === "string"
+				// A kind this build no longer knows (or never wrote) would reach
+				// recordTint/renderRow as undefined, so it is dropped here.
+				(RECENT_KINDS as readonly string[]).includes(r.kind)
 		);
 	} catch {
 		return [];
@@ -58,6 +68,9 @@ export async function getRecents(orgId: string): Promise<RecentRecord[]> {
 	}
 }
 
+/** Tail of the write chain — rejections are swallowed, never propagated. */
+let writes: Promise<unknown> = Promise.resolve();
+
 /**
  * Fire-and-forget: call from record-detail screens once the record has loaded
  * (so the title snapshot is real, not a skeleton placeholder). Never blocks or
@@ -68,7 +81,10 @@ export function recordRecentView(
 	entry: Omit<RecentRecord, "at">
 ): void {
 	if (!orgId) return;
-	getRecents(orgId)
+	// Chained, not concurrent: two screens recording at once would each read the
+	// same list and the later write would drop the earlier entry.
+	writes = writes
+		.then(() => getRecents(orgId))
 		.then((list) =>
 			AsyncStorage.setItem(
 				keyFor(orgId),
@@ -79,3 +95,4 @@ export function recordRecentView(
 			if (__DEV__) console.warn("recordRecentView persist failed", e);
 		});
 }
+

--- a/apps/mobile/lib/route-run.ts
+++ b/apps/mobile/lib/route-run.ts
@@ -174,6 +174,11 @@ export function appleMapsUrl(lat: number, lng: number): string {
 	return `http://maps.apple.com/?daddr=${lat},${lng}&dirflg=d`;
 }
 
+/** Same handoff for records that have an address but no geocode yet. */
+export function appleMapsAddressUrl(address: string): string {
+	return `http://maps.apple.com/?daddr=${encodeURIComponent(address)}&dirflg=d`;
+}
+
 // Google's directions URL caps intermediary waypoints at 9 (documented limit);
 // origin and destination ride on top of that.
 const MAX_GOOGLE_WAYPOINTS = 9;

--- a/apps/mobile/lib/search-focus.test.ts
+++ b/apps/mobile/lib/search-focus.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { consumeSearchFocus, requestSearchFocus } from "./search-focus";
+
+describe("search-focus latch", () => {
+	beforeEach(() => {
+		// Module state is process-global; drain it so each case starts clean.
+		while (consumeSearchFocus()) {
+			/* drain */
+		}
+	});
+
+	it("is off until something requests focus", () => {
+		expect(consumeSearchFocus()).toBe(false);
+	});
+
+	it("fires exactly once per request — the whole point vs. a sticky param", () => {
+		requestSearchFocus();
+		expect(consumeSearchFocus()).toBe(true);
+		expect(consumeSearchFocus()).toBe(false);
+	});
+
+	it("does not queue: two taps before one consume still fire once", () => {
+		requestSearchFocus();
+		requestSearchFocus();
+		expect(consumeSearchFocus()).toBe(true);
+		expect(consumeSearchFocus()).toBe(false);
+	});
+
+	it("can be re-armed after being consumed", () => {
+		requestSearchFocus();
+		consumeSearchFocus();
+		requestSearchFocus();
+		expect(consumeSearchFocus()).toBe(true);
+	});
+});

--- a/apps/mobile/lib/search-focus.ts
+++ b/apps/mobile/lib/search-focus.ts
@@ -1,0 +1,20 @@
+// One-shot "jump to Work and focus the search field" signal (Slice 6).
+//
+// A route param would be WRONG here: expo-router keeps tab params sticky, so
+// `/(tabs)/work?focus=search` re-fires the autofocus on every later visit to the
+// tab. This is a module-level latch instead — the header sets it immediately
+// before navigating, and Work consumes it exactly once on focus.
+
+let pending = false;
+
+/** Called by the header magnifier just before navigating to the Work tab. */
+export function requestSearchFocus(): void {
+	pending = true;
+}
+
+/** Returns true at most once per request. Consuming always clears the latch. */
+export function consumeSearchFocus(): boolean {
+	if (!pending) return false;
+	pending = false;
+	return true;
+}

--- a/apps/mobile/lib/shell-routes.ts
+++ b/apps/mobile/lib/shell-routes.ts
@@ -33,7 +33,7 @@ export function refFromPathname(pathname: string): RecordRef | null {
 	if ((m = pathname.match(/^\/projects\/([^/]+)$/)) && m[1] !== "new") {
 		return { kind: "project", id: m[1] };
 	}
-	if ((m = pathname.match(/^\/quote\/([^/]+)$/))) {
+	if ((m = pathname.match(/^\/quote\/([^/]+)$/)) && m[1] !== "new") {
 		return { kind: "quote", id: m[1] };
 	}
 	if ((m = pathname.match(/^\/invoice\/([^/]+)$/))) {

--- a/apps/mobile/lib/useScheduleView.ts
+++ b/apps/mobile/lib/useScheduleView.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState, useCallback } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+/** Day = the anchored day's timeline. List = a rolling 14-day agenda. */
+export type ScheduleView = "day" | "list";
+
+const VALID: readonly ScheduleView[] = ["day", "list"];
+
+// New key, not the retired `today.viewMode` — that one held the old
+// agenda/timeline split, and a stale value there must never rehydrate here.
+export const SCHEDULE_VIEW_STORAGE_KEY = "today.scheduleView";
+
+/** Persisted Day | List switch for Today's schedule. Defaults to "day". */
+export function useScheduleView(): {
+	view: ScheduleView;
+	setView: (v: ScheduleView) => void;
+	hydrated: boolean;
+} {
+	const [view, setViewState] = useState<ScheduleView>("day");
+	const [hydrated, setHydrated] = useState(false);
+
+	useEffect(() => {
+		let active = true;
+		AsyncStorage.getItem(SCHEDULE_VIEW_STORAGE_KEY)
+			.then((stored) => {
+				if (!active) return;
+				if (VALID.includes(stored as ScheduleView)) {
+					setViewState(stored as ScheduleView);
+				}
+				setHydrated(true);
+			})
+			.catch(() => {
+				if (active) setHydrated(true);
+			});
+		return () => {
+			active = false;
+		};
+	}, []);
+
+	const setView = useCallback((next: ScheduleView) => {
+		setViewState(next);
+		AsyncStorage.setItem(SCHEDULE_VIEW_STORAGE_KEY, next).catch((e) => {
+			if (__DEV__) console.warn("useScheduleView persist failed", e);
+		});
+	}, []);
+
+	return { view, setView, hydrated };
+}

--- a/apps/mobile/lib/work-search.test.ts
+++ b/apps/mobile/lib/work-search.test.ts
@@ -1,20 +1,26 @@
 import { describe, expect, it } from "vitest";
 import {
 	buildClientNameMap,
-	filterRecords,
-	groupByKind,
-	KIND_ORDER,
+	CHIP_ORDER,
+	formatTaskDate,
+	fromClientHit,
+	fromInvoiceHit,
+	fromProjectHit,
+	fromQuoteHit,
+	KIND_LABEL,
 	pathForRecord,
 	sortByRecency,
 	toClientRecord,
 	toInvoiceRecord,
 	toProjectRecord,
 	toQuoteRecord,
+	toTaskRecord,
 	type ClientInput,
 	type InvoiceInput,
 	type ProjectInput,
 	type QuoteInput,
-	type WorkKind,
+	type TaskInput,
+	type WorkChipKind,
 	type WorkRecord,
 } from "./work-search";
 
@@ -58,10 +64,19 @@ const invoice = (over: Partial<InvoiceInput> = {}): InvoiceInput => ({
 	...over,
 });
 
+const task = (over: Partial<TaskInput> = {}): TaskInput => ({
+	_id: "t1",
+	_creationTime: T0,
+	title: "Mow the east lawn",
+	date: T0,
+	status: "pending",
+	...over,
+});
+
 // Minimal hand-built record — used where the adapters can't produce the shape
 // (notably an undefined `updatedAt`, which real Convex docs never yield).
 const record = (
-	kind: WorkKind,
+	kind: WorkChipKind,
 	over: Partial<WorkRecord> & { id: string }
 ): WorkRecord =>
 	({
@@ -69,8 +84,6 @@ const record = (
 		title: over.id,
 		meta: "",
 		status: "active",
-		searchText: over.id.toLowerCase(),
-		amount: 0,
 		...over,
 	}) as WorkRecord;
 
@@ -86,7 +99,20 @@ describe("buildClientNameMap", () => {
 	});
 });
 
-describe("adapters", () => {
+describe("chip vocabulary", () => {
+	it("orders chips record-kinds-then-tasks and labels every one", () => {
+		expect([...CHIP_ORDER]).toEqual([
+			"client",
+			"project",
+			"quote",
+			"invoice",
+			"task",
+		]);
+		for (const kind of CHIP_ORDER) expect(KIND_LABEL[kind]).toBeTruthy();
+	});
+});
+
+describe("list adapters", () => {
 	it("maps a client, preferring description over tags for the meta line", () => {
 		const r = toClientRecord(
 			client({ companyDescription: "Commercial grounds", tags: ["vip"] })
@@ -104,12 +130,6 @@ describe("adapters", () => {
 			"vip · retainer"
 		);
 		expect(toClientRecord(client()).meta).toMatch(/^Added /);
-	});
-
-	it("folds notes and tags into the client haystack but not the meta line", () => {
-		const r = toClientRecord(client({ notes: "Gate code 4821", tags: ["vip"] }));
-		expect(r.searchText).toContain("gate code 4821");
-		expect(r.meta).not.toContain("Gate code");
 	});
 
 	it("maps a project with client name + number in the meta line", () => {
@@ -151,9 +171,9 @@ describe("adapters", () => {
 	});
 
 	it("displays a past-due sent invoice as overdue", () => {
-		const past = toInvoiceRecord(invoice(), { now: T0 + 60 * DAY });
-		expect(past.status).toBe("overdue");
-		expect(past.searchText).toContain("overdue");
+		expect(toInvoiceRecord(invoice(), { now: T0 + 60 * DAY }).status).toBe(
+			"overdue"
+		);
 	});
 
 	it("leaves a not-yet-due sent invoice alone, and never re-flags paid", () => {
@@ -162,77 +182,59 @@ describe("adapters", () => {
 			toInvoiceRecord(invoice({ status: "paid" }), { now: T0 + 60 * DAY }).status
 		).toBe("paid");
 	});
-});
 
-describe("filterRecords", () => {
-	const records = [
-		toClientRecord(client({ companyName: "Northside Landscaping" })),
-		toProjectRecord(project({ title: "Spring Cleanup" }), {
-			clientName: "Northside Landscaping",
-		}),
-		toInvoiceRecord(invoice({ invoiceNumber: "INV-0042" }), { now: T0 }),
-	];
-
-	it("returns everything for an empty or whitespace query", () => {
-		expect(filterRecords(records, "")).toHaveLength(3);
-		expect(filterRecords(records, "   ")).toHaveLength(3);
+	it("maps a task with its UTC day and optional start time", () => {
+		expect(toTaskRecord(task()).meta).toBe("Jul 1, 2026");
+		expect(toTaskRecord(task({ startTime: "14:00" })).meta).toBe(
+			"Jul 1, 2026 · 14:00"
+		);
+		expect(toTaskRecord(task()).status).toBe("pending");
 	});
 
-	it("does not mutate or alias the input array", () => {
-		const out = filterRecords(records, "");
-		expect(out).not.toBe(records);
-		expect(out).toEqual([...records]);
-	});
-
-	it("matches case-insensitively on any casing of the query", () => {
-		expect(filterRecords(records, "NORTHSIDE")).toHaveLength(2);
-		expect(filterRecords(records, "northside")).toHaveLength(2);
-		expect(filterRecords(records, "nOrThSiDe")).toHaveLength(2);
-	});
-
-	it("matches mid-string substrings, including document numbers", () => {
-		expect(filterRecords(records, "cleanup").map((r) => r.kind)).toEqual([
-			"project",
-		]);
-		expect(filterRecords(records, "0042").map((r) => r.kind)).toEqual([
-			"invoice",
-		]);
-	});
-
-	it("returns an empty array when nothing matches", () => {
-		expect(filterRecords(records, "helicopter")).toEqual([]);
+	it("renders a task date in UTC, not the local day before it", () => {
+		// UTC-midnight of the 1st is the evening of Jun 30 in any western tz.
+		expect(formatTaskDate(Date.UTC(2026, 6, 1))).toBe("Jul 1, 2026");
 	});
 });
 
-describe("groupByKind", () => {
-	it("orders groups by KIND_ORDER regardless of input order", () => {
-		const groups = groupByKind([
-			record("invoice", { id: "i1" }),
-			record("client", { id: "c1" }),
-			record("quote", { id: "q1" }),
-			record("project", { id: "p1" }),
-		]);
-		expect(groups.map((g) => g.kind)).toEqual([...KIND_ORDER]);
-		expect(groups.map((g) => g.label)).toEqual([
-			"Clients",
-			"Projects",
-			"Quotes",
-			"Invoices",
-		]);
+describe("search-hit adapters", () => {
+	it("routes a plain client hit to the client and carries no status", () => {
+		const r = fromClientHit({ clientId: "c9", kind: "client", label: "Acme" });
+		expect(r).toMatchObject({ kind: "client", id: "c9", title: "Acme" });
+		expect(r.status).toBeUndefined();
 	});
 
-	it("omits kinds with no records", () => {
-		const groups = groupByKind([
-			record("quote", { id: "q1" }),
-			record("client", { id: "c1" }),
-			record("quote", { id: "q2" }),
-		]);
-		expect(groups.map((g) => g.kind)).toEqual(["client", "quote"]);
-		expect(groups[1].records.map((r) => r.id)).toEqual(["q1", "q2"]);
+	it("resolves contact and property hits to the PARENT client, labelled", () => {
+		expect(
+			fromClientHit({
+				clientId: "c9",
+				kind: "contact",
+				label: "Acme",
+				detail: "Jane Doe",
+			})
+		).toMatchObject({ id: "c9", title: "Acme", meta: "Contact · Jane Doe" });
+		expect(
+			fromClientHit({
+				clientId: "c9",
+				kind: "property",
+				label: "Acme",
+				detail: "12 Elm St, Boston",
+			})
+		).toMatchObject({ meta: "Property · 12 Elm St, Boston" });
 	});
 
-	it("returns no groups for no records", () => {
-		expect(groupByKind([])).toEqual([]);
+	it("maps project/quote/invoice hits with detail as the meta line", () => {
+		expect(
+			fromProjectHit({ projectId: "p9", label: "Deck", detail: "PRJ-9" })
+		).toMatchObject({ kind: "project", id: "p9", meta: "PRJ-9" });
+		expect(
+			fromQuoteHit({ quoteId: "q9", label: "Patio", detail: "Acme" })
+		).toMatchObject({ kind: "quote", id: "q9", meta: "Acme" });
+		expect(fromInvoiceHit({ invoiceId: "i9", label: "INV-1" })).toMatchObject({
+			kind: "invoice",
+			id: "i9",
+			meta: "",
+		});
 	});
 });
 
@@ -280,10 +282,16 @@ describe("sortByRecency", () => {
 });
 
 describe("pathForRecord", () => {
-	it("routes each kind to its existing detail route", () => {
+	it("routes each record kind to its detail route", () => {
 		expect(pathForRecord(record("client", { id: "c1" }))).toBe("/clients/c1");
 		expect(pathForRecord(record("project", { id: "p1" }))).toBe("/projects/p1");
 		expect(pathForRecord(record("quote", { id: "q1" }))).toBe("/quote/q1");
 		expect(pathForRecord(record("invoice", { id: "i1" }))).toBe("/invoice/i1");
+	});
+
+	it("routes a task to the form sheet, matching Today's agenda rows", () => {
+		expect(pathForRecord(record("task", { id: "t1" }))).toBe(
+			"/tasks/form?taskId=t1"
+		);
 	});
 });

--- a/apps/mobile/lib/work-search.ts
+++ b/apps/mobile/lib/work-search.ts
@@ -1,38 +1,45 @@
 import { formatDocumentDate } from "@/lib/format";
 
 // ============================================================================
-// Work tab search/browse logic. Pure — no React, no Convex, no RN. Everything
-// the Work screen decides about matching, grouping and ordering lives here so it
-// can be unit-tested in the node vitest environment.
+// Work tab row model. Pure — no React, no Convex, no RN.
+//
+// Slice 6: matching moved to the backend (`search.globalSearch`, word-prefix +
+// relevance-ordered). What is left here is the shape layer — Convex docs and
+// search hits in, one display row out — so the screen has a single render path
+// for both modes and it stays unit-testable in the node vitest environment.
 // ============================================================================
 
+/** Record kinds that own a detail route AND can fill an iPad detail pane. */
 export type WorkKind = "client" | "project" | "quote" | "invoice";
+
+/** Chip/bucket kinds. Tasks are searchable and browsable but open a form sheet,
+ * never a detail pane — which is exactly why they are not a `WorkKind`. */
+export type WorkChipKind = WorkKind | "task";
 
 type WorkRecordBase = {
 	/** Convex document id, stringly-typed (the screen only routes with it). */
 	id: string;
 	title: string;
-	/** Single metadata line rendered under the title. */
+	/** Single metadata line rendered under the title. May be empty. */
 	meta: string;
-	/** STATUS key for `<Badge status=… />`. */
-	status: string;
+	/** STATUS key for `<Badge status=… />`. Search hits carry no status. */
+	status?: string;
 	/**
-	 * Best available recency signal (ms epoch). No table carries an `updatedAt`
-	 * column, so adapters use the closest activity timestamp and fall back to
-	 * `_creationTime`. Undefined is tolerated by `sortByRecency`.
+	 * Best available recency signal (ms epoch), used to order BROWSE lists. No
+	 * table carries an `updatedAt` column, so adapters use the closest activity
+	 * timestamp and fall back to `_creationTime`.
 	 */
 	updatedAt?: number;
-	/** Pre-lowered haystack — the ONLY thing `filterRecords` matches against. */
-	searchText: string;
 };
 
 export type WorkRecord =
 	| (WorkRecordBase & { kind: "client" })
 	| (WorkRecordBase & { kind: "project" })
-	| (WorkRecordBase & { kind: "quote"; amount: number })
-	| (WorkRecordBase & { kind: "invoice"; amount: number });
+	| (WorkRecordBase & { kind: "quote"; amount?: number })
+	| (WorkRecordBase & { kind: "invoice"; amount?: number })
+	| (WorkRecordBase & { kind: "task" });
 
-/** Chip order, grouped-result order, and section-header order — one list. */
+/** Detail-pane kinds, in chip / section order. */
 export const KIND_ORDER: readonly WorkKind[] = [
 	"client",
 	"project",
@@ -40,11 +47,15 @@ export const KIND_ORDER: readonly WorkKind[] = [
 	"invoice",
 ];
 
-export const KIND_LABEL: Record<WorkKind, string> = {
+/** Chip order and result-section order — one list, tasks last. */
+export const CHIP_ORDER: readonly WorkChipKind[] = [...KIND_ORDER, "task"];
+
+export const KIND_LABEL: Record<WorkChipKind, string> = {
 	client: "Clients",
 	project: "Projects",
 	quote: "Quotes",
 	invoice: "Invoices",
+	task: "Tasks",
 };
 
 // ----------------------------------------------------------------------------
@@ -96,6 +107,17 @@ export type InvoiceInput = {
 	paidAt?: number;
 };
 
+export type TaskInput = {
+	_id: string;
+	_creationTime: number;
+	title: string;
+	/** UTC-midnight instant — render in UTC or a western tz shows the day before. */
+	date: number;
+	status: string;
+	startTime?: string;
+	completedAt?: number;
+};
+
 export type AdapterOptions = {
 	/** Resolved client display name — see `buildClientNameMap`. */
 	clientName?: string;
@@ -114,12 +136,14 @@ function joinMeta(parts: (string | undefined | null)[]): string {
 		.join(" · ");
 }
 
-function haystack(parts: (string | undefined | null)[]): string {
-	return parts
-		.map((p) => p?.trim())
-		.filter((p): p is string => !!p)
-		.join(" ")
-		.toLowerCase();
+/** Task dates are stored at UTC-midnight; format in UTC to keep the day intact. */
+export function formatTaskDate(ts: number): string {
+	return new Date(ts).toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+		timeZone: "UTC",
+	});
 }
 
 /** Map client id → display name, for the meta line of the other three kinds. */
@@ -132,7 +156,7 @@ export function buildClientNameMap(
 }
 
 // ----------------------------------------------------------------------------
-// Adapters
+// Adapters — Convex list docs → rows (BROWSE mode)
 // ----------------------------------------------------------------------------
 
 export function toClientRecord(doc: ClientInput): WorkRecord {
@@ -147,13 +171,6 @@ export function toClientRecord(doc: ClientInput): WorkRecord {
 			`Added ${formatDocumentDate(doc._creationTime)}`,
 		status: doc.status,
 		updatedAt: doc._creationTime,
-		searchText: haystack([
-			doc.companyName,
-			doc.companyDescription,
-			tags,
-			doc.notes,
-			doc.status,
-		]),
 	};
 }
 
@@ -169,13 +186,6 @@ export function toProjectRecord(
 		meta: meta || `Added ${formatDocumentDate(doc._creationTime)}`,
 		status: doc.status,
 		updatedAt: doc.completedAt ?? doc._creationTime,
-		searchText: haystack([
-			doc.title,
-			doc.description,
-			doc.projectNumber,
-			options.clientName,
-			doc.status,
-		]),
 	};
 }
 
@@ -192,12 +202,6 @@ export function toQuoteRecord(
 		status: doc.status,
 		amount: doc.total,
 		updatedAt: doc.approvedAt ?? doc.sentAt ?? doc._creationTime,
-		searchText: haystack([
-			doc.title,
-			doc.quoteNumber,
-			options.clientName,
-			doc.status,
-		]),
 	};
 }
 
@@ -221,45 +225,88 @@ export function toInvoiceRecord(
 		status,
 		amount: doc.total,
 		updatedAt: doc.paidAt ?? doc._creationTime,
-		searchText: haystack([
-			doc.invoiceNumber,
-			options.clientName,
-			status,
-			doc.status,
-		]),
+	};
+}
+
+export function toTaskRecord(doc: TaskInput): WorkRecord {
+	return {
+		kind: "task",
+		id: doc._id,
+		title: doc.title,
+		meta: joinMeta([formatTaskDate(doc.date), doc.startTime]),
+		status: doc.status,
+		updatedAt: doc.completedAt ?? doc.date,
 	};
 }
 
 // ----------------------------------------------------------------------------
-// Query / grouping / ordering
+// Adapters — `search.globalSearch` hits → rows (SEARCH mode)
+//
+// Hits carry no status, amount or timestamp: the backend returns a relevance
+// ordering and a label/detail pair per bucket, and re-fetching every hit's full
+// doc to decorate five rows is not worth the round trips.
 // ----------------------------------------------------------------------------
 
-/** Case-insensitive substring match. An empty query matches everything. */
-export function filterRecords(
-	records: readonly WorkRecord[],
-	query: string
-): WorkRecord[] {
-	const q = query.trim().toLowerCase();
-	if (!q) return [...records];
-	return records.filter((r) => r.searchText.includes(q));
-}
-
-export type WorkGroup = {
-	kind: WorkKind;
+export type ClientHitInput = {
+	clientId: string;
+	kind: "client" | "contact" | "property";
 	label: string;
-	records: WorkRecord[];
+	detail?: string;
 };
 
-/** Groups in `KIND_ORDER`, omitting kinds with no matches. */
-export function groupByKind(records: readonly WorkRecord[]): WorkGroup[] {
-	return KIND_ORDER.map((kind) => ({
-		kind,
-		label: KIND_LABEL[kind],
-		records: records.filter((r) => r.kind === kind),
-	})).filter((g) => g.records.length > 0);
+export type LabelledHitInput = { label: string; detail?: string };
+
+/** Contact/property hits resolve to their PARENT client — the matched contact
+ * name / property address becomes the meta line so the hit explains itself. */
+export function fromClientHit(hit: ClientHitInput): WorkRecord {
+	const meta =
+		hit.kind === "contact"
+			? joinMeta(["Contact", hit.detail])
+			: hit.kind === "property"
+				? joinMeta(["Property", hit.detail])
+				: (hit.detail ?? "");
+	return { kind: "client", id: hit.clientId, title: hit.label, meta };
 }
 
-/** Most recent first. Missing timestamps sort last, preserving input order. */
+export function fromProjectHit(
+	hit: LabelledHitInput & { projectId: string }
+): WorkRecord {
+	return {
+		kind: "project",
+		id: hit.projectId,
+		title: hit.label,
+		meta: hit.detail ?? "",
+	};
+}
+
+export function fromQuoteHit(
+	hit: LabelledHitInput & { quoteId: string }
+): WorkRecord {
+	return {
+		kind: "quote",
+		id: hit.quoteId,
+		title: hit.label,
+		meta: hit.detail ?? "",
+	};
+}
+
+export function fromInvoiceHit(
+	hit: LabelledHitInput & { invoiceId: string }
+): WorkRecord {
+	return {
+		kind: "invoice",
+		id: hit.invoiceId,
+		title: hit.label,
+		meta: hit.detail ?? "",
+	};
+}
+
+// ----------------------------------------------------------------------------
+// Ordering / routing
+// ----------------------------------------------------------------------------
+
+/** Most recent first. Missing timestamps sort last, preserving input order.
+ * BROWSE only — search results keep the backend's relevance order. */
 export function sortByRecency(records: readonly WorkRecord[]): WorkRecord[] {
 	return [...records].sort((a, b) => {
 		const av = a.updatedAt ?? Number.NEGATIVE_INFINITY;
@@ -269,7 +316,8 @@ export function sortByRecency(records: readonly WorkRecord[]): WorkRecord[] {
 	});
 }
 
-/** Detail route for a record. The screen casts this to expo-router's `Href`. */
+/** Destination for a row. Tasks have no detail route — they open the form
+ * sheet, the same way Today's agenda rows do. */
 export function pathForRecord(record: WorkRecord): string {
 	switch (record.kind) {
 		case "client":
@@ -280,5 +328,7 @@ export function pathForRecord(record: WorkRecord): string {
 			return `/quote/${record.id}`;
 		case "invoice":
 			return `/invoice/${record.id}`;
+		case "task":
+			return `/tasks/form?taskId=${record.id}`;
 	}
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -44,6 +44,7 @@
 		"expo-document-picker": "~56.0.4",
 		"expo-file-system": "~56.0.8",
 		"expo-font": "~56.0.5",
+		"expo-haptics": "~56.0.3",
 		"expo-image-picker": "~56.0.18",
 		"expo-keep-awake": "~56.0.3",
 		"expo-linear-gradient": "~56.0.4",

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -93,6 +93,7 @@ import type * as lib_organization from "../lib/organization.js";
 import type * as lib_payments from "../lib/payments.js";
 import type * as lib_permissionKeys from "../lib/permissionKeys.js";
 import type * as lib_permissions from "../lib/permissions.js";
+import type * as lib_planCaps from "../lib/planCaps.js";
 import type * as lib_planLimits from "../lib/planLimits.js";
 import type * as lib_polylineCodec from "../lib/polylineCodec.js";
 import type * as lib_portalAttestation from "../lib/portalAttestation.js";
@@ -279,6 +280,7 @@ declare const fullApi: ApiFromModules<{
   "lib/payments": typeof lib_payments;
   "lib/permissionKeys": typeof lib_permissionKeys;
   "lib/permissions": typeof lib_permissions;
+  "lib/planCaps": typeof lib_planCaps;
   "lib/planLimits": typeof lib_planLimits;
   "lib/polylineCodec": typeof lib_polylineCodec;
   "lib/portalAttestation": typeof lib_portalAttestation;

--- a/packages/backend/convex/automationExecutor.authz.test.ts
+++ b/packages/backend/convex/automationExecutor.authz.test.ts
@@ -1,6 +1,6 @@
 import { convexTest } from "convex-test";
 import { ConvexError } from "convex/values";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { api } from "./_generated/api";
 import { setupConvexTest } from "./test.setup";
 import {
@@ -28,6 +28,27 @@ describe("automation run entry points — per-object authorization", () => {
 
 	beforeEach(() => {
 		t = setupConvexTest();
+	});
+
+	// startTestRun schedules executeAutomation, and a test run then steps through
+	// its nodes on a TEST_STEP_INTERVAL_MS timer. Anything still queued when
+	// `beforeEach` swaps the convex-test instance fires against the OLD db inside
+	// the NEW instance's transaction and throws "Write outside of transaction" —
+	// an unhandled rejection that fails the whole vitest run with every test green.
+	// Cancel the queue rather than wait it out (waiting costs the step interval per
+	// test), then let anything already mid-flight land.
+	afterEach(async () => {
+		for (let i = 0; i < 3; i++) {
+			await t.run(async (ctx) => {
+				const jobs = await ctx.db.system.query("_scheduled_functions").collect();
+				for (const job of jobs) {
+					if (job.state.kind === "pending") {
+						await ctx.scheduler.cancel(job._id);
+					}
+				}
+			});
+			await t.finishInProgressScheduledFunctions();
+		}
 	});
 
 	function forbidden(caught: unknown): Record<string, unknown> {

--- a/packages/backend/convex/clients.ts
+++ b/packages/backend/convex/clients.ts
@@ -27,6 +27,7 @@ import {
 	userMutation,
 	type UserMutationCtx,
 } from "./lib/factories";
+import { assertClientCapacity } from "./lib/planCaps";
 
 /**
  * Client operations
@@ -535,6 +536,9 @@ export const create = userMutation({
 		portalAccessId: v.optional(v.string()),
 	},
 	handler: async (ctx, args): Promise<ClientId> => {
+		// Free-plan ceiling. Enforced here (not in createClient) so the internal
+		// paths — bulk import, community lead conversion — keep their behavior.
+		await assertClientCapacity(ctx, ctx.orgId, args.status);
 		return await createClient(ctx, args, "clients.create");
 	},
 });

--- a/packages/backend/convex/clients.ts
+++ b/packages/backend/convex/clients.ts
@@ -27,7 +27,10 @@ import {
 	userMutation,
 	type UserMutationCtx,
 } from "./lib/factories";
-import { assertClientCapacity } from "./lib/planCaps";
+import {
+	assertClientCapacity,
+	assertClientCapacityForTransition,
+} from "./lib/planCaps";
 
 /**
  * Client operations
@@ -876,6 +879,17 @@ export const update = userMutation({
 		);
 		const oldStatus = existingClient.status;
 
+		// Un-archiving through a status edit re-occupies a slot, so it faces the
+		// same ceiling as clients.create.
+		if (args.status) {
+			await assertClientCapacityForTransition(
+				ctx,
+				ctx.orgId,
+				oldStatus,
+				args.status
+			);
+		}
+
 		// Compute field-level changes before applying the update
 		const changes = computeFieldChanges(
 			"client",
@@ -1022,6 +1036,14 @@ export const restore = userMutation({
 		if (client.status !== "archived") {
 			throw new Error("Only archived clients can be restored");
 		}
+
+		// A restore is an insert as far as the free-plan ceiling is concerned.
+		await assertClientCapacityForTransition(
+			ctx,
+			ctx.orgId,
+			client.status,
+			"active"
+		);
 
 		// Restore the client by setting status back to active and removing archivedAt
 		await ctx.db.patch(args.id, {

--- a/packages/backend/convex/lib/automationExec/actions.ts
+++ b/packages/backend/convex/lib/automationExec/actions.ts
@@ -30,10 +30,7 @@ import {
 	type VariableScope,
 } from "../conditionEval";
 import { calendarDayEpoch } from "../formula";
-import {
-	FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT,
-	FREE_MAX_CLIENTS,
-} from "../planLimits";
+import { checkClientCapacity, checkProjectCapacity } from "../planCaps";
 import {
 	RELATION_FIELD,
 	getFieldDefinition,
@@ -1047,33 +1044,17 @@ export async function checkCreateRecordPlanCap(
 	payload: Record<string, unknown>,
 	orgId: Id<"organizations">
 ): Promise<string | null> {
-	if (objectType === "client" && (payload.status as string | undefined) !== "archived") {
-		const clients = await ctx.db
-			.query("clients")
-			.withIndex("by_org", (q) => q.eq("orgId", orgId))
-			.collect();
-		const active = clients.filter((c) => c.status !== "archived").length;
-		if (active >= FREE_MAX_CLIENTS) {
-			return `Your plan is limited to ${FREE_MAX_CLIENTS} clients — upgrade to add more.`;
-		}
+	const status = payload.status as string | undefined;
+	if (objectType === "client") {
+		return await checkClientCapacity(ctx, orgId, status);
 	}
 	if (objectType === "project") {
 		// Only an active candidate (planned/in-progress) consumes a per-client slot.
-		const status = payload.status as string | undefined;
-		const projectActive = status === "planned" || status === "in-progress";
-		const clientId = payload.clientId as Id<"clients"> | undefined;
-		if (clientId && projectActive) {
-			const projects = await ctx.db
-				.query("projects")
-				.withIndex("by_client", (q) => q.eq("clientId", clientId))
-				.collect();
-			const active = projects.filter(
-				(p) => p.status === "planned" || p.status === "in-progress"
-			).length;
-			if (active >= FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT) {
-				return `Your plan allows ${FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT} active projects per client — upgrade to add more.`;
-			}
-		}
+		return await checkProjectCapacity(
+			ctx,
+			payload.clientId as Id<"clients"> | undefined,
+			status
+		);
 	}
 	return null;
 }

--- a/packages/backend/convex/lib/planCaps.ts
+++ b/packages/backend/convex/lib/planCaps.ts
@@ -29,6 +29,30 @@ function isActiveProjectStatus(status: string | undefined): boolean {
 	return status === "planned" || status === "in-progress";
 }
 
+/** Client statuses that consume a slot — everything except archived. */
+const COUNTED_CLIENT_STATUSES = ["lead", "active", "inactive"] as const;
+
+/**
+ * Counts non-archived clients, stopping at `limit`. Indexed per status and
+ * bounded by `take`, so an org with a long archive tail is never fully read.
+ */
+async function countCountedClients(
+	ctx: MutationCtx,
+	orgId: Id<"organizations">,
+	limit: number
+): Promise<number> {
+	let total = 0;
+	for (const status of COUNTED_CLIENT_STATUSES) {
+		if (total >= limit) break;
+		const rows = await ctx.db
+			.query("clients")
+			.withIndex("by_status", (q) => q.eq("orgId", orgId).eq("status", status))
+			.take(limit - total);
+		total += rows.length;
+	}
+	return total;
+}
+
 /**
  * Counting-only client cap check. Returns the user-facing message when the
  * insert would exceed the ceiling, or null when it's allowed. Does NOT consider
@@ -41,11 +65,7 @@ export async function checkClientCapacity(
 ): Promise<string | null> {
 	// An archived client doesn't occupy a slot, so creating one never trips.
 	if (newStatus === "archived") return null;
-	const clients = await ctx.db
-		.query("clients")
-		.withIndex("by_org", (q) => q.eq("orgId", orgId))
-		.collect();
-	const active = clients.filter((c) => c.status !== "archived").length;
+	const active = await countCountedClients(ctx, orgId, FREE_MAX_CLIENTS);
 	return active >= FREE_MAX_CLIENTS ? CLIENT_CAP_MESSAGE : null;
 }
 
@@ -103,4 +123,36 @@ export async function assertProjectCapacity(
 	if (await hasPremiumAccess(ctx)) return;
 	const error = await checkProjectCapacity(ctx, clientId, newStatus);
 	if (error) throw planLimitError(error);
+}
+
+/**
+ * Update-path client cap: a record already holding a slot keeps it, but an
+ * archived client coming back (restore, or a status edit) is a fresh insert as
+ * far as the ceiling is concerned.
+ */
+export async function assertClientCapacityForTransition(
+	ctx: MutationCtx,
+	orgId: Id<"organizations">,
+	prevStatus: string | undefined,
+	nextStatus: string | undefined
+): Promise<void> {
+	if (prevStatus !== "archived") return;
+	await assertClientCapacity(ctx, orgId, nextStatus);
+}
+
+/**
+ * Update-path per-client project cap. A project that already occupies a slot on
+ * the SAME client keeps it; reviving a completed/cancelled project, or moving an
+ * active one onto another client, has to clear the destination's ceiling (which
+ * counts every active project there, so the moving row must not be counted yet).
+ */
+export async function assertProjectCapacityForTransition(
+	ctx: MutationCtx,
+	prev: { clientId: Id<"clients">; status: string | undefined },
+	next: { clientId: Id<"clients">; status: string | undefined }
+): Promise<void> {
+	const keepsItsSlot =
+		isActiveProjectStatus(prev.status) && prev.clientId === next.clientId;
+	if (keepsItsSlot) return;
+	await assertProjectCapacity(ctx, next.clientId, next.status);
 }

--- a/packages/backend/convex/lib/planCaps.ts
+++ b/packages/backend/convex/lib/planCaps.ts
@@ -1,0 +1,106 @@
+import { ConvexError } from "convex/values";
+import type { Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+import { hasPremiumAccess } from "./permissions";
+import {
+	FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT,
+	FREE_MAX_CLIENTS,
+} from "./planLimits";
+
+/**
+ * Free-plan cap enforcement shared by every create path: the user-facing
+ * clients.create / projects.create mutations and the automation create_record
+ * executor (lib/automationExec). The counting lives here once so the two paths
+ * can't drift on which records consume a slot.
+ *
+ * Constants stay in planLimits.ts — that module is imported by apps/web and must
+ * remain free of ./_generated / convex/server imports.
+ */
+
+/** Stable code on the thrown ConvexError so clients can branch on it. */
+export const PLAN_LIMIT_ERROR_CODE = "PLAN_LIMIT_REACHED";
+
+export const CLIENT_CAP_MESSAGE = `Your plan is limited to ${FREE_MAX_CLIENTS} clients — upgrade to add more.`;
+
+export const PROJECT_CAP_MESSAGE = `Your plan allows ${FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT} active projects per client — upgrade to add more.`;
+
+/** Project statuses that consume a per-client active slot. */
+function isActiveProjectStatus(status: string | undefined): boolean {
+	return status === "planned" || status === "in-progress";
+}
+
+/**
+ * Counting-only client cap check. Returns the user-facing message when the
+ * insert would exceed the ceiling, or null when it's allowed. Does NOT consider
+ * the plan — callers gate on their own premium check first.
+ */
+export async function checkClientCapacity(
+	ctx: MutationCtx,
+	orgId: Id<"organizations">,
+	newStatus: string | undefined
+): Promise<string | null> {
+	// An archived client doesn't occupy a slot, so creating one never trips.
+	if (newStatus === "archived") return null;
+	const clients = await ctx.db
+		.query("clients")
+		.withIndex("by_org", (q) => q.eq("orgId", orgId))
+		.collect();
+	const active = clients.filter((c) => c.status !== "archived").length;
+	return active >= FREE_MAX_CLIENTS ? CLIENT_CAP_MESSAGE : null;
+}
+
+/**
+ * Counting-only per-client active-project cap check. Returns the user-facing
+ * message when the insert would exceed the ceiling, or null when it's allowed.
+ * Does NOT consider the plan.
+ */
+export async function checkProjectCapacity(
+	ctx: MutationCtx,
+	clientId: Id<"clients"> | undefined,
+	newStatus: string | undefined
+): Promise<string | null> {
+	if (!clientId || !isActiveProjectStatus(newStatus)) return null;
+	const projects = await ctx.db
+		.query("projects")
+		.withIndex("by_client", (q) => q.eq("clientId", clientId))
+		.collect();
+	const active = projects.filter((p) => isActiveProjectStatus(p.status)).length;
+	return active >= FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT
+		? PROJECT_CAP_MESSAGE
+		: null;
+}
+
+function planLimitError(message: string): ConvexError<{
+	code: string;
+	message: string;
+}> {
+	return new ConvexError({ code: PLAN_LIMIT_ERROR_CODE, message });
+}
+
+/**
+ * Throw when a free-plan org is at the client ceiling. Premium (user- or
+ * org-level, via the live identity) bypasses.
+ */
+export async function assertClientCapacity(
+	ctx: MutationCtx,
+	orgId: Id<"organizations">,
+	newStatus: string | undefined
+): Promise<void> {
+	if (await hasPremiumAccess(ctx)) return;
+	const error = await checkClientCapacity(ctx, orgId, newStatus);
+	if (error) throw planLimitError(error);
+}
+
+/**
+ * Throw when a free-plan org is at the per-client active-project ceiling.
+ * Callers must have already verified the client belongs to the caller's org.
+ */
+export async function assertProjectCapacity(
+	ctx: MutationCtx,
+	clientId: Id<"clients">,
+	newStatus: string | undefined
+): Promise<void> {
+	if (await hasPremiumAccess(ctx)) return;
+	const error = await checkProjectCapacity(ctx, clientId, newStatus);
+	if (error) throw planLimitError(error);
+}

--- a/packages/backend/convex/planCaps.test.ts
+++ b/packages/backend/convex/planCaps.test.ts
@@ -272,5 +272,128 @@ describe("free-plan create caps", () => {
 				})
 			).resolves.toBeDefined();
 		});
+
+		it("reviving a completed project faces the cap", async () => {
+			const { asUser, clientId } = await seedClient();
+			await createProjects(
+				asUser,
+				clientId,
+				FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT
+			);
+			const doneId = await asUser.mutation(api.projects.create, {
+				clientId,
+				title: "Finished",
+				status: "completed",
+				projectType: "one-off",
+			});
+			await expectPlanLimit(
+				asUser.mutation(api.projects.update, {
+					id: doneId,
+					status: "in-progress",
+				})
+			);
+		});
+
+		it("moving an active project onto a full client faces that client's cap", async () => {
+			const { asUser, clientId } = await seedClient();
+			await createProjects(
+				asUser,
+				clientId,
+				FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT
+			);
+			const otherId = await asUser.mutation(api.clients.create, {
+				companyName: "Other client",
+				status: "active",
+			});
+			const movingId = await asUser.mutation(api.projects.create, {
+				clientId: otherId,
+				title: "Moving",
+				status: "planned",
+				projectType: "one-off",
+			});
+			await expectPlanLimit(
+				asUser.mutation(api.projects.update, {
+					id: movingId,
+					clientId,
+				})
+			);
+		});
+
+		it("editing a project that already holds its slot still works at the cap", async () => {
+			const { asUser, clientId } = await seedClient();
+			await createProjects(
+				asUser,
+				clientId,
+				FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT
+			);
+			const activeId = await t.run(async (ctx) => {
+				const rows = await ctx.db
+					.query("projects")
+					.withIndex("by_client", (q) => q.eq("clientId", clientId))
+					.collect();
+				return rows[0]._id;
+			});
+			await expect(
+				asUser.mutation(api.projects.update, {
+					id: activeId,
+					title: "Renamed",
+					status: "in-progress",
+				})
+			).resolves.toBeDefined();
+		});
+	});
+
+	// The ceiling counts states, not inserts: a client coming back from the
+	// archive occupies a slot exactly like a fresh create.
+	describe("client status transitions", () => {
+		/** Fills the org to the cap and leaves one archived client behind. */
+		async function seedFullOrgWithArchived() {
+			const { asUser, orgId } = await seedOrg();
+			const ids = await createClients(asUser, FREE_MAX_CLIENTS);
+			await t.run(async (ctx) => {
+				await ctx.db.patch(ids[0], { status: "archived" });
+			});
+			// Back to the cap, with ids[0] parked in the archive.
+			await asUser.mutation(api.clients.create, {
+				companyName: "Refill",
+				status: "active",
+			});
+			return { asUser, orgId, archivedId: ids[0], activeId: ids[1] };
+		}
+
+		it("restore is refused at the cap", async () => {
+			const { asUser, archivedId } = await seedFullOrgWithArchived();
+			await expectPlanLimit(
+				asUser.mutation(api.clients.restore, { id: archivedId })
+			);
+		});
+
+		it("un-archiving through clients.update is refused at the cap", async () => {
+			const { asUser, archivedId } = await seedFullOrgWithArchived();
+			await expectPlanLimit(
+				asUser.mutation(api.clients.update, {
+					id: archivedId,
+					status: "active",
+				})
+			);
+		});
+
+		it("a client that already holds a slot can still be edited at the cap", async () => {
+			const { asUser, activeId } = await seedFullOrgWithArchived();
+			await expect(
+				asUser.mutation(api.clients.update, {
+					id: activeId,
+					status: "inactive",
+				})
+			).resolves.toBeDefined();
+		});
+
+		it("paid plan can still restore at the cap", async () => {
+			const { asUser, orgId, archivedId } = await seedFullOrgWithArchived();
+			await makePaid(orgId);
+			await expect(
+				asUser.mutation(api.clients.restore, { id: archivedId })
+			).resolves.toBeDefined();
+		});
 	});
 });

--- a/packages/backend/convex/planCaps.test.ts
+++ b/packages/backend/convex/planCaps.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { ConvexError } from "convex/values";
+import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { setupConvexTest } from "./test.setup";
+import { createTestOrg, createTestIdentity } from "./test.helpers";
+import { PREMIUM_PLAN_SLUG } from "./lib/permissions";
+import {
+	FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT,
+	FREE_MAX_CLIENTS,
+} from "./lib/planLimits";
+
+// Free-plan ceilings are enforced in the create mutations via lib/planCaps.ts,
+// which the automation create_record executor shares. Test orgs have no
+// clerkPlanSlug, so they are free-plan by default.
+describe("free-plan create caps", () => {
+	let t: ReturnType<typeof setupConvexTest>;
+
+	beforeEach(() => {
+		t = setupConvexTest();
+	});
+
+	async function seedOrg() {
+		const { orgId, clerkUserId, clerkOrgId } = await t.run(async (ctx) =>
+			createTestOrg(ctx)
+		);
+		return {
+			orgId,
+			asUser: t.withIdentity(createTestIdentity(clerkUserId, clerkOrgId)),
+		};
+	}
+
+	/** Flip the org doc to the paid plan (hasPremiumAccess falls back to it). */
+	async function makePaid(orgId: Id<"organizations">) {
+		await t.run(async (ctx) => {
+			await ctx.db.patch(orgId, {
+				clerkPlanSlug: PREMIUM_PLAN_SLUG,
+				subscriptionStatus: "active",
+			});
+		});
+	}
+
+	/** Sequential — never Promise.all across components (aggregate cross-wiring). */
+	async function createClients(
+		asUser: ReturnType<typeof t.withIdentity>,
+		count: number,
+		status: "active" | "archived" = "active"
+	) {
+		const ids: Id<"clients">[] = [];
+		for (let i = 0; i < count; i++) {
+			ids.push(
+				await asUser.mutation(api.clients.create, {
+					companyName: `Client ${i}`,
+					status,
+				})
+			);
+		}
+		return ids;
+	}
+
+	async function expectPlanLimit(promise: Promise<unknown>) {
+		let caught: unknown;
+		try {
+			await promise;
+		} catch (error) {
+			caught = error;
+		}
+		expect(caught).toBeDefined();
+		// The stable code is the contract clients branch on.
+		const payload =
+			caught instanceof ConvexError ? caught.data : String(caught);
+		expect(JSON.stringify(payload)).toContain("PLAN_LIMIT_REACHED");
+	}
+
+	describe("clients.create", () => {
+		it("allows creates under the cap", async () => {
+			const { asUser } = await seedOrg();
+			const ids = await createClients(asUser, FREE_MAX_CLIENTS - 1);
+			expect(ids).toHaveLength(FREE_MAX_CLIENTS - 1);
+			await expect(
+				asUser.mutation(api.clients.create, {
+					companyName: "One more",
+					status: "active",
+				})
+			).resolves.toBeDefined();
+		});
+
+		it("rejects the create that would exceed the cap", async () => {
+			const { asUser } = await seedOrg();
+			await createClients(asUser, FREE_MAX_CLIENTS);
+			await expectPlanLimit(
+				asUser.mutation(api.clients.create, {
+					companyName: "Over the line",
+					status: "active",
+				})
+			);
+		});
+
+		it("archived clients don't consume a slot", async () => {
+			const { asUser, orgId } = await seedOrg();
+			await createClients(asUser, FREE_MAX_CLIENTS);
+			await t.run(async (ctx) => {
+				const clients = await ctx.db
+					.query("clients")
+					.withIndex("by_org", (q) => q.eq("orgId", orgId))
+					.collect();
+				await ctx.db.patch(clients[0]._id, { status: "archived" });
+			});
+			await expect(
+				asUser.mutation(api.clients.create, {
+					companyName: "Backfill",
+					status: "active",
+				})
+			).resolves.toBeDefined();
+		});
+
+		it("paid plan bypasses the cap", async () => {
+			const { asUser, orgId } = await seedOrg();
+			await createClients(asUser, FREE_MAX_CLIENTS);
+			await makePaid(orgId);
+			await expect(
+				asUser.mutation(api.clients.create, {
+					companyName: "Paid extra",
+					status: "active",
+				})
+			).resolves.toBeDefined();
+		});
+
+		it("premium override flag bypasses the cap", async () => {
+			const { asUser, orgId } = await seedOrg();
+			await createClients(asUser, FREE_MAX_CLIENTS);
+			await t.run(async (ctx) => {
+				await ctx.db.patch(orgId, { hasPremiumFeatureAccess: true });
+			});
+			await expect(
+				asUser.mutation(api.clients.create, {
+					companyName: "Override extra",
+					status: "active",
+				})
+			).resolves.toBeDefined();
+		});
+	});
+
+	describe("projects.create", () => {
+		async function seedClient() {
+			const { asUser, orgId } = await seedOrg();
+			const [clientId] = await createClients(asUser, 1);
+			return { asUser, orgId, clientId };
+		}
+
+		async function createProjects(
+			asUser: ReturnType<typeof t.withIdentity>,
+			clientId: Id<"clients">,
+			count: number,
+			status: "planned" | "in-progress" | "completed" | "cancelled" = "planned"
+		) {
+			for (let i = 0; i < count; i++) {
+				await asUser.mutation(api.projects.create, {
+					clientId,
+					title: `Project ${status} ${i}`,
+					status,
+					projectType: "one-off",
+				});
+			}
+		}
+
+		it("allows creates under the per-client cap", async () => {
+			const { asUser, clientId } = await seedClient();
+			await createProjects(
+				asUser,
+				clientId,
+				FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT - 1
+			);
+			await expect(
+				asUser.mutation(api.projects.create, {
+					clientId,
+					title: "Last slot",
+					status: "planned",
+					projectType: "one-off",
+				})
+			).resolves.toBeDefined();
+		});
+
+		it("rejects a fourth active project on the same client", async () => {
+			const { asUser, clientId } = await seedClient();
+			await createProjects(
+				asUser,
+				clientId,
+				FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT
+			);
+			await expectPlanLimit(
+				asUser.mutation(api.projects.create, {
+					clientId,
+					title: "Too many",
+					status: "in-progress",
+					projectType: "one-off",
+				})
+			);
+		});
+
+		it("completed and cancelled projects don't consume a slot", async () => {
+			const { asUser, clientId } = await seedClient();
+			await createProjects(asUser, clientId, 5, "completed");
+			await createProjects(asUser, clientId, 5, "cancelled");
+			await createProjects(
+				asUser,
+				clientId,
+				FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT - 1
+			);
+			await expect(
+				asUser.mutation(api.projects.create, {
+					clientId,
+					title: "Still allowed",
+					status: "planned",
+					projectType: "one-off",
+				})
+			).resolves.toBeDefined();
+		});
+
+		it("the cap is per client, not per org", async () => {
+			const { asUser, clientId } = await seedClient();
+			await createProjects(
+				asUser,
+				clientId,
+				FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT
+			);
+			const otherId = await asUser.mutation(api.clients.create, {
+				companyName: "Other client",
+				status: "active",
+			});
+			await expect(
+				asUser.mutation(api.projects.create, {
+					clientId: otherId,
+					title: "Fresh client",
+					status: "planned",
+					projectType: "one-off",
+				})
+			).resolves.toBeDefined();
+		});
+
+		it("creating a completed project is allowed at the cap", async () => {
+			const { asUser, clientId } = await seedClient();
+			await createProjects(
+				asUser,
+				clientId,
+				FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT
+			);
+			await expect(
+				asUser.mutation(api.projects.create, {
+					clientId,
+					title: "Archived-style",
+					status: "completed",
+					projectType: "one-off",
+				})
+			).resolves.toBeDefined();
+		});
+
+		it("paid plan bypasses the cap", async () => {
+			const { asUser, orgId, clientId } = await seedClient();
+			await createProjects(
+				asUser,
+				clientId,
+				FREE_MAX_ACTIVE_PROJECTS_PER_CLIENT
+			);
+			await makePaid(orgId);
+			await expect(
+				asUser.mutation(api.projects.create, {
+					clientId,
+					title: "Paid extra",
+					status: "planned",
+					projectType: "one-off",
+				})
+			).resolves.toBeDefined();
+		});
+	});
+});

--- a/packages/backend/convex/projects.ts
+++ b/packages/backend/convex/projects.ts
@@ -24,6 +24,7 @@ import {
 	userMutation,
 	type UserMutationCtx,
 } from "./lib/factories";
+import { assertProjectCapacity } from "./lib/planCaps";
 import { calculateQuoteTotals } from "./lib/quoteTotals";
 
 /**
@@ -567,6 +568,11 @@ export const create = userMutation({
 		if (args.startDate && args.endDate && args.startDate > args.endDate) {
 			throw new Error("Start date cannot be after end date");
 		}
+
+		// Org-scope the client before counting its projects (and before the
+		// free-plan ceiling check, so a foreign client can't be probed).
+		await validateClientAccess(ctx, args.clientId, ctx.orgId);
+		await assertProjectCapacity(ctx, args.clientId, args.status);
 
 		const assignedUserIds = await resolveScopedCreateAssignees(
 			ctx,

--- a/packages/backend/convex/projects.ts
+++ b/packages/backend/convex/projects.ts
@@ -24,7 +24,10 @@ import {
 	userMutation,
 	type UserMutationCtx,
 } from "./lib/factories";
-import { assertProjectCapacity } from "./lib/planCaps";
+import {
+	assertProjectCapacity,
+	assertProjectCapacityForTransition,
+} from "./lib/planCaps";
 import { calculateQuoteTotals } from "./lib/quoteTotals";
 
 /**
@@ -789,6 +792,24 @@ export const update = userMutation({
 		if (startDate && endDate && startDate > endDate) {
 			throw new Error("Start date cannot be after end date");
 		}
+
+		// Reviving a finished project, or moving an active one to another client,
+		// takes a per-client slot the create path would have had to clear.
+		const nextClientId = (filteredUpdates.clientId ??
+			currentProject.clientId) as Id<"clients">;
+		if (filteredUpdates.clientId) {
+			// assertProjectCapacityForTransition counts the destination's projects,
+			// so org-scope it first (updateProjectWithValidation repeats this later).
+			await validateClientAccess(ctx, nextClientId, ctx.orgId);
+		}
+		await assertProjectCapacityForTransition(
+			ctx,
+			{ clientId: currentProject.clientId, status: currentProject.status },
+			{
+				clientId: nextClientId,
+				status: filteredUpdates.status ?? currentProject.status,
+			}
+		);
 
 		// Check if status is being changed to completed
 		const wasCompleted = currentProject.status === "completed";

--- a/packages/backend/convex/quotes.editRules.test.ts
+++ b/packages/backend/convex/quotes.editRules.test.ts
@@ -357,3 +357,70 @@ describe("quote edit rules", () => {
 		});
 	});
 });
+
+describe("quotes.create project binding", () => {
+	let t: ReturnType<typeof setupConvexTest>;
+
+	beforeEach(() => {
+		t = setupConvexTest();
+	});
+
+	// Org scope alone let a quote point at another client's project, which would
+	// print the wrong job on the document.
+	it("refuses a project belonging to a different client", async () => {
+		const { clientId, clerkUserId, clerkOrgId, otherClientId } = await t.run(
+			async (ctx) => {
+				const { orgId, clerkUserId, clerkOrgId } = await createTestOrg(ctx);
+				const clientId = await createTestClient(ctx, orgId);
+				const otherClientId = await createTestClient(ctx, orgId, {
+					companyName: "Other Co",
+				});
+				return { clientId, clerkUserId, clerkOrgId, otherClientId };
+			}
+		);
+		const asUser = t.withIdentity(createTestIdentity(clerkUserId, clerkOrgId));
+
+		const projectId = await asUser.mutation(api.projects.create, {
+			clientId: otherClientId,
+			title: "Other client's job",
+			status: "planned",
+			projectType: "one-off",
+		});
+
+		await expect(
+			asUser.mutation(api.quotes.create, {
+				clientId,
+				projectId,
+				status: "draft",
+				subtotal: 0,
+				total: 0,
+			})
+		).rejects.toThrow(/does not belong to the selected client/);
+	});
+
+	it("accepts the client's own project", async () => {
+		const { clientId, clerkUserId, clerkOrgId } = await t.run(async (ctx) => {
+			const { orgId, clerkUserId, clerkOrgId } = await createTestOrg(ctx);
+			const clientId = await createTestClient(ctx, orgId);
+			return { clientId, clerkUserId, clerkOrgId };
+		});
+		const asUser = t.withIdentity(createTestIdentity(clerkUserId, clerkOrgId));
+
+		const projectId = await asUser.mutation(api.projects.create, {
+			clientId,
+			title: "Their job",
+			status: "planned",
+			projectType: "one-off",
+		});
+
+		await expect(
+			asUser.mutation(api.quotes.create, {
+				clientId,
+				projectId,
+				status: "draft",
+				subtotal: 0,
+				total: 0,
+			})
+		).resolves.toBeDefined();
+	});
+});

--- a/packages/backend/convex/quotes.ts
+++ b/packages/backend/convex/quotes.ts
@@ -129,6 +129,15 @@ async function createQuoteWithOrg(
 	// Validate project access if provided
 	if (data.projectId) {
 		await validateProjectAccess(ctx, data.projectId, ctx.orgId);
+		// Org scope alone still allows a project belonging to a DIFFERENT client,
+		// which would print the wrong job on the quote.
+		const project = await ctx.db.get(data.projectId);
+		if (project && project.clientId !== data.clientId) {
+			throw new ConvexError({
+				code: "BAD_REQUEST",
+				message: "Project does not belong to the selected client",
+			});
+		}
 	}
 
 	// Auto-generate quote number if not provided

--- a/packages/help-content/articles/mobile-app.ts
+++ b/packages/help-content/articles/mobile-app.ts
@@ -41,8 +41,8 @@ export const mobileAppArticles: HelpArticle[] = [
 					{
 						type: "list",
 						items: [
-							"**Today** is your schedule. A week strip picks the date, and a **Day / List** toggle switches views: Day is a timeline of the chosen day — timed work in order with a *Now* marker, plus an all-day band for projects and unscheduled tasks — while List looks ahead two weeks, grouped by day. A **Me** and **Team** toggle switches between your own work and the whole team's, urgent items are called out at the top, and your organization's activity feed opens from here too.",
-							"**Work** is where you find anything. Type in the search field to search every record — clients (including their contacts and properties), projects, quotes, invoices, and tasks — with results grouped by type; the chips narrow to one type or browse its full list. Before you search, the screen shows records you've recently opened on this device.",
+							"**Today** is your schedule. A week strip picks the date, and a **Day / List** toggle switches views: Day is a timeline of the chosen day (timed work in order with a *Now* marker, plus an all-day band for projects and unscheduled tasks), while List looks ahead two weeks, grouped by day. A **Me** and **Team** toggle switches between your own work and the whole team's, urgent items are called out at the top, and your organization's activity feed opens from here too.",
+							"**Work** is where you find anything. Type in the search field to search every record: clients (including their contacts and properties), projects, quotes, invoices, and tasks, with results grouped by type; the chips narrow to one type or browse its full list. Before you search, the screen shows records you've recently opened on this device.",
 							"**Money** holds your invoices and quotes, with an outstanding total up top and a chart of what you've collected recently.",
 							"**Routes** plans the day's stops and gets you from one to the next. See [Planning a route](/help/routing/planning-a-route).",
 						],
@@ -58,7 +58,7 @@ export const mobileAppArticles: HelpArticle[] = [
 				blocks: [
 					{
 						type: "paragraph",
-						text: "The **+** button floats above the bottom-right of every tab and fans out into **New project**, **New task**, **New client**, and **New quote** — you only see the ones your role can create. On iPad, the same menu lives behind the **+** in the sidebar.",
+						text: "The **+** button floats above the bottom-right of every tab and fans out into **New project**, **New task**, **New client**, and **New quote**; you only see the ones your role can create. On iPad, the same menu lives behind the **+** in the sidebar.",
 					},
 					{
 						type: "list",
@@ -66,7 +66,7 @@ export const mobileAppArticles: HelpArticle[] = [
 							"**New project** is built for speed: pick a client, type a title, optionally set a start date, and it's created. If the client isn't in OneTool yet, tap **+ New client** inside the picker to add them with just a name and phone without leaving the form. You can also start a project straight from a client's detail screen.",
 							"**New quote** picks a client and creates a draft, then opens it so you can add line items right away.",
 							"**New task** and **New client** open the full forms you already know.",
-							"On the Free plan, the 10-client and 3-active-projects-per-client limits apply here the same as on the web — the app tells you when you've hit one.",
+							"On the Free plan, the 10-client and 3-active-projects-per-client limits apply here the same as on the web, and the app tells you when you've hit one.",
 						],
 					},
 				],
@@ -76,16 +76,16 @@ export const mobileAppArticles: HelpArticle[] = [
 				blocks: [
 					{
 						type: "paragraph",
-						text: "The **Money** tab is a combined list with an **Invoices** and **Quotes** toggle; tap any row to open the full record. From a detail screen, the buttons follow the record's status: a draft offers **Send** (with **Mark as sent** under the \u2022\u2022\u2022 menu when you delivered the quote yourself \u2014 no email goes out), a sent quote offers **Get signature** \u2014 the client picks who's signing, signs on your screen (turn the phone sideways; iPad signs full-width), and the quote is approved with the signature saved to its approval history \u2014 plus **Resend** and a manual **Mark approved**, an approved quote converts to an invoice in one tap, and a sent or overdue invoice offers **Record payment** and **Share pay link**.",
+						text: "The **Money** tab is a combined list with an **Invoices** and **Quotes** toggle; tap any row to open the full record. From a detail screen, the buttons follow the record's status: a draft offers **Send** (with **Mark as sent** under the \u2022\u2022\u2022 menu when you delivered the quote yourself, so no email goes out), a sent quote offers **Get signature** (the client picks who's signing, signs on your screen, and the quote is approved with the signature saved to its approval history; turn the phone sideways, and iPad signs full-width) plus **Resend** and a manual **Mark approved**, an approved quote converts to an invoice in one tap, and a sent or overdue invoice offers **Record payment** and **Share pay link**.",
 					},
 					{
 						type: "list",
 						items: [
-							"**Sending** shows a preview of the document first, then emails your client a link to review it — and, for invoices, pay it — in their client portal. The client needs portal access and a primary contact email; the buttons explain what's missing if they can't be reached.",
+							"**Sending** shows a preview of the document first, then emails your client a link to review it (and, for invoices, pay it) in their client portal. The client needs portal access and a primary contact email; the buttons explain what's missing if they can't be reached.",
 							"**Record payment** logs a cash or check payment on the spot. The amount starts at the remaining balance and can be edited down for deposits and partial payments; the confirm button always shows the exact amount it will record.",
 							"**Share pay link** opens the share sheet with the invoice's portal payment link, so a client can pay by card on their own phone while you're standing together.",
-							"**Line items** are editable right on the record: tap a row to change its description, quantity, unit, or rate, or tap **Add line item** below the list — the total updates as you type. Draft quotes edit directly; a sent quote asks to move back to draft first (its portal link pauses until you resend), while invoices stay editable until a payment is recorded.",
-							"**Extend valid until** (under the ••• menu on a sent or expired quote) picks a new date without emailing the client — and extending an expired quote makes it available in the portal again.",
+							"**Line items** are editable right on the record: tap a row to change its description, quantity, unit, or rate, or tap **Add line item** below the list, and the total updates as you type. Draft quotes edit directly; a sent quote asks to move back to draft first (its portal link pauses until you resend), while invoices stay editable until a payment is recorded.",
+							"**Extend valid until** (under the ••• menu on a sent or expired quote) picks a new date without emailing the client, and extending an expired quote makes it available in the portal again.",
 						],
 					},
 				],

--- a/packages/help-content/articles/mobile-app.ts
+++ b/packages/help-content/articles/mobile-app.ts
@@ -41,15 +41,15 @@ export const mobileAppArticles: HelpArticle[] = [
 					{
 						type: "list",
 						items: [
-							"**Today** shows your day at a glance: a week strip to pick a date, urgent items called out at the top, your plan for the day in order, and a peek at tomorrow. A **Me** and **Team** toggle switches between your own work and the whole team's. Your organization's activity feed opens from here too.",
-							"**Work** is the hub for clients, projects, and tasks.",
+							"**Today** is your schedule. A week strip picks the date, and a **Day / List** toggle switches views: Day is a timeline of the chosen day — timed work in order with a *Now* marker, plus an all-day band for projects and unscheduled tasks — while List looks ahead two weeks, grouped by day. A **Me** and **Team** toggle switches between your own work and the whole team's, urgent items are called out at the top, and your organization's activity feed opens from here too.",
+							"**Work** is where you find anything. Type in the search field to search every record — clients (including their contacts and properties), projects, quotes, invoices, and tasks — with results grouped by type; the chips narrow to one type or browse its full list. Before you search, the screen shows records you've recently opened on this device.",
 							"**Money** holds your invoices and quotes, with an outstanding total up top and a chart of what you've collected recently.",
 							"**Routes** plans the day's stops and gets you from one to the next. See [Planning a route](/help/routing/planning-a-route).",
 						],
 					},
 					{
 						type: "paragraph",
-						text: "The center button opens the AI assistant, a Business plan feature. See [Meet the assistant](/help/ai-assistant/meet-the-assistant).",
+						text: "A magnifier in the header of the other tabs jumps straight to Work with the search field ready. The center button opens the AI assistant, a Business plan feature. See [Meet the assistant](/help/ai-assistant/meet-the-assistant).",
 					},
 				],
 			},

--- a/packages/help-content/articles/mobile-app.ts
+++ b/packages/help-content/articles/mobile-app.ts
@@ -54,6 +54,24 @@ export const mobileAppArticles: HelpArticle[] = [
 				],
 			},
 			{
+				heading: "Create anything with the + button",
+				blocks: [
+					{
+						type: "paragraph",
+						text: "The **+** button floats above the bottom-right of every tab and fans out into **New project**, **New task**, **New client**, and **New quote** — you only see the ones your role can create. On iPad, the same menu lives behind the **+** in the sidebar.",
+					},
+					{
+						type: "list",
+						items: [
+							"**New project** is built for speed: pick a client, type a title, optionally set a start date, and it's created. If the client isn't in OneTool yet, tap **+ New client** inside the picker to add them with just a name and phone without leaving the form. You can also start a project straight from a client's detail screen.",
+							"**New quote** picks a client and creates a draft, then opens it so you can add line items right away.",
+							"**New task** and **New client** open the full forms you already know.",
+							"On the Free plan, the 10-client and 3-active-projects-per-client limits apply here the same as on the web — the app tells you when you've hit one.",
+						],
+					},
+				],
+			},
+			{
 				heading: "Send, collect, and share from the Money tab",
 				blocks: [
 					{

--- a/packages/help-content/articles/quotes.ts
+++ b/packages/help-content/articles/quotes.ts
@@ -90,7 +90,7 @@ export const quotesArticles: HelpArticle[] = [
 					},
 					{
 						type: "note",
-						text: "Line items, pricing, the title, and the terms are editable while the quote is a **draft**. Once it is sent, the grid goes read only — click **Revert to draft** in the quote header to make changes, which pulls the quote from your client's portal until you send it again.",
+						text: "Line items, pricing, the title, and the terms are editable while the quote is a **draft**. Once it is sent, the grid goes read only. Click **Revert to draft** in the quote header to make changes, which pulls the quote from your client's portal until you send it again.",
 					},
 				],
 			},
@@ -136,7 +136,7 @@ export const quotesArticles: HelpArticle[] = [
 			},
 			{
 				question: "Can I still edit line items after I send the quote?",
-				answer: "Not directly. Editing is draft only, so click Revert to draft in the quote header first — that pulls the quote from your client's portal until you resend it. Approved and declined quotes stay locked for good, so the priced agreement keeps exactly what the client saw. To price a new version, create a new quote.",
+				answer: "Not directly. Editing is draft only, so click Revert to draft in the quote header first, which pulls the quote from your client's portal until you resend it. Approved and declined quotes stay locked for good, so the priced agreement keeps exactly what the client saw. To price a new version, create a new quote.",
 			},
 			{
 				question: "Can I delete a quote?",
@@ -214,7 +214,7 @@ export const quotesArticles: HelpArticle[] = [
 				blocks: [
 					{
 						type: "paragraph",
-						text: "A sent quote is locked, so the numbers never change under your client while they are deciding. To fix a price, a line item, the title, or the terms, click **Revert to draft** in the quote header and confirm. The quote leaves your client's portal and their link stops working, and everything is editable again. Click **Send** when it is ready to go back — that emails the revised quote and makes their link work again. (**Mark as Sent** only flips the status, so save it for quotes you delivered outside OneTool.)",
+						text: "A sent quote is locked, so the numbers never change under your client while they are deciding. To fix a price, a line item, the title, or the terms, click **Revert to draft** in the quote header and confirm. The quote leaves your client's portal and their link stops working, and everything is editable again. Click **Send** when it is ready to go back; that emails the revised quote and makes their link work again. (**Mark as Sent** only flips the status, so save it for quotes you delivered outside OneTool.)",
 					},
 					{
 						type: "note",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
     dependencies:
       '@clerk/expo':
         specifier: 3.7.8
-        version: 3.7.8(08f0c880c816922864719ccc76ee555d)
+        version: 3.7.8(a33c4e003d2a1d5b7f789c5fe241f096)
       '@convex-dev/agent':
         specifier: 0.6.4
         version: 0.6.4(@ai-sdk/provider-utils@4.0.35(zod@4.3.4))(ai@6.0.218(zod@4.3.4))(convex-helpers@0.1.113(@standard-schema/spec@1.1.0)(convex@1.40.0(@clerk/clerk-react@5.59.2(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@clerk/react@6.14.1(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(hono@4.11.3)(react@19.2.3)(typescript@6.0.3)(zod@4.3.4))(convex@1.40.0(@clerk/clerk-react@5.59.2(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@clerk/react@6.14.1(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
@@ -29,37 +29,37 @@ importers:
         version: 0.2.3
       '@expo/ui':
         specifier: ~56.0.16
-        version: 56.0.16(94346998af484511c4f886182959f669)
+        version: 56.0.16(d01a745d9ed6b5cb99c2fd5eca507f23)
       '@gorhom/bottom-sheet':
         specifier: 5.2.14
-        version: 5.2.14(@types/react@19.2.17)(react-native-gesture-handler@2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 5.2.14(0b50fa2baed5085e8f8952c5c3f505ef)
       '@onetool/backend':
         specifier: workspace:*
         version: link:../../packages/backend
       '@react-native-async-storage/async-storage':
         specifier: 2.2.0
-        version: 2.2.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+        version: 2.2.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       '@rnmapbox/maps':
         specifier: 10.3.5
-        version: 10.3.5(expo@56.0.9)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 10.3.5(expo@56.0.9)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@shopify/flash-list':
         specifier: 2.0.2
-        version: 2.0.2(@babel/runtime@7.28.4)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 2.0.2(@babel/runtime@7.28.4)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       convex:
         specifier: ~1.40.0
         version: 1.40.0(@clerk/clerk-react@5.59.2(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@clerk/react@6.14.1(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       expo:
         specifier: ~56.0.9
-        version: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+        version: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       expo-apple-authentication:
         specifier: ~56.0.4
-        version: 56.0.4(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 56.0.4(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       expo-auth-session:
         specifier: ~56.0.13
-        version: 56.0.13(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 56.0.13(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       expo-blur:
         specifier: ~56.0.3
-        version: 56.0.3(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 56.0.3(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       expo-build-properties:
         specifier: ~56.0.18
         version: 56.0.18(expo@56.0.9)
@@ -68,7 +68,7 @@ importers:
         version: 56.0.4(expo@56.0.9)
       expo-dev-client:
         specifier: ~56.0.19
-        version: 56.0.19(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+        version: 56.0.19(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       expo-device:
         specifier: ~56.0.4
         version: 56.0.4(expo@56.0.9)
@@ -77,10 +77,13 @@ importers:
         version: 56.0.4(expo@56.0.9)
       expo-file-system:
         specifier: ~56.0.8
-        version: 56.0.8(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+        version: 56.0.8(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       expo-font:
         specifier: ~56.0.5
-        version: 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      expo-haptics:
+        specifier: ~56.0.3
+        version: 56.0.3(expo@56.0.9)
       expo-image-picker:
         specifier: ~56.0.18
         version: 56.0.18(expo@56.0.9)
@@ -89,19 +92,19 @@ importers:
         version: 56.0.3(expo@56.0.9)(react@19.2.3)
       expo-linear-gradient:
         specifier: ~56.0.4
-        version: 56.0.4(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 56.0.4(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       expo-location:
         specifier: ~56.0.22
         version: 56.0.22(expo@56.0.9)(typescript@6.0.3)
       expo-notifications:
         specifier: ~56.0.17
-        version: 56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
+        version: 56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
       expo-router:
         specifier: ~56.2.9
-        version: 56.2.9(564bcd835d0b248bd1c8e6861c20bca0)
+        version: 56.2.9(bb36438237fbcf319888e30dc0060c53)
       expo-screen-orientation:
         specifier: ~56.0.5
-        version: 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+        version: 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       expo-secure-store:
         specifier: ~56.0.4
         version: 56.0.4(expo@56.0.9)
@@ -110,40 +113,40 @@ importers:
         version: 56.0.10(expo@56.0.9)(typescript@6.0.3)
       expo-status-bar:
         specifier: ~56.0.4
-        version: 56.0.4(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 56.0.4(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       expo-web-browser:
         specifier: ~56.0.5
-        version: 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+        version: 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       lucide-react-native:
         specifier: ^0.475.0
-        version: 0.475.0(react-native-svg@15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 0.475.0(react-native-svg@15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
       react-native:
         specifier: 0.85.3
-        version: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+        version: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       react-native-calendars:
         specifier: ^1.1313.0
-        version: 1.1313.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 1.1313.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-gesture-handler:
         specifier: ~2.31.2
-        version: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-reanimated:
         specifier: 4.3.1
-        version: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-safe-area-context:
         specifier: 5.7.0
-        version: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-screens:
         specifier: ~4.25.2
-        version: 4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-svg:
         specifier: ~15.15.4
-        version: 15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-worklets:
         specifier: 0.8.3
-        version: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -6666,6 +6669,11 @@ packages:
       react: 19.2.3
       react-native: '*'
 
+  expo-haptics@56.0.3:
+    resolution: {integrity: sha512-ycoahZJnR9tWAVh/0mJYxbETtHRYaWjiWS8cHlP6aDGU6Q6Y8rZ5NKsuBwWw6HR2Pe30mfVFgbF2HrBR6gtYmw==}
+    peerDependencies:
+      expo: '*'
+
   expo-image-loader@56.0.3:
     resolution: {integrity: sha512-JgUo4fUeU1ZC+z8iBFj8v7yoGQnZrLbOVPyNE+DWVrld55F2F6R1ck+rmdm/8TNWLz1LhNQfD7c3XYP1ZikxXA==}
     peerDependencies:
@@ -11537,13 +11545,13 @@ snapshots:
       - react
       - react-dom
 
-  '@clerk/clerk-js@6.28.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bs58@5.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.4)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@4.3.4)':
+  '@clerk/clerk-js@6.28.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bs58@5.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.4)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@4.3.4)':
     dependencies:
       '@base-org/account': 2.0.1(@types/react@19.2.17)(bufferutil@4.1.0)(immer@11.1.4)(react@19.2.3)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@4.3.4)
       '@clerk/shared': 4.28.1(react-dom@19.2.7(react@19.2.3))(react@19.2.3)
       '@coinbase/wallet-sdk': 4.3.7(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@4.3.4)
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
-      '@solana/wallet-adapter-react': 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bs58@5.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
+      '@solana/wallet-adapter-react': 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bs58@5.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
       '@solana/wallet-standard': 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bs58@5.0.0)(react@19.2.3)
       '@stripe/stripe-js': 5.6.0
       '@swc/helpers': 0.5.21
@@ -11587,24 +11595,24 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@clerk/expo@3.7.8(08f0c880c816922864719ccc76ee555d)':
+  '@clerk/expo@3.7.8(a33c4e003d2a1d5b7f789c5fe241f096)':
     dependencies:
-      '@clerk/clerk-js': 6.28.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bs58@5.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.4)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@4.3.4)
+      '@clerk/clerk-js': 6.28.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bs58@5.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.4)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@6.0.6)(zod@4.3.4)
       '@clerk/react': 6.14.1(react-dom@19.2.7(react@19.2.3))(react@19.2.3)
       '@clerk/shared': 4.28.1(react-dom@19.2.7(react@19.2.3))(react@19.2.3)
       base-64: 1.0.0
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
-      react-native-url-polyfill: 2.0.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native-url-polyfill: 2.0.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       tslib: 2.8.1
     optionalDependencies:
-      expo-apple-authentication: 56.0.4(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      expo-auth-session: 56.0.13(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      expo-constants: 56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+      expo-apple-authentication: 56.0.4(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      expo-auth-session: 56.0.13(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      expo-constants: 56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       expo-crypto: 56.0.4(expo@56.0.9)
       expo-secure-store: 56.0.4(expo@56.0.9)
-      expo-web-browser: 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+      expo-web-browser: 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       react-dom: 19.2.7(react@19.2.3)
     transitivePeerDependencies:
       - '@solana/web3.js'
@@ -12260,7 +12268,7 @@ snapshots:
 
   '@expo-google-fonts/outfit@0.2.3': {}
 
-  '@expo/cli@56.1.14(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-constants@56.0.17)(expo-font@56.0.5)(expo-router@56.2.9)(expo@56.0.9)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+  '@expo/cli@56.1.14(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-constants@56.0.17)(expo-font@56.0.5)(expo-router@56.2.9)(expo@56.0.9)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
       '@expo/config': 56.0.9(typescript@6.0.3)
@@ -12270,7 +12278,7 @@ snapshots:
       '@expo/image-utils': 0.10.1(typescript@6.0.3)
       '@expo/inline-modules': 0.0.11(typescript@6.0.3)
       '@expo/json-file': 10.2.0
-      '@expo/log-box': 56.0.12(@expo/dom-webview@56.0.5)(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      '@expo/log-box': 56.0.12(@expo/dom-webview@56.0.5)(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@expo/metro': 56.0.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@expo/metro-config': 56.0.13(bufferutil@4.1.0)(expo@56.0.9)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@expo/metro-file-map': 56.0.3
@@ -12295,7 +12303,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3
       dnssd-advertise: 1.1.4
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       expo-server: 56.0.5
       fetch-nodeshim: 0.4.10
       getenv: 2.0.0
@@ -12321,8 +12329,8 @@ snapshots:
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 56.2.9(564bcd835d0b248bd1c8e6861c20bca0)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      expo-router: 56.2.9(bb36438237fbcf319888e30dc0060c53)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@expo/dom-webview'
       - '@expo/metro-runtime'
@@ -12384,18 +12392,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/devtools@56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
+  '@expo/devtools@56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
       chalk: 4.1.2
     optionalDependencies:
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
-  '@expo/dom-webview@56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
+  '@expo/dom-webview@56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   '@expo/env@2.3.0':
     dependencies:
@@ -12469,13 +12477,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@expo/log-box@56.0.12(@expo/dom-webview@56.0.5)(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
+  '@expo/log-box@56.0.12(@expo/dom-webview@56.0.5)(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
-      '@expo/dom-webview': 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      '@expo/dom-webview': 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       anser: 1.4.10
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       stacktrace-parser: 0.1.11
 
   '@expo/metro-config@56.0.13(bufferutil@4.1.0)(expo@56.0.9)(typescript@6.0.3)(utf-8-validate@6.0.6)':
@@ -12505,7 +12513,7 @@ snapshots:
       postcss: 8.5.15
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -12523,14 +12531,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/metro-runtime@56.0.14(@expo/log-box@56.0.12)(expo@56.0.9)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
+  '@expo/metro-runtime@56.0.14(@expo/log-box@56.0.12)(expo@56.0.9)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
-      '@expo/log-box': 56.0.12(@expo/dom-webview@56.0.5)(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      '@expo/log-box': 56.0.12(@expo/dom-webview@56.0.5)(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       anser: 1.4.10
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       pretty-format: 29.7.0
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
     optionalDependencies:
@@ -12615,14 +12623,14 @@ snapshots:
   '@expo/router-server@56.0.13(@expo/metro-runtime@56.0.14)(expo-constants@56.0.17)(expo-font@56.0.5)(expo-router@56.2.9)(expo-server@56.0.5)(expo@56.0.9)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)':
     dependencies:
       debug: 4.4.3
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
-      expo-constants: 56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
-      expo-font: 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo-constants: 56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+      expo-font: 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       expo-server: 56.0.5
       react: 19.2.3
     optionalDependencies:
-      '@expo/metro-runtime': 56.0.14(@expo/log-box@56.0.12)(expo@56.0.9)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      expo-router: 56.2.9(564bcd835d0b248bd1c8e6861c20bca0)
+      '@expo/metro-runtime': 56.0.14(@expo/log-box@56.0.12)(expo@56.0.9)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      expo-router: 56.2.9(bb36438237fbcf319888e30dc0060c53)
       react-dom: 19.2.7(react@19.2.3)
     transitivePeerDependencies:
       - supports-color
@@ -12637,18 +12645,18 @@ snapshots:
 
   '@expo/sudo-prompt@9.3.2': {}
 
-  '@expo/ui@56.0.16(94346998af484511c4f886182959f669)':
+  '@expo/ui@56.0.16(d01a745d9ed6b5cb99c2fd5eca507f23)':
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       sf-symbols-typescript: 2.2.0
       vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)
     optionalDependencies:
       '@babel/core': 7.29.7
       react-dom: 19.2.7(react@19.2.3)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -12711,22 +12719,22 @@ snapshots:
 
   '@fontsource/caveat@5.2.8': {}
 
-  '@gorhom/bottom-sheet@5.2.14(@types/react@19.2.17)(react-native-gesture-handler@2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
+  '@gorhom/bottom-sheet@5.2.14(0b50fa2baed5085e8f8952c5c3f505ef)':
     dependencies:
-      '@gorhom/portal': 1.0.14(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      '@gorhom/portal': 1.0.14(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       invariant: 2.2.4
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
-      react-native-gesture-handler: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native-gesture-handler: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.17
 
-  '@gorhom/portal@1.0.14(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
+  '@gorhom/portal@1.0.14(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
       nanoid: 3.3.12
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   '@headless-tree/core@1.7.0': {}
 
@@ -13756,21 +13764,21 @@ snapshots:
     dependencies:
       react: 19.2.3
 
-  '@react-native-async-storage/async-storage@1.24.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))':
+  '@react-native-async-storage/async-storage@1.24.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))':
     dependencies:
       merge-options: 3.0.4
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     optional: true
 
-  '@react-native-async-storage/async-storage@2.2.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))':
+  '@react-native-async-storage/async-storage@2.2.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))':
     dependencies:
       merge-options: 3.0.4
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
-  '@react-native-masked-view/masked-view@0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
+  '@react-native-masked-view/masked-view@0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   '@react-native/assets-registry@0.85.3': {}
 
@@ -13830,7 +13838,7 @@ snapshots:
       tinyglobby: 0.2.15
       yargs: 17.7.2
 
-  '@react-native/community-cli-plugin@0.85.3(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@react-native/community-cli-plugin@0.85.3(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@react-native/dev-middleware': 0.85.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       debug: 4.4.3
@@ -13840,7 +13848,7 @@ snapshots:
       metro-core: 0.84.4
       semver: 7.8.2
     optionalDependencies:
-      '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)
+      '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -13888,7 +13896,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/metro-config@0.85.3(@babel/core@7.29.7)':
+  '@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@react-native/js-polyfills': 0.85.3
       '@react-native/metro-babel-transformer': 0.85.3(@babel/core@7.29.7)
@@ -13896,16 +13904,18 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.85.3': {}
 
-  '@react-native/virtualized-lists@0.85.3(@types/react@19.2.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
+  '@react-native/virtualized-lists@0.85.3(@types/react@19.2.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     optionalDependencies:
       '@types/react': 19.2.17
 
@@ -14304,7 +14314,7 @@ snapshots:
       - react
       - react-dom
 
-  '@rnmapbox/maps@10.3.5(expo@56.0.9)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
+  '@rnmapbox/maps@10.3.5(expo@56.0.9)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
       '@turf/along': 6.5.0
       '@turf/distance': 6.5.0
@@ -14314,9 +14324,9 @@ snapshots:
       '@types/geojson': 7946.0.16
       debounce: 2.2.0
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     optionalDependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       react-dom: 19.2.7(react@19.2.3)
 
   '@rollup/rollup-android-arm-eabi@4.54.0':
@@ -14468,11 +14478,11 @@ snapshots:
       domhandler: 5.0.3
       selderee: 0.11.0
 
-  '@shopify/flash-list@2.0.2(@babel/runtime@7.28.4)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
+  '@shopify/flash-list@2.0.2(@babel/runtime@7.28.4)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.28.4
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       tslib: 2.8.1
 
   '@sinclair/typebox@0.27.8': {}
@@ -14481,9 +14491,9 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
-  '@solana-mobile/mobile-wallet-adapter-protocol-web3js@2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)':
+  '@solana-mobile/mobile-wallet-adapter-protocol-web3js@2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)':
     dependencies:
-      '@solana-mobile/mobile-wallet-adapter-protocol': 2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bs58@5.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
+      '@solana-mobile/mobile-wallet-adapter-protocol': 2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bs58@5.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
       bs58: 5.0.0
       js-base64: 3.7.8
@@ -14494,14 +14504,14 @@ snapshots:
       - react-native
       - typescript
 
-  '@solana-mobile/mobile-wallet-adapter-protocol@2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bs58@5.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)':
+  '@solana-mobile/mobile-wallet-adapter-protocol@2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bs58@5.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-strings': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/wallet-standard': 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bs58@5.0.0)(react@19.2.3)
       '@solana/wallet-standard-util': 1.1.2
       '@wallet-standard/core': 1.1.1
       js-base64: 3.7.8
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@solana/wallet-adapter-base'
       - '@solana/web3.js'
@@ -14510,25 +14520,25 @@ snapshots:
       - react
       - typescript
 
-  '@solana-mobile/wallet-adapter-mobile@2.2.5(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)':
+  '@solana-mobile/wallet-adapter-mobile@2.2.5(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)':
     dependencies:
-      '@solana-mobile/mobile-wallet-adapter-protocol-web3js': 2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
-      '@solana-mobile/wallet-standard-mobile': 0.4.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
+      '@solana-mobile/mobile-wallet-adapter-protocol-web3js': 2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
+      '@solana-mobile/wallet-standard-mobile': 0.4.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/wallet-standard-features': 1.3.0
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
       js-base64: 3.7.8
     optionalDependencies:
-      '@react-native-async-storage/async-storage': 1.24.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+      '@react-native-async-storage/async-storage': 1.24.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - react
       - react-native
       - typescript
 
-  '@solana-mobile/wallet-standard-mobile@0.4.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)':
+  '@solana-mobile/wallet-standard-mobile@0.4.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)':
     dependencies:
-      '@solana-mobile/mobile-wallet-adapter-protocol': 2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bs58@5.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
+      '@solana-mobile/mobile-wallet-adapter-protocol': 2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bs58@5.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
       '@solana/wallet-standard-chains': 1.1.1
       '@solana/wallet-standard-features': 1.3.0
       '@wallet-standard/base': 1.1.0
@@ -14598,9 +14608,9 @@ snapshots:
       '@wallet-standard/features': 1.1.0
       eventemitter3: 5.0.4
 
-  '@solana/wallet-adapter-react@0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bs58@5.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)':
+  '@solana/wallet-adapter-react@0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bs58@5.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)':
     dependencies:
-      '@solana-mobile/wallet-adapter-mobile': 2.2.5(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
+      '@solana-mobile/wallet-adapter-mobile': 2.2.5(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/wallet-standard-wallet-adapter-react': 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bs58@5.0.0)(react@19.2.3)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
@@ -16254,7 +16264,7 @@ snapshots:
       react-refresh: 0.14.2
     optionalDependencies:
       '@babel/runtime': 7.28.4
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -17727,158 +17737,162 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  expo-apple-authentication@56.0.4(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  expo-apple-authentication@56.0.4(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   expo-application@56.0.3(expo@56.0.9):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
-  expo-asset@56.0.16(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3):
+  expo-asset@56.0.16(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3):
     dependencies:
       '@expo/image-utils': 0.10.1(typescript@6.0.3)
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
-      expo-constants: 56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo-constants: 56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-auth-session@56.0.13(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  expo-auth-session@56.0.13(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       expo-application: 56.0.3(expo@56.0.9)
-      expo-constants: 56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+      expo-constants: 56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       expo-crypto: 56.0.4(expo@56.0.9)
-      expo-linking: 56.0.13(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      expo-web-browser: 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+      expo-linking: 56.0.13(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      expo-web-browser: 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       invariant: 2.2.4
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - expo
       - supports-color
 
-  expo-blur@56.0.3(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  expo-blur@56.0.3(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   expo-build-properties@56.0.18(expo@56.0.9):
     dependencies:
       '@expo/schema-utils': 56.0.1
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       resolve-from: 5.0.0
       semver: 7.8.2
 
-  expo-constants@56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
+  expo-constants@56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
       '@expo/env': 2.3.0
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - supports-color
 
-  expo-constants@56.0.18(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
+  expo-constants@56.0.18(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
       '@expo/env': 2.3.0
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - supports-color
 
   expo-crypto@56.0.4(expo@56.0.9):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
-  expo-dev-client@56.0.19(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
+  expo-dev-client@56.0.19(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
-      expo-dev-launcher: 56.0.19(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
-      expo-dev-menu: 56.0.16(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo-dev-launcher: 56.0.19(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+      expo-dev-menu: 56.0.16(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       expo-dev-menu-interface: 56.0.1(expo@56.0.9)
       expo-manifests: 56.0.4(expo@56.0.9)
       expo-updates-interface: 56.0.2(expo@56.0.9)
     transitivePeerDependencies:
       - react-native
 
-  expo-dev-launcher@56.0.19(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
+  expo-dev-launcher@56.0.19(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
       '@expo/schema-utils': 56.0.1
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
-      expo-dev-menu: 56.0.16(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo-dev-menu: 56.0.16(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       expo-manifests: 56.0.4(expo@56.0.9)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   expo-dev-menu-interface@56.0.1(expo@56.0.9):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
-  expo-dev-menu@56.0.16(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
+  expo-dev-menu@56.0.16(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       expo-dev-menu-interface: 56.0.1(expo@56.0.9)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   expo-device@56.0.4(expo@56.0.9):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       ua-parser-js: 0.7.41
 
   expo-document-picker@56.0.4(expo@56.0.9):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
-  expo-file-system@56.0.8(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
+  expo-file-system@56.0.8(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
-  expo-font@56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  expo-font@56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       fontfaceobserver: 2.3.0
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
-  expo-glass-effect@56.0.4(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  expo-glass-effect@56.0.4(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+
+  expo-haptics@56.0.3(expo@56.0.9):
+    dependencies:
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
   expo-image-loader@56.0.3(expo@56.0.9):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
   expo-image-picker@56.0.18(expo@56.0.9):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       expo-image-loader: 56.0.3(expo@56.0.9)
 
   expo-json-utils@56.0.0: {}
 
   expo-keep-awake@56.0.3(expo@56.0.9)(react@19.2.3):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       react: 19.2.3
 
-  expo-linear-gradient@56.0.4(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  expo-linear-gradient@56.0.4(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
-  expo-linking@56.0.13(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  expo-linking@56.0.13(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
-      expo-constants: 56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+      expo-constants: 56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       invariant: 2.2.4
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - expo
       - supports-color
@@ -17886,14 +17900,14 @@ snapshots:
   expo-location@56.0.22(expo@56.0.9)(typescript@6.0.3):
     dependencies:
       '@expo/image-utils': 0.10.4(typescript@6.0.3)
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
   expo-manifests@56.0.4(expo@56.0.9):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       expo-json-utils: 56.0.0
 
   expo-modules-autolinking@56.0.15(typescript@6.0.3):
@@ -17906,55 +17920,55 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-modules-core@56.0.15(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  expo-modules-core@56.0.15(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       '@expo/expo-modules-macros-plugin': 0.0.9
-      expo-modules-jsi: 56.0.8(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+      expo-modules-jsi: 56.0.8(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       invariant: 2.2.4
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     optionalDependencies:
-      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
 
-  expo-modules-jsi@56.0.8(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
+  expo-modules-jsi@56.0.8(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
-  expo-notifications@56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3):
+  expo-notifications@56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3):
     dependencies:
       '@expo/image-utils': 0.10.1(typescript@6.0.3)
       abort-controller: 3.0.0
       badgin: 1.2.3
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       expo-application: 56.0.3(expo@56.0.9)
-      expo-constants: 56.0.18(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+      expo-constants: 56.0.18(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-router@56.2.9(564bcd835d0b248bd1c8e6861c20bca0):
+  expo-router@56.2.9(bb36438237fbcf319888e30dc0060c53):
     dependencies:
-      '@expo/log-box': 56.0.12(@expo/dom-webview@56.0.5)(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      '@expo/metro-runtime': 56.0.14(@expo/log-box@56.0.12)(expo@56.0.9)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      '@expo/log-box': 56.0.12(@expo/dom-webview@56.0.5)(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      '@expo/metro-runtime': 56.0.14(@expo/log-box@56.0.12)(expo@56.0.9)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@expo/schema-utils': 56.0.1
-      '@expo/ui': 56.0.16(94346998af484511c4f886182959f669)
+      '@expo/ui': 56.0.16(d01a745d9ed6b5cb99c2fd5eca507f23)
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.17)(react@19.2.3)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)
-      '@react-native-masked-view/masked-view': 0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      '@react-native-masked-view/masked-view': 0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       client-only: 0.0.1
       color: 4.2.3
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
-      expo-constants: 56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
-      expo-glass-effect: 56.0.4(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      expo-linking: 56.0.13(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo-constants: 56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+      expo-glass-effect: 56.0.4(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      expo-linking: 56.0.13(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       expo-server: 56.0.5
-      expo-symbols: 56.0.6(expo-font@56.0.5)(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      expo-symbols: 56.0.6(expo-font@56.0.5)(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
       nanoid: 3.3.12
@@ -17962,18 +17976,18 @@ snapshots:
       react: 19.2.3
       react-fast-compare: 3.2.2
       react-is: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
-      react-native-drawer-layout: 4.2.4(react-native-gesture-handler@2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      react-native-safe-area-context: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      react-native-screens: 4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native-drawer-layout: 4.2.4(06d536604f4e3d21ebf12a08385bc763)
+      react-native-safe-area-context: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-screens: 4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       server-only: 0.0.1
       sf-symbols-typescript: 2.2.0
       shallowequal: 1.1.0
       vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)
     optionalDependencies:
       react-dom: 19.2.7(react@19.2.3)
-      react-native-gesture-handler: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-gesture-handler: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
     transitivePeerDependencies:
       - '@babel/core'
       - '@testing-library/dom'
@@ -17983,14 +17997,14 @@ snapshots:
       - react-native-worklets
       - supports-color
 
-  expo-screen-orientation@56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
+  expo-screen-orientation@56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   expo-secure-store@56.0.4(expo@56.0.9):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
   expo-server@56.0.5: {}
 
@@ -17998,65 +18012,65 @@ snapshots:
     dependencies:
       '@expo/config-plugins': 56.0.8(typescript@6.0.3)
       '@expo/image-utils': 0.10.1(typescript@6.0.3)
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       xml2js: 0.6.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-status-bar@56.0.4(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  expo-status-bar@56.0.4(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
-  expo-symbols@56.0.6(expo-font@56.0.5)(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  expo-symbols@56.0.6(expo-font@56.0.5)(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       '@expo-google-fonts/material-symbols': 0.4.38
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
-      expo-font: 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo-font: 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       sf-symbols-typescript: 2.2.0
 
   expo-updates-interface@56.0.2(expo@56.0.9):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
-  expo-web-browser@56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
+  expo-web-browser@56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      expo: 56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
-  expo@56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6):
+  expo@56.0.9(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-router@56.2.9)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6):
     dependencies:
       '@babel/runtime': 7.28.4
-      '@expo/cli': 56.1.14(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-constants@56.0.17)(expo-font@56.0.5)(expo-router@56.2.9)(expo@56.0.9)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@expo/cli': 56.1.14(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.14)(bufferutil@4.1.0)(expo-constants@56.0.17)(expo-font@56.0.5)(expo-router@56.2.9)(expo@56.0.9)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@expo/config': 56.0.9(typescript@6.0.3)
       '@expo/config-plugins': 56.0.8(typescript@6.0.3)
-      '@expo/devtools': 56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      '@expo/devtools': 56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@expo/fingerprint': 0.19.4
       '@expo/local-build-cache-provider': 56.0.8(typescript@6.0.3)
-      '@expo/log-box': 56.0.12(@expo/dom-webview@56.0.5)(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      '@expo/log-box': 56.0.12(@expo/dom-webview@56.0.5)(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@expo/metro': 56.0.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@expo/metro-config': 56.0.13(bufferutil@4.1.0)(expo@56.0.9)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@ungap/structured-clone': 1.3.0
       babel-preset-expo: 56.0.14(@babel/core@7.29.7)(@babel/runtime@7.28.4)(expo@56.0.9)(react-refresh@0.14.2)
-      expo-asset: 56.0.16(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
-      expo-constants: 56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
-      expo-file-system: 56.0.8(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
-      expo-font: 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      expo-asset: 56.0.16(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
+      expo-constants: 56.0.17(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+      expo-file-system: 56.0.8(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+      expo-font: 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       expo-keep-awake: 56.0.3(expo@56.0.9)(react@19.2.3)
       expo-modules-autolinking: 56.0.15(typescript@6.0.3)
-      expo-modules-core: 56.0.15(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      expo-modules-core: 56.0.15(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       pretty-format: 29.7.0
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       react-refresh: 0.14.2
       whatwg-url-minimum: 0.1.2
     optionalDependencies:
-      '@expo/dom-webview': 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      '@expo/metro-runtime': 56.0.14(@expo/log-box@56.0.12)(expo@56.0.9)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      '@expo/dom-webview': 56.0.5(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      '@expo/metro-runtime': 56.0.14(@expo/log-box@56.0.12)(expo@56.0.9)(react-dom@19.2.7(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-dom: 19.2.7(react@19.2.3)
     transitivePeerDependencies:
       - '@babel/core'
@@ -19154,11 +19168,11 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
-  lucide-react-native@0.475.0(react-native-svg@15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  lucide-react-native@0.475.0(react-native-svg@15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
-      react-native-svg: 15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native-svg: 15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
 
   lucide-react@0.544.0(react@19.2.3):
     dependencies:
@@ -20743,15 +20757,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-native-calendars@1.1313.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  react-native-calendars@1.1313.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       hoist-non-react-statics: 3.3.2
       lodash: 4.17.21
       memoize-one: 5.2.1
       prop-types: 15.8.1
-      react-native-safe-area-context: 4.5.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-safe-area-context: 4.5.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-swipe-gestures: 1.0.5
-      recyclerlistview: 4.2.3(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      recyclerlistview: 4.2.3(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       xdate: 0.8.3
     optionalDependencies:
       moment: 2.30.1
@@ -20759,70 +20773,70 @@ snapshots:
       - react
       - react-native
 
-  react-native-drawer-layout@4.2.4(react-native-gesture-handler@2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  react-native-drawer-layout@4.2.4(06d536604f4e3d21ebf12a08385bc763):
     dependencies:
       color: 4.2.3
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
-      react-native-gesture-handler: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native-gesture-handler: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       use-latest-callback: 0.2.6(react@19.2.3)
 
-  react-native-gesture-handler@2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  react-native-gesture-handler@2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       '@types/react-test-renderer': 19.1.0
       hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
-  react-native-is-edge-to-edge@1.3.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  react-native-is-edge-to-edge@1.3.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
-  react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       semver: 7.8.2
 
-  react-native-safe-area-context@4.5.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  react-native-safe-area-context@4.5.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
-  react-native-safe-area-context@5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  react-native-safe-area-context@5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
-  react-native-screens@4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  react-native-screens@4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-freeze: 1.0.4(react@19.2.3)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       warn-once: 0.1.1
 
-  react-native-svg@15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  react-native-svg@15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       css-select: 5.2.2
       css-tree: 1.1.3
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       warn-once: 0.1.1
 
   react-native-swipe-gestures@1.0.5: {}
 
-  react-native-url-polyfill@2.0.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
+  react-native-url-polyfill@2.0.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       whatwg-url-without-unicode: 8.0.0-3
 
-  react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7)
@@ -20834,23 +20848,23 @@ snapshots:
       '@babel/plugin-transform-template-literals': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.7)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.7)
-      '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)
+      '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       convert-source-map: 2.0.0
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       semver: 7.8.2
     transitivePeerDependencies:
       - supports-color
 
-  react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6):
+  react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6):
     dependencies:
       '@react-native/assets-registry': 0.85.3
       '@react-native/codegen': 0.85.3(@babel/core@7.29.7)
-      '@react-native/community-cli-plugin': 0.85.3(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@react-native/community-cli-plugin': 0.85.3(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@react-native/gradle-plugin': 0.85.3
       '@react-native/js-polyfills': 0.85.3
       '@react-native/normalize-colors': 0.85.3
-      '@react-native/virtualized-lists': 0.85.3(@types/react@19.2.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      '@react-native/virtualized-lists': 0.85.3(@types/react@19.2.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -20986,12 +21000,12 @@ snapshots:
       - '@types/react'
       - redux
 
-  recyclerlistview@4.2.3(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  recyclerlistview@4.2.3(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       lodash.debounce: 4.0.8
       prop-types: 15.8.1
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       ts-object-utils: 0.0.5
 
   redent@3.0.0:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Today Day/List schedule views with team or personal scope, upcoming agenda, loading states, and clearer empty states.
  - Added quick creation flows for projects and quotes, plus permission-aware floating and iPad creation menus.
  - Expanded Work search across tasks, clients, projects, quotes, and invoices.
  - Added recently viewed records and improved client/project detail layouts.
  - Added haptic feedback, Apple Maps directions, and refreshed headers.

- **Bug Fixes**
  - Added clearer plan-limit error messages and enforced creation limits.

- **Documentation**
  - Updated mobile app guidance for scheduling, search, creation tools, recent records, and plan limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers the Mobile 3.0 refresh for faster record capture, Today scheduling, Work search, recent records, and permission-aware creation flows. It also adds free-plan client and active-project limits. Those limits are enforced for direct creation but can be exceeded by restoring an archived client or reactivating a completed or cancelled project after the organization is already at capacity. Update the transition paths in `clients.ts` and `projects.ts` to apply the same capacity checks before persisting a counting status.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until free-plan capacity checks also cover restore and project-reactivation transitions.

A focused authenticated Convex persistence harness exercised the affected public mutations at the configured limits, confirmed direct creation is rejected, and then confirmed that the restore and reactivation paths persist records beyond the allowed counts.

**Files Needing Attention:** `packages/backend/convex/clients.ts` needs a capacity check before restoring an archived client, and `packages/backend/convex/projects.ts` needs one before changing a non-active project into an active status.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and referenced the review comment detailing the finding.
- T-Rex produced a proof for a second posted P1 finding and referenced the review comment detailing the finding.
- T-Rex ran the requested verification and noted that local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/backend/convex/clients.ts`, line 1026-1030 ([link](https://github.com/xcarter93/onetool/blob/0284ddf2e252d414bd5f7ed85d147066251f0cd4/packages/backend/convex/clients.ts#L1026-L1030)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Free-plan caps are bypassed by status transitions**

   `restore` changes an archived client to `active` without applying `assertClientCapacity`. The same gap exists in `projects.update` when a completed or cancelled project becomes `planned` or `in-progress`. At the configured limits, these public mutations allow free-plan organizations to exceed their permitted active-client and active-project counts. Apply the matching capacity assertion before either counting-state transition is persisted.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/backend/convex/clients.ts
   Line: 1026-1030

   Comment:
   **Free-plan caps are bypassed by status transitions**

   `restore` changes an archived client to `active` without applying `assertClientCapacity`. The same gap exists in `projects.update` when a completed or cancelled project becomes `planned` or `in-progress`. At the configured limits, these public mutations allow free-plan organizations to exceed their permitted active-client and active-project counts. Apply the matching capacity assertion before either counting-state transition is persisted.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Free-plan caps are bypassed by transitions from non-counting states**

   - **Bug**
     - At the advertised free-plan limits, the public mutations permit records created in a non-counting state to become counting records. The executed harness observed `clients.restore` succeed from archived to active with active-client count 10 → 11. It also observed `projects.update` succeed for completed → planned, completed → in-progress, cancelled → planned, and cancelled → in-progress with active-project count 3 → 4 for the same client. This contradicts the advertised caps and the create-path enforcement.
   - **Cause**
     - Capacity assertions are invoked only by the create handlers. `clients.restore` directly patches `status: "active"` at `packages/backend/convex/clients.ts:1026-1030`, and `projects.update` directly calls `updateProjectWithValidation` at `packages/backend/convex/projects.ts:810` without invoking `assertClientCapacity` or `assertProjectCapacity`.
   - **Fix**
     - Before a counting transition is persisted, invoke the matching capacity assertion for free-plan callers: in `clients.restore`, assert capacity with target status `active`; in `projects.update`, when the effective status changes from completed/cancelled to planned/in-progress, assert project capacity for the effective client. Add regression tests covering the four project transitions and restore-at-cap rejection.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/backend/convex/clients.ts:1026-1030
**Free-plan caps are bypassed by status transitions**

`restore` changes an archived client to `active` without applying `assertClientCapacity`. The same gap exists in `projects.update` when a completed or cancelled project becomes `planned` or `in-progress`. At the configured limits, these public mutations allow free-plan organizations to exceed their permitted active-client and active-project counts. Apply the matching capacity assertion before either counting-state transition is persisted.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mobile): Slice 6 visual-pass round 2..."](https://github.com/xcarter93/onetool/commit/0284ddf2e252d414bd5f7ed85d147066251f0cd4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52273296)</sub>

<!-- /greptile_comment -->