### PR TITLE
Remove translucency from floating chrome and update styles

### DIFF
--- a/apps/mobile/components/glass-dock.tsx
+++ b/apps/mobile/components/glass-dock.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
-import { BlurView } from "expo-blur";
 import { LinearGradient } from "expo-linear-gradient";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useRouter, usePathname, type Href } from "expo-router";
@@ -96,14 +95,10 @@ export function GlassDock({ state, navigation }: BottomTabBarProps) {
 			]}
 			pointerEvents="box-none"
 		>
-			{/* Pill background: clipped rounded blur + frost. The orb lives in the
-			    unclipped items layer, or the radius clip would behead it. */}
+			{/* Pill background: opaque rounded plate (no blur — content must not
+			    ghost through). The orb lives in the unclipped items layer, or the
+			    radius clip would behead it. */}
 			<View style={styles.pill} pointerEvents="none">
-				<BlurView
-					intensity={40}
-					tint="light"
-					style={StyleSheet.absoluteFill}
-				/>
 				<View style={[StyleSheet.absoluteFill, { backgroundColor: dock.bg }]} />
 			</View>
 

--- a/apps/mobile/components/money/quick-action-row.tsx
+++ b/apps/mobile/components/money/quick-action-row.tsx
@@ -8,7 +8,6 @@ import {
 	StyleSheet,
 	View,
 } from "react-native";
-import { BlurView } from "expo-blur";
 import { MoreHorizontal } from "lucide-react-native";
 import { dock, radii, touch, useTokens } from "@/lib/theme";
 import { Button } from "@/components/ui";
