### PR TITLE
perf(web): code-split /home heavy chunks + upgrade posthog-js

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -85,7 +85,7 @@
 		"next-themes": "^0.4.6",
 		"papaparse": "^5.5.3",
 		"pdf-lib": "^1.17.1",
-		"posthog-js": "^1.404.1",
+		"posthog-js": "^1.418.10",
 		"posthog-node": "^5.45.2",
 		"qrcode": "^1.5.4",
 		"react": "19.2.3",

--- a/apps/web/src/app/(workspace)/home/page.tsx
+++ b/apps/web/src/app/(workspace)/home/page.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import React, { useState, useEffect, useRef } from "react";
+import dynamic from "next/dynamic";
 import ActivityFeed from "@/app/(workspace)/home/components/activity-feed";
 import HomeStats from "@/app/(workspace)/home/components/home-stats-real";
 import { NeedsAttention } from "@/app/(workspace)/home/components/needs-attention";
-import { HomeCalendar } from "@/app/(workspace)/home/components/calendar/home-calendar";
 import { SchedulePanel } from "@/app/(workspace)/home/components/schedule/schedule-panel";
-import ClientPropertiesMap from "@/app/(workspace)/home/components/client-properties-map";
 import { RecentEmails } from "@/app/(workspace)/home/components/recent-emails";
 import { Frame, FramePanel } from "@/components/reui/frame";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
 import { motion } from "motion/react";
@@ -24,6 +24,47 @@ import {
 	HOME_TOUR_CONTENT,
 	HomeTourContext,
 } from "@/components/tours";
+
+// Code-split so maplibre-gl and the event calendar stay out of the initial
+// /home chunk (field LCP p75 ~3.4s was dominated by script cost before paint).
+// Placeholders mirror each component's own loading footprint to avoid CLS.
+const ClientPropertiesMap = dynamic(
+	() => import("@/app/(workspace)/home/components/client-properties-map"),
+	{ ssr: false, loading: () => <MapLoadingFrame /> }
+);
+const HomeCalendar = dynamic(
+	() =>
+		import("@/app/(workspace)/home/components/calendar/home-calendar").then(
+			(m) => ({ default: m.HomeCalendar })
+		),
+	{ ssr: false, loading: () => <Skeleton className="h-full w-full" /> }
+);
+
+function MapLoadingFrame() {
+	return (
+		<Frame className="h-full w-full">
+			<FramePanel className="flex h-full flex-col gap-3">
+				<h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+					Client Locations
+				</h3>
+				<div
+					className="relative min-h-[300px] flex-1 overflow-hidden rounded-lg border border-border bg-muted/30"
+					role="status"
+					aria-live="polite"
+					aria-label="Loading client locations"
+				>
+					<div className="absolute inset-0 flex items-center justify-center">
+						<div className="flex gap-1">
+							<span className="size-1.5 rounded-full bg-muted-foreground/60 animate-pulse" />
+							<span className="size-1.5 rounded-full bg-muted-foreground/60 animate-pulse [animation-delay:150ms]" />
+							<span className="size-1.5 rounded-full bg-muted-foreground/60 animate-pulse [animation-delay:300ms]" />
+						</div>
+					</div>
+				</div>
+			</FramePanel>
+		</Frame>
+	);
+}
 
 type ViewMode = "dashboard" | "calendar";
 

--- a/apps/web/src/providers/PostHogProvider.tsx
+++ b/apps/web/src/providers/PostHogProvider.tsx
@@ -14,7 +14,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
 				// pointing at the real PostHog app.
 				api_host: "/ingest",
 				ui_host: "https://us.posthog.com",
-				defaults: "2026-05-30",
+				defaults: "2026-08-29",
 				// Only create person profiles for identified (signed-in) users — keeps
 				// anonymous autocapture/pageviews cheap.
 				person_profiles: "identified_only",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,8 +386,8 @@ importers:
         specifier: ^1.17.1
         version: 1.17.1
       posthog-js:
-        specifier: ^1.404.1
-        version: 1.404.1
+        specifier: ^1.418.10
+        version: 1.418.10
       posthog-node:
         specifier: ^5.45.2
         version: 5.45.2
@@ -2991,6 +2991,9 @@ packages:
   '@pdf-lib/upng@1.0.1':
     resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
 
