### PR TITLE
Implement quote and invoice sending to client portal on web

### DIFF
--- a/apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-header.tsx
+++ b/apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-header.tsx
@@ -35,6 +35,8 @@ interface InvoiceDetailHeaderProps {
 	onStatusChange: (status: InvoiceStatus) => void;
 	onMarkPaid: () => void;
 	onSendToClient: () => void;
+	/** True while the send-to-client mutation is in flight. */
+	sending?: boolean;
 	onGeneratePdf: () => void;
 	onCancel: () => void;
 }
@@ -45,6 +47,7 @@ export function InvoiceDetailHeader({
 	onStatusChange,
 	onMarkPaid,
 	onSendToClient,
+	sending = false,
 	onGeneratePdf,
 	onCancel,
 }: InvoiceDetailHeaderProps) {
@@ -132,13 +135,19 @@ export function InvoiceDetailHeader({
 	const actions: RecordAction[] = [
 		...statusActions,
 		{
+			// Emails the portal invite. Hidden on paid/cancelled invoices, which the
+			// backend rejects; sent/overdue re-send the same link.
 			key: "send-to-client",
-			label: "Send to Client",
+			label:
+				currentStatus === "draft" ? "Send to Client" : "Resend to Client",
 			icon: <Mail className="h-4 w-4" />,
 			slot: "secondary",
 			variant: "outline",
 			onClick: onSendToClient,
-			disabled: !canModify,
+			disabled: !canModify || sending,
+			loading: sending,
+			loadingLabel: "Sending…",
+			hidden: currentStatus === "paid" || currentStatus === "cancelled",
 		},
 		{
 			key: "generate-pdf",

--- a/apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-header.tsx
+++ b/apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-header.tsx
@@ -53,6 +53,9 @@ export function InvoiceDetailHeader({
 }: InvoiceDetailHeaderProps) {
 	const { can } = usePermissions();
 	const canModify = can("invoices", "modify");
+	// Status writes race an in-flight send, so they wait it out. The send row
+	// itself and Cancel (modal-gated) keep using `canModify` directly.
+	const canModifyNow = canModify && !sending;
 
 	// Status-dependent actions. The primary next step for each status is pinned
 	// left ("start"); everything else is secondary and collapses into the ⋯ menu.
@@ -67,7 +70,7 @@ export function InvoiceDetailHeader({
 						slot: "start",
 						variant: "default",
 						onClick: () => onStatusChange("sent"),
-						disabled: !canModify,
+						disabled: !canModifyNow,
 					},
 					{
 						// TODO(reui-rebuild): success button intent mapped to default
@@ -77,7 +80,7 @@ export function InvoiceDetailHeader({
 						slot: "start",
 						variant: "default",
 						onClick: onMarkPaid,
-						disabled: !canModify,
+						disabled: !canModifyNow,
 					},
 				];
 			case "sent":
@@ -91,7 +94,7 @@ export function InvoiceDetailHeader({
 						slot: "start",
 						variant: "default",
 						onClick: onMarkPaid,
-						disabled: !canModify,
+						disabled: !canModifyNow,
 					},
 					{
 						key: "revert-draft",
@@ -100,7 +103,7 @@ export function InvoiceDetailHeader({
 						slot: "secondary",
 						variant: "outline",
 						onClick: () => onStatusChange("draft"),
-						disabled: !canModify,
+						disabled: !canModifyNow,
 					},
 				];
 			case "paid":
@@ -112,7 +115,7 @@ export function InvoiceDetailHeader({
 						slot: "start",
 						variant: "outline",
 						onClick: () => onStatusChange("sent"),
-						disabled: !canModify,
+						disabled: !canModifyNow,
 					},
 				];
 			case "cancelled":
@@ -124,7 +127,7 @@ export function InvoiceDetailHeader({
 						slot: "start",
 						variant: "outline",
 						onClick: () => onStatusChange("draft"),
-						disabled: !canModify,
+						disabled: !canModifyNow,
 					},
 				];
 			default:

--- a/apps/web/src/app/(workspace)/invoices/[invoiceId]/page.tsx
+++ b/apps/web/src/app/(workspace)/invoices/[invoiceId]/page.tsx
@@ -61,6 +61,7 @@ function InvoiceDetailPageContent() {
 	const [isPaymentsModalOpen, setIsPaymentsModalOpen] = useState(false);
 	const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
 	const [showPreviewModal, setShowPreviewModal] = useState(false);
+	const [isSending, setIsSending] = useState(false);
 
 	// Queries
 	const invoiceWithPayments = useQuery(api.invoices.getWithPayments, {
@@ -215,6 +216,8 @@ function InvoiceDetailPageContent() {
 	};
 
 	const handleSendToClient = async () => {
+		if (isSending) return;
+		setIsSending(true);
 		try {
 			await sendToClient({ id: invoiceId });
 			toast.success(
@@ -225,6 +228,8 @@ function InvoiceDetailPageContent() {
 			const message =
 				convexErrorMessage(err, "Failed to send invoice");
 			toast.error("Couldn't send invoice", message);
+		} finally {
+			setIsSending(false);
 		}
 	};
 
@@ -393,6 +398,7 @@ function InvoiceDetailPageContent() {
 					onStatusChange={handleStatusChange}
 					onMarkPaid={handleMarkPaid}
 					onSendToClient={handleSendToClient}
+					sending={isSending}
 					onGeneratePdf={handleGeneratePdf}
 					onCancel={() => setIsCancelModalOpen(true)}
 				/>

--- a/apps/web/src/app/(workspace)/invoices/components/invoice-detail-drawer.tsx
+++ b/apps/web/src/app/(workspace)/invoices/components/invoice-detail-drawer.tsx
@@ -10,8 +10,8 @@ import {
 	ExternalLink,
 	Loader2,
 	Lock,
+	Mail,
 	Receipt,
-	Send,
 } from "lucide-react";
 
 import { StatusBadge } from "@/components/domain/status-badge";
@@ -50,6 +50,7 @@ import { QuickBooksSyncField } from "@/components/quickbooks/sync-status-row";
 import { formatCurrency } from "@/lib/money";
 import { utcMidnightMsToLocalDate } from "@/lib/dates";
 import { useToast } from "@/hooks/use-toast";
+import { convexErrorMessage } from "@/lib/convex-error";
 
 type InvoiceStatus = Doc<"invoices">["status"];
 type PaymentStatus = Doc<"payments">["status"];
@@ -117,8 +118,10 @@ export function InvoiceDetailDrawer({
 		invoiceId ? { id: invoiceId } : "skip"
 	);
 	const markPaid = useMutation(api.invoices.markPaid);
-	const updateInvoice = useMutation(api.invoices.update);
+	const sendInvoiceToClient = useMutation(api.invoices.sendToClient);
 	const [pending, setPending] = React.useState(false);
+	// Separate from `pending` so the spinner lands on the send row only.
+	const [sending, setSending] = React.useState(false);
 
 	const loading = invoiceId !== null && preview === undefined;
 	const notFound = invoiceId !== null && preview === null;
@@ -156,15 +159,22 @@ export function InvoiceDetailDrawer({
 	};
 
 	const handleSend = async () => {
-		if (!invoiceId) return;
-		setPending(true);
+		if (!invoiceId || sending) return;
+		setSending(true);
 		try {
-			await updateInvoice({ id: invoiceId, status: "sent" });
+			await sendInvoiceToClient({ id: invoiceId });
+			toast.success(
+				"Invoice sent",
+				"Your client will get an email to view and pay it in the portal."
+			);
 		} catch (err) {
 			console.error("Failed to send invoice:", err);
-			toast.error("Couldn't send invoice", "Please try again.");
+			toast.error(
+				"Couldn't send invoice",
+				convexErrorMessage(err, "Please try again.")
+			);
 		} finally {
-			setPending(false);
+			setSending(false);
 		}
 	};
 
@@ -184,18 +194,24 @@ export function InvoiceDetailDrawer({
 			onClick: handleMarkPaid,
 			variant: "default",
 			slot: "start",
-			disabled: pending || !can("invoices", "modify"),
+			disabled: pending || sending || !can("invoices", "modify"),
 			hidden: !canMarkPaid,
 		},
 		{
-			key: "send",
-			label: "Send",
-			icon: <Send className="size-3.5" />,
-			onClick: handleSend,
+			// Emails the portal invite. Hidden on paid/cancelled invoices, which the
+			// backend rejects; sent/overdue re-send the same link.
+			key: "send-to-client",
+			label:
+				effectiveStatus === "draft" ? "Send to client" : "Resend to client",
+			icon: <Mail className="size-3.5" />,
+			onClick: () => void handleSend(),
 			variant: "outline",
 			slot: "secondary",
-			disabled: pending || !can("invoices", "modify"),
-			hidden: effectiveStatus !== "draft",
+			disabled: pending || sending || !can("invoices", "modify"),
+			loading: sending,
+			loadingLabel: "Sending…",
+			hidden:
+				effectiveStatus === "paid" || effectiveStatus === "cancelled",
 		},
 	];
 

--- a/apps/web/src/app/(workspace)/invoices/components/invoice-detail-drawer.tsx
+++ b/apps/web/src/app/(workspace)/invoices/components/invoice-detail-drawer.tsx
@@ -296,6 +296,7 @@ export function InvoiceDetailDrawer({
 							invoiceId={invoice._id}
 							currentStatus={effectiveStatus}
 							canModify={canModify}
+							busy={sending}
 						/>
 					</DrawerSection>
 
@@ -406,10 +407,13 @@ function StatusControl({
 	invoiceId,
 	currentStatus,
 	canModify,
+	busy = false,
 }: {
 	invoiceId: Id<"invoices">;
 	currentStatus: InvoiceStatus;
 	canModify: boolean;
+	/** A send is in flight: its status write would race this one. */
+	busy?: boolean;
 }) {
 	const updateInvoice = useMutation(api.invoices.update);
 	const toast = useToast();
@@ -442,7 +446,7 @@ function StatusControl({
 				<Select
 					value={status}
 					onValueChange={(v) => setStatus(v as InvoiceStatus)}
-					disabled={!canModify}
+					disabled={!canModify || busy}
 				>
 					<SelectTrigger className="h-9 flex-1">
 						<SelectValue />
@@ -456,7 +460,7 @@ function StatusControl({
 					</SelectContent>
 				</Select>
 				{dirty ? (
-					<Button size="sm" disabled={saving} onClick={handleSave}>
+					<Button size="sm" disabled={saving || busy} onClick={handleSave}>
 						{saving && <Loader2 className="h-4 w-4 animate-spin" />}
 						{saving ? "Saving…" : "Save"}
 					</Button>

--- a/apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-header.tsx
+++ b/apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-header.tsx
@@ -30,6 +30,7 @@ import {
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { usePermissions } from "@/hooks/use-permissions";
+import { todayUtcMidnightMs } from "@/lib/dates";
 import { cn } from "@/lib/utils";
 
 type QuoteStatus = "draft" | "sent" | "approved" | "declined" | "expired";
@@ -71,6 +72,13 @@ export function QuoteDetailHeader({
 	const canModifyQuote = can("quotes", "modify");
 	const canDeleteQuote = can("quotes", "delete");
 	const canModifyInvoice = can("invoices", "modify");
+
+	// The backend refuses to send a quote whose valid-until day has passed; the
+	// sidebar's Valid until field is the revive path. Compared as calendar days,
+	// same as the backend, so the final valid day still sends.
+	const validUntilPassed =
+		typeof quote.validUntil === "number" &&
+		quote.validUntil < todayUtcMidnightMs();
 
 	// Reverting a sent quote pulls it out of the client's portal, so it confirms.
 	const [showRevertConfirm, setShowRevertConfirm] = useState(false);
@@ -165,7 +173,10 @@ export function QuoteDetailHeader({
 			slot: "secondary",
 			variant: "outline",
 			onClick: onSendToClient,
-			disabled: !canModifyQuote || sending,
+			disabled: !canModifyQuote || sending || validUntilPassed,
+			disabledReason: validUntilPassed
+				? "Extend the valid-until date before sending"
+				: undefined,
 			loading: sending,
 			loadingLabel: "Sending…",
 			hidden: currentStatus === "approved",

--- a/apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-header.tsx
+++ b/apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-header.tsx
@@ -5,6 +5,7 @@ import { StatusProgressBar } from "@/components/shared/status-progress-bar";
 import { StickyDetailHeader } from "@/components/shared/sticky-detail-header";
 import {
 	PenLine,
+	Mail,
 	FileText,
 	Trash2,
 	Check,
@@ -37,7 +38,11 @@ interface QuoteDetailHeaderProps {
 	quote: Doc<"quotes">;
 	currentStatus: QuoteStatus;
 	onStatusChange: (status: QuoteStatus) => void;
+	/** Emails the client a portal invite for this quote (quotes.sendToClient). */
 	onSendToClient: () => void;
+	/** True while the send-to-client mutation is in flight. */
+	sending?: boolean;
+	onSendForSignature: () => void;
 	/** Disable "Send for e-signature" when the monthly e-signature cap is reached. */
 	sendDisabled?: boolean;
 	sendDisabledReason?: string;
@@ -53,6 +58,8 @@ export function QuoteDetailHeader({
 	currentStatus,
 	onStatusChange,
 	onSendToClient,
+	sending = false,
+	onSendForSignature,
 	sendDisabled = false,
 	sendDisabledReason,
 	onGeneratePdf,
@@ -149,12 +156,27 @@ export function QuoteDetailHeader({
 	const actions: RecordAction[] = [
 		...statusActions,
 		{
+			// Emails the portal invite. Hidden on approved quotes — the backend
+			// rejects those (convert to an invoice instead), same as mobile.
+			key: "send-to-client",
+			label:
+				currentStatus === "sent" ? "Resend to Client" : "Send to Client",
+			icon: <Mail className="h-4 w-4" />,
+			slot: "secondary",
+			variant: "outline",
+			onClick: onSendToClient,
+			disabled: !canModifyQuote || sending,
+			loading: sending,
+			loadingLabel: "Sending…",
+			hidden: currentStatus === "approved",
+		},
+		{
 			key: "send-esign",
 			label: "Send for e-signature",
 			icon: <PenLine className="h-4 w-4" />,
 			slot: "secondary",
 			variant: "outline",
-			onClick: onSendToClient,
+			onClick: onSendForSignature,
 			disabled: sendDisabled || !canModifyQuote,
 			disabledReason: sendDisabled ? sendDisabledReason : undefined,
 		},

--- a/apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-header.tsx
+++ b/apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-header.tsx
@@ -72,6 +72,10 @@ export function QuoteDetailHeader({
 	const canModifyQuote = can("quotes", "modify");
 	const canDeleteQuote = can("quotes", "delete");
 	const canModifyInvoice = can("invoices", "modify");
+	// A send in flight races any status write on the same quote: approve first
+	// and the send comes back "already approved". The conflicting writes wait it
+	// out; Delete stays live, being modal-gated and an abort either way.
+	const canModifyNow = canModifyQuote && !sending;
 
 	// The backend refuses to send a quote whose valid-until day has passed; the
 	// sidebar's Valid until field is the revive path. Compared as calendar days,
@@ -96,7 +100,7 @@ export function QuoteDetailHeader({
 						slot: "start",
 						variant: "default",
 						onClick: () => onStatusChange("sent"),
-						disabled: !canModifyQuote,
+						disabled: !canModifyNow,
 					},
 				];
 			case "sent":
@@ -109,7 +113,7 @@ export function QuoteDetailHeader({
 						slot: "start",
 						variant: "default",
 						onClick: () => onStatusChange("approved"),
-						disabled: !canModifyQuote,
+						disabled: !canModifyNow,
 					},
 					{
 						key: "revert-to-draft",
@@ -118,7 +122,7 @@ export function QuoteDetailHeader({
 						slot: "secondary",
 						variant: "outline",
 						onClick: () => setShowRevertConfirm(true),
-						disabled: !canModifyQuote,
+						disabled: !canModifyNow,
 					},
 				];
 			case "approved":
@@ -130,7 +134,7 @@ export function QuoteDetailHeader({
 						slot: "start",
 						variant: "default",
 						onClick: onConvertToInvoice,
-						disabled: !canModifyInvoice || converting,
+						disabled: !canModifyInvoice || converting || sending,
 						loading: converting,
 					},
 					{
@@ -140,7 +144,7 @@ export function QuoteDetailHeader({
 						slot: "secondary",
 						variant: "outline",
 						onClick: () => onStatusChange("draft"),
-						disabled: !canModifyQuote,
+						disabled: !canModifyNow,
 					},
 				];
 			case "declined":
@@ -153,7 +157,7 @@ export function QuoteDetailHeader({
 						slot: "start",
 						variant: "outline",
 						onClick: () => onStatusChange("draft"),
-						disabled: !canModifyQuote,
+						disabled: !canModifyNow,
 					},
 				];
 			default:

--- a/apps/web/src/app/(workspace)/quotes/[quoteId]/page.tsx
+++ b/apps/web/src/app/(workspace)/quotes/[quoteId]/page.tsx
@@ -18,7 +18,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import { QuoteDetailHeader } from "./components/quote-detail-header";
 import { QuoteDetailTabs } from "./components/quote-detail-tabs";
-import { localDateToUtcMidnightMs } from "@/lib/dates";
+import { localDateToUtcMidnightMs, todayUtcMidnightMs } from "@/lib/dates";
 import { convexErrorMessage } from "@/lib/convex-error";
 
 type QuoteStatus = "draft" | "sent" | "approved" | "declined" | "expired";
@@ -28,7 +28,7 @@ const getQuoteStatus = (
 	validUntilDate?: number
 ): QuoteStatus => {
 	if (status === "expired") return "expired";
-	if (validUntilDate && validUntilDate < Date.now()) return "expired";
+	if (validUntilDate && validUntilDate < todayUtcMidnightMs()) return "expired";
 	return status;
 };
 

--- a/apps/web/src/app/(workspace)/quotes/[quoteId]/page.tsx
+++ b/apps/web/src/app/(workspace)/quotes/[quoteId]/page.tsx
@@ -67,6 +67,7 @@ function QuoteDetailPageContent() {
 	const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 	const [isDeleting, setIsDeleting] = useState(false);
 	const [isConverting, setIsConverting] = useState(false);
+	const [isSending, setIsSending] = useState(false);
 
 	// Queries
 	const quote = useQuery(api.quotes.get, { id: quoteId });
@@ -130,6 +131,7 @@ function QuoteDetailPageContent() {
 	const generateUploadUrl = useMutation(api.documents.generateUploadUrl);
 	const createDocument = useMutation(api.documents.create);
 	const createInvoiceFromQuote = useMutation(api.invoices.createFromQuote);
+	const sendQuoteToClient = useMutation(api.quotes.sendToClient);
 
 	// Plan gate for e-signature sends (server-enforced; this drives button UX).
 	const esignAccess = useCanPerformAction("send_esignature");
@@ -399,7 +401,7 @@ function QuoteDetailPageContent() {
 		}
 	};
 
-	const handleSendToClient = () => {
+	const handleSendForSignature = () => {
 		if (isLatestDocumentLoading) return; // still resolving — ignore the click
 		if (latestDocument === null) {
 			toast.error("No PDF", "Generate a PDF first");
@@ -414,6 +416,23 @@ function QuoteDetailPageContent() {
 			);
 		}
 		router.push(`/quotes/${quoteId}/sign`);
+	};
+
+	const handleSendToClient = async () => {
+		if (isSending) return;
+		setIsSending(true);
+		try {
+			await sendQuoteToClient({ id: quoteId });
+			toast.success(
+				"Quote sent",
+				"Your client will get an email to view and approve it in the portal."
+			);
+		} catch (err) {
+			const message = convexErrorMessage(err, "Failed to send quote");
+			toast.error("Couldn't send quote", message);
+		} finally {
+			setIsSending(false);
+		}
 	};
 
 	// Loading state
@@ -465,6 +484,8 @@ function QuoteDetailPageContent() {
 					currentStatus={currentStatus}
 					onStatusChange={handleStatusChange}
 					onSendToClient={handleSendToClient}
+					sending={isSending}
+					onSendForSignature={handleSendForSignature}
 					sendDisabled={sendBlocked || isLatestDocumentLoading}
 					sendDisabledReason={
 						isLatestDocumentLoading

--- a/apps/web/src/app/(workspace)/quotes/components/quote-detail-drawer.tsx
+++ b/apps/web/src/app/(workspace)/quotes/components/quote-detail-drawer.tsx
@@ -50,7 +50,7 @@ import {
 	formatActivityTime,
 } from "@/components/shared/detail-drawer";
 import { formatCurrency } from "@/lib/money";
-import { utcMidnightMsToLocalDate } from "@/lib/dates";
+import { todayUtcMidnightMs, utcMidnightMsToLocalDate } from "@/lib/dates";
 import { convexErrorMessage } from "@/lib/convex-error";
 
 type QuoteStatus = Doc<"quotes">["status"];
@@ -206,6 +206,12 @@ export function QuoteDetailDrawer({
 				? "Loading…"
 				: "Quote");
 
+	// Mirrors the backend's send guard (calendar-day comparison, so the final
+	// valid day still sends) and the record header's disabled reason.
+	const validUntilPassed =
+		typeof quote?.validUntil === "number" &&
+		quote.validUntil < todayUtcMidnightMs();
+
 	const canSend = quote?.status === "draft" || quote?.status === "sent";
 	const canDecide = quote?.status === "sent";
 	const isApproved = quote?.status === "approved";
@@ -229,7 +235,10 @@ export function QuoteDetailDrawer({
 			variant: "outline",
 			slot: "secondary",
 			onClick: () => void emailToClient(),
-			disabled: !can("quotes", "modify") || sending,
+			disabled: !can("quotes", "modify") || sending || validUntilPassed,
+			disabledReason: validUntilPassed
+				? "Extend the valid-until date on the quote first"
+				: undefined,
 			loading: sending,
 			loadingLabel: "Sending…",
 			hidden: isApproved,

--- a/apps/web/src/app/(workspace)/quotes/components/quote-detail-drawer.tsx
+++ b/apps/web/src/app/(workspace)/quotes/components/quote-detail-drawer.tsx
@@ -264,7 +264,7 @@ export function QuoteDetailDrawer({
 			variant: "default",
 			slot: "start",
 			onClick: () => void setStatus("approved"),
-			disabled: !can("quotes", "modify"),
+			disabled: !can("quotes", "modify") || sending,
 			hidden: !canDecide,
 		},
 		{
@@ -275,7 +275,8 @@ export function QuoteDetailDrawer({
 			variant: "default",
 			slot: "start",
 			onClick: convertToInvoice,
-			disabled: !can("invoices", "modify") || alreadyInvoiced,
+			disabled:
+				!can("invoices", "modify") || alreadyInvoiced || sending,
 			loading: converting,
 			hidden: !isApproved,
 		},
@@ -286,7 +287,7 @@ export function QuoteDetailDrawer({
 			variant: "destructive",
 			slot: "end",
 			onClick: () => void setStatus("declined"),
-			disabled: !can("quotes", "modify"),
+			disabled: !can("quotes", "modify") || sending,
 			hidden: !canDecide,
 		},
 	];
@@ -364,6 +365,7 @@ export function QuoteDetailDrawer({
 							quoteId={quote._id}
 							currentStatus={quote.status}
 							canModify={canModify}
+							busy={sending}
 						/>
 					</DrawerSection>
 
@@ -468,10 +470,13 @@ function StatusControl({
 	quoteId,
 	currentStatus,
 	canModify,
+	busy = false,
 }: {
 	quoteId: Id<"quotes">;
 	currentStatus: QuoteStatus;
 	canModify: boolean;
+	/** A send is in flight: its status write would race this one. */
+	busy?: boolean;
 }) {
 	const updateQuote = useMutation(api.quotes.update);
 	const toast = useToast();
@@ -498,7 +503,7 @@ function StatusControl({
 				<Select
 					value={status}
 					onValueChange={(v) => setStatus(v as QuoteStatus)}
-					disabled={!canModify}
+					disabled={!canModify || busy}
 				>
 					<SelectTrigger className="h-9 flex-1">
 						<SelectValue />
@@ -512,7 +517,7 @@ function StatusControl({
 					</SelectContent>
 				</Select>
 				{dirty ? (
-					<Button size="sm" disabled={saving} onClick={handleSave}>
+					<Button size="sm" disabled={saving || busy} onClick={handleSave}>
 						{saving && <Loader2 className="h-4 w-4 animate-spin" />}
 						{saving ? "Saving…" : "Save"}
 					</Button>

--- a/apps/web/src/app/(workspace)/quotes/components/quote-detail-drawer.tsx
+++ b/apps/web/src/app/(workspace)/quotes/components/quote-detail-drawer.tsx
@@ -11,6 +11,7 @@ import {
 	FileText,
 	Loader2,
 	Lock,
+	Mail,
 	PenLine,
 	Receipt,
 	XCircle,
@@ -103,7 +104,9 @@ export function QuoteDetailDrawer({
 	const toast = useToast();
 	const updateQuote = useMutation(api.quotes.update);
 	const createInvoice = useMutation(api.invoices.createFromQuote);
+	const sendQuoteToClient = useMutation(api.quotes.sendToClient);
 	const [converting, setConverting] = React.useState(false);
+	const [sending, setSending] = React.useState(false);
 
 	const preview = useQuery(
 		api.quotes.getPreview,
@@ -141,6 +144,28 @@ export function QuoteDetailDrawer({
 		if (!quoteId) return;
 		onOpenChange(false);
 		router.push(`/quotes/${quoteId}/sign`);
+	};
+
+	// Emails the client a portal invite for this quote and flips it to sent.
+	// Same mutation the record page and mobile use.
+	const emailToClient = async () => {
+		if (!quoteId || sending) return;
+		setSending(true);
+		try {
+			await sendQuoteToClient({ id: quoteId });
+			toast.success(
+				"Quote sent",
+				"Your client will get an email to view and approve it in the portal."
+			);
+		} catch (err) {
+			console.error("Failed to send quote to client:", err);
+			toast.error(
+				"Couldn't send quote",
+				convexErrorMessage(err, "Please try again.")
+			);
+		} finally {
+			setSending(false);
+		}
 	};
 
 	const setStatus = async (status: QuoteStatus) => {
@@ -196,11 +221,25 @@ export function QuoteDetailDrawer({
 			onClick: openRecord,
 		},
 		{
+			// Hidden on approved quotes: the backend rejects those (convert to an
+			// invoice instead), same rule as the record header and mobile.
+			key: "send-to-client",
+			label: quote?.status === "sent" ? "Resend to client" : "Send to client",
+			icon: <Mail className="size-3.5" />,
+			variant: "outline",
+			slot: "secondary",
+			onClick: () => void emailToClient(),
+			disabled: !can("quotes", "modify") || sending,
+			loading: sending,
+			loadingLabel: "Sending…",
+			hidden: isApproved,
+		},
+		{
 			key: "send",
 			label: "Send for e-signature",
 			icon: <PenLine className="size-3.5" />,
-			variant: "default",
-			slot: "start",
+			variant: "outline",
+			slot: "secondary",
 			onClick: sendForSignature,
 			disabled: !can("quotes", "modify") || missingPdf,
 			disabledReason: missingPdf

--- a/packages/help-content/articles/client-portal.ts
+++ b/packages/help-content/articles/client-portal.ts
@@ -58,7 +58,7 @@ export const clientPortalArticles: HelpArticle[] = [
 				blocks: [
 					{
 						type: "paragraph",
-						text: "The portal is the client-facing half of your quote and invoice flow. When you click **Mark as Sent** on a quote, it appears in your client's portal for approval. When you click **Send to Client** on an invoice, your client gets an email inviting them into the portal to view and pay it.",
+						text: "The portal is the client-facing half of your quote and invoice flow. When you click **Send to Client** on a quote or an invoice, your client gets an email inviting them into the portal: to approve or decline the quote, or to view and pay the invoice.",
 					},
 					{
 						type: "paragraph",
@@ -179,7 +179,7 @@ export const clientPortalArticles: HelpArticle[] = [
 				blocks: [
 					{
 						type: "paragraph",
-						text: "Only quotes you have sent appear in the portal. Drafts stay private to your workspace until you click **Mark as Sent**. Once a quote is sent, here is your client's flow:",
+						text: "Only quotes you have sent appear in the portal. Drafts stay private to your workspace until you send them. Once a quote is sent, here is your client's flow:",
 					},
 					{
 						type: "steps",

--- a/packages/help-content/articles/getting-started.ts
+++ b/packages/help-content/articles/getting-started.ts
@@ -541,7 +541,7 @@ export const gettingStartedArticles: HelpArticle[] = [
 						type: "steps",
 						items: [
 							"Open the quote and review the total.",
-							"Click **Mark as Sent**. The quote becomes visible in your client's portal, where they can approve or decline it with a signature.",
+							"Open the **⋯** menu in the quote header and click **Send to Client**. Your client gets an email with a link to the quote in their portal, where they can approve or decline it with a signature. (**Mark as Sent** just flips the status, so use it for quotes you delivered outside OneTool.)",
 						],
 					},
 					{

--- a/packages/help-content/articles/invoices-and-payments.ts
+++ b/packages/help-content/articles/invoices-and-payments.ts
@@ -117,7 +117,7 @@ export const invoicesAndPaymentsArticles: HelpArticle[] = [
 					},
 					{
 						type: "paragraph",
-						text: "**Send to Client**, **Generate PDF**, and **Cancel** are always available. **Generate PDF** produces a PDF copy of the invoice, and **Cancel** asks for confirmation before it voids the invoice.",
+						text: "**Send to Client** is available until the invoice is paid or cancelled, and reads **Resend to Client** once it has gone out. **Generate PDF** produces a PDF copy of the invoice and is always available, and **Cancel** asks for confirmation before it voids the invoice.",
 					},
 					{
 						type: "media",
@@ -248,12 +248,12 @@ export const invoicesAndPaymentsArticles: HelpArticle[] = [
 						type: "steps",
 						items: [
 							"Open the invoice and review the total.",
-							"Click **Send to Client**.",
+							"Open the **⋯** menu in the invoice header and click **Send to Client**.",
 						],
 					},
 					{
 						type: "note",
-						text: "Sending requires the client to have a primary contact with an email address on file. Add one on the client record first if it is missing.",
+						text: "Sending requires the client to have portal access turned on and a primary contact with an email address on file. Add one on the client record first if it is missing. To send the same link again later, use **Resend to Client**; nothing else about the invoice changes. You can also send straight from the invoice list: open an invoice\u2019s quick-view drawer and use the same action there.",
 					},
 				],
 			},

--- a/packages/help-content/articles/quotes.ts
+++ b/packages/help-content/articles/quotes.ts
@@ -214,7 +214,7 @@ export const quotesArticles: HelpArticle[] = [
 				blocks: [
 					{
 						type: "paragraph",
-						text: "A sent quote is locked, so the numbers never change under your client while they are deciding. To fix a price, a line item, the title, or the terms, click **Revert to draft** in the quote header and confirm. The quote leaves your client's portal and their link stops working, and everything is editable again. Click **Send to Client** when it is ready to go back; that emails the revised quote and makes their link work again. (**Mark as Sent** only flips the status, so save it for quotes you delivered outside OneTool.)",
+						text: "A sent quote is locked, so the numbers never change under your client while they are deciding. To fix a price, a line item, the title, or the terms, click **Revert to draft** in the quote header and confirm. The quote leaves your client's portal and their link stops working, and everything is editable again. Click **Send to Client** when it is ready to go back; that emails the revised quote and makes their link work again. If the **Valid until** date has passed while you were editing, extend it first: sending is blocked past that date in every status, drafts included. (**Mark as Sent** only flips the status, so save it for quotes you delivered outside OneTool.)",
 					},
 					{
 						type: "note",

--- a/packages/help-content/articles/quotes.ts
+++ b/packages/help-content/articles/quotes.ts
@@ -185,7 +185,7 @@ export const quotesArticles: HelpArticle[] = [
 					},
 					{
 						type: "paragraph",
-						text: "**Send to Client**, **Send for e-signature**, **Generate PDF**, and **Delete** are available in every status, with two exceptions: **Send to Client** disappears once a quote is approved (convert it to an invoice instead), and a quote cannot be deleted once an invoice has been created from it until you remove or unlink that invoice.",
+						text: "**Send to Client**, **Send for e-signature**, **Generate PDF**, and **Delete** are available in every status, with these exceptions: **Send to Client** disappears once a quote is approved (convert it to an invoice instead) and greys out once the **Valid until** date has passed (extend it first), and a quote cannot be deleted once an invoice has been created from it until you remove or unlink that invoice.",
 					},
 				],
 			},

--- a/packages/help-content/articles/quotes.ts
+++ b/packages/help-content/articles/quotes.ts
@@ -185,7 +185,7 @@ export const quotesArticles: HelpArticle[] = [
 					},
 					{
 						type: "paragraph",
-						text: "**Send for e-signature**, **Generate PDF**, and **Delete** are available in every status. The one exception: once an invoice has been created from a quote, the quote cannot be deleted until you remove or unlink that invoice.",
+						text: "**Send to Client**, **Send for e-signature**, **Generate PDF**, and **Delete** are available in every status, with two exceptions: **Send to Client** disappears once a quote is approved (convert it to an invoice instead), and a quote cannot be deleted once an invoice has been created from it until you remove or unlink that invoice.",
 					},
 				],
 			},
@@ -196,16 +196,16 @@ export const quotesArticles: HelpArticle[] = [
 						type: "steps",
 						items: [
 							"Open the quote and give the line items and total a final look.",
-							"Click **Mark as Sent**.",
+							"Open the **⋯** menu in the quote header and click **Send to Client**.",
 						],
 					},
 					{
 						type: "paragraph",
-						text: "That is the whole send. The quote becomes visible in your client's portal, where they can approve or decline it.",
+						text: "That is the whole send. Your client's primary contact gets an email with a link straight to the quote in their portal, where they can approve or decline it, and the quote moves to **Sent**. Sending again on a quote that is already sent reads **Resend to Client** and emails the same link without changing anything else.",
 					},
 					{
 						type: "note",
-						text: "**Mark as Sent** on its own makes the quote approvable in the portal. A formal e-signature request is a separate, optional path. See [E-signatures](/help/quotes/e-signatures).",
+						text: "Sending needs the client to have portal access turned on and a primary contact with an email address; OneTool tells you if either is missing. **Mark as Sent** flips the status without emailing anyone, so save it for quotes you delivered outside OneTool. A formal e-signature request is a separate, optional path. See [E-signatures](/help/quotes/e-signatures). You can also send from the quotes list: open a quote's quick-view drawer and use the same action there.",
 					},
 				],
 			},
@@ -214,7 +214,7 @@ export const quotesArticles: HelpArticle[] = [
 				blocks: [
 					{
 						type: "paragraph",
-						text: "A sent quote is locked, so the numbers never change under your client while they are deciding. To fix a price, a line item, the title, or the terms, click **Revert to draft** in the quote header and confirm. The quote leaves your client's portal and their link stops working, and everything is editable again. Click **Send** when it is ready to go back; that emails the revised quote and makes their link work again. (**Mark as Sent** only flips the status, so save it for quotes you delivered outside OneTool.)",
+						text: "A sent quote is locked, so the numbers never change under your client while they are deciding. To fix a price, a line item, the title, or the terms, click **Revert to draft** in the quote header and confirm. The quote leaves your client's portal and their link stops working, and everything is editable again. Click **Send to Client** when it is ready to go back; that emails the revised quote and makes their link work again. (**Mark as Sent** only flips the status, so save it for quotes you delivered outside OneTool.)",
 					},
 					{
 						type: "note",


### PR DESCRIPTION
This pull request improves the user experience for sending invoices and quotes to clients by unifying the "Send to Client" action across the web app. It adds loading states and disables duplicate sends, clarifies UI labels, and updates help content to match the new flow. The changes ensure that users receive clear feedback when sending items and that the actions are consistent across invoices and quotes.

**UI/UX Improvements for Sending Invoices and Quotes:**

- Added a `sending` state and loading indicators to the "Send to Client" actions for both invoices and quotes in their detail headers and drawers, preventing duplicate sends and providing user feedback. Labels now read "Send to Client" or "Resend to Client" based on status, and the action is hidden when not applicable (e.g., paid/cancelled invoices or approved quotes). ([apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-header.tsxR38-R39](diffhunk://#diff-5ab6c872357f171c8468146ccd6934652b72a8d511de77e581648349f0dc739dR38-R39), [apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-header.tsxR50](diffhunk://#diff-5ab6c872357f171c8468146ccd6934652b72a8d511de77e581648349f0dc739dR50), [apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-header.tsxR138-R150](diffhunk://#diff-5ab6c872357f171c8468146ccd6934652b72a8d511de77e581648349f0dc739dR138-R150), [apps/web/src/app/(workspace)/invoices/[invoiceId]/page.tsxR64](diffhunk://#diff-06903284669621c28ef32a12a4ef40f74a7330f304bcb4150b68181f28f39735R64), [apps/web/src/app/(workspace)/invoices/[invoiceId]/page.tsxR219-R220](diffhunk://#diff-06903284669621c28ef32a12a4ef40f74a7330f304bcb4150b68181f28f39735R219-R220), [apps/web/src/app/(workspace)/invoices/[invoiceId]/page.tsxR231-R232](diffhunk://#diff-06903284669621c28ef32a12a4ef40f74a7330f304bcb4150b68181f28f39735R231-R232), [apps/web/src/app/(workspace)/invoices/[invoiceId]/page.tsxR401](diffhunk://#diff-06903284669621c28ef32a12a4ef40f74a7330f304bcb4150b68181f28f39735R401), [[1]](diffhunk://#diff-af7d113fc70b3a251c9f53e94ba3eac62ddeaa87c0ee9738512872ac6ed9eb44R13-L14) [[2]](diffhunk://#diff-af7d113fc70b3a251c9f53e94ba3eac62ddeaa87c0ee9738512872ac6ed9eb44R53) [[3]](diffhunk://#diff-af7d113fc70b3a251c9f53e94ba3eac62ddeaa87c0ee9738512872ac6ed9eb44L120-R124) [[4]](diffhunk://#diff-af7d113fc70b3a251c9f53e94ba3eac62ddeaa87c0ee9738512872ac6ed9eb44L159-R177) [[5]](diffhunk://#diff-af7d113fc70b3a251c9f53e94ba3eac62ddeaa87c0ee9738512872ac6ed9eb44L187-R214) [apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-header.tsxR8](diffhunk://#diff-d60c5538ea8c8911dad5f8ee70871dea6d905604bf0ca23de9e3e86f1458a223R8), [apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-header.tsxR41-R45](diffhunk://#diff-d60c5538ea8c8911dad5f8ee70871dea6d905604bf0ca23de9e3e86f1458a223R41-R45), [apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-header.tsxR61-R62](diffhunk://#diff-d60c5538ea8c8911dad5f8ee70871dea6d905604bf0ca23de9e3e86f1458a223R61-R62), [apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-header.tsxR158-R179](diffhunk://#diff-d60c5538ea8c8911dad5f8ee70871dea6d905604bf0ca23de9e3e86f1458a223R158-R179), [apps/web/src/app/(workspace)/quotes/[quoteId]/page.tsxR70](diffhunk://#diff-6b1893d4f384f0114d884703b6631229037ec3d651b8d4b78c3abb166aad205aR70), [apps/web/src/app/(workspace)/quotes/[quoteId]/page.tsxR134](diffhunk://#diff-6b1893d4f384f0114d884703b6631229037ec3d651b8d4b78c3abb166aad205aR134), [apps/web/src/app/(workspace)/quotes/[quoteId]/page.tsxL402-R404](diffhunk://#diff-6b1893d4f384f0114d884703b6631229037ec3d651b8d4b78c3abb166aad205aL402-R404), [apps/web/src/app/(workspace)/quotes/[quoteId]/page.tsxR421-R437](diffhunk://#diff-6b1893d4f384f0114d884703b6631229037ec3d651b8d4b78c3abb166aad205aR421-R437), [apps/web/src/app/(workspace)/quotes/[quoteId]/page.tsxR487-R488](diffhunk://#diff-6b1893d4f384f0114d884703b6631229037ec3d651b8d4b78c3abb166aad205aR487-R488), [[6]](diffhunk://#diff-763f7cd6a16785d9a976c118e0f444a3b1ec1da53fc12de690aa89e364f55afaR14) [[7]](diffhunk://#diff-763f7cd6a16785d9a976c118e0f444a3b1ec1da53fc12de690aa89e364f55afaR107-R109) [[8]](diffhunk://#diff-763f7cd6a16785d9a976c118e0f444a3b1ec1da53fc12de690aa89e364f55afaR149-R170) [[9]](diffhunk://#diff-763f7cd6a16785d9a976c118e0f444a3b1ec1da53fc12de690aa89e364f55afaR223-R242)

**Help Content and Documentation Updates:**

- Updated help articles to reflect the new "Send to Client" flow, clarifying that this action sends an email invite and is the preferred way to share quotes and invoices with clients. Adjusted instructions and descriptions to match the updated UI and workflow. [[1]](diffhunk://#diff-606dc0994065335613b5e2cab1daefd9a57b41e0d10b76a053a937f09b38fd93L61-R61) [[2]](diffhunk://#diff-606dc0994065335613b5e2cab1daefd9a57b41e0d10b76a053a937f09b38fd93L182-R182) [[3]](diffhunk://#diff-03c47c5132bd3877223d2b48605ee335311045a02db5ff8c106e901aad779a5bL544-R544) [[4]](diffhunk://#diff-5b9a67d95319f43746f5bb4f7863a994a44db7031a5906859d4ece6c68afc2baL120-R120)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds consistent Send to Client and Resend to Client actions for web invoice and quote detail views, including quick-view drawers and in-flight feedback.
- Routes invoice and quote sends through their existing portal-email mutations.
- Separates quote portal sending from the e-signature workflow.
- Adds status-based action visibility, loading indicators, duplicate-click guards, and updated help content.
- The expired-quote case remains exposed even though the backend rejects it.

<h3>Confidence Score: 4/5</h3>

The expired-quote send path should be corrected before merging because the new web action advertises an operation that the backend rejects.

Both quote surfaces expose Send to Client for expired quotes, while the mutation rejects the common expired condition where validUntil has passed, producing a guaranteed user-facing failure on that path.

**Files Needing Attention:** apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-header.tsx, apps/web/src/app/(workspace)/quotes/components/quote-detail-drawer.tsx, packages/help-content/articles/quotes.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/(workspace)/invoices/[invoiceId]/components/invoice-detail-header.tsx | Adds status-aware invoice send/resend presentation and loading behavior consistent with the backend's invoice status restrictions. |
| apps/web/src/app/(workspace)/invoices/[invoiceId]/page.tsx | Adds guarded in-flight state around the existing invoice send mutation. |
| apps/web/src/app/(workspace)/invoices/components/invoice-detail-drawer.tsx | Replaces a status-only update with the actual invoice portal-email mutation and displays mutation feedback. |
| apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-header.tsx | Separates portal sending from e-signature sending, but exposes portal sending for expired quotes that the backend will reject. |
| apps/web/src/app/(workspace)/quotes/[quoteId]/page.tsx | Adds a guarded quote portal-send handler while preserving the separate e-signature route. |
| apps/web/src/app/(workspace)/quotes/components/quote-detail-drawer.tsx | Adds quote portal sending to quick view, including the same unsupported expired-quote state as the full detail header. |
| packages/help-content/articles/quotes.ts | Documents the new send flow but incorrectly describes approved as the only status where Send to Client is unavailable. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant U as Workspace user
  participant W as Web quote/invoice view
  participant C as Convex sendToClient
  participant E as Email service
  participant P as Client portal
  U->>W: Click Send to Client
  W->>W: Set sending state and disable action
  W->>C: sendToClient(record ID)
  C->>C: Validate status, portal access, and contact email
  alt Valid send
    C->>E: Send portal invitation
    E-->>P: Client follows portal link
    C-->>W: Success
    W-->>U: Show sent confirmation
  else Invalid status or prerequisite
    C-->>W: Reject mutation
    W-->>U: Show error toast
  end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/src/app/(workspace)/quotes/[quoteId]/components/quote-detail-header.tsx:171
**Expired quotes expose rejected send**

When a quote is expired because its `validUntil` date has passed, this approved-only check still exposes Send to Client, but `quotes.sendToClient` rejects the request, causing every attempt to end in an error toast. The quick-view drawer applies the same visibility rule, and the updated help content also presents approved as the only exception.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): send quotes to the client por..."](https://github.com/xcarter93/onetool/commit/5117ef2ac844c907e4c1e913b6589670585f4845) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52730651)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Quote → Invoice → Stripe Payment Flow](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/quote-invoice-payments-flow.md)

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Send invoices and quotes directly to clients by email.
  - Resend previously sent invoices and quotes from detail views and quick views.
  - Added loading states and safeguards against duplicate sends.
  - Quote sending now supports separate client delivery and e-signature actions.
  - Sending is unavailable for paid, cancelled, or approved records.
  - Expired quotes require extension before sending.

- **Documentation**
  - Updated help content to explain sending, resending, portal access, approval, and payment workflows.
  - Clarified the difference between “Send to Client” and “Mark as Sent.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->