@@ -92,7 +91,6 @@ export function QuickActionRow({
 				<Button
 					title={secondary.label}
 					variant="primary"
-					blurred={floating}
 					onPress={() => fire(secondary)}
 					style={StyleSheet.flatten([
 						styles.grow,
@@ -108,14 +106,13 @@ export function QuickActionRow({
 					onPress={openOverflow}
 					style={({ pressed }) => [
 						styles.more,
-						// Floating bar: glass like the dock, so the dot grid reads
-						// through it (frame 1h) — an opaque plate looks like a hole
-						// in the canvas texture. Inline bars stay card-colored.
+						// Floating bar: opaque white like the dock pill — alpha/blur
+						// here let scrolling content ghost through on device. Inline
+						// bars stay card-colored.
 						floating
 							? {
 									backgroundColor: pressed ? t.secondary : dock.bg,
 									borderColor: dock.border,
-									overflow: "hidden" as const,
 								}
 							: {
 									backgroundColor: pressed ? t.secondary : t.card,
@@ -123,14 +120,6 @@ export function QuickActionRow({
 								},
 					]}
 				>
-					{floating ? (
-						<BlurView
-							intensity={dock.blur}
-							tint="light"
-							style={StyleSheet.absoluteFill}
-							pointerEvents="none"
-						/>
-					) : null}
 					<MoreHorizontal size={18} color={t.ink} />
 				</Pressable>
 			) : null}

--- a/apps/mobile/components/ui/button.tsx
+++ b/apps/mobile/components/ui/button.tsx
@@ -6,7 +6,6 @@ import {
 	View,
 	type ViewStyle,
 } from "react-native";
-import { BlurView } from "expo-blur";
 import { fontFamily, radii, shadow, touch, type, useTokens } from "@/lib/theme";
 
 type ButtonVariant = "primary" | "solid" | "secondary" | "ghost";
@@ -16,8 +15,8 @@ interface ButtonProps {
 	title: string;
 	onPress?: () => void;
 	/**
-	 * `primary` is the frosted-blue treatment shared with web (translucent sky
-	 * tint + soft blue ring). `solid` is the opaque blue fill — reserve it for the
+	 * `primary` is the frosted-blue treatment shared with web (pre-composited
+	 * sky tint + soft blue ring). `solid` is the opaque blue fill — reserve it for the
 	 * one element per screen that must out-shout everything, or for buttons on a
 	 * dark/photographic ground where a tint would vanish.
 	 */
@@ -26,12 +25,6 @@ interface ButtonProps {
 	size?: ButtonSize;
 	icon?: React.ReactNode;
 	disabled?: boolean;
-	/**
-	 * Render a real blur behind the tint. Only meaningful when the button sits
-	 * over content (map, photo, sheet scrim) — on an opaque card it is a no-op
-	 * and costs a native view, so it defaults off.
-	 */
-	blurred?: boolean;
 	style?: ViewStyle | ViewStyle[];
 }
 
@@ -42,7 +35,6 @@ export function Button({
 	size = "md",
 	icon,
 	disabled,
-	blurred,
 	style,
 }: ButtonProps) {
 	const t = useTokens();
@@ -51,23 +43,13 @@ export function Button({
 		switch (variant) {
 			case "primary":
 				// The tint step alone is a 1.05:1 delta — imperceptible. The border
-				// does the perceptible work on press. Over glass the translucent
-				// tints are load-bearing (an opaque plate reads as a hole in the
-				// canvas texture); everywhere else frosted is opaque.
+				// does the perceptible work on press. Frosted is ALWAYS the opaque
+				// pre-composited tint: alpha fills over scrolling content ghost
+				// through on device (the old `blurred` glass path).
 				return {
-					backgroundColor: blurred
-						? pressed
-							? t.frostedGlassBgPressed
-							: t.frostedGlassBg
-						: pressed
-							? t.frostedBgPressed
-							: t.frostedBg,
+					backgroundColor: pressed ? t.frostedBgPressed : t.frostedBg,
 					borderWidth: 1,
-					borderColor: pressed
-						? t.primaryInk
-						: blurred
-							? t.frostedGlassBorder
-							: t.frostedBorder,
+					borderColor: pressed ? t.primaryInk : t.frostedBorder,
 					boxShadow: shadow.xs,
 				};
 			case "solid":
@@ -105,14 +87,6 @@ export function Button({
 				style,
 			]}
 		>
-			{blurred && variant === "primary" ? (
-				<BlurView
-					intensity={18}
-					tint="light"
-					style={StyleSheet.absoluteFill}
-					pointerEvents="none"
-				/>
-			) : null}
 			<View style={styles.content}>
 				{icon}
 				<Text

--- a/apps/mobile/lib/theme.ts
+++ b/apps/mobile/lib/theme.ts
@@ -63,14 +63,11 @@ export const tokens = {
 	// OPAQUE since Slice 8: the old alpha values (#00a6f4 @ 10/15/30%) let the dot
 	// grid and anything underneath ghost through every frosted button. These are
 	// those same tints pre-composited over `bg` #f6f7f8 — identical hue, no
-	// see-through. The translucent originals live on as `frostedGlass*`, ONLY for
-	// elements over a BlurView (the floating quote CTA), where alpha IS the glass.
+	// see-through. The translucent `frostedGlass*` variants (kept for the floating
+	// quote CTA) are gone: alpha over scrolling content reads as broken on device.
 	frostedBg: "#ddeff8", // primary @ 10% over bg
 	frostedBgPressed: "#d1ebf7", // primary @ 15% over bg (web's hover)
 	frostedBorder: "#acdff7", // primary @ 30% over bg
-	frostedGlassBg: "#00a6f41A",
-	frostedGlassBgPressed: "#00a6f426",
-	frostedGlassBorder: "#00a6f44D",
 	frostedInk: "#0369a1",
 	/** Solid blue fills that carry WHITE content. #00a6f4 + white is 2.7:1 (under
 	 * even the 3:1 non-text floor) and #0084d1 is 4.0:1 — fine for a glyph but
@@ -190,15 +187,15 @@ export const hero = {
 } as const;
 
 export const dock = {
-	/** Floating white glass pill. */
-	bg: "rgba(255,255,255,.86)",
+	/** Floating white pill. Opaque: any alpha lets scrolling content ghost
+	 *  through on device (far more visible than in the simulator). */
+	bg: "#ffffff",
 	border: "rgba(23,24,26,.08)",
 	shadow: "0 12px 32px rgba(15,30,40,.16)",
 	height: 60,
 	radius: 30,
 	sideInset: 16,
 	bottomInset: 14,
-	blur: 18,
 	/** Orb: 50px gradient squircle, risen 16px above the pill's top edge. */
 	orbSize: 50,
 	orbRise: 16,


### PR DESCRIPTION
This pull request removes all use of blurred glass (using `BlurView` and translucent backgrounds) from the mobile app's dock, quick action row, and buttons. Instead, it standardizes these UI elements to use fully opaque backgrounds, addressing issues where alpha or blur allowed underlying content to "ghost" through on real devices. The change simplifies the codebase, eliminates unnecessary props and tokens, and updates comments and documentation to reflect the new design direction.

**UI Refactor: Removal of Blur and Translucency**

- All instances of `BlurView` and alpha backgrounds have been removed from the dock, quick action row, and button components. These elements now use opaque backgrounds to prevent content from showing through, ensuring a more consistent and visually solid UI across devices. [[1]](diffhunk://#diff-a4276d31b1638f100544e9f37b48433ffeb074d6430a56c23bf67434915b7b3aL3) [[2]](diffhunk://#diff-a4276d31b1638f100544e9f37b48433ffeb074d6430a56c23bf67434915b7b3aL99-L106) [[3]](diffhunk://#diff-55d0d0b3af9d5a9ef31625f864d64cfa05cbb7fd10552649e96a0f8e6dcbe41bL11) [[4]](diffhunk://#diff-55d0d0b3af9d5a9ef31625f864d64cfa05cbb7fd10552649e96a0f8e6dcbe41bL95) [[5]](diffhunk://#diff-55d0d0b3af9d5a9ef31625f864d64cfa05cbb7fd10552649e96a0f8e6dcbe41bL111-L133) [[6]](diffhunk://#diff-15a620e03d5d8a597e5d73a345b6b9056c87d1205122a6da465432c0430a056eL9) [[7]](diffhunk://#diff-15a620e03d5d8a597e5d73a345b6b9056c87d1205122a6da465432c0430a056eL45) [[8]](diffhunk://#diff-15a620e03d5d8a597e5d73a345b6b9056c87d1205122a6da465432c0430a056eL54-R52) [[9]](diffhunk://#diff-15a620e03d5d8a597e5d73a345b6b9056c87d1205122a6da465432c0430a056eL108-L115) [[10]](diffhunk://#diff-85364c7a373ed2cc453a00ae526a2ac08787c146deca20434f6044244318748fL193-L201)

**Component and Prop Cleanup**

- The `blurred` prop has been removed from the `Button` component and its usage in all relevant places, as blurred backgrounds are no longer supported or necessary. [[1]](diffhunk://#diff-15a620e03d5d8a597e5d73a345b6b9056c87d1205122a6da465432c0430a056eL29-L34) [[2]](diffhunk://#diff-15a620e03d5d8a597e5d73a345b6b9056c87d1205122a6da465432c0430a056eL45) [[3]](diffhunk://#diff-15a620e03d5d8a597e5d73a345b6b9056c87d1205122a6da465432c0430a056eL54-R52) [[4]](diffhunk://#diff-15a620e03d5d8a597e5d73a345b6b9056c87d1205122a6da465432c0430a056eL108-L115) [[5]](diffhunk://#diff-55d0d0b3af9d5a9ef31625f864d64cfa05cbb7fd10552649e96a0f8e6dcbe41bL95)

**Theme and Token Updates**

- The `frostedGlass*` color tokens and related comments have been removed from the theme, as translucent variants are no longer used. All references now point to pre-composited, opaque tints. The dock background is now a solid white (`#ffffff`), and the blur intensity token has been removed. [[1]](diffhunk://#diff-85364c7a373ed2cc453a00ae526a2ac08787c146deca20434f6044244318748fL66-L73) [[2]](diffhunk://#diff-85364c7a373ed2cc453a00ae526a2ac08787c146deca20434f6044244318748fL193-L201)

**Documentation and Comments**

- Inline comments and documentation have been updated to clarify that all frosted or glass-like UI elements are now fully opaque, and to explain the rationale behind these changes (i.e., fixing ghosting issues on device). [[1]](diffhunk://#diff-a4276d31b1638f100544e9f37b48433ffeb074d6430a56c23bf67434915b7b3aL99-L106) [[2]](diffhunk://#diff-55d0d0b3af9d5a9ef31625f864d64cfa05cbb7fd10552649e96a0f8e6dcbe41bL111-L133) [[3]](diffhunk://#diff-15a620e03d5d8a597e5d73a345b6b9056c87d1205122a6da465432c0430a056eL19-R19) [[4]](diffhunk://#diff-15a620e03d5d8a597e5d73a345b6b9056c87d1205122a6da465432c0430a056eL54-R52) [[5]](diffhunk://#diff-85364c7a373ed2cc453a00ae526a2ac08787c146deca20434f6044244318748fL66-L73) [[6]](diffhunk://#diff-85364c7a373ed2cc453a00ae526a2ac08787c146deca20434f6044244318748fL193-L201)

**Visual Consistency**

- Ensures that all floating UI elements (dock, quick action row, buttons) have a consistent, solid appearance, improving legibility and visual polish across the app. [[1]](diffhunk://#diff-a4276d31b1638f100544e9f37b48433ffeb074d6430a56c23bf67434915b7b3aL99-L106) [[2]](diffhunk://#diff-55d0d0b3af9d5a9ef31625f864d64cfa05cbb7fd10552649e96a0f8e6dcbe41bL111-L133) [[3]](diffhunk://#diff-15a620e03d5d8a597e5d73a345b6b9056c87d1205122a6da465432c0430a056eL54-R52) [[4]](diffhunk://#diff-85364c7a373ed2cc453a00ae526a2ac08787c146deca20434f6044244318748fL193-L201)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces translucent and blurred mobile floating chrome with opaque backgrounds to prevent underlying content from ghosting through.
- Removes `BlurView` usage from the dock, quick-action row, and shared button.
- Removes the obsolete `blurred` button prop and translucent theme tokens.
- Standardizes floating controls on opaque, pre-composited colors.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete functional, build, or security regressions identified.

The removed component props and theme fields have no remaining programmatic consumers, and the updated controls retain valid opaque backgrounds, sizing, and containment.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/mobile/components/glass-dock.tsx | Replaces the dock’s blur layer with an opaque background while preserving its layout and interaction structure. |
| apps/mobile/components/money/quick-action-row.tsx | Removes floating-action blur rendering and uses opaque dock and button colors without leaving stale API references. |
| apps/mobile/components/ui/button.tsx | Removes the optional blurred rendering path so primary buttons consistently use opaque frosted tokens. |
| apps/mobile/lib/theme.ts | Deletes unused translucent and blur tokens and changes the dock background to solid white. |

<sub>Reviews (1): Last reviewed commit: ["fix(mobile): kill translucency on floati..."](https://github.com/xcarter93/onetool/commit/03a29e58669757d6cbbb8703b88bacd9e7c94657) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52611026)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated mobile navigation, action, and button surfaces to use solid backgrounds and borders instead of blur effects.
  * Refined frosted button colors for a more consistent appearance.
* **Bug Fixes**
  * Improved visual consistency and rendering reliability by removing runtime blur overlays from key controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->