+  '@posthog/browser-common@0.5.0':
+    resolution: {integrity: sha512-8DaxVZS1bQPbA514RePurLNbYjei3P4jhnC206DwVv5XThmZM3QdlsXenI2ujE3pLbgQ79hYn9o1Kda8I3WK/Q==}
+
   '@posthog/cli@0.7.34':
     resolution: {integrity: sha512-wrRwj0FhbypW01TLpFRo1HkPBrwZHKP2tFE9xI4NTb84yMKZnXy49ibBdbImktJ5NbW7ndeWidOCZx+2Lkk7/Q==}
     engines: {node: '>=14.14', npm: '>=6'}
@@ -3004,6 +3007,9 @@ packages:
   '@posthog/core@1.43.1':
     resolution: {integrity: sha512-hGM8f5sp3we6Em/RQHXbmyYm554hUx9+9jhf92ZQgDS4/xW72KHyZiO9wcFye+qAx2cJAOhOCDIznmO1FV8IbA==}
 
+  '@posthog/core@1.48.8':
+    resolution: {integrity: sha512-LAOBOjMQrQmgcbZxnubl74l2GQd5OWqxCJJ8mzcWdZRWbfO6Y/A6E3fqWjDtm68hY4LxC/bbopG60cxZW8cfWw==}
+
   '@posthog/nextjs-config@1.9.68':
     resolution: {integrity: sha512-MmzSrompIThnnrDArCKIOBZuD/b3RErH48ZJyzAuX+WfJTiHBjjTMvGWzr+qlIn8jCyJoglSygAwYVG8lJXybg==}
     engines: {node: ^20.20.0 || >=22.22.0}
@@ -3013,8 +3019,8 @@ packages:
   '@posthog/plugin-utils@1.1.2':
     resolution: {integrity: sha512-CS/14cMmny9NN/LHAb4QZdW3TfxhbKzsfyVYMCjsRdE0IKMTrXMr0cPRZxwczsN6VnWvVoy2Dd5wcG6RrIjlYA==}
 
-  '@posthog/types@1.397.0':
-    resolution: {integrity: sha512-Pa7FtsBo3V0XrhY4y8Xquwp8U07syuZ2IGQdlsRyxhz0yejQLceFjI58UssCXE5zDCDj3km5l7H3ufD6rHChCg==}
+  '@posthog/types@1.405.1':
+    resolution: {integrity: sha512-JvaR4ChUKUk7qSTG58vKN2Br6es9riFF5mvlu7YGcwbB476vfyTO0o/TBh+zE88QhsfxnE5Tr/jKxI+e1v3Q5A==}
 
   '@posthog/webpack-plugin@1.5.26':
     resolution: {integrity: sha512-NAsTb81f8QQai7Uzd3IT2Kjt7o9lPxccVfWqD30HyACCEL3NVMTXed5hRYdtY5DkrdCejxhcA80ldXGiUsiGrQ==}
@@ -6245,8 +6251,8 @@ packages:
   dompurify@3.3.1:
     resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.14:
+    resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -6558,6 +6564,7 @@ packages:
   eslint@9.39.2:
     resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -8926,8 +8933,8 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
-  posthog-js@1.404.1:
-    resolution: {integrity: sha512-ck/HOMKuZ6yefUk5OX+h2s9mUWBsnu0mGDUAWjIwAmQQrloZPShzOhOWuEuZQuMnCKORBFRVGsBAuzsl66cBJA==}
+  posthog-js@1.418.10:
+    resolution: {integrity: sha512-XMvmmnuFoesSPjFo+wvzXkvuzYqIho8CVqxugG1Wt768offFARYNZDd1/xWfm9vk/pJTJ4RhUEHRzLpggmGx9Q==}
 
   posthog-node@5.45.2:
     resolution: {integrity: sha512-QhHw/xL0ntMG/DzqA/qdiKu8JY8ChK5Obm8m1nMJor5sjJ7+pfVJSx1yAynC7iUAJfJ9V+OhBNhDCyi5IFWC0Q==}
@@ -10573,6 +10580,9 @@ packages:
 
   web-vitals@5.3.0:
     resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
