### PR TITLE
Fix SSO sign-in buttons to prevent silent failures on mobile

### DIFF
--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -446,16 +446,6 @@ export default function ProfileScreen({
 					<Text style={{ fontSize: 11, fontFamily: fontFamily.regular, color: t.sub }}>
 						OneTool Mobile
 					</Text>
-					<Text
-						style={{
-							fontSize: 11,
-							fontFamily: fontFamily.regular,
-							color: t.sub,
-							marginTop: 4,
-						}}
-					>
-						Version 1.0.0
-					</Text>
 				</View>
 			</ScrollView>
 		</SafeAreaView>

--- a/apps/mobile/components/auth/SignInCard.tsx
+++ b/apps/mobile/components/auth/SignInCard.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
 	ActivityIndicator,
 	Image,
@@ -8,7 +8,7 @@ import {
 	TextInput,
 	View,
 } from "react-native";
-import { useSignIn } from "@clerk/expo";
+import { useClerk, useSignIn } from "@clerk/expo";
 import { useSignInWithApple } from "@clerk/expo/apple";
 import { useSignInWithGoogle } from "@clerk/expo/google";
 import { LinearGradient } from "expo-linear-gradient";
@@ -28,9 +28,24 @@ type Busy = null | "continue" | "verify" | "resend" | "apple" | "google";
 // first "Continue with Google" work — and users without an org still dead-end
 // at the complete-setup screen, so the 3.1.1 stance holds.
 export function SignInCard() {
+	const clerk = useClerk();
 	const { signIn, fetchStatus } = useSignIn();
 	const { startAppleAuthenticationFlow } = useSignInWithApple();
 	const { startGoogleAuthenticationFlow } = useSignInWithGoogle();
+
+	// Clerk recreates the SSO flow functions each render, and each closes over
+	// that render's isLoaded. A tap that waits out the bootstrap must call the
+	// LATEST function, not the stale not-yet-loaded one it captured at tap time.
+	const ssoFlowsRef = useRef({
+		apple: startAppleAuthenticationFlow,
+		google: startGoogleAuthenticationFlow,
+	});
+	useEffect(() => {
+		ssoFlowsRef.current = {
+			apple: startAppleAuthenticationFlow,
+			google: startGoogleAuthenticationFlow,
+		};
+	});
 
 	const [step, setStep] = useState<"start" | "code">("start");
 	const [email, setEmail] = useState("");
@@ -98,19 +113,38 @@ export function SignInCard() {
 		}
 	};
 
+	// Clerk's native SSO hooks silently return { createdSessionId: null } if the
+	// client hasn't bootstrapped yet (App Review hit this as a "dead" button), so
+	// hold the tap until it loads instead of dropping it.
+	const waitForClerk = async () => {
+		const deadline = Date.now() + 10_000;
+		while (!clerk.loaded && Date.now() < deadline) {
+			await new Promise((resolve) => setTimeout(resolve, 250));
+		}
+		return clerk.loaded;
+	};
+
 	const ssoSignIn = async (provider: "apple" | "google") => {
-		if (locked) return;
+		if (busy !== null) return;
 		setBusy(provider);
 		setFormError(null);
 		try {
+			if (!(await waitForClerk())) {
+				setFormError("Couldn't connect. Check your connection and try again.");
+				return;
+			}
 			// Both flows resolve with a null session id when the user cancels the
-			// native sheet — say nothing in that case. Real failures throw.
-			const { createdSessionId, setActive } =
-				provider === "apple"
-					? await startAppleAuthenticationFlow()
-					: await startGoogleAuthenticationFlow();
+			// native sheet. Real failures throw — except sheet-presentation failures,
+			// which iOS also reports as "canceled". Disambiguate by elapsed time: a
+			// near-instant null means the sheet never presented.
+			const startedAt = Date.now();
+			const { createdSessionId, setActive } = await ssoFlowsRef.current[provider]();
 			if (createdSessionId && setActive) {
 				await setActive({ session: createdSessionId });
+			} else if (Date.now() - startedAt < 1500) {
+				setFormError(
+					`${provider === "apple" ? "Apple" : "Google"} sign-in couldn't start. Try again, or sign in with your email.`
+				);
 			}
 		} catch (err) {
 			setFormError(err instanceof Error ? err.message : "Sign-in failed.");
@@ -249,12 +283,14 @@ export function SignInCard() {
 				<Text style={styles.dividerLabel}>or</Text>
 				<View style={styles.dividerLine} />
 			</View>
+			{/* SSO stays tappable while Clerk loads (ssoSignIn waits internally) —
+			    only an in-flight flow disables it. */}
 			<Pressable
 				onPress={() => void ssoSignIn("apple")}
-				disabled={locked}
+				disabled={busy !== null}
 				accessibilityRole="button"
 				accessibilityLabel="Continue with Apple"
-				style={({ pressed }) => [styles.provider, (pressed || locked) && styles.dimmed]}
+				style={({ pressed }) => [styles.provider, (pressed || busy !== null) && styles.dimmed]}
 			>
 				{busy === "apple" ? (
 					<ActivityIndicator color={hero.text} />
@@ -267,10 +303,10 @@ export function SignInCard() {
 			</Pressable>
 			<Pressable
 				onPress={() => void ssoSignIn("google")}
-				disabled={locked}
+				disabled={busy !== null}
 				accessibilityRole="button"
 				accessibilityLabel="Continue with Google"
-				style={({ pressed }) => [styles.provider, (pressed || locked) && styles.dimmed]}
+				style={({ pressed }) => [styles.provider, (pressed || busy !== null) && styles.dimmed]}
 			>
 				{busy === "google" ? (
 					<ActivityIndicator color={hero.text} />

--- a/apps/mobile/components/auth/SignInCard.tsx
+++ b/apps/mobile/components/auth/SignInCard.tsx
@@ -142,8 +142,10 @@ export function SignInCard() {
 			if (createdSessionId && setActive) {
 				await setActive({ session: createdSessionId });
 			} else if (Date.now() - startedAt < 1500) {
+				// Copy must stay accurate for a fast human cancel too, which lands in
+				// this same window — "didn't finish" covers both, "couldn't start" lies.
 				setFormError(
-					`${provider === "apple" ? "Apple" : "Google"} sign-in couldn't start. Try again, or sign in with your email.`
+					`${provider === "apple" ? "Apple" : "Google"} sign-in didn't finish. Try again, or sign in with your email.`
 				);
 			}
 		} catch (err) {


### PR DESCRIPTION
This pull request improves the reliability and user experience of the single sign-on (SSO) buttons in the `SignInCard` component by ensuring that SSO flows only start after Clerk has fully loaded. It also addresses issues where tapping SSO buttons before Clerk was ready resulted in unresponsive or "dead" buttons, and provides clearer error messages for users when SSO flows fail to launch.

**SSO flow reliability and user experience:**

* Added a `waitForClerk` function to delay SSO flow initiation until Clerk is fully loaded, preventing "dead" SSO buttons and improving reliability. [[1]](diffhunk://#diff-a3de4cc4f5caf9877837304c25cb693d0e9e4ce5c5efa1be5e3ab106fb221f44R31-R49) [[2]](diffhunk://#diff-a3de4cc4f5caf9877837304c25cb693d0e9e4ce5c5efa1be5e3ab106fb221f44R116-R147)
* Updated SSO button state and error handling: SSO buttons remain enabled while Clerk loads (but internally wait), and are only disabled during an in-flight flow. Error messages are now shown if SSO flows fail to start or Clerk cannot connect. [[1]](diffhunk://#diff-a3de4cc4f5caf9877837304c25cb693d0e9e4ce5c5efa1be5e3ab106fb221f44R286-R293) [[2]](diffhunk://#diff-a3de4cc4f5caf9877837304c25cb693d0e9e4ce5c5efa1be5e3ab106fb221f44L270-R309) [[3]](diffhunk://#diff-a3de4cc4f5caf9877837304c25cb693d0e9e4ce5c5efa1be5e3ab106fb221f44R116-R147)

**Code improvements:**

* Used a ref (`ssoFlowsRef`) to always call the latest SSO flow functions, preventing stale closures from causing issues on slow Clerk loads.
* Improved detection of SSO sheet presentation failures by measuring elapsed time, and provided user-friendly error messages in those cases.

**Dependency updates:**

* Added `useClerk` to imports to access Clerk's loading state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Apple and Google sign-in reliability while authentication services load.
  * Added clearer connection failure feedback.
  * Better distinguishes sign-in errors from user-cancelled flows.
  * Keeps sign-in options available during loading and prevents duplicate attempts during an active sign-in.

* **Updates**
  * Removed the app version display from the profile screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates the mobile sign-in card to wait for Clerk readiness, retain current SSO flow callbacks, and surface failures that previously appeared silent.
- Adds a bounded Clerk-readiness wait before starting Apple or Google authentication.
- Keeps SSO buttons enabled during readiness checks while preventing concurrent sign-in operations.
- Uses elapsed time to distinguish an unpresented native sheet from cancellation, but that heuristic misclassifies quick Apple cancellations.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until quick Apple sign-in cancellations are distinguished from genuine sheet-presentation failures.

The new fixed-duration heuristic treats a supported cancellation result as an SSO launch failure whenever the user dismisses the Apple sheet within 1.5 seconds.

**Files Needing Attention:** apps/mobile/components/auth/SignInCard.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/mobile/components/auth/SignInCard.tsx | Adds Clerk-readiness handling and improved SSO feedback, but the elapsed-time heuristic reports fast legitimate Apple cancellations as launch failures. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant U as User
  participant C as SignInCard
  participant Clerk
  participant S as Native SSO Sheet
  U->>C: Tap Apple or Google
  C->>Clerk: Wait until loaded
  Clerk-->>C: Ready
  C->>S: Start authentication flow
  alt Session created
    S-->>C: createdSessionId
    C->>Clerk: setActive(session)
  else Null result under 1.5 seconds
    S-->>C: "createdSessionId = null"
    C-->>U: Show “couldn't start” error
  else Null result after 1.5 seconds
    S-->>C: "createdSessionId = null"
    C-->>U: Remain silent
  end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/mobile/components/auth/SignInCard.tsx:143-147
**Quick cancellation becomes launch failure**

When a user opens the Apple sign-in sheet and dismisses it within 1.5 seconds, the null session result is classified as a presentation failure, causing a legitimate cancellation to display the misleading “Apple sign-in couldn't start” error.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mobile): make SSO sign-in buttons ne..."](https://github.com/xcarter93/onetool/commit/0acd2301408933ad406c1d8d7de4162159ea168e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54466865)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Mobile app (apps/mobile)](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/mobile-app.md)

<!-- /greptile_comment -->