### PR TITLE
Fix errors, improve telemetry, and update dependencies

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -86,7 +86,7 @@
 		"papaparse": "^5.5.3",
 		"pdf-lib": "^1.17.1",
 		"posthog-js": "^1.418.10",
-		"posthog-node": "^5.45.2",
+		"posthog-node": "^5.50.0",
 		"qrcode": "^1.5.4",
 		"react": "19.2.3",
 		"react-day-picker": "^9.11.1",

--- a/apps/web/src/app/(workspace)/community/page.tsx
+++ b/apps/web/src/app/(workspace)/community/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { useMutation, useQuery } from "convex/react";
 import {
@@ -249,6 +249,10 @@ function HeroSkeleton() {
 function CommunityPageContent() {
 	const router = useRouter();
 	const toast = useToast();
+	// Pending state for the editor navigation buttons — without it the first
+	// click gives no feedback until the /community/edit route resolves.
+	const [isOpeningEditor, startOpeningEditor] = useTransition();
+	const openEditor = () => startOpeningEditor(() => router.push("/community/edit"));
 	const { organization: clerkOrganization } = useOrganization();
 
 	// Queries
@@ -621,18 +625,28 @@ function CommunityPageContent() {
 						<Button
 							variant="outline"
 							size="sm"
-							onClick={() => router.push("/community/edit")}
+							onClick={openEditor}
+							disabled={isOpeningEditor}
 						>
-							<Send className="size-4 mr-2" />
+							{isOpeningEditor ? (
+								<Loader2 className="size-4 mr-2 animate-spin" />
+							) : (
+								<Send className="size-4 mr-2" />
+							)}
 							Review and publish
 						</Button>
 					)}
 					<Button
 						variant="default"
 						size="sm"
-						onClick={() => router.push("/community/edit")}
+						onClick={openEditor}
+						disabled={isOpeningEditor}
 					>
-						<Pencil className="size-4 mr-2" />
+						{isOpeningEditor ? (
+							<Loader2 className="size-4 mr-2 animate-spin" />
+						) : (
+							<Pencil className="size-4 mr-2" />
+						)}
 						Edit page
 					</Button>
 				</div>

--- a/apps/web/src/lib/error-logger.ts
+++ b/apps/web/src/lib/error-logger.ts
@@ -1,12 +1,4 @@
-/**
- * Secure error logging utility
- *
- * In production, this would send errors to your error reporting service
- * (e.g., Sentry, LogRocket, Rollbar, etc.)
- *
- * For now, it logs at debug level in development and can be configured
- * to send to an error reporting service in production.
- */
+import posthog from "posthog-js";
 
 interface ErrorContext {
 	userId?: string;
@@ -15,39 +7,24 @@ interface ErrorContext {
 }
 
 /**
- * Log an error securely
- * @param error - The error object or message
- * @param context - Additional context about the error
+ * Log a caught error. Dev logs to the console only; production reports to
+ * PostHog error tracking so caught failures stay investigable.
  */
 export function logError(error: unknown, context?: ErrorContext): void {
-	const errorMessage = error instanceof Error ? error.message : String(error);
-	const errorStack = error instanceof Error ? error.stack : undefined;
-
-	// In development, log to console for debugging
 	if (process.env.NODE_ENV === "development") {
 		console.error("[Error Logger]", {
-			message: errorMessage,
-			stack: errorStack,
+			message: error instanceof Error ? error.message : String(error),
+			stack: error instanceof Error ? error.stack : undefined,
 			context,
 			timestamp: new Date().toISOString(),
 		});
+		return;
 	}
 
-	// In production, send to error reporting service
-	// Example: Sentry.captureException(error, { extra: context });
-	// Example: LogRocket.captureException(error, { extra: context });
-
-	// For now, we'll just log at a lower level
-	if (process.env.NODE_ENV === "production") {
-		// Send to your error reporting service here
-		// This prevents exposing sensitive error details to the browser console
-		// Placeholder for error reporting service integration
-		// errorReportingService.captureException(error, {
-		//   user: context?.userId,
-		//   tags: { action: context?.action },
-		//   extra: context?.metadata,
-		// });
-	}
+	posthog.captureException(error, {
+		action: context?.action,
+		...context?.metadata,
+	});
 }
 
 /**

--- a/packages/backend/convex/assistantChat.ts
+++ b/packages/backend/convex/assistantChat.ts
@@ -5,7 +5,7 @@ import {
 	vStreamArgs,
 } from "@convex-dev/agent";
 import { paginationOptsValidator } from "convex/server";
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { components, internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { action, internalQuery } from "./_generated/server";
@@ -19,6 +19,7 @@ import {
 	requireMeter,
 } from "./lib/entitlements";
 import { userMutation, userQuery } from "./lib/factories";
+import { trackServerException } from "./lib/posthog";
 import { rateLimiter } from "./rateLimits";
 
 /**
@@ -98,7 +99,10 @@ export const sendMessage = userMutation({
  *  ctx.runQuery, and the entitlement gate needs a database-backed ctx. */
 export const authorizeThread = internalQuery({
 	args: { threadId: v.string(), promptMessageId: v.string() },
-	handler: async (ctx, args): Promise<{ userId: Id<"users"> }> => {
+	handler: async (
+		ctx,
+		args
+	): Promise<{ userId: Id<"users">; distinctId: string }> => {
 		await requireFeature(ctx, "aiAssistant");
 		const user = await getCurrentUserOrThrow(ctx);
 		const orgId = await getCurrentUserOrgId(ctx);
@@ -118,7 +122,7 @@ export const authorizeThread = internalQuery({
 		) {
 			throw new Error("That message can no longer be regenerated. Send it again.");
 		}
-		return { userId: user._id };
+		return { userId: user._id, distinctId: user.externalId };
 	},
 });
 
@@ -136,7 +140,7 @@ export const streamResponse = action({
 		// authorizeThread also enforces the plan gate and the metered-message
 		// pin — this action can be invoked directly with any saved
 		// promptMessageId, and each call costs a full LLM generation.
-		const { userId } = await ctx.runQuery(
+		const { userId, distinctId } = await ctx.runQuery(
 			internal.assistantChat.authorizeThread,
 			{ threadId: args.threadId, promptMessageId: args.promptMessageId }
 		);
@@ -158,18 +162,41 @@ export const streamResponse = action({
 			args.screenContext.length <= SCREEN_CONTEXT_MAX_LENGTH
 				? `\n\n<current-screen>\n${args.screenContext}\n</current-screen>`
 				: "";
-		await assistantAgent.streamText(
-			ctx,
-			{ threadId: args.threadId, userId },
-			{
-				promptMessageId: args.promptMessageId,
-				system: `${INSTRUCTIONS}\n\nThe current date and time is ${today} (UTC).${screenBlock}`,
-				// No reasoningEffort here: gpt-5.4 chat-completions rejects
-				// reasoning_effort combined with function tools (400), and the
-				// 5.4 models already default to effort "none" — the fast path.
-			},
-			{ saveStreamDeltas: true }
-		);
+		// The AI SDK masks mid-stream provider errors as "An error occurred."
+		// before they reach a catch block; onError is the only place the real
+		// error is still visible, so capture it there and keep its message for
+		// the rethrow below.
+		let streamFailure: string | undefined;
+		try {
+			await assistantAgent.streamText(
+				ctx,
+				{ threadId: args.threadId, userId },
+				{
+					promptMessageId: args.promptMessageId,
+					system: `${INSTRUCTIONS}\n\nThe current date and time is ${today} (UTC).${screenBlock}`,
+					// No reasoningEffort here: gpt-5.4 chat-completions rejects
+					// reasoning_effort combined with function tools (400), and the
+					// 5.4 models already default to effort "none" — the fast path.
+					onError: async ({ error }) => {
+						const cause =
+							error instanceof Error && error.cause ? error.cause : error;
+						streamFailure =
+							cause instanceof Error ? cause.message : String(cause);
+						await trackServerException(ctx, {
+							error: cause,
+							source: "assistantChat.streamResponse",
+							distinctId,
+							properties: { threadId: args.threadId },
+						});
+					},
+				},
+				{ saveStreamDeltas: true }
+			);
+		} catch (error) {
+			throw new ConvexError(
+				`Assistant response failed: ${streamFailure ?? (error instanceof Error ? error.message : String(error))}`
+			);
+		}
 	},
 });
 

--- a/packages/backend/convex/assistantChat.ts
+++ b/packages/backend/convex/assistantChat.ts
@@ -197,6 +197,11 @@ export const streamResponse = action({
 				`Assistant response failed: ${streamFailure ?? (error instanceof Error ? error.message : String(error))}`
 			);
 		}
+		// onError marks the stream failed without guaranteeing the awaited
+		// consumption throws — surface the failure to the client either way.
+		if (streamFailure !== undefined) {
+			throw new ConvexError(`Assistant response failed: ${streamFailure}`);
+		}
 	},
 });
 

--- a/packages/backend/convex/projects.test.ts
+++ b/packages/backend/convex/projects.test.ts
@@ -560,5 +560,36 @@ describe("Projects", () => {
 			expect(projects).toHaveLength(1);
 			expect(projects[0].title).toBe("Org 1 Project");
 		});
+
+		it("get returns null for a project id from another organization", async () => {
+			const { clerkUserId1, clerkOrgId1, org2ProjectId } = await t.run(
+				async (ctx) => {
+					const { clerkUserId, clerkOrgId } = await createTestOrg(ctx, {
+						clerkUserId: "user_1",
+						clerkOrgId: "org_1",
+					});
+
+					const { orgId: orgId2 } = await createTestOrg(ctx, {
+						clerkUserId: "user_2",
+						clerkOrgId: "org_2",
+					});
+					const clientId2 = await createTestClient(ctx, orgId2);
+					const org2ProjectId = await createTestProject(ctx, orgId2, clientId2, {
+						title: "Org 2 Project",
+					});
+
+					return { clerkUserId1: clerkUserId, clerkOrgId1: clerkOrgId, org2ProjectId };
+				}
+			);
+
+			const asUser1 = t.withIdentity(
+				createTestIdentity(clerkUserId1, clerkOrgId1)
+			);
+
+			const project = await asUser1.query(api.projects.get, {
+				id: org2ProjectId,
+			});
+			expect(project).toBeNull();
+		});
 	});
 });

