### PR TITLE
fix(landing): correct the Compare table against live vendor pricing

### DIFF
--- a/apps/web/src/app/components/marketing/sections/compare.tsx
+++ b/apps/web/src/app/components/marketing/sections/compare.tsx
@@ -5,13 +5,15 @@ import { formatCurrency } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import { AmbientLayer } from "../ambient";
 import { CompareHalftoneScene } from "../section-halftone-scenes";
+import { Frame, FrameFooter, FrameHeader, FramePanel } from "@/components/reui/frame";
 import {
-	Frame,
-	FrameFooter,
-	FrameHeader,
-	FramePanel,
-} from "@/components/reui/frame";
-import { Eyebrow, Lede, PlusCorners, PlusMark, Section, SectionHeading } from "../primitives";
+	Eyebrow,
+	Lede,
+	PlusCorners,
+	PlusMark,
+	Section,
+	SectionHeading,
+} from "../primitives";
 import {
 	CREW_SIZES,
 	DEFAULT_CREW,
@@ -38,7 +40,9 @@ import {
 /** Value swaps fade rather than count. Reused keyframe from landing.css; the
  *  reduced-motion block there kills it with `animation: none !important`, and
  *  because the opacity only lives in the keyframe the cell then renders solid. */
-const VALUE_FADE: CSSProperties = { animation: "lp-fade 260ms var(--lp-ease) both" };
+const VALUE_FADE: CSSProperties = {
+	animation: "lp-fade 260ms var(--lp-ease) both",
+};
 
 const people = (crew: number) => (crew === 1 ? "person" : "people");
 
@@ -48,7 +52,6 @@ function priceFor(v: Vendor, crew: number): string | null {
 }
 
 function planFor(v: Vendor, crew: number): string {
-	if (v.quoteOnly) return "Request pricing";
 	const quote = quoteFor(v, crew);
 	if (!quote) return "No published seat price";
 	return `${quote.planName} · ${v.quotedBillingLabel}`;
@@ -65,6 +68,18 @@ function EmDash({ note = "Not published" }: { note?: string }) {
 
 function FeatureValue({ cell, isUs }: { cell: FeatureCell; isUs: boolean }) {
 	if (cell.kind === "unpublished") return <EmDash />;
+	if (cell.kind === "soon") {
+		// Not a check and not an em dash: a stated "not yet". Mono + the accent
+		// rule reads as a dated note rather than a claim.
+		return (
+			<span className="inline-flex items-baseline gap-[7px] text-[13.5px] text-(--ink-3)">
+				<span className="font-mono text-[11px] uppercase tracking-[0.06em] text-(--accent-ink)">
+					Coming soon
+				</span>
+				{cell.label ? <span>{cell.label}</span> : null}
+			</span>
+		);
+	}
 	if (cell.kind === "tier") {
 		return <span className="text-[13.5px] text-(--ink-3)">{cell.label}</span>;
 	}
@@ -197,8 +212,12 @@ function LedgerTable({ crew }: { crew: CrewSize }) {
 			<div className="relative">
 				<table className="w-full table-fixed border-collapse">
 					<caption className="sr-only">
-						Published monthly price and included features for a crew of {crew} {people(crew)}.
+						Published monthly price and included features for a crew of {crew}{" "}
+						{people(crew)}.
 					</caption>
+					{/* 28% + 4×18% = 100%. Both numbers are load-bearing: the elevated
+					    OneTool overlay below is positioned off them, so they must move
+					    together if a vendor is ever added or dropped. */}
 					<colgroup>
 						<col className="w-[28%]" />
 						{VENDORS.map((v) => (
@@ -246,11 +265,7 @@ function LedgerTable({ crew }: { crew: CrewSize }) {
 											</span>
 										) : (
 											<span className="block text-[22px]">
-												<EmDash
-													note={
-														v.quoteOnly ? "Request pricing" : "Not published for this crew size"
-													}
-												/>
+												<EmDash note="Not published for this crew size" />
 											</span>
 										)}
 									</td>
@@ -260,23 +275,15 @@ function LedgerTable({ crew }: { crew: CrewSize }) {
 
 						<tr>
 							<th scope="row" className={ROW_LABEL}>
-								Billed
-							</th>
-							{VENDORS.map((v) => (
-								<td key={v.key} className={cellCls(v, "text-[13.5px] text-(--ink-2)")}>
-									{v.billedLabel}
-								</td>
-							))}
-						</tr>
-
-						<tr>
-							<th scope="row" className={ROW_LABEL}>
 								Plan used
 							</th>
 							{VENDORS.map((v) => (
 								<td
 									key={v.key}
-									className={cellCls(v, "font-mono text-[11px] leading-[1.45] text-(--ink-3)")}
+									className={cellCls(
+										v,
+										"font-mono text-[11px] leading-[1.45] text-(--ink-3)",
+									)}
 								>
 									<span key={crew} style={VALUE_FADE} className="block">
 										{planFor(v, crew)}
@@ -339,7 +346,6 @@ function VendorCard({ v, crew }: { v: Vendor; crew: CrewSize }) {
 				>
 					{v.name}
 				</h3>
-				<span className="font-mono text-[11px] text-(--ink-3)">{v.billedLabel}</span>
 			</div>
 
 			<div className="px-4 py-4">
@@ -356,9 +362,7 @@ function VendorCard({ v, crew }: { v: Vendor; crew: CrewSize }) {
 					</p>
 				) : (
 					<p className="text-[26px] text-(--ink-3)">
-						<EmDash
-							note={v.quoteOnly ? "Request pricing" : "Not published for this crew size"}
-						/>
+						<EmDash note="Not published for this crew size" />
 					</p>
 				)}
 				<p className="mt-1.5 font-mono text-[11px] text-(--ink-3)">{planFor(v, crew)}</p>
@@ -404,17 +408,39 @@ function Footnotes() {
 	return (
 		<div className="grid gap-2 text-[12.5px] leading-[1.65] text-(--ink-2)">
 			<p>
-				<span aria-hidden="true">✓</span> included · a plan name means it is gated to that tier
-				· <span aria-hidden="true">—</span> means the vendor does not publish it.
+				<span aria-hidden="true">✓</span> included · a plan name means it is gated to that
+				tier · &ldquo;coming soon&rdquo; means on the roadmap, not shipped yet ·{" "}
+				<span aria-hidden="true">—</span> means the vendor does not publish it.
 			</p>
 			<p>
 				{mention.name} {mention.note}, so there is no honest way to give it a column.
 			</p>
 			<p>
 				Competitor prices are their published rates as of {RETRIEVED_LABEL} ({linked}).
-				Competitors are shown at the annual-billing rate their own pricing page displays;
-				OneTool is shown month-to-month at {formatCurrency(ONETOOL_MONTHLY, { whole: true })}.
-				Every business is different, so check their sites for current pricing.
+				Every column, ours included, is the month-to-month rate — no annual commitment,
+				and the price Jobber&rsquo;s page shows on load. Jobber&rsquo;s page prices by
+				team size, so its column is the bucket Jobber itself puts that crew in.
+			</p>
+			{/* The row we lose, stated plainly. Jobber and Joby both publish the bare
+          Stripe rate; we add $1 on top. Softening this is the fastest way to
+          make the whole table untrustworthy. */}
+			<p>
+				On card processing we are the dearest of the three Stripe-based tools: Jobber and
+				Joby both pass through the standard{" "}
+				<span className="whitespace-nowrap">2.9% + 30¢</span> with nothing added, while
+				OneTool charges {formatCurrency(1, { whole: true })} per transaction on top of
+				your own Stripe rate. Housecall Pro runs its own processing from 2.59%.
+			</p>
+			{/* The concession that makes the monthly basis fair. Two of these four
+          rivals are cheaper than their column if you commit to a year, and we
+          name their numbers rather than leaving the reader to find the toggle.
+          Do not cut this paragraph to shorten the footnote. */}
+			<p>
+				Committing to a year costs less at three of the five: Jobber from{" "}
+				{formatCurrency(29, { whole: true })}/mo, Housecall Pro from{" "}
+				{formatCurrency(59, { whole: true })}/mo, and OneTool at{" "}
+				{formatCurrency(300, { whole: true })}/year. Joby publishes no annual rate. Every
+				business is different, so check their sites for current pricing.
 			</p>
 		</div>
 	);
@@ -442,10 +468,11 @@ export function Compare() {
 				<Eyebrow>Compare</Eyebrow>
 				<SectionHeading>One price for the whole crew.</SectionHeading>
 				<Lede className="max-w-[46rem]">
-					Jobber adds $29 a month for every user past the plan allowance. Housecall Pro&rsquo;s
-					entry plan covers one person, and extra seats are sold only on its top plan.
-					ServiceTitan prices per technician and publishes no number at all. OneTool is one
-					price for the whole company, however many of you there are.
+					Jobber reprices every plan as your team size grows, then adds $29 a month for
+					each user past the bundled allowance. Housecall Pro&rsquo;s entry plan covers
+					one person, and extra seats are sold only on its top plan. Joby prices flat with
+					unlimited users like we do, and starts at $89. OneTool is one price for the
+					whole company, however many of you there are.
 				</Lede>
 
 				{/* The workspace <Frame>, re-inked by the lp-frame bridge: picker in

--- a/apps/web/src/app/components/marketing/sections/competitor-data.ts
+++ b/apps/web/src/app/components/marketing/sections/competitor-data.ts
@@ -9,25 +9,45 @@
  * `.planning/landing-redesign-2026-08/DIRECTION.md` ("Compare-section data
  * caveats") and `competitor-pricing.json`.
  *
- * BILLING BASIS (disclosed in the section's footnote): competitors are quoted
- * at the annual-billing rate their pricing page displays by default — their
- * cheapest published number. OneTool is quoted month-to-month at $30, its
- * higher price. The comparison is deliberately tilted toward the competitor.
+ * BILLING BASIS (disclosed in the section's footnote): EVERY vendor, us
+ * included, is quoted month-to-month — the no-commitment rate, and the number a
+ * visitor actually sees on Jobber's page, which loads on Monthly. One cadence
+ * across all five columns is the apples-to-apples comparison and the one a
+ * reader can reproduce without discovering a toggle.
  *
- * Jobber's plan prices, seat allowances and extra-seat fee were re-fetched
- * verbatim from https://www.getjobber.com/pricing/ on 2026-08-14 to settle a
- * discrepancy between two earlier reads. Today's fetch confirms:
- * Core "1 user" · Connect "Includes 5 users" · Grow "Includes 10 users" ·
- * Plus "Includes 15 users", each with "Add users for $29/mo each".
+ * Be honest about what changed on 2026-08-16: this basis is NOT tilted toward
+ * the competitor the way the old annual basis was. Jobber and Housecall Pro
+ * both publish cheaper annual rates a buyer could take, and the footnote says
+ * so out loud with their numbers — that disclosure is load-bearing, do not drop
+ * it to tighten the copy. OneTool's own annual ($300/yr) is disclosed with it.
+ *
+ * ServiceTitan was dropped from this table on 2026-08-16. It publishes no
+ * figure anywhere — every tier is "Request Pricing" — so its column was em
+ * dashes end to end, carrying no information while eating a fifth of the table
+ * width. It is not hidden for being expensive; there is simply nothing to
+ * quote. The `quote-only` pricing model and the `quoteOnly` flag went with it,
+ * since it was the only vendor that used them.
+ *
+ * ── 2026-08-16 correction ────────────────────────────────────────────────────
+ * The 2026-08-14 read of Jobber was WRONG, and wrong in Jobber's favour. Jobber
+ * gates its pricing page behind a "Team size" selector (Just me · 2-5 people ·
+ * 6-10 people · 11-15 people · 16 or more). Both the prices AND the bundled
+ * seat count change with the bucket, and which plans are offered changes too.
+ * The old read took the prices from the "Just me" bucket and paired them with
+ * seat allowances (5 / 10 / 15) that belong to the larger buckets, then let a
+ * $29/seat formula fill the gaps — so a crew of four was quoted $99 when Jobber
+ * actually quotes that crew $149 (annual) / $199 (monthly). Plans are now
+ * `seatBand`-scoped so each crew size is priced from the bucket Jobber itself
+ * puts it in, which is exactly reproducible by anyone who loads the page.
  */
 
-export const RETRIEVED_AT = "2026-08-14";
+export const RETRIEVED_AT = "2026-08-16";
 /** Human-facing form of RETRIEVED_AT, used in the footnote. */
-export const RETRIEVED_LABEL = "Aug 14, 2026";
+export const RETRIEVED_LABEL = "Aug 16, 2026";
 
-export type VendorKey = "onetool" | "jobber" | "housecall" | "servicetitan";
+export type VendorKey = "onetool" | "jobber" | "housecall" | "joby";
 
-export type PricingModel = "flat-per-org" | "per-user" | "quote-only";
+export type PricingModel = "flat-per-org" | "per-user";
 
 export interface CompetitorPlan {
 	name: string;
@@ -41,17 +61,25 @@ export interface CompetitorPlan {
 	 * their price — either way, bigger crews are NOT computable here.
 	 */
 	extraSeatFee: number | null;
+	/**
+	 * Crew-size bucket this plan+price is offered in, when the vendor's pricing
+	 * page is gated by a team-size selector (Jobber). A plan is simply not
+	 * quotable outside its band. Absent = the plan is offered at every crew size
+	 * (Housecall Pro).
+	 */
+	seatBand?: { min: number; max: number };
 }
 
 export interface Vendor {
 	key: VendorKey;
 	name: string;
 	isUs: boolean;
+	/** How the vendor charges. Informational — the table no longer renders it:
+	 *  a "Billed: per user" row contradicted the whole-crew total directly above
+	 *  it (Jobber at six people is $299/mo total, not $299 per user), so the row
+	 *  was dropped 2026-08-16. Keep the field; it is what the copy is written
+	 *  from. Do not put it back in the table as a bare label. */
 	pricingModel: PricingModel;
-	/** "Quote-only" vendors get an em-dash column, never a computed price. */
-	quoteOnly: boolean;
-	/** Short label for the "Billed" row. */
-	billedLabel: string;
 	/** Which billing period the quoted `basePrice` figures belong to. */
 	quotedBilling: "monthly" | "annual";
 	/** Suffix printed under the plan name, e.g. "billed annually". */
@@ -73,8 +101,6 @@ export const VENDORS: Vendor[] = [
 		name: "OneTool",
 		isUs: true,
 		pricingModel: "flat-per-org",
-		quoteOnly: false,
-		billedLabel: "Per organisation",
 		quotedBilling: "monthly",
 		quotedBillingLabel: "month-to-month",
 		plans: [
@@ -90,6 +116,9 @@ export const VENDORS: Vendor[] = [
 		notes: [
 			"$30/month, or $300/year. There is also a permanent Free plan.",
 			"$30 is the hardcoded fallback in sections/pricing.tsx; at runtime that section prefers live Clerk plan data. Confirm the live Clerk price before changing this number.",
+			"Client portal ships on every plan: apps/web routes /portal/c/[clientPortalId]/{quotes,invoices} with OTP verification, quote approval, e-signature and card payment.",
+			"Seats are uncapped: lib/planLimits.ts caps only clients (10) and active projects per client (3) on the free plan, never users.",
+			"Card payments run through Stripe Connect on the org's own Stripe account, so the org pays Stripe's rate directly (US standard online card is 2.9% + 30¢). OneTool adds a flat application fee of $1 per transaction on top — portal/invoicesActions.ts sets application_fee_amount from STRIPE_APPLICATION_FEE_CENTS, read as 100 off the deployment on 2026-08-16. It is env-driven, so re-read it before changing the table. Both Jobber and Joby publish the bare Stripe rate with no markup, so this is the one row where we are the most expensive.",
 		],
 	},
 	{
@@ -97,22 +126,111 @@ export const VENDORS: Vendor[] = [
 		name: "Jobber",
 		isUs: false,
 		pricingModel: "per-user",
-		quoteOnly: false,
-		billedLabel: "Per user",
-		quotedBilling: "annual",
-		quotedBillingLabel: "billed annually",
+		quotedBilling: "monthly",
+		quotedBillingLabel: "month-to-month",
+		// Read bucket-by-bucket off getjobber.com/pricing on 2026-08-16, toggling
+		// Team size and Billing. basePrice = the MONTHLY no-commitment rate, which
+		// is what the page shows on load; the annual rate is recorded in `notes`.
+		// Core exists ONLY in the "Just me" bucket; Plus does not exist there.
 		plans: [
-			{ name: "Core", basePrice: 29, includedSeats: 1, extraSeatFee: 29 },
-			{ name: "Connect", basePrice: 99, includedSeats: 5, extraSeatFee: 29 },
-			{ name: "Grow", basePrice: 149, includedSeats: 10, extraSeatFee: 29 },
-			{ name: "Plus", basePrice: 399, includedSeats: 15, extraSeatFee: 29 },
+			{
+				name: "Core",
+				basePrice: 49,
+				includedSeats: 1,
+				extraSeatFee: null,
+				seatBand: { min: 1, max: 1 },
+			},
+			{
+				name: "Connect",
+				basePrice: 139,
+				includedSeats: 1,
+				extraSeatFee: null,
+				seatBand: { min: 1, max: 1 },
+			},
+			{
+				name: "Grow",
+				basePrice: 199,
+				includedSeats: 1,
+				extraSeatFee: null,
+				seatBand: { min: 1, max: 1 },
+			},
+
+			{
+				name: "Connect",
+				basePrice: 199,
+				includedSeats: 5,
+				extraSeatFee: null,
+				seatBand: { min: 2, max: 5 },
+			},
+			{
+				name: "Grow",
+				basePrice: 299,
+				includedSeats: 5,
+				extraSeatFee: null,
+				seatBand: { min: 2, max: 5 },
+			},
+			{
+				name: "Plus",
+				basePrice: 499,
+				includedSeats: 5,
+				extraSeatFee: null,
+				seatBand: { min: 2, max: 5 },
+			},
+
+			{
+				name: "Connect",
+				basePrice: 299,
+				includedSeats: 10,
+				extraSeatFee: null,
+				seatBand: { min: 6, max: 10 },
+			},
+			{
+				name: "Grow",
+				basePrice: 399,
+				includedSeats: 10,
+				extraSeatFee: null,
+				seatBand: { min: 6, max: 10 },
+			},
+			{
+				name: "Plus",
+				basePrice: 599,
+				includedSeats: 10,
+				extraSeatFee: null,
+				seatBand: { min: 6, max: 10 },
+			},
+
+			{
+				name: "Connect",
+				basePrice: 399,
+				includedSeats: 15,
+				extraSeatFee: null,
+				seatBand: { min: 11, max: 15 },
+			},
+			{
+				name: "Grow",
+				basePrice: 499,
+				includedSeats: 15,
+				extraSeatFee: null,
+				seatBand: { min: 11, max: 15 },
+			},
+			{
+				name: "Plus",
+				basePrice: 699,
+				includedSeats: 15,
+				extraSeatFee: null,
+				seatBand: { min: 11, max: 15 },
+			},
 		],
 		sourceUrl: "https://www.getjobber.com/pricing/",
 		retrievedAt: RETRIEVED_AT,
 		notes: [
-			"Re-verified verbatim on 2026-08-14: Core $49/mo no commitment, $39/mo 1-year commitment, $29/mo billed annually, '1 user'; Connect $139/$119/$99, 'Includes 5 users'; Grow $199/$169/$149, 'Includes 10 users'; Plus $499/$439/$399, 'Includes 15 users'. Every plan: 'Add users for $29/mo each'.",
-			"Annual-billing figures are used here — Jobber's cheapest published column.",
-			"Add-ons priced separately: Marketing Suite $99/mo, Receptionist $29/mo, Pipeline $49/mo.",
+			"Read verbatim on 2026-08-16, one team-size bucket at a time (monthly / billed-annually). 'Just me', each card marked '1 user': Core $49/$29, Connect $139/$99, Grow $199/$149 — no Plus card. '2-5 people', each '/Includes 5 users/': Connect $199/$149, Grow $299/$229, Plus $499/$399 — no Core card. '6-10 people', each 'Includes 10 users': Connect $299/$229, Grow $399/$299, Plus $599/$449. '11-15 people', each 'Includes 15 users': Connect $399/$299, Grow $499/$399, Plus $699/$529. '16 or more' replaces every price with 'Let's chat' / Contact Sales and hides the billing toggle.",
+			"Month-to-month figures are used here. Jobber's page loads on Monthly and its monthly cards read 'No commitment'. The annual column is genuinely cheaper — by bucket: Core $29; Connect $99 / $149 / $229 / $299; Grow $149 / $229 / $299 / $399; Plus $399 / $449 / $529 — and the section footnote discloses that.",
+			"Jobber DOES still publish extra seats: the '?' beside 'Includes N users' reads 'A user is anyone who accesses your account at the office or in the field to view or manage the team's schedule. Add users for $29/mo each.' We deliberately do NOT apply that $29 across buckets to synthesise a cheaper configuration (e.g. Core + 5 add-on seats for a crew of six). Jobber's page does not offer the lower-bucket plans to a larger crew, so the bucket price is what that crew is actually quoted — and quoting anything else would not be reproducible by a reader loading the page.",
+			"Add-ons priced separately: Marketing Suite $99/mo, Receptionist $29/mo, Pipeline $49/mo — as read on /pricing/. NOTE a live self-contradiction in Jobber's own copy: /features/ prices Marketing Suite at $79/mo. Neither number is used in any table cell; if one is ever quoted, say which page it came from.",
+			"Card-processing rate IS published — on https://www.getjobber.com/features/ under 'Get Paid', not on /pricing/ (a direct browser read of the pricing page on 2026-08-16 found no rate on it at all). Verbatim: 'Card payments … Rate: 2.9% + 30¢ / transaction' and 'ACH bank payments … Rate: 1% / transaction', alongside 'Online payments are included with your Jobber account with no additional monthly or set up fees—you only pay when you get paid.' Jobber Payments is Stripe-powered (stripe.com/newsroom/news/jobber), so that is the plain Stripe rate with no visible markup. A help-centre snippet suggests card-PRESENT rates vary by plan (2.5% Grow / 2.7% Connect / 2.9% Core) — the table quotes the published online-card headline rate.",
+			"Customer portal is published as 'Client Hub' — getjobber.com/features/ describes customers entering card details 'in client hub' to pay an invoice.",
+			"Offline mobile work shipped 2026-03-18 — productupdates.getjobber.com/134787: job forms, visit details and notes, and time tracking save locally and sync when back online.",
 		],
 	},
 	{
@@ -120,39 +238,77 @@ export const VENDORS: Vendor[] = [
 		name: "Housecall Pro",
 		isUs: false,
 		pricingModel: "per-user",
-		quoteOnly: false,
-		billedLabel: "Per user",
-		quotedBilling: "annual",
-		quotedBillingLabel: "billed annually",
+		quotedBilling: "monthly",
+		quotedBillingLabel: "month-to-month",
 		plans: [
+			// basePrice = the MONTHLY rate. Housecall Pro's toggle defaults to Annual,
+			// so unlike Jobber this is NOT their default view — it is the cadence
+			// every other column is on, and the footnote names their annual rate.
 			// Extra seats are a MAX-plan capability, and MAX's per-extra-user
 			// price is not published — so no plan here can absorb an extra seat.
-			{ name: "Basic", basePrice: 59, includedSeats: 1, extraSeatFee: null },
-			{ name: "Essentials", basePrice: 149, includedSeats: 5, extraSeatFee: null },
-			{ name: "MAX", basePrice: 299, includedSeats: 8, extraSeatFee: null },
+			{ name: "Basic", basePrice: 79, includedSeats: 1, extraSeatFee: null },
+			{
+				name: "Essentials",
+				basePrice: 189,
+				includedSeats: 5,
+				extraSeatFee: null,
+			},
+			{ name: "MAX", basePrice: 329, includedSeats: 8, extraSeatFee: null },
 		],
 		sourceUrl: "https://www.housecallpro.com/pricing/",
 		retrievedAt: RETRIEVED_AT,
 		notes: [
-			"Annual-billing rates $59 / $149 / $299 (vs $79 / $189 / $329 monthly). Seat allowances 1 / 5 / 8 come from Housecall Pro's own machine-readable summary, https://www.housecallpro.com/llm-info/.",
+			"Re-verified 2026-08-16 and UNCHANGED. Monthly rates $79 / $189 / $329 are quoted here; annual is $59 / $149 / $299, and the page's own billing toggle defaults to Annual. Seat allowances 1 / 5 / 8 come from Housecall Pro's own machine-readable summary, https://www.housecallpro.com/llm-info/, which states 'Basic - 1 user', 'Essentials - includes 5 users', 'MAX - includes 8 users' and dates itself 'As of July 2026'.",
 			"'Additional users are available on the MAX plan' — the per-additional-user price is not published, so crews above 8 are not computable and render an em dash.",
+			"The pricing page now leads with a 'Get the right plan' wizard and only reveals the plan cards after it; the card prices above are still in the page payload and match llm-info.",
+			"Customer portal is published as 'Customer Portal', with its own feature page (housecallpro.com/features/customer-portal/) and help-centre collection: customers view past and upcoming appointments, view and pay invoices, and message the business. It is not named in the pricing page's per-plan feature lists, so no tier gating is claimed.",
+			"'Included in every Housecall Pro plan' band lists: live phone and chat support, card processing rates as low as 2.59%, free iOS/Android app, and OFFLINE VIEWING.",
+			"Feature tiers on the pricing page: Essentials adds 'Routes' (group and sequence jobs), 'Checklist automations' and QuickBooks Online sync; MAX adds 'Route optimization', open API and escalated phone support.",
 		],
 	},
 	{
-		key: "servicetitan",
-		name: "ServiceTitan",
+		key: "joby",
+		name: "Joby",
 		isUs: false,
-		pricingModel: "quote-only",
-		quoteOnly: true,
-		billedLabel: "Per technician",
-		quotedBilling: "annual",
-		quotedBillingLabel: "not published",
-		plans: [],
-		sourceUrl: "https://www.servicetitan.com/pricing",
+		// The one rival on this table that prices the way we do. Kept in the
+		// comparison precisely because of that — a reader who already knows Joby
+		// would notice its absence, and we still win the number.
+		pricingModel: "flat-per-org",
+		// Joby publishes no annual rate at all, so its only figure is already the
+		// month-to-month one — it needed no adjustment when the table moved off the
+		// annual basis, and it is the one rival with no annual discount to concede.
+		quotedBilling: "monthly",
+		quotedBillingLabel: "month-to-month",
+		plans: [
+			{
+				name: "Starter",
+				basePrice: 89,
+				includedSeats: "unlimited",
+				extraSeatFee: null,
+			},
+			{
+				name: "Pro",
+				basePrice: 129,
+				includedSeats: "unlimited",
+				extraSeatFee: null,
+			},
+			{
+				name: "Grow",
+				basePrice: 250,
+				includedSeats: "unlimited",
+				extraSeatFee: null,
+			},
+		],
+		sourceUrl: "https://joby.io/pricing",
 		retrievedAt: RETRIEVED_AT,
 		notes: [
-			"All three tiers (Starter, Essentials, The Works) show 'Request Pricing' — no dollar figure is published anywhere on the page, so no cell in this column can be filled in.",
-			"The page states 'Our per-technician pricing is designed to fit your business'.",
+			"Read verbatim on 2026-08-16: 'Flat monthly pricing with unlimited users on every plan. 14-day free trial.' Starter $89/mo, Pro $129/mo, Grow $250/mo. No annual-billing option is published, so these ARE the cheapest published figures.",
+			"Every tier says 'Unlimited users' on the plan card and in the compare grid, so the seat argument does not separate us from Joby — only the price does.",
+			"'Customer self-serve portal' is checked on all three tiers in the compare grid, and joby-pay adds 'A clean, branded payment page that loads on any phone — no Joby account required'.",
+			"Compare grid, read tier-by-tier: 'Estimates & e-signatures', 'Online card payments (Joby Pay / Stripe)', 'CSV import (leads & clients)' and 'Mobile app (iOS & Android)' are checked on all three tiers. 'Workflow automations (visual)' is an em dash on Starter and checked on Pro and Grow.",
+			"joby.io/products/joby-pay publishes the rate outright, verbatim: 'Standard Stripe processing fees apply (2.9% + 30¢ for card, 0.8% for ACH capped at $5). There is no extra Joby fee on top — your seat price covers the platform. Enterprise customers can negotiate custom processing rates with Stripe.' Charges run through the org's own Stripe Express account, the same Connect model as ours, so Joby beats us on this row. Separately, 'Online card payments (Joby Pay / Stripe)' confirms Joby is on Stripe like us and Jobber — so the underlying cost is comparable and only the markup is unknown. Also, nothing about route planning or optimization appears — the closest published rows are 'Service-area matching' and 'Live location team tracking' ($5 per active worker/month add-on). No offline capability is claimed anywhere on the page.",
+			"Support ladder is published as email support (Starter), priority support (Pro), dedicated success manager (Grow) — no phone support for customers is published, which is notable for a vendor whose product IS a phone system.",
+			"Communication usage is billed on top of every plan: calls from $0.006/min local inbound, $0.015/min outbound, SMS $0.008/segment, phone numbers $1/mo local. Our table quotes the plan fee only, which is Joby's best case.",
 		],
 	},
 ];
@@ -168,9 +324,12 @@ export const CREW_SIZES = [1, 2, 3, 4, 5, 6, 8, 10] as const;
 export type CrewSize = (typeof CREW_SIZES)[number];
 export const DEFAULT_CREW: CrewSize = 4;
 
-/** cost(crew) = base + max(0, crew − includedSeats) × extraSeatFee.
- *  `null` when the vendor publishes no way to price that crew on this plan. */
+/** cost(crew) = base + max(0, crew − includedSeats) × extraSeatFee, and `null`
+ *  when the vendor publishes no way to price that crew on this plan — including
+ *  when the crew falls outside the plan's published team-size bucket. */
 function planCost(plan: CompetitorPlan, crew: number): number | null {
+	if (plan.seatBand && (crew < plan.seatBand.min || crew > plan.seatBand.max))
+		return null;
 	if (plan.includedSeats === "unlimited") return plan.basePrice;
 	if (crew <= plan.includedSeats) return plan.basePrice;
 	if (plan.extraSeatFee === null) return null;
@@ -185,11 +344,10 @@ export interface VendorQuote {
 /**
  * The cheapest published configuration for a crew of `crew` — we always give
  * the vendor their best number, and name the plan it came from. `null` when no
- * published plan can cover that crew (quote-only vendors, or Housecall Pro
- * above 8 people).
+ * published plan can cover that crew — today that means only Housecall Pro
+ * above 8 people, whose extra-seat price is unpublished.
  */
 export function quoteFor(v: Vendor, crew: number): VendorQuote | null {
-	if (v.quoteOnly) return null;
 	let best: VendorQuote | null = null;
 	for (const plan of v.plans) {
 		const monthly = planCost(plan, crew);
@@ -209,7 +367,7 @@ export interface RivalQuote extends VendorQuote {
 export function cheapestRival(crew: number): RivalQuote | null {
 	let best: RivalQuote | null = null;
 	for (const v of VENDORS) {
-		if (v.isUs || v.quoteOnly) continue;
+		if (v.isUs) continue;
 		const q = quoteFor(v, crew);
 		if (!q) continue;
 		if (best === null || q.monthly < best.monthly) {
@@ -228,6 +386,8 @@ export type FeatureCell =
 	| { kind: "tier"; label: string }
 	/** A plain published fact (seat allowances, support terms). */
 	| { kind: "text"; label: string }
+	/** On the roadmap, not shipped yet — OneTool only, and only where we can say so. */
+	| { kind: "soon"; label?: string }
 	/** Not published on their pricing page — renders an em dash. */
 	| { kind: "unpublished" };
 
@@ -237,21 +397,29 @@ export interface FeatureRow {
 }
 
 /**
- * Rows are chosen so every cell traces to a published statement. "—" means
- * "not published on their pricing page" (stated in the legend), never "they
- * can't do it" — several of these vendors may well ship the feature without
- * listing it. Phone support is conceded to Jobber and Housecall Pro.
- * There is deliberately NO card-processing-rate row: OneTool's application fee
- * is unpublished, so it is the one row we could not fill in honestly.
+ * Rows are chosen so every cell traces to a published statement on one of the
+ * vendor's own pages — usually /pricing/, but a product or features page counts
+ * too (that is where Jobber's card rate, Jobber's offline post and Housecall
+ * Pro's Customer Portal live). "—" means "the vendor publishes nothing we could
+ * find", never "they can't do it" — several of these vendors may well ship the feature without
+ * listing it. Phone support is conceded to Jobber and Housecall Pro, and as of
+ * 2026-08-16 so is offline mobile: both of them ship it and we do not yet.
+ * The card-processing row USED to be omitted because OneTool's application fee
+ * was unpublished. It is published now — a flat $1 per transaction on top of
+ * the org's own Stripe rate (STRIPE_APPLICATION_FEE_CENTS=100, read off the
+ * deployment 2026-08-16; verify prod before changing it). This is the one row
+ * we LOSE and it stays in on purpose: Jobber and Joby both publish the plain
+ * Stripe rate with no markup on top, so we are the most expensive of the three.
+ * Do not soften it, and do not "fix" it by deleting the row.
  */
 export const FEATURE_ROWS: FeatureRow[] = [
 	{
 		label: "Users included",
 		cells: {
 			onetool: { kind: "included", label: "Unlimited" },
-			jobber: { kind: "text", label: "1–15 by plan" },
+			jobber: { kind: "text", label: "1–15 by team size" },
 			housecall: { kind: "text", label: "1–8 by plan" },
-			servicetitan: { kind: "text", label: "Per technician" },
+			joby: { kind: "included", label: "Unlimited" },
 		},
 	},
 	{
@@ -260,16 +428,43 @@ export const FEATURE_ROWS: FeatureRow[] = [
 			onetool: { kind: "included", label: "Unlimited" },
 			jobber: { kind: "unpublished" },
 			housecall: { kind: "unpublished" },
-			servicetitan: { kind: "unpublished" },
+			joby: { kind: "included" },
+		},
+	},
+	{
+		// A row every vendor wins — deliberately. A reader looking at a $30 tool
+		// assumes it cannot have the client-facing surface the $200 tools have, and
+		// a tie says otherwise better than a claim would. Each vendor ships one
+		// under its own name; the names are in the per-vendor notes rather than the
+		// cells, so the row reads as a level check rather than four brand labels.
+		label: "Customer portal",
+		cells: {
+			onetool: { kind: "included" },
+			jobber: { kind: "included" },
+			housecall: { kind: "included" },
+			joby: { kind: "included" },
 		},
 	},
 	{
 		label: "Online card payments",
 		cells: {
 			onetool: { kind: "included" },
-			jobber: { kind: "included", label: "2.9% + 30¢" },
-			housecall: { kind: "included", label: "From 2.59%" },
-			servicetitan: { kind: "unpublished" },
+			jobber: { kind: "included" },
+			housecall: { kind: "included" },
+			joby: { kind: "included" },
+		},
+	},
+	{
+		// Capability above, cost here — the row we lose, kept deliberately.
+		// Jobber's rate is NOT on /pricing/ (a direct browser read found none
+		// there); it is on /features/ under "Get Paid". Look there, not on the
+		// pricing page, when re-verifying.
+		label: "Card processing fee",
+		cells: {
+			onetool: { kind: "text", label: "Stripe + $1/txn" },
+			jobber: { kind: "text", label: "2.9% + 30¢" },
+			housecall: { kind: "text", label: "From 2.59%" },
+			joby: { kind: "text", label: "2.9% + 30¢" },
 		},
 	},
 	{
@@ -278,7 +473,7 @@ export const FEATURE_ROWS: FeatureRow[] = [
 			onetool: { kind: "included" },
 			jobber: { kind: "unpublished" },
 			housecall: { kind: "tier", label: "Essentials plan" },
-			servicetitan: { kind: "unpublished" },
+			joby: { kind: "unpublished" },
 		},
 	},
 	{
@@ -287,25 +482,30 @@ export const FEATURE_ROWS: FeatureRow[] = [
 			onetool: { kind: "included" },
 			jobber: { kind: "tier", label: "Grow plan" },
 			housecall: { kind: "tier", label: "Essentials plan" },
-			servicetitan: { kind: "unpublished" },
+			joby: { kind: "tier", label: "Pro plan" },
 		},
 	},
 	{
+		// Joby's cell says plain "CSV import" rather than "CSV import, not AI":
+		// they do publish CSV import on every tier, and the row label already makes
+		// the distinction. Editorialising in the cell breaks the no-mockery rule.
 		label: "AI import from CSV",
 		cells: {
 			onetool: { kind: "included" },
 			jobber: { kind: "unpublished" },
 			housecall: { kind: "unpublished" },
-			servicetitan: { kind: "unpublished" },
+			joby: { kind: "text", label: "CSV import" },
 		},
 	},
 	{
-		label: "Offline iOS app",
+		label: "Offline mobile app",
 		cells: {
-			onetool: { kind: "included" },
-			jobber: { kind: "unpublished" },
-			housecall: { kind: "unpublished" },
-			servicetitan: { kind: "unpublished" },
+			// apps/mobile has no offline code today — the PRD exists, the feature
+			// does not. Anything but "coming soon" here would be a false claim.
+			onetool: { kind: "soon" },
+			jobber: { kind: "included", label: "Forms, visits, time" },
+			housecall: { kind: "included", label: "Viewing only" },
+			joby: { kind: "unpublished" },
 		},
 	},
 	{
@@ -314,7 +514,7 @@ export const FEATURE_ROWS: FeatureRow[] = [
 			onetool: { kind: "text", label: "Email, 24h SLA" },
 			jobber: { kind: "included" },
 			housecall: { kind: "included" },
-			servicetitan: { kind: "unpublished" },
+			joby: { kind: "text", label: "Email; priority on Pro" },
 		},
 	},
 ];
@@ -325,7 +525,7 @@ export const FEATURE_ROWS: FeatureRow[] = [
 export const NON_CALCULATOR_MENTIONS = [
 	{
 		name: "Workiz",
-		note: "publishes $55–$65 per extra member per month, but no base price for any tier",
+		note: "shows 'Request pricing' on all three tiers (Standard, Pro, Ultimate) and publishes only $55–$65 per extra member per month",
 		sourceUrl: "https://www.workiz.com/pricing-plans/",
 		retrievedAt: RETRIEVED_AT,
 	},
@@ -335,6 +535,6 @@ export const NON_CALCULATOR_MENTIONS = [
 export const FOOTNOTE_SOURCES = [
 	{ name: "Jobber", url: vendor("jobber").sourceUrl },
 	{ name: "Housecall Pro", url: vendor("housecall").sourceUrl },
-	{ name: "ServiceTitan", url: vendor("servicetitan").sourceUrl },
+	{ name: "Joby", url: vendor("joby").sourceUrl },
 	{ name: "Workiz", url: NON_CALCULATOR_MENTIONS[0].sourceUrl },
 ] as const;

--- a/apps/web/src/app/components/marketing/sections/on-the-job.tsx
+++ b/apps/web/src/app/components/marketing/sections/on-the-job.tsx
@@ -4,9 +4,15 @@ import { Iphone } from "@/components/ui/iphone";
 import { AmbientLayer } from "../ambient";
 import { CheckItem, Eyebrow, Lede, Section, SectionHeading } from "../primitives";
 
-/* On the job — the offline story. A truck-cab photo with the shipping iOS app
- * standing in front of it, in the shared Iphone frame the rest of the app
- * uses. The screen is a real capture, not a rebuilt mock. */
+/* On the job — the "it's already in your pocket" story. A truck-cab photo with
+ * the shipping iOS app standing in front of it, in the shared Iphone frame the
+ * rest of the app uses. The screen is a real capture, not a rebuilt mock.
+ *
+ * This section used to sell offline ("even with no signal at all"). It is not
+ * built: apps/mobile has no offline code, only a PRD. Everything claimed below
+ * is live in the shipped App Store build, and offline is named as roadmap in
+ * one line rather than promised in the heading. Do not put it back until the
+ * outbox actually ships. */
 
 const APP_STORE_URL =
 	"https://apps.apple.com/us/app/onetool-small-business-crm/id6757319255";
@@ -45,18 +51,23 @@ export function OnTheJob() {
 			<div className="relative">
 				<Eyebrow>On the job</Eyebrow>
 				<SectionHeading size="md">
-					Built to work in the truck, even with no signal at all.
+					Your whole day&rsquo;s work, in your pocket.
 				</SectionHeading>
 				<Lede className="max-w-[32rem]">
-					The iOS app keeps your day on the device, so a basement with no signal
-					doesn&rsquo;t stop you writing up the visit. When you come back into range
-					it syncs by itself, with nothing lost and nothing to retry.
+					The iOS app shows the same visits, clients and numbers as the web app, updated
+					the moment anyone touches them. Write the visit up in the driveway and it is on
+					the office screen before you turn the key.
 				</Lede>
 				<ul className="mt-7 grid max-w-[30rem] gap-[10px]">
 					<CheckItem>Real-time sync between phone and web</CheckItem>
-					<CheckItem>Offline day plan with addresses and notes</CheckItem>
+					<CheckItem>The day&rsquo;s visits, addresses and notes on your phone</CheckItem>
 					<CheckItem>Switch between organisations on the go</CheckItem>
 				</ul>
+				{/* Named, not buried: the compare table says "coming soon" in the
+				    offline row, and this section has to agree with it. */}
+				<p className="mt-4 max-w-[30rem] text-[13px] leading-[1.6] text-(--ink-3)">
+					Working with no signal at all is coming — for now the app needs a connection.
+				</p>
 				<a
 					href={APP_STORE_URL}
 					target="_blank"


### PR DESCRIPTION
The 2026-08-14 read of Jobber was wrong, and wrong in Jobber's favour. Jobber's pricing page is gated by a "Team size" selector (Just me · 2-5 · 6-10 · 11-15 · 16 or more) where the price, the bundled seat count AND which plans exist all change with the bucket. The old read took prices from the "Just me" bucket, paired them with seat allowances belonging to the larger buckets, and let a $29/seat formula fill the gaps — quoting a crew of four $99 when Jobber quotes that crew $199. Plans are now seatBand-scoped, so every crew size is priced from the bucket Jobber itself puts it in and the figure is reproducible by any reader.

Re-verified bucket by bucket in a browser; getjobber.com sits behind Cloudflare and a plain fetch only ever returns a challenge page. Housecall Pro, ServiceTitan and Workiz were re-checked and are unchanged.

Also in this pass:

- Quote every column month-to-month, including ours. That is the default view on Jobber's page and one cadence across all columns. It is NOT the competitor-favouring basis the annual rates were, so the footnote now discloses their cheaper annual rates by name.
- Add Joby as a column. It prices the way we do — flat, unlimited users, $89/$129/$250 — so it is the one real like-for-like rival, and it is the cheapest rival at every crew size above one.
- Stop claiming offline. apps/mobile has no offline code, only a PRD, so the row reads "coming soon" and on-the-job.tsx loses its "even with no signal at all" heading. Jobber shipped offline in March 2026 and Housecall Pro publishes "Offline viewing"; both get checks.
- Add a card-processing-fee row we lose. OneTool adds $1 per transaction on top of the org's Stripe rate; Jobber and Joby both pass the bare 2.9% + 30c through. Jobber's rate is published on /features/, not on /pricing/, which is why an earlier pass concluded it was unpublished.
- Add a customer-portal row. All four ship one; a tie answers the reader who assumes a $30 tool cannot have the surface the $200 tools have.
- Drop ServiceTitan entirely. Every tier is "Request Pricing", so the column was em dashes end to end. The quoteOnly flag and quote-only pricing model went with it as its only user.
- Drop the "Billed" row. "Per user" sat directly beneath a whole-crew total and contradicted it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Coming soon” labels for roadmap features in comparisons.
  * Added Joby pricing and feature comparisons.
  * Added team-size-based Jobber pricing and improved quote calculations.
  * Expanded comparison details for customer portals, processing fees, and offline mobile support.

* **Updates**
  * Refreshed competitor pricing with current month-to-month rates.
  * Updated comparison footnotes, sources, and pricing explanations.
  * Clarified that the mobile app currently requires an internet connection, with no-signal support planned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates the landing-page comparison to use month-to-month, team-size-scoped vendor pricing and replaces ServiceTitan with Joby.
- Corrects Jobber quote calculation by restricting plans to their published team-size bands.
- Adds customer-portal and card-processing comparisons and accurately marks OneTool offline support as forthcoming.
- Revises the mobile marketing copy to describe connected, real-time behavior rather than offline operation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The selectable crew sizes resolve to valid bucket-scoped Jobber quotes, the four-vendor rendering remains internally consistent, and the revised OneTool capability claims match the checked implementation and stated production configuration.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/components/marketing/sections/compare.tsx | Updates comparison rendering, disclosures, and feature-state presentation consistently with the revised four-vendor data model. |
| apps/web/src/app/components/marketing/sections/competitor-data.ts | Introduces Jobber team-size bands, month-to-month prices, Joby data, and revised feature claims without exposing a concrete calculation defect. |
| apps/web/src/app/components/marketing/sections/on-the-job.tsx | Removes unsupported offline claims and replaces them with connected-app behavior consistent with the implementation. |

<sub>Reviews (1): Last reviewed commit: ["fix(landing): correct the Compare table ..."](https://github.com/xcarter93/onetool/commit/7c3ef39bd53dd75fa0bdafb9091aa40b58a2e736) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53774168)</sub>

<!-- /greptile_comment -->