### PR TITLE
fix(review): Greptile round 2 — expired-quote resend guard + refund-r…

### DIFF
--- a/packages/backend/convex/businessHealth.test.ts
+++ b/packages/backend/convex/businessHealth.test.ts
@@ -131,6 +131,44 @@ describe("businessHealth.get", () => {
 		expect(health.recentPayments).toHaveLength(0);
 	});
 
+	it("restores a refunded balance to outstanding when the invoice stayed paid", async () => {
+		// The Stripe refund webhook flips only the payment row — the invoice
+		// keeps status "paid". Its restored balance must still surface.
+		const { clerkUserId, clerkOrgId } = await t.run(async (ctx) => {
+			const org = await createTestOrg(ctx);
+			const clientId = await createTestClient(ctx, org.orgId);
+			const refundedId = await createTestInvoice(ctx, org.orgId, clientId, {
+				status: "paid",
+				total: 10000,
+				dueDate: Date.now() - 5 * DAY_MS,
+			});
+			await insertPayment(ctx, org.orgId, refundedId, {
+				paymentAmount: 10000,
+				status: "refunded",
+				paidAt: Date.now(),
+			});
+			// Control: a settled paid invoice stays excluded.
+			const settledId = await createTestInvoice(ctx, org.orgId, clientId, {
+				status: "paid",
+				total: 4000,
+				dueDate: Date.now() - 5 * DAY_MS,
+			});
+			await insertPayment(ctx, org.orgId, settledId, {
+				paymentAmount: 4000,
+				status: "paid",
+				paidAt: Date.now(),
+			});
+			return org;
+		});
+
+		const asUser = t.withIdentity(createTestIdentity(clerkUserId, clerkOrgId));
+		const health = await asUser.query(api.businessHealth.get, {});
+
+		expect(health.outstanding.total).toBe(10000);
+		expect(health.outstanding.overdue).toBe(10000);
+		expect(health.outstanding.invoiceCount).toBe(1);
+	});
+
 	it("ignores a fully-covered invoice that is still marked sent", async () => {
 		const { clerkUserId, clerkOrgId } = await t.run(async (ctx) => {
 			const org = await createTestOrg(ctx);

--- a/packages/backend/convex/businessHealth.ts
+++ b/packages/backend/convex/businessHealth.ts
@@ -154,12 +154,21 @@ export const get = optionalUserQuery({
 		const overdueInvoices: Doc<"invoices">[] = [];
 
 		for (const invoice of invoices) {
+			const remaining = remainingFor(invoice);
+			// A paid invoice with a remaining balance can only mean a refund
+			// (markPaid settles every payment row) — per the header contract, the
+			// refund restores the balance to outstanding.
+			const isRefundRestored = invoice.status === "paid" && remaining > 0;
 			const isEffectiveOverdue =
 				invoice.status === "overdue" ||
-				(invoice.status === "sent" && invoice.dueDate < now);
-			if (invoice.status !== "sent" && !isEffectiveOverdue) continue;
-
-			const remaining = remainingFor(invoice);
+				((invoice.status === "sent" || isRefundRestored) &&
+					invoice.dueDate < now);
+			if (
+				invoice.status !== "sent" &&
+				!isRefundRestored &&
+				!isEffectiveOverdue
+			)
+				continue;
 			if (remaining <= 0) continue;
 
 			outstandingTotals.push(remaining);

--- a/packages/backend/convex/quotes.sendToClient.test.ts
+++ b/packages/backend/convex/quotes.sendToClient.test.ts
@@ -124,6 +124,49 @@ describe("quotes.sendToClient", () => {
 		expect(typeof quote?.sentAt).toBe("number");
 	});
 
+	it("refuses to send when the valid-until date has passed", async () => {
+		const { asUser, quoteId } = await seed({
+			portalAccess: true,
+			contactEmail: "client@example.com",
+			status: "expired",
+		});
+		// create rejects past dates, so backdate directly — the state a quote
+		// reaches once its window lapses.
+		await t.run(async (ctx) => {
+			await ctx.db.patch(quoteId, {
+				validUntil: Date.now() - 30 * 24 * 60 * 60 * 1000,
+			});
+		});
+
+		await expect(
+			asUser.mutation(api.quotes.sendToClient, { id: quoteId })
+		).rejects.toThrow(/valid-until date has passed/);
+
+		// No revive: the portal must not regain an approvable expired offer.
+		const quote = await asUser.query(api.quotes.get, { id: quoteId });
+		expect(quote?.status).toBe("expired");
+		expect(await pendingQuoteEmails()).toHaveLength(0);
+	});
+
+	it("revives an expired quote whose valid-until date is still ahead", async () => {
+		const { asUser, quoteId } = await seed({
+			portalAccess: true,
+			contactEmail: "client@example.com",
+			status: "expired",
+		});
+		await t.run(async (ctx) => {
+			await ctx.db.patch(quoteId, {
+				validUntil: Date.now() + 30 * 24 * 60 * 60 * 1000,
+			});
+		});
+
+		await asUser.mutation(api.quotes.sendToClient, { id: quoteId });
+		await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+		const quote = await asUser.query(api.quotes.get, { id: quoteId });
+		expect(quote?.status).toBe("sent");
+	});
+
 	it("schedules a server-side PDF render when the quote has no document", async () => {
 		const { asUser, quoteId } = await seed({
 			portalAccess: true,

--- a/packages/backend/convex/quotes.ts
+++ b/packages/backend/convex/quotes.ts
@@ -1069,6 +1069,22 @@ export const sendToClient = userMutation({
 			});
 		}
 
+		// The portal gates approval on sent status alone, so sending is the last
+		// line of defense against putting an expired offer back in front of the
+		// client (extendValidUntil is the revive path that refreshes the window).
+		// Same calendar-day comparison as extendValidUntil: valid through today
+		// still sends.
+		if (quote.validUntil !== undefined) {
+			const tz = (await ctx.db.get(ctx.orgId))?.timezone ?? "UTC";
+			if (quote.validUntil < calendarDayEpoch(Date.now(), tz)) {
+				throw new ConvexError({
+					code: "CONFLICT",
+					message:
+						"This quote's valid-until date has passed — extend it before sending.",
+				});
+			}
+		}
+
 		// The client must be reachable in the portal: portal access enabled and a
 		// primary contact with an email to receive the invite.
 		const client = await ctx.db.get(quote.clientId);


### PR DESCRIPTION
…estored outstanding

sendToClient now refuses to (re)send a quote whose validUntil has passed (same calendar-day comparison as extendValidUntil, which stays the revive path). businessHealth counts a paid invoice's refund-restored balance as outstanding/overdue, matching its own header contract. Regression tests for both.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change prevents quote emails from reopening offers after their valid-until date and returns refunded balances to the Money hub’s outstanding and overdue figures. A reproduced reporting issue remains: manually marking a sent invoice as paid without creating a payment row makes the invoice appear as outstanding and overdue again. Update the restored-balance detection so it requires evidence of a refund rather than inferring one solely from a paid invoice with a remaining balance.

<h3>Confidence Score: 4/5</h3>

Not ready to merge until paid invoices without refund evidence are prevented from returning to outstanding and overdue totals.

The reporting failure was reproduced through the real invoice update mutation and Business Health query in an isolated Convex runtime. The quote expiration guard and refund-restoration behavior are covered by the changed test suites.

**Files Needing Attention:** packages/backend/convex/businessHealth.ts needs the restored-balance condition narrowed to actual refund evidence.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding.
- T-Rex performed a general-contract-validation-proof showing that a paid invoice can retain a positive computed balance without any refund, and Business Health reports it as outstanding and overdue.
- T-Rex produced another proof for a posted P1 finding.

<a href="https://app.greptile.com/trex/runs/18505965/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Paid invoices without payment rows are treated as refund-restored debt**

   - **Bug**
     - A user can manually transition a sent invoice with no payment rows to `paid`. The update mutation leaves it paid with zero payment rows; Business Health computes the full invoice total as remaining and treats the paid status plus positive remaining balance as a refund-restored balance.
   - **Cause**
     - `packages/backend/convex/businessHealth.ts` lines 158-165 infer that every paid invoice with `remaining > 0` must have been refunded, without checking for an actual refunded payment row or another refund indicator.
   - **Fix**
     - Restrict refund-restored treatment to invoices with evidence of a refund (for example, a related payment row in `refunded` status), rather than using only `invoice.status === "paid" && remaining > 0`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/backend/convex/businessHealth.ts:161-165
**Paid invoices without payment rows are treated as refund-restored debt**

A user can manually mark an overdue sent invoice as paid without creating a payment record. That leaves the invoice in `paid` with a positive computed balance, which this condition assumes can only be a refund and therefore adds back to outstanding and overdue totals. Restrict this path to invoices with an actual refunded payment, or another durable refund indicator, so manually settled invoices do not reappear as debt.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(review): Greptile round 2 — expired-..."](https://github.com/xcarter93/onetool/commit/b730081cc42f22315348d333896dcf98d0c9848e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52596957)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->