--- a/packages/backend/convex/projects.ts
+++ b/packages/backend/convex/projects.ts
@@ -255,15 +255,18 @@ export const get = optionalUserQuery({
 	handler: async (ctx, args: any): Promise<ProjectDocument | null> => {
 		if (!ctx.orgId) return null;
 		await ctx.requireLevel("projects", "view");
-		let project: ProjectDocument;
+		// Stale links and org switches can carry another org's project id —
+		// return null (not-found UI) instead of an opaque server error.
+		let project: ProjectDocument | null;
 		try {
-			project = await ctx.orgEntity("projects", args.id);
+			project = await ctx.orgEntity("projects", args.id, { onMismatch: "skip" });
 		} catch (error) {
 			if (error instanceof Error && error.message.startsWith("Entity not found in projects:")) {
 				return null;
 			}
 			throw error;
 		}
+		if (project === null) return null;
 
 
 		const visibleProjects = await ctx.scopedToActor("projects", 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -113,7 +113,7 @@
   "@convex-dev/resend": "^0.2.0",
   "@convex-dev/workpool": "0.4.8",
   "@onetool/help-content": "workspace:*",
-  "@posthog/convex": "2.0.32",
+  "@posthog/convex": "^2.1.1",
   "@react-email/components": "^1.0.3",
   "@react-email/render": "^2.0.1",
   "@react-pdf/renderer": "^4.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,8 +392,8 @@ importers:
         specifier: ^1.418.10
         version: 1.418.10
       posthog-node:
-        specifier: ^5.45.2
-        version: 5.45.2
+        specifier: ^5.50.0
+        version: 5.50.0
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -561,8 +561,8 @@ importers:
         specifier: workspace:*
         version: link:../help-content
       '@posthog/convex':
-        specifier: 2.0.32
-        version: 2.0.32(convex@1.40.0(@clerk/clerk-react@5.59.2(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@clerk/react@6.14.1(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+        specifier: ^2.1.1
+        version: 2.1.1(convex@1.40.0(@clerk/clerk-react@5.59.2(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@clerk/react@6.14.1(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       '@react-email/components':
         specifier: ^1.0.3
         version: 1.0.3(react-dom@19.2.7(react@19.2.3))(react@19.2.3)
@@ -3002,13 +3002,10 @@ packages:
     engines: {node: '>=14.14', npm: '>=6'}
     hasBin: true
 
-  '@posthog/convex@2.0.32':
-    resolution: {integrity: sha512-diYqpk0XRDA9g3Yu2f+3VS6nsj+OR0EQglh+urC3KkbrNiL+yoDZs1sWiFRx9aEJlwjN0nbHLVJqxkaW838syg==}
+  '@posthog/convex@2.1.1':
+    resolution: {integrity: sha512-T9OSsCdMTB8ncWFVtO4wStFgiGWERdDsYWVPNxi/IkZUU3DYAZUsqxsq2KoTTSQ8wvZ0zwgV2YIT0xE4k16IJg==}
     peerDependencies:
       convex: ^1.39.0
-
-  '@posthog/core@1.43.1':
-    resolution: {integrity: sha512-hGM8f5sp3we6Em/RQHXbmyYm554hUx9+9jhf92ZQgDS4/xW72KHyZiO9wcFye+qAx2cJAOhOCDIznmO1FV8IbA==}
 
   '@posthog/core@1.48.8':
     resolution: {integrity: sha512-LAOBOjMQrQmgcbZxnubl74l2GQd5OWqxCJJ8mzcWdZRWbfO6Y/A6E3fqWjDtm68hY4LxC/bbopG60cxZW8cfWw==}
@@ -8939,8 +8936,8 @@ packages:
   posthog-js@1.418.10:
     resolution: {integrity: sha512-XMvmmnuFoesSPjFo+wvzXkvuzYqIho8CVqxugG1Wt768offFARYNZDd1/xWfm9vk/pJTJ4RhUEHRzLpggmGx9Q==}
 
-  posthog-node@5.45.2:
-    resolution: {integrity: sha512-QhHw/xL0ntMG/DzqA/qdiKu8JY8ChK5Obm8m1nMJor5sjJ7+pfVJSx1yAynC7iUAJfJ9V+OhBNhDCyi5IFWC0Q==}
+  posthog-node@5.50.0:
+    resolution: {integrity: sha512-7trcTN4EcPBiYAI1nnD1rk+VB+OcjgN0Mdnp7kOK09PTCSW0LCAUVAYj3FD7u8Ne5zYCnW/ESv6k3VU7sOsL5w==}
     engines: {node: ^20.20.0 || >=22.22.0}
     peerDependencies:
       rxjs: ^7.0.0
@@ -13701,17 +13698,13 @@ snapshots:
     dependencies:
       detect-libc: 2.1.2
 
-  '@posthog/convex@2.0.32(convex@1.40.0(@clerk/clerk-react@5.59.2(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@clerk/react@6.14.1(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))':
+  '@posthog/convex@2.1.1(convex@1.40.0(@clerk/clerk-react@5.59.2(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@clerk/react@6.14.1(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@posthog/core': 1.43.1
+      '@posthog/core': 1.48.8
       convex: 1.40.0(@clerk/clerk-react@5.59.2(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@clerk/react@6.14.1(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
-      posthog-node: 5.45.2
+      posthog-node: 5.50.0
     transitivePeerDependencies:
       - rxjs
-
-  '@posthog/core@1.43.1':
-    dependencies:
-      '@posthog/types': 1.405.1
 
   '@posthog/core@1.48.8':
     dependencies:
@@ -21161,9 +21154,9 @@ snapshots:
     transitivePeerDependencies:
       - preact-render-to-string
 
-  posthog-node@5.45.2:
+  posthog-node@5.50.0:
     dependencies:
-      '@posthog/core': 1.43.1
+      '@posthog/core': 1.48.8
 
   potpack@2.1.0: {}
 


### PR DESCRIPTION
This pull request introduces several improvements related to error logging, user experience, and dependency updates. The most significant changes are the integration of PostHog for server-side and client-side error tracking, improved user feedback during navigation, more robust project fetching logic, and dependency upgrades for analytics and error reporting.

**Error logging and observability:**

* Integrated PostHog for production error tracking on both client (`posthog-js`) and server (`@posthog/convex`, `posthog-node`), replacing placeholder or console-only error logging. Now, errors are captured and sent to PostHog with relevant context, improving visibility into failures. (`apps/web/src/lib/error-logger.ts` [[1]](diffhunk://#diff-2f5be8b74b62ef7905e9d02a8e648c2354b235feb2c4916ed7b22881d7e4039fL1-R1) [[2]](diffhunk://#diff-2f5be8b74b62ef7905e9d02a8e648c2354b235feb2c4916ed7b22881d7e4039fL18-R27); `packages/backend/convex/assistantChat.ts` [[3]](diffhunk://#diff-f1e4d8b9722d4f75ec5fad50511e56f2876d005de08f88eaf4cf359942a309e1R22) [[4]](diffhunk://#diff-f1e4d8b9722d4f75ec5fad50511e56f2876d005de08f88eaf4cf359942a309e1R180-R199)
* Enhanced server-side error handling in the AI assistant chat: mid-stream errors are now captured and reported to PostHog, and more informative error messages are returned to clients. (`packages/backend/convex/assistantChat.ts` [[1]](diffhunk://#diff-f1e4d8b9722d4f75ec5fad50511e56f2876d005de08f88eaf4cf359942a309e1R165-R170) [[2]](diffhunk://#diff-f1e4d8b9722d4f75ec5fad50511e56f2876d005de08f88eaf4cf359942a309e1R180-R199)

**User experience improvements:**

* Added a loading spinner and disabled state to the "Review and publish" and "Edit page" buttons on the Community page, providing immediate feedback when navigating to the editor. (`apps/web/src/app/(workspace)/community/page.tsx` [[1]](diffhunk://#diff-ca220fbf52366f603c9ae05610ed0a329b588e425a2786a34d85f28338f5c40cL3-R3) [[2]](diffhunk://#diff-ca220fbf52366f603c9ae05610ed0a329b588e425a2786a34d85f28338f5c40cR252-R255) [[3]](diffhunk://#diff-ca220fbf52366f603c9ae05610ed0a329b588e425a2786a34d85f28338f5c40cL624-R649)

**Backend robustness:**

* Improved project fetching logic to gracefully handle stale links or organization switches by returning `null` instead of throwing an error when a project is not found or does not match the current organization. (`packages/backend/convex/projects.ts` [packages/backend/convex/projects.tsL258-R269](diffhunk://#diff-819378f608720a44d6b96f18b5a469af242f28b31e6f7d1ade6a81094870d1b7L258-R269))

**Dependency updates:**

* Upgraded analytics and error reporting dependencies: `posthog-node` to `5.50.0`, `@posthog/convex` to `2.1.1`, and their transitive dependencies, ensuring access to the latest features and bug fixes. (`apps/web/package.json` [[1]](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L89-R89); `packages/backend/package.json` [[2]](diffhunk://#diff-e095a6dd10bb40447d8290e79f70c15334e874e757e25a569b9d3449ed4fe27dL116-R116); `pnpm-lock.yaml` [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL395-R396) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL564-R565) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3005-L3012) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8942-R8940) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13704-L13715) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL21164-R21159)

**API changes:**

* Updated the `authorizeThread` internal query to return both `userId` and `distinctId`, enabling improved user tracking for error reporting. (`packages/backend/convex/assistantChat.ts` [[1]](diffhunk://#diff-f1e4d8b9722d4f75ec5fad50511e56f2876d005de08f88eaf4cf359942a309e1L101-R105) [[2]](diffhunk://#diff-f1e4d8b9722d4f75ec5fad50511e56f2876d005de08f88eaf4cf359942a309e1L121-R125) [[3]](diffhunk://#diff-f1e4d8b9722d4f75ec5fad50511e56f2876d005de08f88eaf4cf359942a309e1L139-R143)

Let me know if you want to dive deeper into any of these areas!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added loading indicators and disabled states when opening the community editor, providing clearer navigation feedback.

* **Bug Fixes**
  * Improved handling of stale or inaccessible project links by treating them as unavailable.
  * Improved assistant error handling so failures are reported clearly while preserving the original message.
  * Prevented access to projects belonging to another organization.

* **Reliability**
  * Enhanced production error tracking to help identify and resolve issues more effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds PostHog-backed exception reporting, improves assistant-stream error handling and community editor navigation feedback, makes stale project lookups return null, and upgrades PostHog dependencies.

- Adds client and server exception capture through PostHog.
- Adds pending navigation states to Community editor buttons.
- Changes project lookup behavior for stale or cross-organization identifiers.
- Updates PostHog packages and their locked transitive dependencies.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with the non-blocking caveat that its newly detailed assistant failure message is still discarded by both clients.

The changed backend constructs useful stream-failure detail, but existing web and mobile error formatters reduce that response to generic feedback; no blocking correctness or security failure was established.

**Files Needing Attention:** packages/backend/convex/assistantChat.ts and the web/mobile assistant error-formatting paths

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/backend/convex/assistantChat.ts | Adds PostHog capture and detailed stream errors, but the new error detail is not surfaced by existing web or mobile client formatters. |
| apps/web/src/lib/error-logger.ts | Replaces production no-op logging with PostHog exception capture while retaining development console output. |
| apps/web/src/app/(workspace)/community/page.tsx | Uses a transition to disable both editor navigation buttons and show loading indicators during route changes. |
| packages/backend/convex/projects.ts | Makes missing or organization-mismatched project reads return null before actor scoping. |
| apps/web/package.json | Upgrades posthog-node to the lockfile-resolved 5.50.0 release. |
| packages/backend/package.json | Upgrades @posthog/convex to 2.1.1 with versions aligned to the repository’s Convex dependency. |
| pnpm-lock.yaml | Locks the upgraded PostHog packages and their compatible shared transitive dependencies. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  actor User
  participant Client as Web or mobile client
  participant Chat as Assistant streamResponse
  participant Agent as Assistant agent
  participant PostHog as PostHog telemetry
  User->>Client: Send assistant message
  Client->>Chat: streamResponse
  Chat->>Agent: streamText
  alt Stream succeeds
    Agent-->>Client: Streamed response
  else Stream fails
    Agent-->>Chat: onError(error)
    Chat->>PostHog: captureException
    Chat-->>Client: ConvexError with failure detail
    Client-->>User: Generic fallback message
  end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/backend/convex/assistantChat.ts:195-198
**Detailed error remains hidden**

The new `ConvexError` contains the stream failure detail, but both assistant clients only decode `PLAN_LIMIT_REACHED` and replace other errors with generic fallback text. Users therefore never receive the more informative failure message introduced here.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(assistant): capture real streamText ..."](https://github.com/xcarter93/onetool/commit/e530c84395d2ade6dbd5a81e627062fa97041e05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56010352)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Web workspace](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/web-workspace.md)
- Knowledge Base — [Projects and tasks](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/projects-and-tasks.md)
- Knowledge Base — [Assistant experience](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/assistant-experience.md)
- Knowledge Base — [Automation and AI](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/automation-and-ai.md)
</details>


<!-- /greptile_comment -->