### PR TITLE
feat(auth): sign-in-wrap legal notice on mobile and web auth

### DIFF
--- a/apps/mobile/components/auth/SignInCard.tsx
+++ b/apps/mobile/components/auth/SignInCard.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import {
 	ActivityIndicator,
 	Image,
+	Linking,
 	Pressable,
 	StyleSheet,
 	Text,
@@ -319,6 +320,35 @@ export function SignInCard() {
 					</>
 				)}
 			</Pressable>
+			{/* Sign-in-wrap assent: Clerk's express-consent checkbox is off (native
+			    token sign-ups can't render it), so this notice carries agreement. */}
+			<Text style={styles.legal}>
+				By continuing, you agree to our{" "}
+				<Text
+					style={styles.legalLink}
+					accessibilityRole="link"
+					onPress={() =>
+						void Linking.openURL(
+							"https://www.onetool.biz/terms-of-service"
+						).catch(() => {})
+					}
+				>
+					Terms of Service
+				</Text>{" "}
+				and{" "}
+				<Text
+					style={styles.legalLink}
+					accessibilityRole="link"
+					onPress={() =>
+						void Linking.openURL(
+							"https://www.onetool.biz/privacy-policy"
+						).catch(() => {})
+					}
+				>
+					Privacy Policy
+				</Text>
+				.
+			</Text>
 		</View>
 	);
 }
@@ -458,5 +488,18 @@ const styles = StyleSheet.create({
 		fontFamily: fontFamily.medium,
 		fontSize: 13,
 		color: hero.textMid,
+	},
+	legal: {
+		fontFamily: fontFamily.regular,
+		fontSize: 11.5,
+		color: hero.textSub,
+		textAlign: "center",
+		lineHeight: 17,
+		marginTop: 8,
+	},
+	legalLink: {
+		fontFamily: fontFamily.medium,
+		color: hero.textMid,
+		textDecorationLine: "underline",
 	},
 });

--- a/apps/web/src/app/(auth)/components/SignInUpForm.tsx
+++ b/apps/web/src/app/(auth)/components/SignInUpForm.tsx
@@ -5,6 +5,7 @@ import { dark } from "@clerk/themes";
 import { useTheme } from "next-themes";
 import { AnimatePresence, motion, type Transition } from "framer-motion";
 import Image from "next/image";
+import Link from "next/link";
 import { AuthGridBackground } from "@/components/blocks/auth-6/components/auth-grid-background";
 
 const BASE_TRANSITION: Transition = { ease: "anticipate", duration: 0.5 };
@@ -80,6 +81,26 @@ export function SignInUpForm({ mode }: SignInUpFormProps) {
 							)}
 						</motion.div>
 					</AnimatePresence>
+					{/* Sign-in-wrap assent: Clerk's express-consent checkbox is off
+					    (native mobile sign-ups can't render it), so this notice
+					    carries agreement on web too. */}
+					<p className="text-muted-foreground mt-6 text-center text-xs">
+						By continuing, you agree to our{" "}
+						<Link
+							href="/terms-of-service"
+							className="hover:text-foreground underline underline-offset-2"
+						>
+							Terms of Service
+						</Link>{" "}
+						and{" "}
+						<Link
+							href="/privacy-policy"
+							className="hover:text-foreground underline underline-offset-2"
+						>
+							Privacy Policy
+						</Link>
+						.
+					</p>
 				</div>
 			</section>
 


### PR DESCRIPTION
Clerk's express-consent requirement is being turned off because the native Apple/Google token sign-ups can't render its checkbox (the transfer sign-up stalls with a null session — the App Review "returned to login" rejection). This notice line under the sign-in controls becomes the assent mechanism on both surfaces.


Claude-Session: https://claude.ai/code/session_013HYTnopyn53Q6xNWdKx4kr

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds sign-in-wrap Terms of Service and Privacy Policy assent notices to the mobile and web Clerk authentication surfaces.
- Adds tappable native legal links beneath the mobile email and social sign-in controls.
- Adds internal legal-page links beneath the web Clerk sign-in and sign-up forms.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with non-blocking mobile layout and link-failure handling issues worth addressing.

The web notice uses valid public routes, while the mobile notice can worsen clipping on constrained phone layouts and silently ignores failures to open either legal document.

**Files Needing Attention:** apps/mobile/components/auth/SignInCard.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/mobile/components/auth/SignInCard.tsx | Adds the mobile assent notice and links, but increases a non-scrollable phone card's height and suppresses link-opening failures. |
| apps/web/src/app/(auth)/components/SignInUpForm.tsx | Adds an assent notice using existing public Terms and Privacy routes without an identified functional defect. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/mobile/components/auth/SignInCard.tsx:325-351
**Legal notice increases card clipping**

On small phones with the keyboard visible or large Dynamic Type enabled, the added multi-line notice increases the height of a bottom-aligned auth card that has no scrolling, leaving the logo and welcome heading clipped above the viewport with no way to reach them.

### Issue 2
apps/mobile/components/auth/SignInCard.tsx:330-346
**Legal link failures are silent**

When the device rejects either `Linking.openURL` request, the empty catch handler silently discards the failure, so tapping Terms of Service or Privacy Policy does nothing and provides no recovery feedback.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(auth): sign-in-wrap legal notice on..."](https://github.com/xcarter93/onetool/commit/1a4ca2e6148f8f580ee480ea5847a23cf68be974) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54918731)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Mobile app (apps/mobile)](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/mobile-app.md)
- Knowledge Base — [Organizations, Auth Identity, and Permission Gating](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/org-auth-permissions.md)

<!-- /greptile_comment -->