### PR TITLE
Implement metered assistant unlock and plan-meter counters

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "OneTool",
     "slug": "onetool-mg3hyu",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "scheme": "onetool",
     "orientation": "default",
     "icon": "./assets/icon.png",

--- a/apps/mobile/app/(tabs)/clients/index.tsx
+++ b/apps/mobile/app/(tabs)/clients/index.tsx
@@ -369,6 +369,7 @@ const styles = StyleSheet.create({
 		flex: 1,
 		fontFamily: fontFamily.regular,
 		fontSize: 13,
+		letterSpacing: 0, // RN#42589: pin kern so iOS placeholder can't randomly letter-space
 		paddingVertical: 0,
 	},
 	chipRow: {

--- a/apps/mobile/app/(tabs)/clients/new.tsx
+++ b/apps/mobile/app/(tabs)/clients/new.tsx
@@ -458,6 +458,7 @@ const styles = StyleSheet.create({
 		paddingVertical: 12,
 		fontFamily: fontFamily.regular,
 		fontSize: 13,
+		letterSpacing: 0, // RN#42589: pin kern so iOS placeholder can't randomly letter-space
 		minHeight: 48,
 	},
 	multiline: {

--- a/apps/mobile/app/(tabs)/clients/new.tsx
+++ b/apps/mobile/app/(tabs)/clients/new.tsx
@@ -188,13 +188,11 @@ export function ClientCreateBody({
 				err,
 				"Couldn't save your changes. Check your connection and try again."
 			);
-			Alert.alert(
-				planLimit ? "Plan limit reached" : "Couldn't save",
-				planLimit
-					? `${message} Upgrade on the web app to add more.`
-					: "Couldn't save your changes. Check your connection and try again.",
-				[{ text: "OK" }]
-			);
+			// Plan-limit copy renders as-is — no directional upsell text on
+			// mobile (Apple anti-steering).
+			Alert.alert(planLimit ? "Plan limit reached" : "Couldn't save", message, [
+				{ text: "OK" },
+			]);
 		} finally {
 			setSubmitting(false);
 		}

--- a/apps/mobile/app/(tabs)/projects/index.tsx
+++ b/apps/mobile/app/(tabs)/projects/index.tsx
@@ -341,6 +341,7 @@ const styles = StyleSheet.create({
 		flex: 1,
 		fontFamily: fontFamily.regular,
 		fontSize: 13,
+		letterSpacing: 0, // RN#42589: pin kern so iOS placeholder can't randomly letter-space
 		paddingVertical: 0,
 	},
 	chipRow: {

--- a/apps/mobile/app/business-details.tsx
+++ b/apps/mobile/app/business-details.tsx
@@ -347,6 +347,7 @@ const styles = StyleSheet.create({
 		paddingVertical: 12,
 		fontFamily: fontFamily.regular,
 		fontSize: type.body,
+		letterSpacing: 0, // RN#42589: pin kern so iOS placeholder can't randomly letter-space
 		color: tokens.ink,
 		minHeight: 48,
 	},

--- a/apps/mobile/app/invoice/[id].tsx
+++ b/apps/mobile/app/invoice/[id].tsx
@@ -721,6 +721,7 @@ export function InvoiceDetailBody({
 				totalsRows={totalsRows}
 				totalValue={formatCurrency(invoice.total, { exact: true })}
 				resend={displayStatus !== "draft"}
+				firstSend={invoice.status === "draft" && !invoice.firstSentAt}
 				onSend={async () => {
 					await sendToClient({ id: invoice._id });
 				}}

--- a/apps/mobile/app/project/new.tsx
+++ b/apps/mobile/app/project/new.tsx
@@ -198,9 +198,7 @@ export default function NewProjectSheet() {
 
 				{error ? (
 					<Text style={[styles.error, { color: t.destructive }]}>
-						{error.planLimit
-							? `${error.message} Upgrade on the web app to add more.`
-							: error.message}
+						{error.message}
 					</Text>
 				) : null}
 

--- a/apps/mobile/app/project/new.tsx
+++ b/apps/mobile/app/project/new.tsx
@@ -371,6 +371,7 @@ const styles = StyleSheet.create({
 		paddingVertical: 12,
 		fontSize: type.h4,
 		fontFamily: fontFamily.regular,
+		letterSpacing: 0, // RN#42589: pin kern so iOS placeholder can't randomly letter-space
 		marginTop: 8,
 	},
 	select: {

--- a/apps/mobile/app/quote/[id].tsx
+++ b/apps/mobile/app/quote/[id].tsx
@@ -37,6 +37,7 @@ import {
 	type RecordActionKey,
 } from "@/lib/record-actions";
 import { useShellNav } from "@/lib/shell-nav";
+import { describeMutationError } from "@/lib/mutation-error";
 import { useQuoteCapabilities } from "@/lib/use-record-capabilities";
 import { usePermissions } from "@/lib/use-permissions";
 import { formatCurrency, formatDocumentDate } from "@/lib/format";
@@ -306,8 +307,13 @@ export function QuoteDetailBody({
 	const setStatus = async (next: "draft" | "sent" | "approved" | "declined") => {
 		try {
 			await updateQuote({ id: quote._id, status: next });
-		} catch {
-			Alert.alert("Couldn't update this quote", "Please try again.");
+		} catch (err) {
+			// Draft→sent flips debit the clientSends meter and can refuse —
+			// surface the real message instead of a generic retry prompt.
+			Alert.alert(
+				"Couldn't update this quote",
+				describeMutationError(err, "Please try again.").message
+			);
 		}
 	};
 
@@ -806,6 +812,7 @@ export function QuoteDetailBody({
 				totalsRows={totalsRows}
 				totalValue={formatCurrency(quote.total, { exact: true })}
 				resend={status === "sent"}
+				firstSend={!quote.firstSentAt && !quote.sentAt}
 				onSend={async () => {
 					await sendToClient({ id: quote._id });
 				}}

--- a/apps/mobile/app/quote/new.tsx
+++ b/apps/mobile/app/quote/new.tsx
@@ -189,9 +189,7 @@ export default function NewQuoteSheet() {
 
 				{error ? (
 					<Text style={[styles.error, { color: t.destructive }]}>
-						{error.planLimit
-							? `${error.message} Upgrade on the web app to add more.`
-							: error.message}
+						{error.message}
 					</Text>
 				) : null}
 

--- a/apps/mobile/app/quote/new.tsx
+++ b/apps/mobile/app/quote/new.tsx
@@ -283,6 +283,7 @@ const styles = StyleSheet.create({
 		paddingVertical: 12,
 		fontSize: type.h4,
 		fontFamily: fontFamily.regular,
+		letterSpacing: 0, // RN#42589: pin kern so iOS placeholder can't randomly letter-space
 		marginTop: 8,
 	},
 	error: {

--- a/apps/mobile/app/route-edit.tsx
+++ b/apps/mobile/app/route-edit.tsx
@@ -778,6 +778,7 @@ const styles = StyleSheet.create({
 		paddingVertical: 12,
 		fontFamily: fontFamily.regular,
 		fontSize: 13,
+		letterSpacing: 0, // RN#42589: pin kern so iOS placeholder can't randomly letter-space
 		minHeight: 48,
 	},
 	group: {
@@ -890,6 +891,7 @@ const styles = StyleSheet.create({
 		flex: 1,
 		fontFamily: fontFamily.regular,
 		fontSize: 13,
+		letterSpacing: 0,
 		paddingVertical: 10,
 	},
 	errorText: {

--- a/apps/mobile/app/tasks/form.tsx
+++ b/apps/mobile/app/tasks/form.tsx
@@ -57,10 +57,8 @@ const REPEAT_OPTIONS = [
 const SHEET_SLIDE = 600;
 
 // Layout floor for a FieldMenu row (14+14 padding + 1+1 border + ~18 line box).
-// The native SwiftUI menu host under-measures its RN child, so a bare <FieldMenu>
-// reserves less vertical space than it paints and the NEXT field's label lands
-// underneath it. The wrapper below reserves the real row box; kept at/below the
-// true height so a correctly-measured host is unchanged.
+// FieldMenu now overlays the SwiftUI menu host absolutely so its under-measuring
+// can't displace siblings; this floor stays as a cheap belt-and-suspenders.
 const MENU_ROW_MIN_HEIGHT = 48;
 
 type TaskType = "external" | "internal";

--- a/apps/mobile/app/tasks/form.tsx
+++ b/apps/mobile/app/tasks/form.tsx
@@ -812,6 +812,7 @@ const styles = StyleSheet.create({
 		paddingVertical: 12,
 		fontSize: type.h4,
 		fontFamily: fontFamily.regular,
+		letterSpacing: 0, // RN#42589: pin kern so iOS placeholder can't randomly letter-space
 	},
 	multiline: {
 		minHeight: 96,

--- a/apps/mobile/components/AddressAutocomplete.native.tsx
+++ b/apps/mobile/components/AddressAutocomplete.native.tsx
@@ -300,6 +300,7 @@ const styles = StyleSheet.create({
 		flex: 1,
 		fontFamily: fontFamily.regular,
 		fontSize: 13,
+		letterSpacing: 0, // RN#42589: pin kern so iOS placeholder can't randomly letter-space
 		paddingVertical: 10,
 	},
 	suggestions: {
@@ -340,6 +341,7 @@ const styles = StyleSheet.create({
 		paddingVertical: 12,
 		fontFamily: fontFamily.regular,
 		fontSize: 13,
+		letterSpacing: 0,
 		minHeight: 48,
 	},
 	manualRow: {

--- a/apps/mobile/components/EditableField.tsx
+++ b/apps/mobile/components/EditableField.tsx
@@ -264,6 +264,7 @@ const styles = StyleSheet.create({
 		minHeight: touch.min,
 		fontSize: type.rowTitle,
 		fontFamily: fontFamily.regular,
+		letterSpacing: 0, // RN#42589: pin kern so iOS placeholder can't randomly letter-space
 	},
 	actions: {
 		flexDirection: "row",

--- a/apps/mobile/components/FieldMenu.tsx
+++ b/apps/mobile/components/FieldMenu.tsx
@@ -67,18 +67,28 @@ export function FieldMenu({
 
 	if (inert) return <>{trigger}</>;
 
+	// The SwiftUI menu host under-measures its RN child, so making it the
+	// laid-out row lets it displace whatever follows (labels vanish under the
+	// painted overflow). Instead the trigger owns the layout and the host is
+	// absolutely overlaid on top — its measurement can no longer move siblings;
+	// the transparent child is the tap target and menu anchor.
 	return (
-		<MenuView
-			title={title}
-			onPressAction={({ nativeEvent }) => onSelect(nativeEvent.event)}
-			actions={options.map((o) => ({
-				id: o.value,
-				title: o.label,
-				state: o.value === value ? "on" : "off",
-			}))}
-		>
+		<View collapsable={false}>
 			{trigger}
-		</MenuView>
+			<View style={StyleSheet.absoluteFill}>
+				<MenuView
+					title={title}
+					onPressAction={({ nativeEvent }) => onSelect(nativeEvent.event)}
+					actions={options.map((o) => ({
+						id: o.value,
+						title: o.label,
+						state: o.value === value ? "on" : "off",
+					}))}
+				>
+					<View style={styles.anchor} />
+				</MenuView>
+			</View>
+		</View>
 	);
 }
 
@@ -97,5 +107,8 @@ const styles = StyleSheet.create({
 		fontSize: type.h4,
 		fontFamily: fontFamily.regular,
 		marginRight: 8,
+	},
+	anchor: {
+		flex: 1,
 	},
 });

--- a/apps/mobile/components/MentionInput.tsx
+++ b/apps/mobile/components/MentionInput.tsx
@@ -551,6 +551,7 @@ const styles = StyleSheet.create({
 		paddingVertical: spacing.sm,
 		fontSize: 13,
 		fontFamily: fontFamily.regular,
+		letterSpacing: 0, // RN#42589: pin kern so iOS placeholder can't randomly letter-space
 		color: colors.foreground,
 	},
 	actions: {

--- a/apps/mobile/components/assistant/assistant-chat.tsx
+++ b/apps/mobile/components/assistant/assistant-chat.tsx
@@ -16,6 +16,8 @@ import { optimisticallySendMessage, useUIMessages } from "@convex-dev/agent/reac
 import { History, MessageSquarePlus, Sparkles } from "lucide-react-native";
 import { fontFamily, radii, touch, type, useTokens } from "@/lib/theme";
 import { mapWebPathToMobileRoute } from "@/lib/assistant-nav";
+import { describeMutationError, type MutationError } from "@/lib/mutation-error";
+import { useEntitlements } from "@/lib/use-entitlements";
 import { Composer } from "./composer";
 import { AssistantMessage, UserBubble, type AssistantToolPart } from "./message-parts";
 
@@ -41,8 +43,13 @@ export function AssistantChat({ screenContext }: { screenContext?: string }) {
 	const [resumeAttempted, setResumeAttempted] = useState(false);
 	const [input, setInput] = useState("");
 	const [isResponding, setIsResponding] = useState(false);
-	const [error, setError] = useState<string | null>(null);
+	const [error, setError] = useState<MutationError | null>(null);
 	const [showHistory, setShowHistory] = useState(false);
+
+	// Free orgs get a finite daily allowance; business orgs ship no meter at
+	// all, so the counter simply doesn't render for them.
+	const { meter } = useEntitlements();
+	const messageMeter = meter("assistantMessages");
 
 	// User message already saved but streamResponse failed — retry must reuse
 	// this messageId instead of re-saving a duplicate user message.
@@ -156,10 +163,10 @@ export function AssistantChat({ screenContext }: { screenContext?: string }) {
 				screenContext,
 			});
 			pendingRetryRef.current = null;
-		} catch {
+		} catch (err) {
 			// Restore the failed prompt, but never clobber a newer draft.
 			setInput((current) => (current.trim() ? current : prompt));
-			setError("The assistant hit a snag.");
+			setError(describeMutationError(err, "The assistant hit a snag."));
 		} finally {
 			setIsResponding(false);
 		}
@@ -330,6 +337,14 @@ export function AssistantChat({ screenContext }: { screenContext?: string }) {
 							</Pressable>
 						))}
 					</View>
+					{/* A pre-save failure (plan limit, createThread) leaves no message
+					    behind, so this branch must show the error too — there is
+					    nothing retryable, so no Try again here. */}
+					{error ? (
+						<Text style={[styles.errorText, { color: t.destructive }]}>
+							{error.message}
+						</Text>
+					) : null}
 				</View>
 			) : (
 				<ScrollView
@@ -361,30 +376,44 @@ export function AssistantChat({ screenContext }: { screenContext?: string }) {
 					{error ? (
 						<View style={styles.errorRow}>
 							<Text style={[styles.errorText, { color: t.destructive }]}>
-								{error}
+								{error.message}
 							</Text>
-							<Pressable
-								onPress={handleRetry}
-								hitSlop={8}
-								accessibilityRole="button"
-								accessibilityLabel="Try sending that again"
-							>
-								<Text style={[styles.retryText, { color: t.frostedInk }]}>
-									Try again
-								</Text>
-							</Pressable>
+							{/* A plan-limit refusal happens before the message saves, so
+							    there is nothing to retry until the meter resets. */}
+							{!error.planLimit ? (
+								<Pressable
+									onPress={handleRetry}
+									hitSlop={8}
+									accessibilityRole="button"
+									accessibilityLabel="Try sending that again"
+								>
+									<Text style={[styles.retryText, { color: t.frostedInk }]}>
+										Try again
+									</Text>
+								</Pressable>
+							) : null}
 						</View>
 					) : null}
 				</ScrollView>
 			)}
 
 			{!showHistory ? (
-				<Composer
-					value={input}
-					onChangeText={setInput}
-					onSend={() => void handleSend()}
-					disabled={isResponding}
-				/>
+				<>
+					{messageMeter &&
+					messageMeter.limit !== null &&
+					messageMeter.remaining !== null ? (
+						<Text style={[styles.meterText, { color: t.faint }]}>
+							{messageMeter.remaining} of {messageMeter.limit} messages left
+							today
+						</Text>
+					) : null}
+					<Composer
+						value={input}
+						onChangeText={setInput}
+						onSend={() => void handleSend()}
+						disabled={isResponding}
+					/>
+				</>
 			) : null}
 		</KeyboardAvoidingView>
 	);
@@ -508,6 +537,13 @@ const styles = StyleSheet.create({
 		flexDirection: "row",
 		alignItems: "center",
 		gap: 12,
+	},
+	meterText: {
+		fontFamily: fontFamily.regular,
+		fontSize: type.xs,
+		textAlign: "right",
+		paddingHorizontal: 20,
+		marginBottom: 2,
 	},
 	errorText: {
 		fontFamily: fontFamily.regular,

--- a/apps/mobile/components/assistant/assistant-chat.tsx
+++ b/apps/mobile/components/assistant/assistant-chat.tsx
@@ -47,9 +47,14 @@ export function AssistantChat({ screenContext }: { screenContext?: string }) {
 	const [showHistory, setShowHistory] = useState(false);
 
 	// Free orgs get a finite daily allowance; business orgs ship no meter at
-	// all, so the counter simply doesn't render for them.
+	// all, so the counter simply doesn't render for them. Exhausted stays
+	// false while the meter loads so the composer never flashes disabled.
 	const { meter } = useEntitlements();
 	const messageMeter = meter("assistantMessages");
+	const messagesExhausted =
+		messageMeter !== undefined &&
+		messageMeter.remaining !== null &&
+		messageMeter.remaining <= 0;
 
 	// User message already saved but streamResponse failed — retry must reuse
 	// this messageId instead of re-saving a duplicate user message.
@@ -135,7 +140,7 @@ export function AssistantChat({ screenContext }: { screenContext?: string }) {
 
 	const handleSend = async (promptOverride?: string) => {
 		const prompt = (promptOverride ?? input).trim();
-		if (!prompt || isResponding) return;
+		if (!prompt || isResponding || messagesExhausted) return;
 		setInput("");
 		setIsResponding(true);
 		setError(null);
@@ -326,11 +331,14 @@ export function AssistantChat({ screenContext }: { screenContext?: string }) {
 							<Pressable
 								key={s}
 								onPress={() => void handleSend(s)}
-								disabled={isResponding}
+								disabled={isResponding || messagesExhausted}
 								accessibilityRole="button"
 								style={[
 									styles.suggestionChip,
-									{ borderColor: t.line, opacity: isResponding ? 0.5 : 1 },
+									{
+										borderColor: t.line,
+										opacity: isResponding || messagesExhausted ? 0.5 : 1,
+									},
 								]}
 							>
 								<Text style={[styles.suggestionText, { color: t.ink }]}>{s}</Text>
@@ -411,7 +419,7 @@ export function AssistantChat({ screenContext }: { screenContext?: string }) {
 						value={input}
 						onChangeText={setInput}
 						onSend={() => void handleSend()}
-						disabled={isResponding}
+						disabled={isResponding || messagesExhausted}
 					/>
 				</>
 			) : null}

--- a/apps/mobile/components/assistant/assistant-chat.tsx
+++ b/apps/mobile/components/assistant/assistant-chat.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import {
 	ActivityIndicator,
-	KeyboardAvoidingView,
+	Keyboard,
+	type KeyboardEvent,
+	LayoutAnimation,
 	Platform,
 	Pressable,
 	ScrollView,
@@ -38,6 +40,28 @@ const SUGGESTIONS = [
 export function AssistantChat({ screenContext }: { screenContext?: string }) {
 	const t = useTokens();
 	const scrollRef = useRef<ScrollView>(null);
+	const containerRef = useRef<View>(null);
+
+	// KeyboardAvoidingView is broken inside the native formSheet this chat is
+	// presented in (its window-coordinate math ignores the sheet's own layer),
+	// so avoid the keyboard by hand: on every keyboard frame change, measure
+	// where this container actually sits in the window and pad by the overlap.
+	const [keyboardPad, setKeyboardPad] = useState(0);
+	useEffect(() => {
+		if (Platform.OS !== "ios") return;
+		const onFrame = (e: KeyboardEvent) => {
+			containerRef.current?.measureInWindow((_x, y, _w, h) => {
+				const overlap = Math.max(0, y + h - e.endCoordinates.screenY);
+				LayoutAnimation.configureNext({
+					duration: e.duration > 0 ? e.duration : 250,
+					update: { type: "keyboard" },
+				});
+				setKeyboardPad(overlap);
+			});
+		};
+		const sub = Keyboard.addListener("keyboardWillChangeFrame", onFrame);
+		return () => sub.remove();
+	}, []);
 
 	const [threadId, setThreadId] = useState<string | null>(null);
 	const [resumeAttempted, setResumeAttempted] = useState(false);
@@ -227,9 +251,10 @@ export function AssistantChat({ screenContext }: { screenContext?: string }) {
 	const showEmptyState = !showLoadingHistory && results.length === 0;
 
 	return (
-		<KeyboardAvoidingView
-			style={styles.flex}
-			behavior={Platform.OS === "ios" ? "padding" : undefined}
+		<View
+			ref={containerRef}
+			collapsable={false}
+			style={[styles.flex, { paddingBottom: keyboardPad }]}
 		>
 			{/* The ink header above the chat already names the surface — this row is
 			    just the two actions, splitting the width evenly (visual-pass r1). */}
@@ -423,7 +448,7 @@ export function AssistantChat({ screenContext }: { screenContext?: string }) {
 					/>
 				</>
 			) : null}
-		</KeyboardAvoidingView>
+		</View>
 	);
 }
 

--- a/apps/mobile/components/assistant/assistant-host.tsx
+++ b/apps/mobile/components/assistant/assistant-host.tsx
@@ -1,18 +1,20 @@
 import { StyleSheet, Text, View } from "react-native";
 import { Sparkles } from "lucide-react-native";
-import { useQuery } from "convex/react";
-import { api } from "@onetool/backend/convex/_generated/api";
 import { fontFamily, radii, type, useTokens } from "@/lib/theme";
+import { useEntitlements } from "@/lib/use-entitlements";
 import { AssistantChat } from "./assistant-chat";
 
-// Server-truth plan gate around the chat. The locked copy states unavailability
-// and NOTHING else — no upsell, no "upgrade on the web", no billing link
-// (Apple anti-steering treats even directional text as a violation).
+// Server-truth access gate around the chat. The aiAssistant switch is on for
+// every plan (volume rides the assistantMessages meter inside the chat);
+// LockedBody survives only as the kill-switch state. The locked copy states
+// unavailability and NOTHING else — no upsell, no "upgrade on the web", no
+// billing link (Apple anti-steering treats even directional text as a
+// violation).
 export function AssistantHost({ screenContext }: { screenContext?: string }) {
-	const premium = useQuery(api.permissions.hasPremiumAccess);
+	const { isLoading, allows } = useEntitlements();
 
-	if (premium === undefined) return <View style={styles.fill} />;
-	if (!premium) return <LockedBody />;
+	if (isLoading) return <View style={styles.fill} />;
+	if (!allows("aiAssistant")) return <LockedBody />;
 	return <AssistantChat screenContext={screenContext} />;
 }
 

--- a/apps/mobile/components/assistant/composer.tsx
+++ b/apps/mobile/components/assistant/composer.tsx
@@ -79,6 +79,7 @@ const styles = StyleSheet.create({
 		flex: 1,
 		fontFamily: fontFamily.regular,
 		fontSize: type.body,
+		letterSpacing: 0, // RN#42589: pin kern so iOS placeholder can't randomly letter-space
 		maxHeight: 110,
 		paddingVertical: 8,
 	},

--- a/apps/mobile/components/auth/SignInCard.tsx
+++ b/apps/mobile/components/auth/SignInCard.tsx
@@ -414,6 +414,7 @@ const styles = StyleSheet.create({
 		paddingHorizontal: 16,
 		fontFamily: fontFamily.regular,
 		fontSize: 15,
+		letterSpacing: 0, // RN#42589: pin kern so iOS placeholder can't randomly letter-space
 		color: hero.text,
 	},
 	codeInput: {

--- a/apps/mobile/components/create/client-picker.tsx
+++ b/apps/mobile/components/create/client-picker.tsx
@@ -119,12 +119,13 @@ export function ClientPicker({
 			setQuickName("");
 			setQuickPhone("");
 		} catch (err) {
-			const { message, planLimit } = describeMutationError(
-				err,
-				"Couldn't add that client. Check your connection and try again."
-			);
+			// Plan-limit copy renders as-is — no directional upsell text on
+			// mobile (Apple anti-steering).
 			setQuickError(
-				planLimit ? `${message} Upgrade on the web app to continue.` : message
+				describeMutationError(
+					err,
+					"Couldn't add that client. Check your connection and try again."
+				).message
 			);
 		} finally {
 			setQuickSaving(false);

--- a/apps/mobile/components/create/client-picker.tsx
+++ b/apps/mobile/components/create/client-picker.tsx
@@ -357,6 +357,7 @@ const styles = StyleSheet.create({
 		flex: 1,
 		fontFamily: fontFamily.regular,
 		fontSize: type.body,
+		letterSpacing: 0, // RN#42589: pin kern so iOS placeholder can't randomly letter-space
 	},
 	empty: {
 		fontFamily: fontFamily.medium,
@@ -386,6 +387,7 @@ const styles = StyleSheet.create({
 		paddingVertical: 11,
 		fontFamily: fontFamily.regular,
 		fontSize: type.body,
+		letterSpacing: 0,
 	},
 	quickCta: { marginTop: 2 },
 	hint: {

--- a/apps/mobile/components/money/extend-valid-until-sheet.tsx
+++ b/apps/mobile/components/money/extend-valid-until-sheet.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-native";
 import { X } from "lucide-react-native";
 import { fontFamily, type, useTokens } from "@/lib/theme";
+import { describeMutationError } from "@/lib/mutation-error";
 import { Button } from "@/components/ui";
 import { AppCalendar } from "@/components/AppCalendar";
 import {
@@ -73,8 +74,13 @@ export function ExtendValidUntilSheet({
 		try {
 			await onSubmit(utcMsFromDateId(selectedId));
 			onClose();
-		} catch {
-			Alert.alert("Couldn't extend that date", "Please try again.");
+		} catch (err) {
+			// Extending an expired quote revives it to sent, which can debit the
+			// clientSends meter and refuse — show the real reason.
+			Alert.alert(
+				"Couldn't extend that date",
+				describeMutationError(err, "Please try again.").message
+			);
 			setSaving(false);
 		}
 	};

--- a/apps/mobile/components/money/line-item-sheet.tsx
+++ b/apps/mobile/components/money/line-item-sheet.tsx
@@ -328,6 +328,7 @@ const styles = StyleSheet.create({
 		minHeight: 68,
 		fontFamily: fontFamily.regular,
 		fontSize: type.body,
+		letterSpacing: 0, // RN#42589: pin kern so iOS placeholder can't randomly letter-space
 		textAlignVertical: "top",
 	},
 	numberInput: {
@@ -337,6 +338,7 @@ const styles = StyleSheet.create({
 		paddingVertical: 12,
 		fontFamily: fontFamily.semibold,
 		fontSize: type.body,
+		letterSpacing: 0,
 		fontVariant: ["tabular-nums"],
 	},
 	rateBox: {

--- a/apps/mobile/components/money/record-payment-sheet.tsx
+++ b/apps/mobile/components/money/record-payment-sheet.tsx
@@ -284,6 +284,7 @@ const styles = StyleSheet.create({
 		minHeight: 76,
 		fontFamily: fontFamily.regular,
 		fontSize: type.body,
+		letterSpacing: 0, // RN#42589: pin kern so iOS placeholder can't randomly letter-space
 		textAlignVertical: "top",
 	},
 	footer: {

--- a/apps/mobile/components/money/send-preview-sheet.tsx
+++ b/apps/mobile/components/money/send-preview-sheet.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import {
-	Alert,
 	Modal,
 	Pressable,
 	ScrollView,
@@ -10,6 +9,8 @@ import {
 } from "react-native";
 import { Mail, X } from "lucide-react-native";
 import { fontFamily, radii, type, useTokens } from "@/lib/theme";
+import { describeMutationError } from "@/lib/mutation-error";
+import { useEntitlements } from "@/lib/use-entitlements";
 import { Button, Eyebrow, TotalsBlock } from "@/components/ui";
 import { MoneyAmount } from "./money-amount";
 
@@ -38,6 +39,7 @@ export function SendPreviewSheet({
 	totalsRows,
 	totalValue,
 	resend,
+	firstSend,
 	onSend,
 }: {
 	visible: boolean;
@@ -53,20 +55,42 @@ export function SendPreviewSheet({
 	totalValue: string;
 	/** Already sent — button reads "Resend", no status implication. */
 	resend?: boolean;
+	/**
+	 * This send would debit the clientSends meter (the doc has never been
+	 * sent). Resends never debit, so the meter line and the exhausted
+	 * disable apply only when this is true.
+	 */
+	firstSend: boolean;
 	onSend: () => Promise<void>;
 }) {
 	const t = useTokens();
 	const [sending, setSending] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	// Meter absent = loading, business (unlimited), or signed out — in every
+	// case there is nothing to show and nothing to disable.
+	const { meter } = useEntitlements();
+	const sends = firstSend ? meter("clientSends") : undefined;
+	const sendsExhausted =
+		sends !== undefined && sends.remaining !== null && sends.remaining <= 0;
+
+	const close = () => {
+		setError(null);
+		onClose();
+	};
 
 	const send = async () => {
 		setSending(true);
+		setError(null);
 		try {
 			await onSend();
-			onClose();
-		} catch {
-			Alert.alert(
-				`Couldn't send this ${kind}`,
-				"Check the client's portal access and try again."
+			close();
+		} catch (err) {
+			setError(
+				describeMutationError(
+					err,
+					`Couldn't send this ${kind}. Check the client's portal access and try again.`
+				).message
 			);
 		} finally {
 			setSending(false);
@@ -80,7 +104,7 @@ export function SendPreviewSheet({
 			visible={visible}
 			animationType="slide"
 			presentationStyle="pageSheet"
-			onRequestClose={onClose}
+			onRequestClose={close}
 		>
 			<View style={[styles.root, { backgroundColor: t.bg }]}>
 				<View style={styles.topBar}>
@@ -90,7 +114,7 @@ export function SendPreviewSheet({
 					<Pressable
 						accessibilityRole="button"
 						accessibilityLabel="Close"
-						onPress={onClose}
+						onPress={close}
 						hitSlop={8}
 						style={[styles.close, { backgroundColor: t.secondary }]}
 					>
@@ -174,6 +198,23 @@ export function SendPreviewSheet({
 								: "No primary contact email on this client"}
 						</Text>
 					</View>
+					{sends && sends.limit !== null && sends.remaining !== null ? (
+						<Text
+							style={[
+								styles.meterLine,
+								{ color: sendsExhausted ? t.warning : t.faint },
+							]}
+						>
+							{sendsExhausted
+								? "You've used all of this month's document sends. They reset at the start of next month."
+								: `${sends.remaining} of ${sends.limit} document sends left this month`}
+						</Text>
+					) : null}
+					{error ? (
+						<Text style={[styles.errorLine, { color: t.destructive }]}>
+							{error}
+						</Text>
+					) : null}
 					<Button
 						title={
 							sending
@@ -183,7 +224,7 @@ export function SendPreviewSheet({
 									: `Send ${kind}`
 						}
 						variant="solid"
-						disabled={sending || !recipientEmail}
+						disabled={sending || !recipientEmail || sendsExhausted}
 						onPress={send}
 					/>
 				</View>
@@ -269,5 +310,13 @@ const styles = StyleSheet.create({
 		flex: 1,
 		fontFamily: fontFamily.medium,
 		fontSize: type.sm,
+	},
+	meterLine: {
+		fontFamily: fontFamily.medium,
+		fontSize: type.xs,
+	},
+	errorLine: {
+		fontFamily: fontFamily.medium,
+		fontSize: type.xs,
 	},
 });

--- a/apps/mobile/components/work/search-field.tsx
+++ b/apps/mobile/components/work/search-field.tsx
@@ -83,6 +83,7 @@ const styles = StyleSheet.create({
 		minWidth: 0,
 		fontFamily: fontFamily.regular,
 		fontSize: type.body,
+		letterSpacing: 0, // RN#42589: pin kern so iOS placeholder can't randomly letter-space
 		paddingVertical: 0,
 	},
 	clear: {

--- a/apps/mobile/lib/use-entitlements.ts
+++ b/apps/mobile/lib/use-entitlements.ts
@@ -1,0 +1,31 @@
+import { useQuery } from "convex/react";
+import { api } from "@onetool/backend/convex/_generated/api";
+import type { FunctionReturnType } from "convex/server";
+
+type MyEntitlements = FunctionReturnType<typeof api.entitlements.getMine>;
+type MeterUsage = MyEntitlements["meters"][number];
+type FeatureKey = keyof MyEntitlements["features"];
+type MeterKey = MeterUsage["key"];
+
+/**
+ * Mobile mirror of the web `useEntitlements` hook: one `getMine` read plus
+ * helpers over the server-resolved plan contract.
+ *
+ * While loading, `allows` returns false and `meter` returns undefined — gated
+ * UI renders locked-by-default. `meter(key) === undefined` is ambiguous
+ * (loading, business — only finite-limit meters ship — or signed out), so
+ * anything that DISABLES an action on a meter must also check the meter's
+ * fields, never just its presence.
+ */
+export function useEntitlements() {
+	const entitlements = useQuery(api.entitlements.getMine, {});
+	const plan = entitlements?.plan ?? "free";
+	return {
+		isLoading: entitlements === undefined,
+		plan,
+		isBusiness: plan === "business",
+		allows: (key: FeatureKey) => entitlements?.features[key] ?? false,
+		meter: (key: MeterKey): MeterUsage | undefined =>
+			entitlements?.meters.find((m) => m.key === key),
+	};
+}

--- a/apps/mobile/scripts/check-app-store-config.cjs
+++ b/apps/mobile/scripts/check-app-store-config.cjs
@@ -16,8 +16,8 @@ const ios = expo.ios || {};
 const infoPlist = ios.infoPlist || {};
 const pm = ios.privacyManifests;
 
-// (a) version pinned to 2.0.0
-if (expo.version !== "2.0.0") fail(`expo.version must be "2.0.0", got ${JSON.stringify(expo.version)}`);
+// (a) version pinned to 2.0.1
+if (expo.version !== "2.0.1") fail(`expo.version must be "2.0.1", got ${JSON.stringify(expo.version)}`);
 
 // (b) ios.buildNumber must be absent (EAS remote autoIncrement owns CFBundleVersion)
 if (ios.buildNumber != null) fail("expo.ios.buildNumber must be absent (EAS autoIncrement owns it)");

--- a/packages/help-content/articles/mobile-app.ts
+++ b/packages/help-content/articles/mobile-app.ts
@@ -49,7 +49,7 @@ export const mobileAppArticles: HelpArticle[] = [
 					},
 					{
 						type: "paragraph",
-						text: "A magnifier in the header of the other tabs jumps straight to Work with the search field ready. The center button opens the AI assistant. In the current app version the assistant needs the Business plan; on the web it is available on every plan, and an app update to match is on the way. See [Meet the assistant](/help/ai-assistant/meet-the-assistant).",
+						text: "A magnifier in the header of the other tabs jumps straight to Work with the search field ready. The center button opens the AI assistant, available on every plan. On the Free plan the assistant allows 10 messages per day for your organization, and a counter above the message field shows how many are left; the allowance resets at midnight UTC. See [Meet the assistant](/help/ai-assistant/meet-the-assistant).",
 					},
 				],
 			},
@@ -66,7 +66,7 @@ export const mobileAppArticles: HelpArticle[] = [
 							"**New project** is built for speed: pick a client, type a title, optionally set a start date, and it's created. If the client isn't in OneTool yet, tap **+ New client** inside the picker to add them with just a name and phone without leaving the form. You can also start a project straight from a client's detail screen.",
 							"**New quote** picks a client and creates a draft, then opens it so you can add line items right away.",
 							"**New task** and **New client** open the full forms you already know.",
-							"Clients and projects are unlimited on every plan, so creating from the app is never capped. The Free plan's monthly document send meter applies the same as on the web. The current app version shows a generic send error when the allowance runs out; the Billing tab on the web names the limit.",
+							"Clients and projects are unlimited on every plan, so creating from the app is never capped. The Free plan's monthly document send meter applies the same as on the web: the send preview shows how many sends you have left this month and explains when the allowance runs out. Resending an already-sent document is always free.",
 						],
 					},
 				],


### PR DESCRIPTION
This pull request makes several improvements to the mobile app's handling of feature entitlements, usage meters, and error messaging, with a focus on compliance with platform guidelines (e.g., Apple's anti-steering rules). The changes introduce a new `useEntitlements` hook to centralize entitlement and meter logic, update UI components to use this hook, improve user feedback for plan limits and errors, and ensure that no upsell or upgrade prompts appear in the mobile app. Additionally, usage meters for assistant messages and document sends are now displayed and enforced in the UI.

**Entitlements and Meter Integration**
- Added a new `useEntitlements` hook to encapsulate entitlement and usage meter logic, mirroring the web implementation and providing helpers for feature access and meter state (`apps/mobile/lib/use-entitlements.ts`).
- Updated the assistant and send-preview components to use `useEntitlements` for access control and to display usage meters for assistant messages and document sends, including disabling actions when limits are reached (`apps/mobile/components/assistant/assistant-chat.tsx`, `apps/mobile/components/assistant/assistant-host.tsx`, `apps/mobile/components/money/send-preview-sheet.tsx`). [[1]](diffhunk://#diff-5248c94a00118ba93a5f43f579af1b970709fadac9350c306d61351e3d318cc0L44-R53) [[2]](diffhunk://#diff-5248c94a00118ba93a5f43f579af1b970709fadac9350c306d61351e3d318cc0R394-R416) [[3]](diffhunk://#diff-e01d989a291f55bd8beaa2ef6d1339cb05c9f5f7dad111fa39f0b965829641dfL3-R17) [[4]](diffhunk://#diff-86b63d1c8e691064c7a3a82b557c19a215d43a0fefdbfd1d048732ee1b276759R58-R93) [[5]](diffhunk://#diff-86b63d1c8e691064c7a3a82b557c19a215d43a0fefdbfd1d048732ee1b276759R201-R217) [[6]](diffhunk://#diff-86b63d1c8e691064c7a3a82b557c19a215d43a0fefdbfd1d048732ee1b276759L186-R227)

**Error Handling and Messaging**
- Standardized error handling using `describeMutationError` across multiple components, ensuring that plan limit and mutation errors are surfaced with appropriate, non-upsell messages, and that retry options are only shown when applicable (`apps/mobile/app/(tabs)/clients/new.tsx`, `apps/mobile/components/create/client-picker.tsx`, `apps/mobile/components/assistant/assistant-chat.tsx`, `apps/mobile/components/money/extend-valid-until-sheet.tsx`, `apps/mobile/components/money/send-preview-sheet.tsx`, `apps/mobile/app/quote/[id].tsx`). [[1]](diffhunk://#diff-ed08332838baf2c8711d8dc9a347fdd75d82aeac7ca9fb2e6b85468e0cc769faL191-R195) [[2]](diffhunk://#diff-3224449a06538166cefa6b659d09f5b21d698b48c82ae3820410a425e74d453fL122-R128) [[3]](diffhunk://#diff-5248c94a00118ba93a5f43f579af1b970709fadac9350c306d61351e3d318cc0L159-R169) [[4]](diffhunk://#diff-0c0ee0b74d4deb9079702ed610f8811f7ce0da6d38b0f7581396996cb9e8159bL76-R83) [[5]](diffhunk://#diff-86b63d1c8e691064c7a3a82b557c19a215d43a0fefdbfd1d048732ee1b276759R58-R93) [apps/mobile/app/quote/[id].tsxL309-R316](diffhunk://#diff-a9a26673d31e494d98d48f523d7fd4cc128cd3922e44319431c1a727fb5e0ab8L309-R316))

**UI/UX Compliance and Copy Updates**
- Removed all upgrade/upsell messaging from error displays and plan limit warnings in compliance with Apple anti-steering policies, ensuring that users are not directed to upgrade or visit the web app for plan changes (`apps/mobile/app/(tabs)/clients/new.tsx`, `apps/mobile/app/project/new.tsx`, `apps/mobile/app/quote/new.tsx`, `apps/mobile/components/create/client-picker.tsx`). [[1]](diffhunk://#diff-ed08332838baf2c8711d8dc9a347fdd75d82aeac7ca9fb2e6b85468e0cc769faL191-R195) [[2]](diffhunk://#diff-c4a81d6a9c592438febd779d89c55ace9901a29839fb3757a1603f3532c76ed8L201-R201) [[3]](diffhunk://#diff-96a12e41d677153f2add34f678242477eece2e2c282a04eb7129ec62fe2156acL192-R192) [[4]](diffhunk://#diff-3224449a06538166cefa6b659d09f5b21d698b48c82ae3820410a425e74d453fL122-R128)
- Updated error and meter display logic in the assistant chat and send-preview sheets to clearly show when usage limits are reached and to disable actions accordingly (`apps/mobile/components/assistant/assistant-chat.tsx`, `apps/mobile/components/money/send-preview-sheet.tsx`). [[1]](diffhunk://#diff-5248c94a00118ba93a5f43f579af1b970709fadac9350c306d61351e3d318cc0R394-R416) [[2]](diffhunk://#diff-86b63d1c8e691064c7a3a82b557c19a215d43a0fefdbfd1d048732ee1b276759R201-R217) [[3]](diffhunk://#diff-86b63d1c8e691064c7a3a82b557c19a215d43a0fefdbfd1d048732ee1b276759L186-R227)

**Feature Enhancements**
- Added support for showing the number of remaining assistant messages and document sends, with clear messaging when limits are reached and disabling further sends until the meter resets (`apps/mobile/components/assistant/assistant-chat.tsx`, `apps/mobile/components/money/send-preview-sheet.tsx`). [[1]](diffhunk://#diff-5248c94a00118ba93a5f43f579af1b970709fadac9350c306d61351e3d318cc0R394-R416) [[2]](diffhunk://#diff-86b63d1c8e691064c7a3a82b557c19a215d43a0fefdbfd1d048732ee1b276759R201-R217)

**Minor Updates**
- Bumped the app version in `app.json` from `2.0.0` to `2.0.1` to reflect these changes.
- Passed new props (`firstSend`) to send-preview and detail components to support correct meter logic (`apps/mobile/app/invoice/[id].tsx`, `apps/mobile/app/quote/[id].tsx`, `apps/mobile/components/money/send-preview-sheet.tsx`). ([apps/mobile/app/invoice/[id].tsxR724](diffhunk://#diff-c2498113c990998602ff1673dbe7986cb7c264dcca905d25078a84e19e9ca8b9R724), [apps/mobile/app/quote/[id].tsxR815](diffhunk://#diff-a9a26673d31e494d98d48f523d7fd4cc128cd3922e44319431c1a727fb5e0ab8R815), [apps/mobile/components/money/send-preview-sheet.tsxR42](diffhunk://#diff-86b63d1c8e691064c7a3a82b557c19a215d43a0fefdbfd1d048732ee1b276759R42))

These changes collectively improve user experience, ensure compliance with platform rules, and provide clear, actionable feedback on feature access and usage limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added entitlement-aware access controls for the mobile AI assistant.
  - Added daily message allowance visibility and clearer limit handling.
  - Added send-capacity indicators for initial document sends, while keeping resends available.
  - Improved first-send and resend experiences for invoices and quotes.

- **Bug Fixes**
  - Improved error messages across mobile creation, update, and sending flows.
  - Removed confusing web-upgrade instructions from plan-limit errors.
  - Fixed inconsistent iOS text spacing and menu layout behavior.

- **Documentation**
  - Updated mobile plan guidance for AI assistant limits and document sending.

- **Chores**
  - Updated the mobile app version to 2.0.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes mobile entitlement reads, exposes assistant and document-send counters, improves plan-limit errors, and removes mobile upgrade direction. It also aligns first-send document metering with backend debit predicates, but assistant exhaustion is not wired into the send controls.

- Adds a mobile `useEntitlements` hook and unlocks metered Assistant access across plans.
- Displays Assistant and document-send usage counters with server-derived limits.
- Adds first-send classification for quote and invoice previews.
- Standardizes mutation errors and removes mobile upsell copy.
- Updates mobile help content and bumps the app version to 2.0.1.

<h3>Confidence Score: 4/5</h3>

The assistant-meter integration should be fixed before merging because exhausted Free-plan users can still initiate sends that the backend will reject.

The new Assistant counter accurately reports remaining capacity, but neither primary prompt entry point consults it, leaving a current mismatch between displayed exhaustion and actionable controls.

**Files Needing Attention:** apps/mobile/components/assistant/assistant-chat.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/mobile/lib/use-entitlements.ts | Adds a typed mobile entitlement query wrapper whose feature and meter semantics align with the backend response. |
| apps/mobile/components/assistant/assistant-chat.tsx | Adds the daily counter and structured plan-limit errors, but leaves typed and suggested sends enabled when the counter reaches zero. |
| apps/mobile/components/assistant/assistant-host.tsx | Replaces the premium-only query with the centralized feature entitlement and preserves a loading gate. |
| apps/mobile/components/money/send-preview-sheet.tsx | Adds first-send document-meter display and exhaustion gating while preserving server-side enforcement and readable errors. |
| apps/mobile/app/invoice/[id].tsx | Supplies an invoice first-send predicate that matches the backend meter-debit condition. |
| apps/mobile/app/quote/[id].tsx | Supplies a quote first-send predicate matching backend semantics and improves status-change error reporting. |
| packages/help-content/articles/mobile-app.ts | Documents cross-plan Assistant access and the Free-plan Assistant and document-send allowances. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User
    participant Mobile as Mobile Assistant
    participant Entitlements as Entitlement query
    participant Chat as Assistant mutation
    Entitlements-->>Mobile: remaining daily messages
    Mobile-->>User: Display remaining counter
    User->>Mobile: Submit prompt
    Mobile->>Chat: Save message
    Chat->>Chat: Enforce assistantMessages meter
    alt Capacity remains
        Chat-->>Mobile: Message saved
    else Meter exhausted
        Chat-->>Mobile: PLAN_LIMIT_REACHED
        Mobile-->>User: Inline limit error
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/mobile/components/assistant/assistant-chat.tsx:414
**Assistant exhaustion stays actionable**

When a Free-plan organization has exhausted its daily assistant messages, the Composer and suggestion chips remain enabled because their disabled states only check `isResponding`. Both paths call `sendMessage`, causing the app to clear the input and start responding before the backend predictably refuses the request with `PLAN_LIMIT_REACHED`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(mobile): bump app version to 2.0.1..."](https://github.com/xcarter93/onetool/commit/f1bba2b7d6728caf68e8d39a9214f341c96674ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55987263)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Mobile application](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/mobile-application.md)
- Knowledge Base — [Assistant experience](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/assistant-experience.md)
- Knowledge Base — [Commercial lifecycle](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/commercial-lifecycle.md)
- Knowledge Base — [Organization security and integrations](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/organization-security-and-integrations.md)
</details>


<!-- /greptile_comment -->