+
+  web-vitals@6.0.0:
+    resolution: {integrity: sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -13686,6 +13696,11 @@ snapshots:
     dependencies:
       pako: 1.0.11
 
+  '@posthog/browser-common@0.5.0':
+    dependencies:
+      '@posthog/core': 1.48.8
+      '@posthog/types': 1.405.1
+
   '@posthog/cli@0.7.34':
     dependencies:
       detect-libc: 2.1.2
@@ -13700,7 +13715,11 @@ snapshots:
 
   '@posthog/core@1.43.1':
     dependencies:
-      '@posthog/types': 1.397.0
+      '@posthog/types': 1.405.1
+
+  '@posthog/core@1.48.8':
+    dependencies:
+      '@posthog/types': 1.405.1
 
   '@posthog/nextjs-config@1.9.68(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(webpack@5.105.0(lightningcss@1.30.2)(postcss@8.5.15))':
     dependencies:
@@ -13716,12 +13735,12 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@posthog/types@1.397.0': {}
+  '@posthog/types@1.405.1': {}
 
   '@posthog/webpack-plugin@1.5.26(webpack@5.105.0(lightningcss@1.30.2)(postcss@8.5.15))':
     dependencies:
       '@posthog/cli': 0.7.34
-      '@posthog/core': 1.43.1
+      '@posthog/core': 1.48.8
       '@posthog/plugin-utils': 1.1.2
       webpack: 5.105.0(esbuild@0.28.1)(lightningcss@1.30.2)(postcss@8.5.15)
 
@@ -17576,7 +17595,7 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
-  dompurify@3.4.12:
+  dompurify@3.4.14:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -21124,16 +21143,18 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  posthog-js@1.404.1:
+  posthog-js@1.418.10:
     dependencies:
-      '@posthog/core': 1.43.1
-      '@posthog/types': 1.397.0
+      '@posthog/browser-common': 0.5.0
+      '@posthog/core': 1.48.8
+      '@posthog/types': 1.405.1
       core-js: 3.49.0
-      dompurify: 3.4.12
+      dompurify: 3.4.14
       fflate: 0.4.8
       preact: 10.29.7
       query-selector-shadow-dom: 1.0.1
       web-vitals: 5.3.0
+      web-vitals-soft-navs: web-vitals@6.0.0
     transitivePeerDependencies:
       - preact-render-to-string
 
@@ -23161,6 +23182,8 @@ snapshots:
   web-streams-polyfill@3.3.3: {}
 
   web-vitals@5.3.0: {}
+
+  web-vitals@6.0.0: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
- Lazy-load ClientPropertiesMap (maplibre-gl, 266KB gz) and HomeCalendar via next/dynamic so they stay out of the initial /home bundle; field LCP p75 was ~3.4s dominated by script cost before first paint
- Upgrade posthog-js 1.404.1 -> 1.418.10 (versioned lazy-recorder fixes the duplicated recorder.js loads Lighthouse flagged)
- Bump PostHog defaults to 2026-08-29 (streamNetworkBody, no URL hashes, cookieWinsOnConflict)


Claude-Session: https://claude.ai/code/session_01FJprwbxXw8LHsgmCniC5jU

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reduces the initial `/home` JavaScript bundle and updates PostHog behavior.
- Lazy-loads the client-properties map and home calendar with stable loading placeholders.
- Upgrades `posthog-js` from 1.404.1 to 1.418.10 and updates its locked transitive dependencies.
- Advances the PostHog defaults preset to `2026-08-29`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

The lazy loaders match the components’ export and prop contracts, while the dependency and defaults updates reveal no reachable build, runtime, analytics, or security regression.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/(workspace)/home/page.tsx | Replaces two matching static component imports with client-only dynamic imports and loading placeholders; no concrete regression was identified. |
| apps/web/src/providers/PostHogProvider.tsx | Advances the PostHog defaults preset while retaining the existing explicit initialization settings. |
| apps/web/package.json | Upgrades posthog-js to the intended compatible range, with the resolved version pinned by the lockfile. |
| pnpm-lock.yaml | Consistently updates posthog-js and its transitive dependency graph to version 1.418.10. |

<sub>Reviews (1): Last reviewed commit: ["perf(web): code-split /home heavy chunks..."](https://github.com/xcarter93/onetool/commit/5300d5522daf3121acd546f02ec166428d6240ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55829406)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Reliability**
  * Improved loading behavior for the home page’s interactive map and calendar with dedicated loading placeholders.
  * Enhanced the map loading state with clearer status messaging and visual indicators.

* **Maintenance**
  * Updated analytics support to a newer version.
  * Extended the analytics initialization date range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->