### PR TITLE
Add launch promo codes to signup and upgrade paths

### DIFF
--- a/apps/web/src/app/(onboarding)/organization/complete/complete-organization.tsx
+++ b/apps/web/src/app/(onboarding)/organization/complete/complete-organization.tsx
@@ -14,6 +14,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { Frame, FramePanel } from "@/components/reui/frame";
 import SelectService from "@/components/shared/choice-set";
+import { LaunchPromoBanner } from "@/components/shared/launch-promo";
 import { Input } from "@/components/ui/input";
 import { PhoneInput } from "@/components/reui/phone-input";
 import {
@@ -1134,7 +1135,9 @@ export function CompleteOrganizationMetadata() {
 	);
 
 	const renderStep4 = () => (
-		<PricingTable
+		<div className="space-y-6">
+			<LaunchPromoBanner />
+			<PricingTable
 			for="organization"
 			newSubscriptionRedirectUrl="/organization/complete"
 			fallback={
@@ -1401,6 +1404,7 @@ export function CompleteOrganizationMetadata() {
 				},
 			}}
 		/>
+		</div>
 	);
 
 	const renderStep5 = () => (

--- a/apps/web/src/app/(workspace)/organization/profile/_components/billing-tab.tsx
+++ b/apps/web/src/app/(workspace)/organization/profile/_components/billing-tab.tsx
@@ -27,6 +27,7 @@ import {
 	Route,
 	Send,
 	Sparkles,
+	Tag,
 	Upload,
 	Users,
 	Wand2,
@@ -40,7 +41,9 @@ import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/reui/badge";
 import { SegmentedControl } from "@/components/domain/segmented-control";
+import { PromoCodeChip } from "@/components/shared/launch-promo";
 import { LearnMoreLink } from "@/components/help/learn-more";
+import { isLaunchPromoActive, LAUNCH_PROMO } from "@/lib/promo";
 import { PLAN_MATRIX } from "@onetool/backend/convex/lib/planMatrix";
 import type { MeterUsage } from "@onetool/backend";
 import { useEntitlements } from "@/hooks/use-entitlements";
@@ -272,6 +275,14 @@ export function BillingTab() {
 		const usage = meter(row.key);
 		return usage ? [{ ...row, usage }] : [];
 	});
+	// Launch promo: shown to free/trial orgs only — paying and override-sourced
+	// orgs have nothing to redeem it against.
+	const promoOffer =
+		period === "annual" ? LAUNCH_PROMO.annual : LAUNCH_PROMO.monthly;
+	const showPromo =
+		isLaunchPromoActive() &&
+		(source === "free" || source === "trial") &&
+		!checkoutDone;
 
 	if (accessLoading) {
 		return (
@@ -405,6 +416,22 @@ export function BillingTab() {
 						)}
 					</div>
 				</SettingsCardHeader>
+				{showPromo && (
+					<div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-t border-border bg-primary/4 px-[22px] py-3">
+						<div className="flex items-center gap-2">
+							<Tag className="size-4 text-primary" aria-hidden="true" />
+							<p className="text-sm">
+								<span className="font-semibold">Launch offer:</span>{" "}
+								{promoOffer.label.toLowerCase()} with code
+							</p>
+						</div>
+						<PromoCodeChip code={promoOffer.code} />
+						<p className="text-xs text-muted-foreground">
+							Enter it at checkout under “Add promo code”. Ends{" "}
+							{LAUNCH_PROMO.endsLabel}.
+						</p>
+					</div>
+				)}
 				<div className="overflow-x-auto">
 					<table className="w-full min-w-[560px] border-t border-border">
 						<thead>

--- a/apps/web/src/app/(workspace)/organization/profile/_components/billing-tab.tsx
+++ b/apps/web/src/app/(workspace)/organization/profile/_components/billing-tab.tsx
@@ -43,7 +43,7 @@ import { Badge } from "@/components/reui/badge";
 import { SegmentedControl } from "@/components/domain/segmented-control";
 import { PromoCodeChip } from "@/components/shared/launch-promo";
 import { LearnMoreLink } from "@/components/help/learn-more";
-import { isLaunchPromoActive, LAUNCH_PROMO } from "@/lib/promo";
+import { LAUNCH_PROMO, useLaunchPromoActive } from "@/lib/promo";
 import { PLAN_MATRIX } from "@onetool/backend/convex/lib/planMatrix";
 import type { MeterUsage } from "@onetool/backend";
 import { useEntitlements } from "@/hooks/use-entitlements";
@@ -279,10 +279,9 @@ export function BillingTab() {
 	// orgs have nothing to redeem it against.
 	const promoOffer =
 		period === "annual" ? LAUNCH_PROMO.annual : LAUNCH_PROMO.monthly;
+	const promoActive = useLaunchPromoActive();
 	const showPromo =
-		isLaunchPromoActive() &&
-		(source === "free" || source === "trial") &&
-		!checkoutDone;
+		promoActive && (source === "free" || source === "trial") && !checkoutDone;
 
 	if (accessLoading) {
 		return (

--- a/apps/web/src/app/components/marketing/launch-offer-note.tsx
+++ b/apps/web/src/app/components/marketing/launch-offer-note.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { isLaunchPromoActive, LAUNCH_PROMO } from "@/lib/promo";
+
+/* Client island so the note self-retires at the promo deadline even on a
+ * statically rendered page (hydration removes it once the window closes). */
+export function LaunchOfferNote() {
+	if (!isLaunchPromoActive()) {
+		return null;
+	}
+
+	return (
+		<p className="mt-[14px] flex items-center gap-2 text-sm font-medium text-(--accent-ink)">
+			<span
+				aria-hidden="true"
+				className="h-[7px] w-[7px] flex-none rounded-full bg-(--accent)"
+			/>
+			Launch offer: {LAUNCH_PROMO.headline}. Claim your code at signup.
+		</p>
+	);
+}

--- a/apps/web/src/app/components/marketing/launch-offer-note.tsx
+++ b/apps/web/src/app/components/marketing/launch-offer-note.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { isLaunchPromoActive, LAUNCH_PROMO } from "@/lib/promo";
+import { LAUNCH_PROMO, useLaunchPromoActive } from "@/lib/promo";
 
 /* Client island so the note self-retires at the promo deadline even on a
  * statically rendered page (hydration removes it once the window closes). */
 export function LaunchOfferNote() {
-	if (!isLaunchPromoActive()) {
+	const promoActive = useLaunchPromoActive();
+	if (!promoActive) {
 		return null;
 	}
 

--- a/apps/web/src/app/components/marketing/sections/faq.tsx
+++ b/apps/web/src/app/components/marketing/sections/faq.tsx
@@ -2,7 +2,7 @@
 
 import { useId, useState } from "react";
 import { cn } from "@/lib/utils";
-import { isLaunchPromoActive, LAUNCH_PROMO } from "@/lib/promo";
+import { LAUNCH_PROMO, useLaunchPromoActive } from "@/lib/promo";
 import { AmbientLayer } from "../ambient";
 import { Eyebrow, Lede, Section, SectionHeading } from "../primitives";
 import { FaqHalftoneScene } from "../section-halftone-scenes";
@@ -84,7 +84,8 @@ const DISCOUNT_FAQ_INDEX =
 export function Faq() {
 	const [openIndex, setOpenIndex] = useState(0);
 	const baseId = useId();
-	const faqs = isLaunchPromoActive()
+	const promoActive = useLaunchPromoActive();
+	const faqs = promoActive
 		? [
 				...FAQS.slice(0, DISCOUNT_FAQ_INDEX),
 				DISCOUNT_FAQ,

--- a/apps/web/src/app/components/marketing/sections/faq.tsx
+++ b/apps/web/src/app/components/marketing/sections/faq.tsx
@@ -2,6 +2,7 @@
 
 import { useId, useState } from "react";
 import { cn } from "@/lib/utils";
+import { isLaunchPromoActive, LAUNCH_PROMO } from "@/lib/promo";
 import { AmbientLayer } from "../ambient";
 import { Eyebrow, Lede, Section, SectionHeading } from "../primitives";
 import { FaqHalftoneScene } from "../section-halftone-scenes";
@@ -69,9 +70,27 @@ const FAQS: ReadonlyArray<readonly [string, string]> = [
 	],
 ];
 
+const DISCOUNT_FAQ: readonly [string, string] = [
+	"Do you offer discounts?",
+	`Yes. Through ${LAUNCH_PROMO.endsLabel} we are running a launch offer: ${LAUNCH_PROMO.annual.label.toLowerCase()} of Business on the annual plan, or ${LAUNCH_PROMO.monthly.label.toLowerCase()} on monthly. Your promo codes are shown when you create your organization and on the Billing tab, and you enter one at checkout under "Add promo code".`,
+];
+
+// The discount entry rides directly after the trial question and disappears
+// with the promo window.
+const DISCOUNT_FAQ_INDEX =
+	FAQS.findIndex(([question]) => question === "How does the free trial work?") +
+	1;
+
 export function Faq() {
 	const [openIndex, setOpenIndex] = useState(0);
 	const baseId = useId();
+	const faqs = isLaunchPromoActive()
+		? [
+				...FAQS.slice(0, DISCOUNT_FAQ_INDEX),
+				DISCOUNT_FAQ,
+				...FAQS.slice(DISCOUNT_FAQ_INDEX),
+			]
+		: FAQS;
 
 	return (
 		<Section
@@ -103,7 +122,7 @@ export function Faq() {
 			</div>
 
 			<ul className="relative">
-				{FAQS.map(([question, answer], index) => {
+				{faqs.map(([question, answer], index) => {
 					const open = openIndex === index;
 					const panelId = `${baseId}-faq-panel-${index}`;
 					const triggerId = `${baseId}-faq-trigger-${index}`;

--- a/apps/web/src/app/components/marketing/sections/hero.tsx
+++ b/apps/web/src/app/components/marketing/sections/hero.tsx
@@ -1,4 +1,5 @@
 import { HeroHalftoneScene } from "../hero-halftone-scene";
+import { LaunchOfferNote } from "../launch-offer-note";
 import { PrimaryButton } from "../marketing-nav";
 import { ParticleMark } from "../particle-mark";
 import { HeroReelCta } from "../reel-cta";
@@ -139,6 +140,10 @@ export function Hero() {
 						<CheckItem>No credit card</CheckItem>
 						<CheckItem>14 days of Business, free</CheckItem>
 					</ul>
+
+					<div className="lp-rise" style={at("300ms")}>
+						<LaunchOfferNote />
+					</div>
 				</div>
 
 				<div

--- a/apps/web/src/app/components/marketing/sections/pricing.tsx
+++ b/apps/web/src/app/components/marketing/sections/pricing.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { usePlans } from "@clerk/nextjs/experimental";
 import { cn } from "@/lib/utils";
-import { isLaunchPromoActive, LAUNCH_PROMO } from "@/lib/promo";
+import { LAUNCH_PROMO, useLaunchPromoActive } from "@/lib/promo";
 import { AmbientLayer } from "../ambient";
 import { PricingHalftoneScene } from "../section-halftone-scenes";
 import { CheckItem, Eyebrow, Lede, Section, SectionHeading, PlusCorners } from "../primitives";
@@ -158,6 +158,7 @@ function BillingToggle({
 
 export function Pricing() {
 	const [annual, setAnnual] = useState(false);
+	const promoActive = useLaunchPromoActive();
 	const { symbol, monthly, yearly, monthlyMinor, yearlyMinor } = useBusinessPrice();
 
 	// What paying yearly actually saves against twelve monthly charges.
@@ -292,7 +293,7 @@ export function Pricing() {
 							<span className="text-base text-(--ink-2)">{priceUnit}</span>
 						</p>
 						<p className="mt-[10px] text-[15px] text-(--ink-2)">{priceNote}</p>
-						{isLaunchPromoActive() && (
+						{promoActive && (
 							<p className="mt-[10px] text-[15px] font-medium text-(--accent-ink)">
 								Launch offer:{" "}
 								{annual

--- a/apps/web/src/app/components/marketing/sections/pricing.tsx
+++ b/apps/web/src/app/components/marketing/sections/pricing.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { usePlans } from "@clerk/nextjs/experimental";
 import { cn } from "@/lib/utils";
+import { isLaunchPromoActive, LAUNCH_PROMO } from "@/lib/promo";
 import { AmbientLayer } from "../ambient";
 import { PricingHalftoneScene } from "../section-halftone-scenes";
 import { CheckItem, Eyebrow, Lede, Section, SectionHeading, PlusCorners } from "../primitives";
@@ -291,6 +292,15 @@ export function Pricing() {
 							<span className="text-base text-(--ink-2)">{priceUnit}</span>
 						</p>
 						<p className="mt-[10px] text-[15px] text-(--ink-2)">{priceNote}</p>
+						{isLaunchPromoActive() && (
+							<p className="mt-[10px] text-[15px] font-medium text-(--accent-ink)">
+								Launch offer:{" "}
+								{annual
+									? LAUNCH_PROMO.annual.label.toLowerCase()
+									: LAUNCH_PROMO.monthly.label.toLowerCase()}
+								. Claim your code at signup. Ends {LAUNCH_PROMO.endsLabel}.
+							</p>
+						)}
 					</div>
 
 					<PrimaryButton

--- a/apps/web/src/components/layout/plan-usage-card.tsx
+++ b/apps/web/src/components/layout/plan-usage-card.tsx
@@ -22,6 +22,7 @@ import { SidebarGroup } from "@/components/ui/sidebar";
 import { useAuth } from "@clerk/nextjs";
 import { useEntitlements } from "@/hooks/use-entitlements";
 import { usePermissions } from "@/hooks/use-permissions";
+import { isLaunchPromoActive, LAUNCH_PROMO } from "@/lib/promo";
 import { cn } from "@/lib/utils";
 
 /** Display order + chrome for the finite-limit meters the backend can return. */
@@ -166,16 +167,24 @@ export function PlanUsageCard() {
 						/>
 					))}
 					{can("billing") && (
-						<Button
-							size="sm"
-							className="w-full justify-center"
-							onClick={() =>
-								router.push("/organization/profile?tab=billing")
-							}
-						>
-							<ArrowUpRight className="size-4" />
-							Upgrade
-						</Button>
+						<div className="space-y-1.5">
+							{isLaunchPromoActive() && (
+								<p className="text-center text-[11px] font-medium text-primary">
+									Launch offer: {LAUNCH_PROMO.headline} through{" "}
+									{LAUNCH_PROMO.endsLabel}
+								</p>
+							)}
+							<Button
+								size="sm"
+								className="w-full justify-center"
+								onClick={() =>
+									router.push("/organization/profile?tab=billing")
+								}
+							>
+								<ArrowUpRight className="size-4" />
+								Upgrade
+							</Button>
+						</div>
 					)}
 				</FramePanel>
 			</Frame>

--- a/apps/web/src/components/layout/plan-usage-card.tsx
+++ b/apps/web/src/components/layout/plan-usage-card.tsx
@@ -22,7 +22,7 @@ import { SidebarGroup } from "@/components/ui/sidebar";
 import { useAuth } from "@clerk/nextjs";
 import { useEntitlements } from "@/hooks/use-entitlements";
 import { usePermissions } from "@/hooks/use-permissions";
-import { isLaunchPromoActive, LAUNCH_PROMO } from "@/lib/promo";
+import { LAUNCH_PROMO, useLaunchPromoActive } from "@/lib/promo";
 import { cn } from "@/lib/utils";
 
 /** Display order + chrome for the finite-limit meters the backend can return. */
@@ -141,6 +141,7 @@ export function PlanUsageCard() {
 	const { isBusiness, isLoading, meter } = useEntitlements();
 	const { orgId } = useAuth();
 	const { can } = usePermissions();
+	const promoActive = useLaunchPromoActive();
 	const rows = METER_DISPLAY.flatMap((row) => {
 		const usage = meter(row.key);
 		return usage ? [{ ...row, usage }] : [];
@@ -168,7 +169,7 @@ export function PlanUsageCard() {
 					))}
 					{can("billing") && (
 						<div className="space-y-1.5">
-							{isLaunchPromoActive() && (
+							{promoActive && (
 								<p className="text-center text-[11px] font-medium text-primary">
 									Launch offer: {LAUNCH_PROMO.headline} through{" "}
 									{LAUNCH_PROMO.endsLabel}

--- a/apps/web/src/components/shared/launch-promo.tsx
+++ b/apps/web/src/components/shared/launch-promo.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { Check, Copy, Tag } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { isLaunchPromoActive, LAUNCH_PROMO } from "@/lib/promo";
+import { LAUNCH_PROMO, useLaunchPromoActive } from "@/lib/promo";
 
 /**
  * Copyable promo-code chip. One click copies the code; feedback is the quiet
@@ -62,7 +62,8 @@ export function PromoCodeChip({
  * terms, shown only while the promo window is open.
  */
 export function LaunchPromoBanner({ className }: { className?: string }) {
-	if (!isLaunchPromoActive()) {
+	const promoActive = useLaunchPromoActive();
+	if (!promoActive) {
 		return null;
 	}
 

--- a/apps/web/src/components/shared/launch-promo.tsx
+++ b/apps/web/src/components/shared/launch-promo.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import * as React from "react";
+import { Check, Copy, Tag } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { isLaunchPromoActive, LAUNCH_PROMO } from "@/lib/promo";
+
+/**
+ * Copyable promo-code chip. One click copies the code; feedback is the quiet
+ * inline icon swap rather than a toast.
+ */
+export function PromoCodeChip({
+	code,
+	className,
+}: {
+	code: string;
+	className?: string;
+}) {
+	const [copied, setCopied] = React.useState(false);
+	const timerRef = React.useRef<number | undefined>(undefined);
+
+	React.useEffect(() => () => window.clearTimeout(timerRef.current), []);
+
+	const copy = async () => {
+		try {
+			await navigator.clipboard.writeText(code);
+		} catch {
+			return;
+		}
+		setCopied(true);
+		window.clearTimeout(timerRef.current);
+		timerRef.current = window.setTimeout(() => setCopied(false), 2000);
+	};
+
+	return (
+		<button
+			type="button"
+			onClick={copy}
+			aria-label={`Copy promo code ${code}`}
+			className={cn(
+				"inline-flex cursor-pointer items-center gap-2 rounded-lg border border-dashed border-primary/45 bg-primary/5 py-1.5 pl-3 pr-2.5 font-mono text-sm font-semibold tracking-wide text-foreground transition-colors hover:border-primary/70 hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+				className,
+			)}
+		>
+			{code}
+			<span aria-live="polite">
+				{copied ? (
+					<Check className="size-3.5 text-success" aria-label="Copied" />
+				) : (
+					<Copy
+						className="size-3.5 text-muted-foreground"
+						aria-hidden="true"
+					/>
+				)}
+			</span>
+		</button>
+	);
+}
+
+/**
+ * Launch-offer banner for the onboarding plan step: both codes with their
+ * terms, shown only while the promo window is open.
+ */
+export function LaunchPromoBanner({ className }: { className?: string }) {
+	if (!isLaunchPromoActive()) {
+		return null;
+	}
+
+	return (
+		<div
+			className={cn(
+				"rounded-xl border border-primary/20 bg-primary/5 p-4 sm:p-5",
+				className,
+			)}
+		>
+			<div className="flex items-center gap-2">
+				<Tag className="size-4 text-primary" aria-hidden="true" />
+				<p className="text-sm font-semibold">
+					Launch offer, ends {LAUNCH_PROMO.endsLabel}
+				</p>
+			</div>
+			<div className="mt-3 flex flex-col gap-2.5 sm:flex-row sm:gap-6">
+				{([LAUNCH_PROMO.annual, LAUNCH_PROMO.monthly] as const).map(
+					(offer) => (
+						<div key={offer.code} className="flex items-center gap-2.5">
+							<PromoCodeChip code={offer.code} />
+							<span className="text-sm text-muted-foreground">
+								{offer.label}
+							</span>
+						</div>
+					),
+				)}
+			</div>
+			<p className="mt-3 text-xs text-muted-foreground">
+				Copy your code, then enter it at checkout under “Add promo code”.
+			</p>
+		</div>
+	);
+}

--- a/apps/web/src/lib/promo.ts
+++ b/apps/web/src/lib/promo.ts
@@ -1,0 +1,25 @@
+/**
+ * Launch-offer promo codes, mirrored from the Clerk dashboard discounts
+ * (Clerk has no API to read discount definitions, so this file is the app's
+ * source of truth for display). Both codes expire together; every surface
+ * gates on isLaunchPromoActive() so the whole campaign self-retires at endsAt
+ * with no code changes.
+ */
+export const LAUNCH_PROMO = {
+	monthly: {
+		code: "START50-K7M2",
+		label: "50% off your first 3 months",
+	},
+	annual: {
+		code: "YEAR20-V8XR",
+		label: "20% off your first year",
+	},
+	/** Matches the discounts' expiry in Clerk: Nov 23 2026, 3:52 PM EST. */
+	endsAt: Date.parse("2026-11-23T15:52:00-05:00"),
+	endsLabel: "November 23",
+	headline: "up to 50% off",
+} as const;
+
+export function isLaunchPromoActive(now: number = Date.now()): boolean {
+	return now < LAUNCH_PROMO.endsAt;
+}

--- a/apps/web/src/lib/promo.ts
+++ b/apps/web/src/lib/promo.ts
@@ -1,3 +1,5 @@
+import * as React from "react";
+
 /**
  * Launch-offer promo codes, mirrored from the Clerk dashboard discounts
  * (Clerk has no API to read discount definitions, so this file is the app's
@@ -22,4 +24,38 @@ export const LAUNCH_PROMO = {
 
 export function isLaunchPromoActive(now: number = Date.now()): boolean {
 	return now < LAUNCH_PROMO.endsAt;
+}
+
+// setTimeout clamps its delay at 2^31-1 ms (~24.8 days), so chain shorter
+// timers until the deadline actually passes.
+function subscribeToExpiry(onExpire: () => void): () => void {
+	let id: number | undefined;
+	const arm = () => {
+		const remaining = LAUNCH_PROMO.endsAt - Date.now();
+		if (remaining <= 0) {
+			return;
+		}
+		id = window.setTimeout(() => {
+			if (isLaunchPromoActive()) {
+				arm();
+			} else {
+				onExpire();
+			}
+		}, Math.min(remaining, 0x7fffffff));
+	};
+	arm();
+	return () => window.clearTimeout(id);
+}
+
+/**
+ * Live variant of isLaunchPromoActive for promo surfaces: re-renders at the
+ * deadline so an open tab drops the offer the moment it expires, and keeps
+ * server and client renders in sync during hydration.
+ */
+export function useLaunchPromoActive(): boolean {
+	return React.useSyncExternalStore(
+		subscribeToExpiry,
+		isLaunchPromoActive,
+		isLaunchPromoActive,
+	);
 }

--- a/packages/help-content/articles/getting-started.ts
+++ b/packages/help-content/articles/getting-started.ts
@@ -138,7 +138,7 @@ export const gettingStartedArticles: HelpArticle[] = [
 				blocks: [
 					{
 						type: "paragraph",
-						text: "Pick the size of your team, then choose a plan. The **Plan** step shows the Free and Business plans with a monthly or annual toggle. You can start on Free and upgrade later from Billing.",
+						text: "Pick the size of your team, then choose a plan. The **Plan** step shows the Free and Business plans with a monthly or annual toggle. You can start on Free and upgrade later from Billing. Through November 23, 2026, a launch offer above the plans shows promo codes you can copy and enter at checkout under **Add promo code**.",
 					},
 					{
 						type: "paragraph",

--- a/packages/help-content/articles/settings-and-team.ts
+++ b/packages/help-content/articles/settings-and-team.ts
@@ -466,6 +466,10 @@ export const settingsAndTeamArticles: HelpArticle[] = [
 						type: "paragraph",
 						text: "Once you are subscribed, the button becomes **Manage subscription**, which opens your subscription details so you can review or change it.",
 					},
+					{
+						type: "paragraph",
+						text: "Through November 23, 2026, a launch offer appears on the Billing tab: a promo code for 20% off your first year on the annual plan, or 50% off your first 3 months on monthly. Click the code to copy it, then enter it at checkout under **Add promo code**.",
+					},
 				],
 			},
 			{


### PR DESCRIPTION
This pull request adds support for a time-limited launch promo campaign throughout the app, including promo code display, copy functionality, and contextual banners. The promo is now surfaced in onboarding, billing, marketing, and help content, and will automatically retire after the set expiry date. The main logic and UI components for the promo are centralized for easy maintenance.

**Launch Promo Infrastructure and Logic:**
- Added `LAUNCH_PROMO` constants and the `isLaunchPromoActive()` utility in `lib/promo.ts` to define promo codes, labels, expiry, and provide a single source of truth for promo status checks.

**User Interface Components:**
- Introduced `PromoCodeChip` (copyable promo code button) and `LaunchPromoBanner` (onboarding promo banner) in `shared/launch-promo.tsx`, and integrated them into the onboarding plan step and billing tab for eligible users. [[1]](diffhunk://#diff-a1082858304fcb6413eb4c211d0b0dab040b3ad9ed5e68363e24bc09c22eb212R1-R99) [[2]](diffhunk://#diff-4f2223b0f9b7d1f5e03541066a276d7460018057599aea58da90eee734c37cf6R17) [[3]](diffhunk://#diff-4f2223b0f9b7d1f5e03541066a276d7460018057599aea58da90eee734c37cf6R1138-R1139) [[4]](diffhunk://#diff-4f2223b0f9b7d1f5e03541066a276d7460018057599aea58da90eee734c37cf6R1407) [[5]](diffhunk://#diff-c593ce380169bf6994cd5c6038815c45ad23468931b5b087ad2acb55ead194c8R44-R46) [[6]](diffhunk://#diff-c593ce380169bf6994cd5c6038815c45ad23468931b5b087ad2acb55ead194c8R278-R285) [[7]](diffhunk://#diff-c593ce380169bf6994cd5c6038815c45ad23468931b5b087ad2acb55ead194c8R419-R434)
- Added `LaunchOfferNote` for marketing sections, displaying the promo headline and expiry, and surfaced it in the homepage hero and pricing sections. [[1]](diffhunk://#diff-0eb7e903733783dfd4489b4e73557a5fd2b20100f174335c4905f9b1338d9cbdR1-R21) [[2]](diffhunk://#diff-b16acfedd2ce00d4d5c3954095e863c224842714e57f0d35ee50153a9495c1d0R2) [[3]](diffhunk://#diff-b16acfedd2ce00d4d5c3954095e863c224842714e57f0d35ee50153a9495c1d0R143-R146) [[4]](diffhunk://#diff-a5b8796d79d90b78c9ee5766527d71bc134868bb2d2e81f853437e4e9872528bR6) [[5]](diffhunk://#diff-a5b8796d79d90b78c9ee5766527d71bc134868bb2d2e81f853437e4e9872528bR295-R303)
- Updated the plan usage card to show a promo note for users with billing access. [[1]](diffhunk://#diff-d4c306c8ea7852c775b3f09c0811921391a21fc17872e2802a794507e7b1eb2dR25) [[2]](diffhunk://#diff-d4c306c8ea7852c775b3f09c0811921391a21fc17872e2802a794507e7b1eb2dR170-R176) [[3]](diffhunk://#diff-d4c306c8ea7852c775b3f09c0811921391a21fc17872e2802a794507e7b1eb2dR187)

**Marketing and FAQ Updates:**
- Dynamically inserted a "Do you offer discounts?" FAQ entry during the promo window, with details about the offer and redemption instructions. [[1]](diffhunk://#diff-d9f2e1c467211ce19c24432426911ebad2705f1b7faa554c77e9a93bdc6f38bdR5) [[2]](diffhunk://#diff-d9f2e1c467211ce19c24432426911ebad2705f1b7faa554c77e9a93bdc6f38bdR73-R93) [[3]](diffhunk://#diff-d9f2e1c467211ce19c24432426911ebad2705f1b7faa554c77e9a93bdc6f38bdL106-R125)

**Help Content Updates:**
- Updated onboarding and billing help articles to mention the promo, codes, and redemption steps, with expiry details. [[1]](diffhunk://#diff-03c47c5132bd3877223d2b48605ee335311045a02db5ff8c106e901aad779a5bL141-R141) [[2]](diffhunk://#diff-c0df02cc518d446ea0c06e7692fef153276248439dff86219a6e383bfa8cd3bdR469-R472)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes a time-limited launch promotion and surfaces its codes and campaign messaging across onboarding, billing, marketing, usage, FAQ, and help content.
- Adds shared promotion constants, expiry logic, copyable code chips, and banners.
- Connects billing-tab messaging to the selected monthly or annual checkout period.
- Adds self-retiring promotional copy to marketing and product surfaces.
- Updates onboarding and billing help articles with redemption instructions.

<h3>Confidence Score: 4/5</h3>

The promotion should not merge until its expiry gate produces deterministic server and initial client output on statically generated marketing pages.

Marketing promo client components evaluate the deadline at build time for server HTML and at visit time during hydration, so requests after expiry receive stale promotional markup that disagrees with the browser’s initial render.

**Files Needing Attention:** apps/web/src/lib/promo.ts and the marketing promo callers

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/lib/promo.ts | Centralizes campaign codes and expiry, but its render-time wall-clock default makes server and hydration output diverge after expiry. |
| apps/web/src/components/shared/launch-promo.tsx | Adds reusable copyable-code and onboarding-banner components with cleanup for copy feedback. |
| apps/web/src/app/(workspace)/organization/profile/_components/billing-tab.tsx | Shows the eligible free/trial organization a code derived from the same billing period passed to checkout. |
| apps/web/src/app/components/marketing/sections/faq.tsx | Inserts a campaign FAQ during the active window, but participates in the static-render versus hydration time mismatch. |
| apps/web/src/app/components/marketing/launch-offer-note.tsx | Adds a hero promotion island whose documented post-expiry removal relies on mismatched hydration output. |
| apps/web/src/app/components/marketing/sections/pricing.tsx | Adds period-aware launch messaging but evaluates its expiry directly during render. |
| apps/web/src/components/layout/plan-usage-card.tsx | Adds promotion copy to the existing free-plan upgrade card for users with billing access. |
| apps/web/src/app/(onboarding)/organization/complete/complete-organization.tsx | Places the shared two-code campaign banner above Clerk’s organization pricing table. |
| packages/help-content/articles/getting-started.ts | Documents the onboarding promotion and checkout redemption path. |
| packages/help-content/articles/settings-and-team.ts | Documents billing-tab promotion terms and redemption instructions. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/src/lib/promo.ts:23-24
**Render-time expiry breaks hydration**

When the statically generated marketing page is built before the deadline and visited afterward, `isLaunchPromoActive()` evaluates to different values for the server markup and the browser's initial render, causing stale promo content to flash and React hydration mismatches in the hero, pricing, and FAQ sections.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(billing): surface launch promo code..."](https://github.com/xcarter93/onetool/commit/6386a2da20ff264730fb2c3bb7e6a2766f88924c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56070497)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a launch promotion offering 20% off the first annual year or 50% off the first three monthly months.
  * Displayed promotion details, expiration dates, and copyable promo codes across onboarding, pricing, billing, and upgrade screens.
  * Added launch-offer messaging to the homepage hero, pricing section, FAQ, and plan usage card.
* **Documentation**
  * Updated setup and billing guidance with promotion details and checkout instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->