### PR TITLE
fix(backend): allow HEIC/HEIF uploads

### DIFF
--- a/packages/backend/convex/lib/storage.ts
+++ b/packages/backend/convex/lib/storage.ts
@@ -31,6 +31,9 @@ export const StorageConfig = {
 		"image/gif",
 		"image/webp",
 		"image/svg+xml",
+		// iPhone camera default format
+		"image/heic",
+		"image/heif",
 		// Documents
 		"application/pdf",
 		"application/msword",


### PR DESCRIPTION
iPhones shoot HEIC by default; the attachment allowlist rejected it, so photo-library uploads from the mobile app failed at createDocument.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for attaching HEIC and HEIF image files to messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds HEIC and HEIF MIME types to the backend attachment allowlist so iPhone photo-library files can pass document validation.

- Extends the shared image attachment MIME allowlist with `image/heic` and `image/heif`.
- Leaves the mobile filename-based MIME fallback without matching HEIC/HEIF extension mappings.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking mobile MIME-fallback gap for HEIC/HEIF assets reported with an absent or generic MIME type.

Exact HEIC/HEIF MIME values now pass backend validation, but mobile uploads that must infer their type from a filename still reject those extensions before calling the backend.

**Files Needing Attention:** packages/backend/convex/lib/storage.ts and apps/mobile/lib/mime.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/lib/storage.ts | Correctly expands backend validation for HEIC/HEIF, but the associated mobile fallback remains inconsistent for assets lacking a specific MIME value. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/backend/convex/lib/storage.ts:35-36
**Mobile fallback omits HEIC types**

The backend now accepts HEIC/HEIF, but mobile assets with an absent or generic MIME type fall back to an extension map that lacks `heic` and `heif`; those files are reported as unsupported before `createDocument` runs, leaving this part of the iPhone upload flow inconsistent with the expanded backend allowlist.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(backend): allow HEIC/HEIF uploads"](https://github.com/xcarter93/onetool/commit/cb7388ecb015cf3a795b434c7bd6819546124994) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54492163)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->