### PR TITLE
Enhance PostHog support features and email handling

### DIFF
--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -17,9 +17,17 @@ import { api } from "@onetool/backend/convex/_generated/api";
 import { DOCK_CLEARANCE, useTokens, radii, fontFamily } from "@/lib/theme";
 import { Avatar, Card, DotGrid } from "@/components/ui";
 import { useRouter, type Href } from "expo-router";
-import { Mail, Building, LogOut, Shield, Trash2, SquarePen, ChevronRight, Bell, QrCode } from "lucide-react-native";
+import { Mail, Building, LogOut, Shield, Trash2, SquarePen, ChevronRight, Bell, QrCode, MessageCircle, Bug, Lightbulb } from "lucide-react-native";
 import { InkTabHeader } from "@/components/ink-tab-header";
 import { usePermissions } from "@/lib/use-permissions";
+import { openExternal } from "@/lib/open-external";
+
+const SUPPORT_EMAIL = "support@onetool.biz";
+
+/** Subject carries "(mobile)" — the support inbox tags mobile mail on it. */
+function supportMailto(subject: string, body: string): string {
+	return `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+}
 
 // headerMode defaults to "root" → the iPhone path (self-mounted AppHeader,
 // edge-to-edge content) is byte-identical. The iPad shell renders Profile as a
@@ -382,6 +390,94 @@ export default function ProfileScreen({
 					</Text>
 					<ChevronRight size={18} color={t.sub} />
 				</Pressable>
+
+				{/* Support — mailto rows (no PostHog RN SDK; email is the mobile channel).
+				    Prefilled subjects carry "(mobile)" so tickets get tagged; bodies
+				    prompt the same two bug questions the web form asks. */}
+				<Text
+					style={{
+						marginTop: 24,
+						marginBottom: 8,
+						marginLeft: 4,
+						fontSize: 11,
+						fontFamily: fontFamily.semibold,
+						color: t.sub,
+						textTransform: "uppercase",
+						letterSpacing: 0.5,
+					}}
+				>
+					Support
+				</Text>
+				{(
+					[
+						{
+							key: "contact",
+							icon: MessageCircle,
+							label: "Contact support",
+							subtext: "We reply within one business day",
+							subject: "Support request (mobile)",
+							body: `How can we help?\n\n\n—\nOrganization: ${organization?.name ?? ""}\nOneTool Mobile`,
+						},
+						{
+							key: "bug",
+							icon: Bug,
+							label: "Report a bug",
+							subtext: "Something broken or not working right",
+							subject: "Bug report (mobile)",
+							body: `What were you trying to do?\n\n\nWhat happened instead?\n\n\n—\nOrganization: ${organization?.name ?? ""}\nOneTool Mobile`,
+						},
+						{
+							key: "feature",
+							icon: Lightbulb,
+							label: "Request a feature",
+							subtext: "Tell us what OneTool should do next",
+							subject: "Feature request (mobile)",
+							body: `What would you like OneTool to do?\n\n\n—\nOrganization: ${organization?.name ?? ""}\nOneTool Mobile`,
+						},
+					] as const
+				).map((row, index) => (
+					<Pressable
+						key={row.key}
+						style={{
+							flexDirection: "row",
+							alignItems: "center",
+							paddingVertical: 16,
+							paddingHorizontal: 16,
+							borderRadius: radii.lg,
+							marginTop: index === 0 ? 0 : 12,
+							backgroundColor: t.card,
+							borderWidth: 1,
+							borderColor: t.line,
+						}}
+						onPress={() =>
+							openExternal(supportMailto(row.subject, row.body), "Mail")
+						}
+					>
+						<row.icon size={20} color={t.sub} />
+						<View style={{ marginLeft: 12, flex: 1 }}>
+							<Text
+								style={{
+									color: t.ink,
+									fontFamily: fontFamily.semibold,
+									fontSize: 13,
+								}}
+							>
+								{row.label}
+							</Text>
+							<Text
+								style={{
+									marginTop: 2,
+									color: t.sub,
+									fontFamily: fontFamily.regular,
+									fontSize: 11,
+								}}
+							>
+								{row.subtext}
+							</Text>
+						</View>
+						<ChevronRight size={18} color={t.sub} />
+					</Pressable>
+				))}
 
 				{/* Sign Out Button */}
 				<Pressable

--- a/apps/web/src/app/(legal)/privacy-policy/page.tsx
+++ b/apps/web/src/app/(legal)/privacy-policy/page.tsx
@@ -2,7 +2,7 @@ import { LegalPageLayout } from "../components/legal-page-layout";
 
 export default function PrivacyPolicyPage() {
 	return (
-		<LegalPageLayout title="Privacy Policy" lastUpdated="July 17, 2026">
+		<LegalPageLayout title="Privacy Policy" lastUpdated="August 23, 2026">
 			<div className="space-y-8">
 				<section>
 					<h2 className="text-2xl font-semibold text-foreground mb-4">
@@ -456,8 +456,9 @@ export default function PrivacyPolicyPage() {
 						<li>
 							<strong>Analytics:</strong> You can block analytics using browser
 							tools or content blockers without affecting core functionality.
-							Our web app does not currently respond to &quot;Do Not
-							Track&quot; browser signals.
+							Our web app honors the &quot;Do Not Track&quot; browser signal:
+							when it is enabled, analytics and session replay are disabled
+							(see Section 2.2).
 						</li>
 					</ul>
 					<p className="text-muted-foreground leading-relaxed mt-4">
@@ -596,7 +597,7 @@ export default function PrivacyPolicyPage() {
 
 				<section className="pt-4 border-t border-border mt-8">
 					<p className="text-xs text-muted-foreground">
-						This Privacy Policy is effective as of July 17, 2026.
+						This Privacy Policy is effective as of August 23, 2026.
 					</p>
 				</section>
 			</div>

--- a/apps/web/src/app/(legal)/privacy-policy/page.tsx
+++ b/apps/web/src/app/(legal)/privacy-policy/page.tsx
@@ -101,9 +101,12 @@ export default function PrivacyPolicyPage() {
 							performance metrics, and application errors. Analytics is tied to
 							your account (name, email, role, organization, and plan type) so
 							we can understand usage per customer. PostHog receives your IP
-							address as part of standard event delivery. We do not use session
-							recording in our analytics configuration, and our mobile app
-							contains no analytics.
+							address as part of standard event delivery. In the signed-in web
+							workspace we also use session replay: your interactions with the
+							app may be recorded so we can reproduce bugs you report and
+							improve the product. All form inputs are masked in recordings, and
+							recordings are retained under PostHog&apos;s retention settings.
+							Our mobile app contains no analytics.
 						</li>
 						<li>
 							<strong>Log Data:</strong> Our hosting and backend providers
@@ -278,9 +281,12 @@ export default function PrivacyPolicyPage() {
 							signature and signer names and email addresses.
 						</li>
 						<li>
-							<strong>PostHog</strong> — web analytics: usage events and your
-							account identity (name, email, role, organization, plan), plus IP
-							address on event delivery.
+							<strong>PostHog</strong> — web analytics and customer support:
+							usage events, session replay (inputs masked), and your account
+							identity (name, email, role, organization, plan), plus IP address
+							on event delivery. Support messages you send us — in-app or by
+							email to support@onetool.biz — are processed in PostHog&apos;s
+							support inbox.
 						</li>
 						<li>
 							<strong>OpenAI</strong> — AI features: the data described in

--- a/apps/web/src/app/(legal)/privacy-policy/page.tsx
+++ b/apps/web/src/app/(legal)/privacy-policy/page.tsx
@@ -106,7 +106,9 @@ export default function PrivacyPolicyPage() {
 							app may be recorded so we can reproduce bugs you report and
 							improve the product. All form inputs are masked in recordings, and
 							recordings are retained under PostHog&apos;s retention settings.
-							Our mobile app contains no analytics.
+							We honor your browser&apos;s Do Not Track setting: when it is
+							enabled, analytics and session replay are disabled for your
+							visits. Our mobile app contains no analytics.
 						</li>
 						<li>
 							<strong>Log Data:</strong> Our hosting and backend providers

--- a/apps/web/src/app/(workspace)/layout.tsx
+++ b/apps/web/src/app/(workspace)/layout.tsx
@@ -10,6 +10,7 @@ import { CelebrationListener } from "@/components/celebrations/celebration-liste
 import { ScreenContextProvider } from "@/components/assistant/use-screen-context";
 import { CurrentRecordProvider } from "@/components/assistant/use-current-record";
 import { CreateRecordProvider } from "@/components/domain/create-record-provider";
+import { SupportDialogProvider } from "@/components/support/support-dialog-provider";
 import "./workspace-theme.css";
 
 // Every workspace route is auth-gated and user-specific; none may be
@@ -38,7 +39,9 @@ export default function WorkspaceLayout({
 								<ScreenContextProvider>
 									<CurrentRecordProvider>
 										<CreateRecordProvider>
-											<SidebarWithHeader>{children}</SidebarWithHeader>
+											<SupportDialogProvider>
+												<SidebarWithHeader>{children}</SidebarWithHeader>
+											</SupportDialogProvider>
 										</CreateRecordProvider>
 									</CurrentRecordProvider>
 								</ScreenContextProvider>

--- a/apps/web/src/app/(workspace)/support/components/support-message-body.tsx
+++ b/apps/web/src/app/(workspace)/support/components/support-message-body.tsx
@@ -56,8 +56,14 @@ function renderMarks(text: string, marks: TipTapMark[] | undefined, key: number)
 	return <React.Fragment key={key}>{node}</React.Fragment>;
 }
 
-function renderNode(node: TipTapNode, key: number): React.ReactNode {
-	const children = node.content?.map((child, index) => renderNode(child, index));
+function renderNode(
+	node: TipTapNode,
+	key: number,
+	doc: { unsupported: boolean }
+): React.ReactNode {
+	const children = node.content?.map((child, index) =>
+		renderNode(child, index, doc)
+	);
 	switch (node.type) {
 		case "text":
 			return renderMarks(node.text ?? "", node.marks, key);
@@ -101,7 +107,9 @@ function renderNode(node: TipTapNode, key: number): React.ReactNode {
 				</pre>
 			);
 		default:
-			// Unknown block: bail so the caller falls back to plain text.
+			// Unknown node at any depth: flag it so the whole message falls
+			// back to plain text instead of silently dropping content.
+			doc.unsupported = true;
 			return null;
 	}
 }
@@ -116,8 +124,11 @@ export function SupportMessageBody({
 	const rich = message.rich_content;
 	let rendered: React.ReactNode = null;
 	if (rich?.type === "doc" && rich.content?.length) {
-		const blocks = rich.content.map((node, index) => renderNode(node, index));
-		if (!blocks.some((block) => block === null)) rendered = blocks;
+		const doc = { unsupported: false };
+		const blocks = rich.content.map((node, index) =>
+			renderNode(node, index, doc)
+		);
+		if (!doc.unsupported) rendered = blocks;
 	}
 	return (
 		<div className={className}>

--- a/apps/web/src/app/(workspace)/support/components/support-message-body.tsx
+++ b/apps/web/src/app/(workspace)/support/components/support-message-body.tsx
@@ -1,0 +1,129 @@
+import * as React from "react";
+import type { Message, TipTapMark, TipTapNode } from "posthog-js";
+
+/**
+ * Minimal renderer for the TipTap JSON agent replies arrive in (bold/italic/
+ * links/lists — the marks the PostHog composer offers). Anything unrecognized
+ * falls back to the message's plain-text `content`.
+ */
+
+function safeHref(href: unknown): string | null {
+	if (typeof href !== "string") return null;
+	return /^(https?:|mailto:)/i.test(href.trim()) ? href : null;
+}
+
+function renderMarks(text: string, marks: TipTapMark[] | undefined, key: number) {
+	let node: React.ReactNode = text;
+	for (const mark of marks ?? []) {
+		switch (mark.type) {
+			case "bold":
+				node = <strong>{node}</strong>;
+				break;
+			case "italic":
+				node = <em>{node}</em>;
+				break;
+			case "underline":
+				node = <u>{node}</u>;
+				break;
+			case "strike":
+				node = <s>{node}</s>;
+				break;
+			case "code":
+				node = (
+					<code className="rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]">
+						{node}
+					</code>
+				);
+				break;
+			case "link": {
+				const href = safeHref(mark.attrs?.href);
+				if (href) {
+					node = (
+						<a
+							href={href}
+							target="_blank"
+							rel="noreferrer"
+							className="text-primary underline underline-offset-2"
+						>
+							{node}
+						</a>
+					);
+				}
+				break;
+			}
+		}
+	}
+	return <React.Fragment key={key}>{node}</React.Fragment>;
+}
+
+function renderNode(node: TipTapNode, key: number): React.ReactNode {
+	const children = node.content?.map((child, index) => renderNode(child, index));
+	switch (node.type) {
+		case "text":
+			return renderMarks(node.text ?? "", node.marks, key);
+		case "hardBreak":
+			return <br key={key} />;
+		case "paragraph":
+			return <p key={key}>{children}</p>;
+		case "heading":
+			return (
+				<p key={key} className="font-semibold">
+					{children}
+				</p>
+			);
+		case "bulletList":
+			return (
+				<ul key={key} className="list-disc pl-5">
+					{children}
+				</ul>
+			);
+		case "orderedList":
+			return (
+				<ol key={key} className="list-decimal pl-5">
+					{children}
+				</ol>
+			);
+		case "listItem":
+			return <li key={key}>{children}</li>;
+		case "blockquote":
+			return (
+				<blockquote key={key} className="border-l-2 border-border pl-3 text-muted-foreground">
+					{children}
+				</blockquote>
+			);
+		case "codeBlock":
+			return (
+				<pre
+					key={key}
+					className="overflow-x-auto rounded-md bg-muted p-3 font-mono text-xs"
+				>
+					{children}
+				</pre>
+			);
+		default:
+			// Unknown block: bail so the caller falls back to plain text.
+			return null;
+	}
+}
+
+export function SupportMessageBody({
+	message,
+	className,
+}: {
+	message: Message;
+	className?: string;
+}) {
+	const rich = message.rich_content;
+	let rendered: React.ReactNode = null;
+	if (rich?.type === "doc" && rich.content?.length) {
+		const blocks = rich.content.map((node, index) => renderNode(node, index));
+		if (!blocks.some((block) => block === null)) rendered = blocks;
+	}
+	return (
+		<div className={className}>
+			{rendered ?? (
+				<p className="whitespace-pre-wrap">{message.content}</p>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/app/(workspace)/support/components/support-screen.tsx
+++ b/apps/web/src/app/(workspace)/support/components/support-screen.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import * as React from "react";
+import { useUser } from "@clerk/nextjs";
+import { useSupportDialog } from "@/components/support/support-dialog-provider";
+import { recallTicketIntents, type SupportIntent } from "@/lib/support";
+import {
+	refreshSupportTickets,
+	useSupportTickets,
+} from "@/lib/support-tickets";
+import { cn } from "@/lib/utils";
+import { isResolved } from "../lib/support-utils";
+import { TicketList } from "./ticket-list";
+import { TicketView, TicketViewEmpty } from "./ticket-view";
+import { EmptyState } from "@/components/domain/empty-state";
+
+export function SupportScreen() {
+	const { status, tickets } = useSupportTickets();
+	const openSupport = useSupportDialog();
+	const { user } = useUser();
+
+	const [selectedTicketId, setSelectedTicketId] = React.useState<string | null>(
+		null
+	);
+	const [showResolved, setShowResolved] = React.useState(false);
+	const [intents, setIntents] = React.useState<Record<string, SupportIntent>>(
+		() => (typeof window === "undefined" ? {} : recallTicketIntents())
+	);
+
+	// Fetch on navigate (V2-2). The identity effect usually got here first;
+	// this covers direct loads and the no-identity dev fallback.
+	React.useEffect(() => {
+		void refreshSupportTickets();
+	}, []);
+
+	const resolvedCount = React.useMemo(
+		() => tickets.filter((t) => isResolved(t.status)).length,
+		[tickets]
+	);
+	const visibleTickets = React.useMemo(
+		() => (showResolved ? tickets : tickets.filter((t) => !isResolved(t.status))),
+		[tickets, showResolved]
+	);
+
+	const handleIntentDiscovered = React.useCallback(
+		(ticketId: string, intent: SupportIntent) => {
+			setIntents((prev) =>
+				prev[ticketId] === intent ? prev : { ...prev, [ticketId]: intent }
+			);
+		},
+		[]
+	);
+
+	const replyTraits = React.useMemo(
+		() => ({
+			name: user?.fullName ?? undefined,
+			email: user?.primaryEmailAddress?.emailAddress ?? undefined,
+		}),
+		[user]
+	);
+
+	const hasSelection = selectedTicketId !== null;
+	const unavailable = status === "unavailable";
+
+	return (
+		<div
+			// Same pane insets as the Inbox: clear the top notch rail and the
+			// bottom Assistant notch.
+			className="flex h-full min-h-0 gap-3 overflow-hidden px-3 pb-12 pt-3 md:pt-10"
+		>
+			<aside
+				className={cn(
+					"w-full flex-col overflow-hidden rounded-xl border border-border bg-card shadow-sm md:flex md:w-[340px] md:shrink-0",
+					"min-h-0",
+					hasSelection ? "hidden md:flex" : "flex"
+				)}
+			>
+				{unavailable ? (
+					<div className="flex h-full items-center p-4">
+						<EmptyState
+							size="sm"
+							illustration="messages-none"
+							title="Support couldn't load"
+							description="This is usually an ad blocker. Email us at support@onetool.biz and we'll reply within one business day."
+						/>
+					</div>
+				) : (
+					<TicketList
+						loading={status === "idle" || status === "loading"}
+						tickets={visibleTickets}
+						intents={intents}
+						hiddenResolvedCount={resolvedCount}
+						showResolved={showResolved}
+						onShowResolvedChange={setShowResolved}
+						selectedTicketId={selectedTicketId}
+						onSelect={setSelectedTicketId}
+						onNewRequest={openSupport}
+						onRefresh={() => void refreshSupportTickets()}
+						refreshing={status === "loading"}
+					/>
+				)}
+			</aside>
+
+			<section
+				className={cn(
+					"min-w-0 flex-1 flex-col overflow-hidden rounded-xl border border-border bg-card shadow-sm md:flex",
+					"min-h-0",
+					hasSelection ? "flex" : "hidden md:flex"
+				)}
+			>
+				{selectedTicketId ? (
+					<TicketView
+						key={selectedTicketId}
+						ticketId={selectedTicketId}
+						intent={intents[selectedTicketId]}
+						onIntentDiscovered={handleIntentDiscovered}
+						onBack={() => setSelectedTicketId(null)}
+						onNewRequest={() => openSupport("contact")}
+						replyTraits={replyTraits}
+					/>
+				) : (
+					<TicketViewEmpty />
+				)}
+			</section>
+		</div>
+	);
+}

--- a/apps/web/src/app/(workspace)/support/components/support-screen.tsx
+++ b/apps/web/src/app/(workspace)/support/components/support-screen.tsx
@@ -15,7 +15,7 @@ import { TicketView, TicketViewEmpty } from "./ticket-view";
 import { EmptyState } from "@/components/domain/empty-state";
 
 export function SupportScreen() {
-	const { status, tickets } = useSupportTickets();
+	const { status, tickets, refreshing } = useSupportTickets();
 	const openSupport = useSupportDialog();
 	const { user } = useUser();
 
@@ -96,7 +96,7 @@ export function SupportScreen() {
 						onSelect={setSelectedTicketId}
 						onNewRequest={openSupport}
 						onRefresh={() => void refreshSupportTickets()}
-						refreshing={status === "loading"}
+						refreshing={refreshing}
 					/>
 				)}
 			</aside>

--- a/apps/web/src/app/(workspace)/support/components/ticket-list.tsx
+++ b/apps/web/src/app/(workspace)/support/components/ticket-list.tsx
@@ -93,11 +93,7 @@ export function TicketList({
 										onClick={() => onNewRequest(intent)}
 									>
 										<meta.icon className="size-4" aria-hidden="true" />
-										{intent === "contact"
-											? "Contact support"
-											: intent === "bug"
-												? "Report a bug"
-												: "Request a feature"}
+										{meta.actionLabel}
 									</DropdownMenuItem>
 								))}
 							</DropdownMenuContent>

--- a/apps/web/src/app/(workspace)/support/components/ticket-list.tsx
+++ b/apps/web/src/app/(workspace)/support/components/ticket-list.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { formatDistanceToNowStrict } from "date-fns";
+import { ChevronDown, Plus, RefreshCw } from "lucide-react";
+import type { Ticket } from "posthog-js";
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import { EmptyState } from "@/components/domain/empty-state";
+import { StatusBadge } from "@/components/domain/status-badge";
+import type { SupportIntent } from "@/lib/support";
+import { cn } from "@/lib/utils";
+import {
+	INTENT_META,
+	intentMeta,
+	isUnread,
+	ticketStatusBadge,
+} from "../lib/support-utils";
+
+interface TicketListProps {
+	loading: boolean;
+	tickets: Ticket[];
+	/** Best-effort ticket id → intent (localStorage + opened threads). */
+	intents: Record<string, SupportIntent>;
+	hiddenResolvedCount: number;
+	showResolved: boolean;
+	onShowResolvedChange: (show: boolean) => void;
+	selectedTicketId: string | null;
+	onSelect: (ticketId: string) => void;
+	onNewRequest: (intent: SupportIntent) => void;
+	onRefresh: () => void;
+	refreshing: boolean;
+}
+
+export function TicketList({
+	loading,
+	tickets,
+	intents,
+	hiddenResolvedCount,
+	showResolved,
+	onShowResolvedChange,
+	selectedTicketId,
+	onSelect,
+	onNewRequest,
+	onRefresh,
+	refreshing,
+}: TicketListProps) {
+	return (
+		<>
+			<div className="sticky top-0 z-10 shrink-0 space-y-3 border-b border-border bg-card px-4 pb-3 pt-4">
+				<div className="flex items-center justify-between gap-2">
+					<h1 className="text-lg font-semibold tracking-tight">Support</h1>
+					<div className="flex items-center gap-1.5">
+						<Button
+							size="sm"
+							variant="ghost"
+							onClick={onRefresh}
+							disabled={refreshing}
+							aria-label="Refresh requests"
+						>
+							<RefreshCw
+								className={cn("size-4", refreshing && "animate-spin")}
+								aria-hidden="true"
+							/>
+						</Button>
+						<DropdownMenu>
+							<DropdownMenuTrigger
+								render={
+									<Button size="sm" variant="outline">
+										<Plus className="size-4" aria-hidden="true" />
+										New request
+										<ChevronDown
+											className="size-3.5 text-muted-foreground"
+											aria-hidden="true"
+										/>
+									</Button>
+								}
+							/>
+							<DropdownMenuContent align="end">
+								{(
+									Object.entries(INTENT_META) as Array<
+										[SupportIntent, (typeof INTENT_META)[SupportIntent]]
+									>
+								).map(([intent, meta]) => (
+									<DropdownMenuItem
+										key={intent}
+										onClick={() => onNewRequest(intent)}
+									>
+										<meta.icon className="size-4" aria-hidden="true" />
+										{intent === "contact"
+											? "Contact support"
+											: intent === "bug"
+												? "Report a bug"
+												: "Request a feature"}
+									</DropdownMenuItem>
+								))}
+							</DropdownMenuContent>
+						</DropdownMenu>
+					</div>
+				</div>
+
+				<label className="flex w-fit cursor-pointer items-center gap-2 text-xs text-muted-foreground">
+					<Switch
+						checked={showResolved}
+						onCheckedChange={onShowResolvedChange}
+						aria-label="Show resolved requests"
+					/>
+					Show resolved
+					{!showResolved && hiddenResolvedCount > 0 && (
+						<span className="tabular-nums">({hiddenResolvedCount})</span>
+					)}
+				</label>
+			</div>
+
+			<div className="min-h-0 flex-1 overflow-y-auto">
+				{loading ? (
+					<TicketListSkeleton />
+				) : tickets.length === 0 ? (
+					<div className="flex h-full items-center p-4">
+						<EmptyState
+							size="sm"
+							illustration="messages-none"
+							title={
+								hiddenResolvedCount > 0
+									? "No open requests"
+									: "No support requests yet"
+							}
+							description={
+								hiddenResolvedCount > 0
+									? "Everything's resolved. Flip the toggle above to see past requests."
+									: "Questions, bugs, ideas — send us a message and the whole thread lives here."
+							}
+						/>
+					</div>
+				) : (
+					<ul className="divide-y divide-border/60 py-0.5">
+						{tickets.map((ticket) => (
+							<li key={ticket.id}>
+								<TicketRow
+									ticket={ticket}
+									intent={intents[ticket.id]}
+									selected={selectedTicketId === ticket.id}
+									onSelect={onSelect}
+								/>
+							</li>
+						))}
+					</ul>
+				)}
+			</div>
+		</>
+	);
+}
+
+function TicketRow({
+	ticket,
+	intent,
+	selected,
+	onSelect,
+}: {
+	ticket: Ticket;
+	intent: SupportIntent | undefined;
+	selected: boolean;
+	onSelect: (ticketId: string) => void;
+}) {
+	const unread = isUnread(ticket);
+	const meta = intentMeta(intent);
+	const badge = ticketStatusBadge(ticket.status);
+	const timestamp = ticket.last_message_at ?? ticket.created_at;
+
+	return (
+		<button
+			type="button"
+			onClick={() => onSelect(ticket.id)}
+			aria-current={selected ? "true" : undefined}
+			className={cn(
+				"flex w-full cursor-pointer items-start gap-2.5 border-l-2 py-2.5 pl-3 pr-3 text-left transition-colors duration-150",
+				"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+				selected
+					? "border-l-primary bg-accent"
+					: "border-l-transparent hover:bg-accent/60"
+			)}
+		>
+			<span className="relative mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+				<meta.icon className="size-4" aria-hidden="true" />
+				{unread && (
+					<span
+						aria-hidden="true"
+						className="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-primary ring-2 ring-card"
+					/>
+				)}
+			</span>
+			{unread && <span className="sr-only">Unread reply.</span>}
+			<span className="min-w-0 flex-1">
+				<span className="flex items-baseline justify-between gap-2">
+					<span className="flex min-w-0 items-center gap-1.5">
+						<span
+							className={cn(
+								"truncate text-sm text-foreground",
+								unread ? "font-semibold" : "font-medium"
+							)}
+						>
+							{meta.label}
+						</span>
+						<StatusBadge role={badge.role} size="sm" className="shrink-0">
+							{badge.label}
+						</StatusBadge>
+					</span>
+					<span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+						{formatDistanceToNowStrict(new Date(timestamp), {
+							addSuffix: true,
+						})}
+					</span>
+				</span>
+				<span
+					className={cn(
+						"line-clamp-1 block text-xs",
+						unread ? "font-medium text-foreground" : "text-muted-foreground"
+					)}
+				>
+					{ticket.last_message || "No messages yet"}
+				</span>
+			</span>
+		</button>
+	);
+}
+
+function TicketListSkeleton() {
+	return (
+		<div className="space-y-1 p-2">
+			{Array.from({ length: 5 }).map((_, i) => (
+				<div key={i} className="flex items-start gap-2.5 px-2 py-2.5">
+					<Skeleton className="size-7 rounded-md" />
+					<div className="flex-1 space-y-1.5">
+						<div className="flex items-center justify-between gap-2">
+							<Skeleton className="h-3.5 w-28" />
+							<Skeleton className="h-3 w-12" />
+						</div>
+						<Skeleton className="h-3 w-4/5" />
+					</div>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/apps/web/src/app/(workspace)/support/components/ticket-view.tsx
+++ b/apps/web/src/app/(workspace)/support/components/ticket-view.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import * as React from "react";
+import { format } from "date-fns";
+import { ArrowLeft, Plus } from "lucide-react";
+import type { GetMessagesResponse, Message } from "posthog-js";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import { EmptyState } from "@/components/domain/empty-state";
+import { StatusBadge } from "@/components/domain/status-badge";
+import { SupportMessageBody } from "./support-message-body";
+import {
+	getSupportMessages,
+	intentFromMessage,
+	markSupportTicketRead,
+	rememberTicketIntent,
+	replyToSupportTicket,
+	type SupportIntent,
+} from "@/lib/support";
+import {
+	markTicketReadLocally,
+	refreshSupportTickets,
+} from "@/lib/support-tickets";
+import { cn } from "@/lib/utils";
+import {
+	intentMeta,
+	isResolved,
+	ticketStatusBadge,
+} from "../lib/support-utils";
+
+const MAX_REPLY_LENGTH = 2000;
+
+interface TicketViewProps {
+	ticketId: string;
+	intent: SupportIntent | undefined;
+	/** Recovered from the thread's opening message (cross-device tickets). */
+	onIntentDiscovered: (ticketId: string, intent: SupportIntent) => void;
+	onBack: () => void;
+	onNewRequest: () => void;
+	replyTraits: { name?: string; email?: string };
+}
+
+export function TicketView({
+	ticketId,
+	intent,
+	onIntentDiscovered,
+	onBack,
+	onNewRequest,
+	replyTraits,
+}: TicketViewProps) {
+	// undefined = loading, null = failed to load.
+	const [data, setData] = React.useState<GetMessagesResponse | null | undefined>(
+		undefined
+	);
+	const [reply, setReply] = React.useState("");
+	const [sending, setSending] = React.useState(false);
+	const [sendError, setSendError] = React.useState<string | null>(null);
+
+	// Reset per ticket during render (setState-in-effect is a lint error).
+	const [prevTicketId, setPrevTicketId] = React.useState(ticketId);
+	if (ticketId !== prevTicketId) {
+		setPrevTicketId(ticketId);
+		setData(undefined);
+		setReply("");
+		setSending(false);
+		setSendError(null);
+	}
+
+	const load = React.useCallback(async () => {
+		const response = await getSupportMessages(ticketId);
+		if (response && (response.unread_count ?? 0) > 0) {
+			void markSupportTicketRead(ticketId).then((ok) => {
+				if (ok) markTicketReadLocally(ticketId);
+			});
+		}
+		return response;
+	}, [ticketId]);
+
+	React.useEffect(() => {
+		let cancelled = false;
+		void load().then((response) => {
+			if (cancelled) return;
+			setData(response);
+			const opening = response?.messages.find(
+				(m) => m.author_type === "customer"
+			);
+			const discovered = opening ? intentFromMessage(opening.content) : null;
+			if (discovered) {
+				rememberTicketIntent(ticketId, discovered);
+				onIntentDiscovered(ticketId, discovered);
+			}
+		});
+		return () => {
+			cancelled = true;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ticketId]);
+
+	const messages = React.useMemo(
+		() =>
+			[...(data?.messages ?? [])]
+				.filter((m) => !m.is_private)
+				.sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at)),
+		[data]
+	);
+
+	const meta = intentMeta(intent);
+	const badge = data ? ticketStatusBadge(data.ticket_status) : null;
+	const resolved = data ? isResolved(data.ticket_status) : false;
+	const canSend = !sending && reply.trim().length > 0;
+
+	const handleSend = async () => {
+		if (!canSend) return;
+		setSending(true);
+		setSendError(null);
+		const sent = await replyToSupportTicket(ticketId, reply.trim(), replyTraits);
+		if (!sent) {
+			setSending(false);
+			setSendError(
+				"That didn't go through. Try again, or email support@onetool.biz."
+			);
+			return;
+		}
+		const response = await load();
+		setData(response ?? null);
+		setReply("");
+		setSending(false);
+		// The list's snippet/timestamp are stale now.
+		void refreshSupportTickets();
+	};
+
+	return (
+		<>
+			<header className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-3 md:px-6">
+				<button
+					type="button"
+					onClick={onBack}
+					aria-label="Back to requests"
+					className="-ml-1 inline-flex cursor-pointer items-center justify-center rounded-md p-1 text-muted-foreground transition-colors duration-150 hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring md:hidden"
+				>
+					<ArrowLeft className="size-4" aria-hidden="true" />
+				</button>
+				<span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+					<meta.icon className="size-4" aria-hidden="true" />
+				</span>
+				<div className="min-w-0 flex-1">
+					<div className="flex items-center gap-2">
+						<h2 className="truncate text-sm font-semibold text-foreground">
+							{meta.label}
+						</h2>
+						{badge && (
+							<StatusBadge role={badge.role} size="sm" className="shrink-0">
+								{badge.label}
+							</StatusBadge>
+						)}
+					</div>
+					{messages[0] && (
+						<p className="text-xs text-muted-foreground">
+							Started {format(new Date(messages[0].created_at), "MMM d, yyyy")}
+						</p>
+					)}
+				</div>
+			</header>
+
+			<div className="min-h-0 flex-1 overflow-y-auto px-4 md:px-6">
+				{data === undefined ? (
+					<MessageSkeleton />
+				) : data === null ? (
+					<div className="flex h-full items-center justify-center p-6">
+						<EmptyState
+							size="sm"
+							illustration="messages-none"
+							title="Couldn't load this conversation"
+							description="Check your connection and try again, or email support@onetool.biz."
+						/>
+					</div>
+				) : (
+					<ol className="space-y-4 py-4">
+						{messages.map((message) => (
+							<li key={message.id}>
+								<SupportMessage message={message} />
+							</li>
+						))}
+					</ol>
+				)}
+			</div>
+
+			<div className="shrink-0 border-t border-border bg-background p-3">
+				{resolved ? (
+					<div className="flex flex-wrap items-center justify-between gap-2 rounded-lg bg-muted/20 px-3 py-2.5 text-sm text-muted-foreground">
+						<p>This conversation was resolved.</p>
+						<Button size="sm" variant="outline" onClick={onNewRequest}>
+							<Plus className="size-4" aria-hidden="true" />
+							New request
+						</Button>
+					</div>
+				) : (
+					<div className="space-y-2">
+						{sendError && (
+							<p
+								role="alert"
+								className="rounded-md border border-danger/30 bg-danger/10 px-3 py-2 text-[13px] text-danger"
+							>
+								{sendError}
+							</p>
+						)}
+						<div className="flex items-end gap-2">
+							<Textarea
+								value={reply}
+								onChange={(e) => setReply(e.target.value)}
+								placeholder="Reply…"
+								aria-label="Reply"
+								rows={2}
+								maxLength={MAX_REPLY_LENGTH}
+								disabled={data === undefined || data === null}
+								className="min-h-9 flex-1 resize-none"
+								onKeyDown={(e) => {
+									if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+										e.preventDefault();
+										void handleSend();
+									}
+								}}
+							/>
+							<Button
+								onClick={() => void handleSend()}
+								disabled={!canSend || data == null}
+							>
+								{sending ? "Sending…" : "Send"}
+							</Button>
+						</div>
+					</div>
+				)}
+			</div>
+		</>
+	);
+}
+
+function SupportMessage({ message }: { message: Message }) {
+	const fromCustomer = message.author_type === "customer";
+	const senderName = fromCustomer
+		? "You"
+		: message.author_name || "OneTool Support";
+
+	return (
+		<article>
+			<div className="flex items-baseline justify-between gap-3">
+				<span
+					className={cn(
+						"text-sm font-medium",
+						fromCustomer ? "text-foreground" : "text-primary"
+					)}
+				>
+					{senderName}
+				</span>
+				<time className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+					{format(new Date(message.created_at), "MMM d, h:mm a")}
+				</time>
+			</div>
+			<SupportMessageBody
+				message={message}
+				className="mt-1 space-y-2 text-sm leading-relaxed text-foreground/90"
+			/>
+		</article>
+	);
+}
+
+function MessageSkeleton() {
+	return (
+		<div className="space-y-5 py-4">
+			{Array.from({ length: 3 }).map((_, i) => (
+				<div key={i} className="space-y-2">
+					<div className="flex items-center justify-between gap-2">
+						<Skeleton className="h-3.5 w-24" />
+						<Skeleton className="h-3 w-16" />
+					</div>
+					<Skeleton className="h-3 w-full" />
+					<Skeleton className="h-3 w-3/4" />
+				</div>
+			))}
+		</div>
+	);
+}
+
+/** Desktop no-selection placeholder. */
+export function TicketViewEmpty() {
+	return (
+		<div className="flex h-full items-center justify-center p-6">
+			<EmptyState
+				size="md"
+				illustration="select-conversation"
+				illustrationSize="hero"
+				title="Select a request"
+				description="Choose a request on the left to read the thread and reply."
+			/>
+		</div>
+	);
+}

--- a/apps/web/src/app/(workspace)/support/lib/support-utils.ts
+++ b/apps/web/src/app/(workspace)/support/lib/support-utils.ts
@@ -1,0 +1,40 @@
+import { Bug, Lightbulb, MessageCircle } from "lucide-react";
+import type { Ticket, TicketStatus } from "posthog-js";
+import type { SupportIntent } from "@/lib/support";
+
+export const INTENT_META: Record<
+	SupportIntent,
+	{ label: string; icon: typeof MessageCircle }
+> = {
+	contact: { label: "Support request", icon: MessageCircle },
+	bug: { label: "Bug report", icon: Bug },
+	feature: { label: "Feature request", icon: Lightbulb },
+};
+
+/** Cross-device tickets whose intent we can't recover locally. */
+export const UNKNOWN_INTENT_META = {
+	label: "Conversation",
+	icon: MessageCircle,
+} as const;
+
+export function intentMeta(intent: SupportIntent | undefined) {
+	return intent ? INTENT_META[intent] : UNKNOWN_INTENT_META;
+}
+
+/** V2-8: statuses collapse to two buckets. */
+export function isResolved(status: TicketStatus): boolean {
+	return status === "resolved";
+}
+
+export function ticketStatusBadge(status: TicketStatus): {
+	label: string;
+	role: "info" | "neutral";
+} {
+	return isResolved(status)
+		? { label: "Resolved", role: "neutral" }
+		: { label: "Open", role: "info" };
+}
+
+export function isUnread(ticket: Ticket): boolean {
+	return (ticket.unread_count ?? 0) > 0;
+}

--- a/apps/web/src/app/(workspace)/support/lib/support-utils.ts
+++ b/apps/web/src/app/(workspace)/support/lib/support-utils.ts
@@ -4,11 +4,19 @@ import type { SupportIntent } from "@/lib/support";
 
 export const INTENT_META: Record<
 	SupportIntent,
-	{ label: string; icon: typeof MessageCircle }
+	{ label: string; actionLabel: string; icon: typeof MessageCircle }
 > = {
-	contact: { label: "Support request", icon: MessageCircle },
-	bug: { label: "Bug report", icon: Bug },
-	feature: { label: "Feature request", icon: Lightbulb },
+	contact: {
+		label: "Support request",
+		actionLabel: "Contact support",
+		icon: MessageCircle,
+	},
+	bug: { label: "Bug report", actionLabel: "Report a bug", icon: Bug },
+	feature: {
+		label: "Feature request",
+		actionLabel: "Request a feature",
+		icon: Lightbulb,
+	},
 };
 
 /** Cross-device tickets whose intent we can't recover locally. */

--- a/apps/web/src/app/(workspace)/support/page.tsx
+++ b/apps/web/src/app/(workspace)/support/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+import { SupportScreen } from "./components/support-screen";
+
+export const metadata: Metadata = {
+	title: "Support",
+};
+
+export default function SupportPage() {
+	return <SupportScreen />;
+}

--- a/apps/web/src/app/api/schedule-demo/route.ts
+++ b/apps/web/src/app/api/schedule-demo/route.ts
@@ -67,7 +67,7 @@ export async function POST(request: NextRequest) {
 
 		// Send email via Resend
 		const data = await resend.emails.send({
-			from: "OneTool Demo Requests <support@onetool.biz>",
+			from: "OneTool Demo Requests <no-reply@onetool.biz>",
 			to: ["support@onetool.biz"],
 			subject: `New Demo Request from ${name}${company ? ` - ${company}` : ""}`,
 			html: emailHtml,

--- a/apps/web/src/components/help/help-menu.tsx
+++ b/apps/web/src/components/help/help-menu.tsx
@@ -2,7 +2,14 @@
 
 import * as React from "react";
 import { usePathname } from "next/navigation";
-import { ArrowUpRight, CircleHelp, Sparkles } from "lucide-react";
+import {
+	ArrowUpRight,
+	Bug,
+	CircleHelp,
+	Lightbulb,
+	MessageCircle,
+	Sparkles,
+} from "lucide-react";
 import {
 	Command,
 	CommandEmpty,
@@ -20,6 +27,34 @@ import { HelpArticleDrawer } from "@/components/help/learn-more";
 import { headerIconButtonClass } from "@/components/layout/header-icon-button";
 import { resolveHelpRef, searchHelpArticles } from "@/lib/help";
 import { DEFAULT_HELP_REFS, getRouteHelpRefs } from "@/lib/help/route-help";
+import { useOptionalSupportDialog } from "@/components/support/support-dialog-provider";
+import type { SupportIntent } from "@/components/support/support-dialog";
+
+const SUPPORT_ROWS: Array<{
+	intent: SupportIntent;
+	icon: typeof MessageCircle;
+	label: string;
+	subtext: string;
+}> = [
+	{
+		intent: "contact",
+		icon: MessageCircle,
+		label: "Contact support",
+		subtext: "We reply within one business day",
+	},
+	{
+		intent: "bug",
+		icon: Bug,
+		label: "Report a bug",
+		subtext: "Something broken or not working right",
+	},
+	{
+		intent: "feature",
+		icon: Lightbulb,
+		label: "Request a feature",
+		subtext: "Tell us what OneTool should do next",
+	},
+];
 
 /**
  * Header "?" menu: suggests articles for the current page and searches the
@@ -58,6 +93,16 @@ export function HelpMenu() {
 		setDrawerOpen(true);
 	};
 
+	// Null outside the workspace provider — the section simply doesn't render.
+	const openSupport = useOptionalSupportDialog();
+	const supportRows = !openSupport
+		? []
+		: searching
+			? SUPPORT_ROWS.filter((row) =>
+					row.label.toLowerCase().includes(query.trim().toLowerCase())
+				)
+			: SUPPORT_ROWS;
+
 	return (
 		<>
 			<Popover open={open} onOpenChange={handleOpenChange}>
@@ -85,7 +130,9 @@ export function HelpMenu() {
 							onValueChange={setQuery}
 						/>
 						<CommandList>
-							<CommandEmpty>No articles match your search.</CommandEmpty>
+							{supportRows.length === 0 && (
+								<CommandEmpty>No articles match your search.</CommandEmpty>
+							)}
 							{refs.length > 0 && (
 								<CommandGroup heading={heading}>
 									{refs.map((ref) => {
@@ -120,6 +167,34 @@ export function HelpMenu() {
 											</CommandItem>
 										);
 									})}
+								</CommandGroup>
+							)}
+							{supportRows.length > 0 && (
+								<CommandGroup heading="Get in touch">
+									{supportRows.map((row) => (
+										<CommandItem
+											key={row.intent}
+											value={`support:${row.intent}`}
+											onSelect={() => {
+												setOpen(false);
+												setQuery("");
+												openSupport?.(row.intent);
+											}}
+											className="cursor-pointer"
+										>
+											<span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+												<row.icon className="size-4" aria-hidden="true" />
+											</span>
+											<span className="min-w-0">
+												<span className="block truncate text-sm font-medium text-foreground">
+													{row.label}
+												</span>
+												<span className="block truncate text-xs text-muted-foreground">
+													{row.subtext}
+												</span>
+											</span>
+										</CommandItem>
+									))}
 								</CommandGroup>
 							)}
 						</CommandList>

--- a/apps/web/src/components/help/help-menu.tsx
+++ b/apps/web/src/components/help/help-menu.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import * as React from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import {
 	ArrowUpRight,
 	Bug,
 	CircleHelp,
 	Lightbulb,
 	MessageCircle,
+	MessagesSquare,
 	Sparkles,
 } from "lucide-react";
 import {
@@ -29,6 +30,8 @@ import { resolveHelpRef, searchHelpArticles } from "@/lib/help";
 import { DEFAULT_HELP_REFS, getRouteHelpRefs } from "@/lib/help/route-help";
 import { useOptionalSupportDialog } from "@/components/support/support-dialog-provider";
 import type { SupportIntent } from "@/components/support/support-dialog";
+import { supportUnreadCount, useSupportTickets } from "@/lib/support-tickets";
+import { cn } from "@/lib/utils";
 
 const SUPPORT_ROWS: Array<{
 	intent: SupportIntent;
@@ -103,6 +106,15 @@ export function HelpMenu() {
 				)
 			: SUPPORT_ROWS;
 
+	const router = useRouter();
+	const { tickets } = useSupportTickets();
+	const unreadCount = supportUnreadCount(tickets);
+	const requestsRowLabel = "Your support requests";
+	const showRequestsRow =
+		!!openSupport &&
+		(!searching ||
+			requestsRowLabel.toLowerCase().includes(query.trim().toLowerCase()));
+
 	return (
 		<>
 			<Popover open={open} onOpenChange={handleOpenChange}>
@@ -110,12 +122,22 @@ export function HelpMenu() {
 					render={
 						<button
 							type="button"
-							className={headerIconButtonClass}
-							aria-label="Help"
+							className={cn(headerIconButtonClass, "relative")}
+							aria-label={
+								unreadCount > 0
+									? `Help — ${unreadCount} unread support ${unreadCount === 1 ? "reply" : "replies"}`
+									: "Help"
+							}
 						/>
 					}
 				>
 					<CircleHelp className="size-[18px]" />
+					{unreadCount > 0 && (
+						<span
+							aria-hidden="true"
+							className="absolute right-1 top-1 size-2 rounded-full bg-primary ring-2 ring-background"
+						/>
+					)}
 				</PopoverTrigger>
 				<PopoverContent
 					className="w-80 rounded-xl border-border p-0 shadow-xl"
@@ -130,7 +152,7 @@ export function HelpMenu() {
 							onValueChange={setQuery}
 						/>
 						<CommandList>
-							{supportRows.length === 0 && (
+							{supportRows.length === 0 && !showRequestsRow && (
 								<CommandEmpty>No articles match your search.</CommandEmpty>
 							)}
 							{refs.length > 0 && (
@@ -169,7 +191,7 @@ export function HelpMenu() {
 									})}
 								</CommandGroup>
 							)}
-							{supportRows.length > 0 && (
+							{(supportRows.length > 0 || showRequestsRow) && (
 								<CommandGroup heading="Get in touch">
 									{supportRows.map((row) => (
 										<CommandItem
@@ -195,6 +217,37 @@ export function HelpMenu() {
 											</span>
 										</CommandItem>
 									))}
+									{showRequestsRow && (
+										<CommandItem
+											value="support:requests"
+											onSelect={() => {
+												setOpen(false);
+												setQuery("");
+												router.push("/support");
+											}}
+											className="cursor-pointer"
+										>
+											<span className="relative flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+												<MessagesSquare className="size-4" aria-hidden="true" />
+												{unreadCount > 0 && (
+													<span
+														aria-hidden="true"
+														className="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-primary ring-2 ring-popover"
+													/>
+												)}
+											</span>
+											<span className="min-w-0">
+												<span className="block truncate text-sm font-medium text-foreground">
+													{requestsRowLabel}
+												</span>
+												<span className="block truncate text-xs text-muted-foreground">
+													{unreadCount > 0
+														? `${unreadCount} unread ${unreadCount === 1 ? "reply" : "replies"}`
+														: "See your open and past requests"}
+												</span>
+											</span>
+										</CommandItem>
+									)}
 								</CommandGroup>
 							)}
 						</CommandList>

--- a/apps/web/src/components/layout/command-palette.tsx
+++ b/apps/web/src/components/layout/command-palette.tsx
@@ -7,10 +7,13 @@ import { api } from "@onetool/backend/convex/_generated/api";
 import type { FunctionReturnType } from "convex/server";
 import {
 	Building2,
+	Bug,
 	CheckSquare,
 	FileText,
 	FolderKanban,
+	Lightbulb,
 	MapPin,
+	MessageCircle,
 	Plus,
 	Receipt,
 	Search,
@@ -34,6 +37,7 @@ import {
 } from "@/components/ui/sidebar";
 import { TaskSheet } from "@/components/shared/task-sheet";
 import { useCreateRecord } from "@/components/domain/create-record-provider";
+import { useOptionalSupportDialog } from "@/components/support/support-dialog-provider";
 import {
 	NAV_GROUPS,
 	canViewNavItem,
@@ -192,6 +196,20 @@ export function CommandPaletteProvider({
 			)
 		: createActions;
 
+	const openSupport = useOptionalSupportDialog();
+	const supportActions = openSupport
+		? ([
+				{ key: "contact", label: "Contact support", icon: MessageCircle },
+				{ key: "bug", label: "Report a bug", icon: Bug },
+				{ key: "feature", label: "Request a feature", icon: Lightbulb },
+			] as const)
+		: [];
+	const filteredSupport = trimmed
+		? supportActions.filter((action) =>
+				action.label.toLowerCase().includes(trimmed),
+			)
+		: supportActions;
+
 	return (
 		<CommandPaletteContext.Provider value={value}>
 			{children}
@@ -236,6 +254,22 @@ export function CommandPaletteProvider({
 										onSelect={() => runSelect(action.run)}
 									>
 										<Plus />
+										<span>{action.label}</span>
+									</CommandItem>
+								))}
+							</CommandGroup>
+						)}
+						{filteredSupport.length > 0 && (
+							<CommandGroup heading="Support">
+								{filteredSupport.map((action) => (
+									<CommandItem
+										key={action.key}
+										value={`support:${action.key}`}
+										onSelect={() =>
+											runSelect(() => openSupport?.(action.key))
+										}
+									>
+										<action.icon />
 										<span>{action.label}</span>
 									</CommandItem>
 								))}

--- a/apps/web/src/components/layout/command-palette.tsx
+++ b/apps/web/src/components/layout/command-palette.tsx
@@ -12,6 +12,7 @@ import {
 	FileText,
 	FolderKanban,
 	Lightbulb,
+	MessagesSquare,
 	MapPin,
 	MessageCircle,
 	Plus,
@@ -259,7 +260,9 @@ export function CommandPaletteProvider({
 								))}
 							</CommandGroup>
 						)}
-						{filteredSupport.length > 0 && (
+						{(filteredSupport.length > 0 ||
+							!trimmed ||
+							"your support requests".includes(trimmed)) && (
 							<CommandGroup heading="Support">
 								{filteredSupport.map((action) => (
 									<CommandItem
@@ -273,6 +276,15 @@ export function CommandPaletteProvider({
 										<span>{action.label}</span>
 									</CommandItem>
 								))}
+								{(!trimmed || "your support requests".includes(trimmed)) && (
+									<CommandItem
+										value="support:requests"
+										onSelect={() => runSelect(() => router.push("/support"))}
+									>
+										<MessagesSquare />
+										<span>Your support requests</span>
+									</CommandItem>
+								)}
 							</CommandGroup>
 						)}
 						{results && results.clients.length > 0 && (

--- a/apps/web/src/components/shared/receiving-address-field.tsx
+++ b/apps/web/src/components/shared/receiving-address-field.tsx
@@ -24,6 +24,8 @@ export const MAX_LOCAL_PART_LENGTH = 24;
 const RESERVED_LOCAL_PARTS = new Set([
 	"support",
 	"noreply",
+	"no-reply",
+	"replies",
 	"new",
 	"create",
 	"edit",

--- a/apps/web/src/components/support/support-dialog-provider.tsx
+++ b/apps/web/src/components/support/support-dialog-provider.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import * as React from "react";
+import {
+	SupportDialog,
+	type SupportIntent,
+} from "@/components/support/support-dialog";
+
+const SupportDialogContext = React.createContext<
+	((intent: SupportIntent) => void) | null
+>(null);
+
+/** Null outside the provider (e.g. the public help center) — callers fall back to mailto. */
+export function useOptionalSupportDialog() {
+	return React.useContext(SupportDialogContext);
+}
+
+export function useSupportDialog(): (intent: SupportIntent) => void {
+	const ctx = React.useContext(SupportDialogContext);
+	if (!ctx) {
+		throw new Error(
+			"useSupportDialog must be used within SupportDialogProvider"
+		);
+	}
+	return ctx;
+}
+
+/**
+ * Hosts the support composer so the HelpMenu and ⌘K palette can open it from
+ * anywhere in the workspace. Same mount-on-demand + two-step unmount as
+ * CreateRecordProvider: close plays the exit animation, then unmount.
+ */
+export function SupportDialogProvider({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	const [intent, setIntent] = React.useState<SupportIntent | null>(null);
+	const [open, setOpen] = React.useState(false);
+
+	const openSupport = React.useCallback((next: SupportIntent) => {
+		setIntent(next);
+		setOpen(true);
+	}, []);
+
+	return (
+		<SupportDialogContext.Provider value={openSupport}>
+			{children}
+			{intent && (
+				<SupportDialog
+					intent={intent}
+					open={open}
+					onOpenChange={(next) => {
+						if (!next) setOpen(false);
+					}}
+					onOpenChangeComplete={(nowOpen) => {
+						if (!nowOpen) setIntent(null);
+					}}
+				/>
+			)}
+		</SupportDialogContext.Provider>
+	);
+}

--- a/apps/web/src/components/support/support-dialog.tsx
+++ b/apps/web/src/components/support/support-dialog.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import * as React from "react";
+import { usePathname } from "next/navigation";
+import { useUser, useOrganization } from "@clerk/nextjs";
+import { useQuery } from "convex/react";
+import { api } from "@onetool/backend/convex/_generated/api";
+
+import { CreateRecordDialog } from "@/components/domain/create-record-dialog";
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/hooks/use-toast";
+import {
+	isSupportAvailable,
+	sendSupportMessage,
+	showSupportWidget,
+} from "@/lib/support";
+
+export type SupportIntent = "contact" | "bug" | "feature";
+
+const MAX_DETAIL_LENGTH = 2000;
+
+const INTENT_COPY: Record<
+	SupportIntent,
+	{
+		title: string;
+		description: string;
+		/** D13: PostHog Workflows tag tickets by matching this first line. */
+		messagePrefix: string;
+		detailLabel: string;
+		detailPlaceholder: string;
+	}
+> = {
+	contact: {
+		title: "Contact support",
+		description: "Questions, billing, anything — we read every message.",
+		messagePrefix: "Support request",
+		detailLabel: "How can we help?",
+		detailPlaceholder: "Tell us what you need…",
+	},
+	bug: {
+		title: "Report a bug",
+		description:
+			"The technical details (page, session, errors) attach automatically.",
+		messagePrefix: "Bug report",
+		detailLabel: "What happened instead?",
+		detailPlaceholder: "What you saw, including any error message…",
+	},
+	feature: {
+		title: "Request a feature",
+		description: "Tell us what OneTool should do next.",
+		messagePrefix: "Feature request",
+		detailLabel: "What would you like OneTool to do?",
+		detailPlaceholder: "The task you're trying to get done…",
+	},
+};
+
+interface SupportDialogProps {
+	intent: SupportIntent;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onOpenChangeComplete?: (open: boolean) => void;
+}
+
+/**
+ * One dialog for all three support intents; creates a PostHog Support ticket
+ * via conversations.sendMessage. Widget tickets auto-attach replay, events,
+ * errors, and identity, so the form stays minimal (no severity/category —
+ * D12). When the conversations module can't load (ad blockers), falls back
+ * to a mailto link.
+ */
+export function SupportDialog({
+	intent,
+	open,
+	onOpenChange,
+	onOpenChangeComplete,
+}: SupportDialogProps) {
+	const copy = INTENT_COPY[intent];
+	const pathname = usePathname();
+	const { user } = useUser();
+	const { organization } = useOrganization();
+	const entitlements = useQuery(api.entitlements.getMine, {});
+	const toast = useToast();
+
+	const [tryingTo, setTryingTo] = React.useState("");
+	const [detail, setDetail] = React.useState("");
+	const [submitting, setSubmitting] = React.useState(false);
+	const [submitError, setSubmitError] = React.useState<string | null>(null);
+
+	// Reset when closing — during render via the previous-value pattern
+	// (setState-in-effect is a lint error in apps/web).
+	const [prevOpen, setPrevOpen] = React.useState(open);
+	if (open !== prevOpen) {
+		setPrevOpen(open);
+		if (!open) {
+			setTryingTo("");
+			setDetail("");
+			setSubmitting(false);
+			setSubmitError(null);
+		}
+	}
+
+	const available = isSupportAvailable();
+	const email = user?.primaryEmailAddress?.emailAddress ?? "";
+	const canSubmit =
+		available &&
+		detail.trim().length > 0 &&
+		(intent !== "bug" || tryingTo.trim().length > 0);
+
+	const handleSubmit = async () => {
+		if (submitting || !canSubmit) return;
+		setSubmitting(true);
+		setSubmitError(null);
+
+		// D13: visible intent line first (Workflow tag match), then the user's
+		// text, then a compact context block.
+		const body =
+			intent === "bug"
+				? `Trying to: ${tryingTo.trim()}\nWhat happened: ${detail.trim()}`
+				: detail.trim();
+		const context = [
+			organization?.name,
+			entitlements?.plan,
+			pathname,
+			"web",
+		]
+			.filter(Boolean)
+			.join(" · ");
+		const message = `${copy.messagePrefix}\n\n${body}\n\n— ${context}`;
+
+		const sent = await sendSupportMessage(message, {
+			name: user?.fullName ?? undefined,
+			email: email || undefined,
+		});
+		setSubmitting(false);
+
+		if (!sent) {
+			setSubmitError(
+				"That didn't go through. Try again, or email support@onetool.biz."
+			);
+			return;
+		}
+
+		onOpenChange(false);
+		toast.success("Message sent", "We'll reply within one business day.", {
+			action: { label: "View conversation", onClick: showSupportWidget },
+		});
+	};
+
+	return (
+		<CreateRecordDialog
+			open={open}
+			onOpenChange={onOpenChange}
+			onOpenChangeComplete={onOpenChangeComplete}
+			title={copy.title}
+			description={copy.description}
+			submitLabel="Send message"
+			submittingLabel="Sending…"
+			isSubmitting={submitting}
+			canSubmit={canSubmit}
+			onSubmit={handleSubmit}
+			className="max-w-lg"
+		>
+			{available ? (
+				<>
+					<FieldGroup>
+						{intent === "bug" && (
+							<Field>
+								<FieldLabel htmlFor="support-trying-to">
+									What were you trying to do?
+								</FieldLabel>
+								<Input
+									id="support-trying-to"
+									value={tryingTo}
+									onChange={(e) => setTryingTo(e.target.value)}
+									placeholder="e.g., Send a quote to a client"
+									maxLength={200}
+									autoFocus
+								/>
+							</Field>
+						)}
+						<Field>
+							<FieldLabel htmlFor="support-detail">
+								{copy.detailLabel}
+							</FieldLabel>
+							<Textarea
+								id="support-detail"
+								value={detail}
+								onChange={(e) => setDetail(e.target.value)}
+								placeholder={copy.detailPlaceholder}
+								rows={5}
+								maxLength={MAX_DETAIL_LENGTH}
+								autoFocus={intent !== "bug"}
+							/>
+							<span className="self-end text-xs tabular-nums text-muted-foreground">
+								{detail.length}/{MAX_DETAIL_LENGTH}
+							</span>
+						</Field>
+					</FieldGroup>
+
+					{submitError && (
+						<p
+							role="alert"
+							className="rounded-md border border-danger/30 bg-danger/10 px-3 py-2 text-[13px] text-danger"
+						>
+							{submitError}
+						</p>
+					)}
+
+					<div className="space-y-1 text-xs text-muted-foreground">
+						{email && (
+							<p>
+								A real person reads every message — we&apos;ll reply to{" "}
+								<span className="font-medium text-foreground">{email}</span>{" "}
+								within one business day.
+							</p>
+						)}
+						<p>Please don&apos;t include client payment details.</p>
+					</div>
+				</>
+			) : (
+				<p className="text-sm text-muted-foreground">
+					Support chat couldn&apos;t load — this is usually an ad blocker.
+					Email us instead at{" "}
+					<a
+						href="mailto:support@onetool.biz"
+						className="font-medium text-primary underline-offset-4 hover:underline"
+					>
+						support@onetool.biz
+					</a>{" "}
+					and we&apos;ll reply within one business day.
+				</p>
+			)}
+		</CreateRecordDialog>
+	);
+}

--- a/apps/web/src/components/support/support-dialog.tsx
+++ b/apps/web/src/components/support/support-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useUser, useOrganization } from "@clerk/nextjs";
 import { useQuery } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
@@ -13,11 +13,14 @@ import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
 import {
 	isSupportAvailable,
+	rememberTicketIntent,
 	sendSupportMessage,
-	showSupportWidget,
+	SUPPORT_INTENT_PREFIX,
+	type SupportIntent,
 } from "@/lib/support";
+import { refreshSupportTickets } from "@/lib/support-tickets";
 
-export type SupportIntent = "contact" | "bug" | "feature";
+export type { SupportIntent };
 
 const MAX_DETAIL_LENGTH = 2000;
 
@@ -26,33 +29,37 @@ const INTENT_COPY: Record<
 	{
 		title: string;
 		description: string;
-		/** D13: PostHog Workflows tag tickets by matching this first line. */
-		messagePrefix: string;
 		detailLabel: string;
 		detailPlaceholder: string;
+		/** V2-3: per-intent post-submit promise. */
+		toastTitle: string;
+		toastDescription: string;
 	}
 > = {
 	contact: {
 		title: "Contact support",
 		description: "Questions, billing, anything — we read every message.",
-		messagePrefix: "Support request",
 		detailLabel: "How can we help?",
 		detailPlaceholder: "Tell us what you need…",
+		toastTitle: "Message sent",
+		toastDescription: "We'll reply within one business day.",
 	},
 	bug: {
 		title: "Report a bug",
 		description:
 			"The technical details (page, session, errors) attach automatically.",
-		messagePrefix: "Bug report",
 		detailLabel: "What happened instead?",
 		detailPlaceholder: "What you saw, including any error message…",
+		toastTitle: "Bug report sent",
+		toastDescription: "We'll investigate and reply within one business day.",
 	},
 	feature: {
 		title: "Request a feature",
 		description: "Tell us what OneTool should do next.",
-		messagePrefix: "Feature request",
 		detailLabel: "What would you like OneTool to do?",
 		detailPlaceholder: "The task you're trying to get done…",
+		toastTitle: "Thanks — we've logged it",
+		toastDescription: "We'll email you if we ship it or need more detail.",
 	},
 };
 
@@ -78,6 +85,7 @@ export function SupportDialog({
 }: SupportDialogProps) {
 	const copy = INTENT_COPY[intent];
 	const pathname = usePathname();
+	const router = useRouter();
 	const { user } = useUser();
 	const { organization } = useOrganization();
 	const entitlements = useQuery(api.entitlements.getMine, {});
@@ -127,24 +135,26 @@ export function SupportDialog({
 		]
 			.filter(Boolean)
 			.join(" · ");
-		const message = `${copy.messagePrefix}\n\n${body}\n\n— ${context}`;
+		const message = `${SUPPORT_INTENT_PREFIX[intent]}\n\n${body}\n\n— ${context}`;
 
-		const sent = await sendSupportMessage(message, {
+		const ticketId = await sendSupportMessage(message, {
 			name: user?.fullName ?? undefined,
 			email: email || undefined,
 		});
 		setSubmitting(false);
 
-		if (!sent) {
+		if (!ticketId) {
 			setSubmitError(
 				"That didn't go through. Try again, or email support@onetool.biz."
 			);
 			return;
 		}
 
+		rememberTicketIntent(ticketId, intent);
+		void refreshSupportTickets();
 		onOpenChange(false);
-		toast.success("Message sent", "We'll reply within one business day.", {
-			action: { label: "View conversation", onClick: showSupportWidget },
+		toast.success(copy.toastTitle, copy.toastDescription, {
+			action: { label: "View request", onClick: () => router.push("/support") },
 		});
 	};
 

--- a/apps/web/src/components/support/support-dialog.tsx
+++ b/apps/web/src/components/support/support-dialog.tsx
@@ -17,6 +17,7 @@ import {
 	sendSupportMessage,
 	SUPPORT_INTENT_PREFIX,
 	type SupportIntent,
+	waitForSupportAvailable,
 } from "@/lib/support";
 import { refreshSupportTickets } from "@/lib/support-tickets";
 
@@ -109,7 +110,19 @@ export function SupportDialog({
 		}
 	}
 
-	const available = isSupportAvailable();
+	// The PostHog SDK loads async: a render-only check could freeze the dialog
+	// in its "unavailable" branch when opened right after page load.
+	const [available, setAvailable] = React.useState(isSupportAvailable);
+	React.useEffect(() => {
+		if (!open || available) return;
+		let cancelled = false;
+		void waitForSupportAvailable().then((ok) => {
+			if (!cancelled && ok) setAvailable(true);
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [open, available]);
 	const email = user?.primaryEmailAddress?.emailAddress ?? "";
 	const canSubmit =
 		available &&

--- a/apps/web/src/hooks/use-analytics-identity.ts
+++ b/apps/web/src/hooks/use-analytics-identity.ts
@@ -12,6 +12,10 @@ import {
 	resetAnalytics,
 } from "@/lib/analytics";
 import { setSupportIdentity } from "@/lib/support";
+import {
+	refreshSupportTickets,
+	resetSupportTickets,
+} from "@/lib/support-tickets";
 
 /**
  * Hook that handles PostHog user and organization identification.
@@ -50,6 +54,7 @@ export function useAnalyticsIdentity() {
 	useEffect(() => {
 		if (prevSignedIn.current === true && isSignedIn === false) {
 			resetAnalytics();
+			resetSupportTickets();
 			hasIdentified.current = false;
 			lastPlanSent.current = null;
 			lastGroupPlanSent.current = null;
@@ -66,6 +71,10 @@ export function useAnalyticsIdentity() {
 		if (lastSupportIdentitySent.current === supportIdentity.distinctId) return;
 		setSupportIdentity(supportIdentity.distinctId, supportIdentity.hash);
 		lastSupportIdentitySent.current = supportIdentity.distinctId;
+		// V2-4: the one getTickets fetch on workspace load feeds the "?" unread
+		// dot — runs after identity so it lists the user's tickets, not the
+		// anonymous widget session's.
+		void refreshSupportTickets();
 	}, [isSignedIn, supportIdentity]);
 
 	// Identify user immediately when Clerk data is available (don't wait for Convex)

--- a/apps/web/src/hooks/use-analytics-identity.ts
+++ b/apps/web/src/hooks/use-analytics-identity.ts
@@ -11,6 +11,7 @@ import {
 	setOrganizationGroup,
 	resetAnalytics,
 } from "@/lib/analytics";
+import { setSupportIdentity } from "@/lib/support";
 
 /**
  * Hook that handles PostHog user and organization identification.
@@ -34,10 +35,15 @@ export function useAnalyticsIdentity() {
 		api.entitlements.getMine,
 		isSignedIn ? {} : "skip"
 	);
+	const supportIdentity = useQuery(
+		api.support.getConversationsIdentity,
+		isSignedIn ? {} : "skip"
+	);
 
 	const hasIdentified = useRef(false);
 	const lastPlanSent = useRef<string | null>(null);
 	const lastGroupPlanSent = useRef<string | null>(null);
+	const lastSupportIdentitySent = useRef<string | null>(null);
 	const prevSignedIn = useRef<boolean | null>(null);
 
 	// Handle sign-out - reset PostHog identity and flags
@@ -47,9 +53,20 @@ export function useAnalyticsIdentity() {
 			hasIdentified.current = false;
 			lastPlanSent.current = null;
 			lastGroupPlanSent.current = null;
+			lastSupportIdentitySent.current = null;
 		}
 		prevSignedIn.current = isSignedIn ?? null;
 	}, [isSignedIn]);
+
+	// Support (conversations) HMAC identity — ticket ownership that survives
+	// posthog.reset() and cross-device sign-ins. Null when the backend secret
+	// is unset (widget then falls back to session-based access).
+	useEffect(() => {
+		if (!isSignedIn || !supportIdentity) return;
+		if (lastSupportIdentitySent.current === supportIdentity.distinctId) return;
+		setSupportIdentity(supportIdentity.distinctId, supportIdentity.hash);
+		lastSupportIdentitySent.current = supportIdentity.distinctId;
+	}, [isSignedIn, supportIdentity]);
 
 	// Identify user immediately when Clerk data is available (don't wait for Convex)
 	useEffect(() => {

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -78,8 +78,11 @@ export function setOrganizationGroup(
 /**
  * Reset analytics identity on sign-out.
  * Clears the current user identification and starts a new anonymous session.
+ * Also clears the Support HMAC identity — reset() wipes the widget's session
+ * state, and a stale verified identity must not outlive the sign-in.
  */
 export function resetAnalytics() {
+	posthog.clearIdentity();
 	posthog.reset();
 }
 

--- a/apps/web/src/lib/help/route-help.ts
+++ b/apps/web/src/lib/help/route-help.ts
@@ -84,6 +84,13 @@ export const ROUTE_HELP: Array<{ pattern: RegExp; refs: string[] }> = [
 		refs: ["routing/planning-a-route", "routing/saved-routes"],
 	},
 	{
+		pattern: /^\/support/,
+		refs: [
+			"getting-started/get-help-and-share-feedback",
+			"getting-started/welcome-to-onetool",
+		],
+	},
+	{
 		pattern: /^\/reports/,
 		refs: ["reports/building-a-report", "reports/report-presets", "settings-and-team/limits-and-fair-use"],
 	},

--- a/apps/web/src/lib/support-tickets.test.ts
+++ b/apps/web/src/lib/support-tickets.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Ticket } from "posthog-js";
+
+const waitForSupportAvailable = vi.fn<() => Promise<boolean>>();
+const getSupportTickets = vi.fn<() => Promise<Ticket[] | null>>();
+
+vi.mock("@/lib/support", () => ({
+	waitForSupportAvailable: () => waitForSupportAvailable(),
+	getSupportTickets: () => getSupportTickets(),
+}));
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((r) => {
+		resolve = r;
+	});
+	return { promise, resolve };
+}
+
+const TICKET = { id: "t1", unread_count: 1 } as unknown as Ticket;
+
+async function loadStore() {
+	vi.resetModules();
+	return import("./support-tickets");
+}
+
+describe("support-tickets store", () => {
+	beforeEach(() => {
+		// The store no-ops without a window (edge-runtime has none).
+		vi.stubGlobal("window", {});
+		waitForSupportAvailable.mockReset();
+		getSupportTickets.mockReset();
+	});
+
+	it("populates tickets on refresh", async () => {
+		const store = await loadStore();
+		waitForSupportAvailable.mockResolvedValue(true);
+		getSupportTickets.mockResolvedValue([TICKET]);
+
+		await store.refreshSupportTickets();
+
+		expect(store.supportTicketsSnapshot()).toEqual({
+			status: "ready",
+			tickets: [TICKET],
+		});
+	});
+
+	it("discards a fetch that was in flight when reset happens (sign-out)", async () => {
+		const store = await loadStore();
+		waitForSupportAvailable.mockResolvedValue(true);
+		const fetch = deferred<Ticket[] | null>();
+		getSupportTickets.mockReturnValue(fetch.promise);
+
+		const refresh = store.refreshSupportTickets();
+		// Let the loop reach the getSupportTickets await before resetting.
+		await Promise.resolve();
+		store.resetSupportTickets();
+		fetch.resolve([TICKET]);
+		await refresh;
+
+		expect(store.supportTicketsSnapshot()).toEqual({
+			status: "idle",
+			tickets: [],
+		});
+	});
+});

--- a/apps/web/src/lib/support-tickets.test.ts
+++ b/apps/web/src/lib/support-tickets.test.ts
@@ -42,6 +42,7 @@ describe("support-tickets store", () => {
 		expect(store.supportTicketsSnapshot()).toEqual({
 			status: "ready",
 			tickets: [TICKET],
+			refreshing: false,
 		});
 	});
 
@@ -61,6 +62,7 @@ describe("support-tickets store", () => {
 		expect(store.supportTicketsSnapshot()).toEqual({
 			status: "idle",
 			tickets: [],
+			refreshing: false,
 		});
 	});
 });

--- a/apps/web/src/lib/support-tickets.ts
+++ b/apps/web/src/lib/support-tickets.ts
@@ -25,6 +25,7 @@ const INITIAL_STATE: SupportTicketsState = { status: "idle", tickets: [] };
 let state: SupportTicketsState = INITIAL_STATE;
 const listeners = new Set<() => void>();
 let inflight: Promise<void> | null = null;
+let rerunRequested = false;
 
 function emit(next: SupportTicketsState) {
 	state = next;
@@ -33,24 +34,33 @@ function emit(next: SupportTicketsState) {
 
 export function refreshSupportTickets(): Promise<void> {
 	if (typeof window === "undefined") return Promise.resolve();
-	if (inflight) return inflight;
+	if (inflight) {
+		// Don't swallow a refresh that races an in-flight one — the identity
+		// effect can land mid-fetch and its results must not be the stale
+		// anonymous-session list. Re-run once the current fetch settles.
+		rerunRequested = true;
+		return inflight;
+	}
 	inflight = (async () => {
-		// Keep the current list on screen while a manual refresh runs.
-		emit({
-			status: state.status === "ready" ? "ready" : "loading",
-			tickets: state.tickets,
-		});
-		const available = await waitForSupportAvailable();
-		if (!available) {
-			emit({ status: "unavailable", tickets: [] });
-			return;
-		}
-		const tickets = await getSupportTickets();
-		if (tickets === null) {
-			emit({ status: "error", tickets: state.tickets });
-		} else {
-			emit({ status: "ready", tickets });
-		}
+		do {
+			rerunRequested = false;
+			// Keep the current list on screen while a manual refresh runs.
+			emit({
+				status: state.status === "ready" ? "ready" : "loading",
+				tickets: state.tickets,
+			});
+			const available = await waitForSupportAvailable();
+			if (!available) {
+				emit({ status: "unavailable", tickets: [] });
+				continue;
+			}
+			const tickets = await getSupportTickets();
+			if (tickets === null) {
+				emit({ status: "error", tickets: state.tickets });
+			} else {
+				emit({ status: "ready", tickets });
+			}
+		} while (rerunRequested);
 	})().finally(() => {
 		inflight = null;
 	});

--- a/apps/web/src/lib/support-tickets.ts
+++ b/apps/web/src/lib/support-tickets.ts
@@ -1,0 +1,94 @@
+import { useSyncExternalStore } from "react";
+import type { Ticket } from "posthog-js";
+import { getSupportTickets, waitForSupportAvailable } from "@/lib/support";
+
+/**
+ * Session-wide support ticket cache (V2-4): one getTickets fetch on workspace
+ * load feeds both the "?" unread dot and the /support list — never polled.
+ * Refreshed explicitly: identity set, page refresh button, after a send.
+ */
+
+export type SupportTicketsStatus =
+	| "idle"
+	| "loading"
+	| "ready"
+	| "unavailable"
+	| "error";
+
+export interface SupportTicketsState {
+	status: SupportTicketsStatus;
+	tickets: Ticket[];
+}
+
+const INITIAL_STATE: SupportTicketsState = { status: "idle", tickets: [] };
+
+let state: SupportTicketsState = INITIAL_STATE;
+const listeners = new Set<() => void>();
+let inflight: Promise<void> | null = null;
+
+function emit(next: SupportTicketsState) {
+	state = next;
+	for (const listener of listeners) listener();
+}
+
+export function refreshSupportTickets(): Promise<void> {
+	if (typeof window === "undefined") return Promise.resolve();
+	if (inflight) return inflight;
+	inflight = (async () => {
+		// Keep the current list on screen while a manual refresh runs.
+		emit({
+			status: state.status === "ready" ? "ready" : "loading",
+			tickets: state.tickets,
+		});
+		const available = await waitForSupportAvailable();
+		if (!available) {
+			emit({ status: "unavailable", tickets: [] });
+			return;
+		}
+		const tickets = await getSupportTickets();
+		if (tickets === null) {
+			emit({ status: "error", tickets: state.tickets });
+		} else {
+			emit({ status: "ready", tickets });
+		}
+	})().finally(() => {
+		inflight = null;
+	});
+	return inflight;
+}
+
+/** Sign-out: drop the previous user's tickets. */
+export function resetSupportTickets() {
+	emit(INITIAL_STATE);
+}
+
+/** Reflect a markAsRead immediately without a refetch. */
+export function markTicketReadLocally(ticketId: string) {
+	if (!state.tickets.some((t) => t.id === ticketId && (t.unread_count ?? 0) > 0)) {
+		return;
+	}
+	emit({
+		status: state.status,
+		tickets: state.tickets.map((t) =>
+			t.id === ticketId ? { ...t, unread_count: 0 } : t
+		),
+	});
+}
+
+function subscribe(listener: () => void): () => void {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+}
+
+export function useSupportTickets(): SupportTicketsState {
+	return useSyncExternalStore(
+		subscribe,
+		() => state,
+		() => INITIAL_STATE
+	);
+}
+
+/** Tickets with unread team replies (resolved included — a reply is a reply). */
+export function supportUnreadCount(tickets: Ticket[]): number {
+	return tickets.filter((t) => (t.unread_count ?? 0) > 0).length;
+}

--- a/apps/web/src/lib/support-tickets.ts
+++ b/apps/web/src/lib/support-tickets.ts
@@ -26,6 +26,9 @@ let state: SupportTicketsState = INITIAL_STATE;
 const listeners = new Set<() => void>();
 let inflight: Promise<void> | null = null;
 let rerunRequested = false;
+// Bumped on reset so a fetch that was in flight at sign-out can't emit the
+// previous user's tickets over the cleared state.
+let generation = 0;
 
 function emit(next: SupportTicketsState) {
 	state = next;
@@ -44,17 +47,20 @@ export function refreshSupportTickets(): Promise<void> {
 	inflight = (async () => {
 		do {
 			rerunRequested = false;
+			const startedGeneration = generation;
 			// Keep the current list on screen while a manual refresh runs.
 			emit({
 				status: state.status === "ready" ? "ready" : "loading",
 				tickets: state.tickets,
 			});
 			const available = await waitForSupportAvailable();
+			if (generation !== startedGeneration) continue;
 			if (!available) {
 				emit({ status: "unavailable", tickets: [] });
 				continue;
 			}
 			const tickets = await getSupportTickets();
+			if (generation !== startedGeneration) continue;
 			if (tickets === null) {
 				emit({ status: "error", tickets: state.tickets });
 			} else {
@@ -69,7 +75,13 @@ export function refreshSupportTickets(): Promise<void> {
 
 /** Sign-out: drop the previous user's tickets. */
 export function resetSupportTickets() {
+	generation += 1;
 	emit(INITIAL_STATE);
+}
+
+/** Test-only snapshot of the store state. */
+export function supportTicketsSnapshot(): SupportTicketsState {
+	return state;
 }
 
 /** Reflect a markAsRead immediately without a refetch. */

--- a/apps/web/src/lib/support-tickets.ts
+++ b/apps/web/src/lib/support-tickets.ts
@@ -18,9 +18,16 @@ export type SupportTicketsStatus =
 export interface SupportTicketsState {
 	status: SupportTicketsStatus;
 	tickets: Ticket[];
+	/** A fetch is running — distinct from status so a manual refresh of an
+	 * already-loaded list can show progress without blanking the tickets. */
+	refreshing: boolean;
 }
 
-const INITIAL_STATE: SupportTicketsState = { status: "idle", tickets: [] };
+const INITIAL_STATE: SupportTicketsState = {
+	status: "idle",
+	tickets: [],
+	refreshing: false,
+};
 
 let state: SupportTicketsState = INITIAL_STATE;
 const listeners = new Set<() => void>();
@@ -52,19 +59,20 @@ export function refreshSupportTickets(): Promise<void> {
 			emit({
 				status: state.status === "ready" ? "ready" : "loading",
 				tickets: state.tickets,
+				refreshing: true,
 			});
 			const available = await waitForSupportAvailable();
 			if (generation !== startedGeneration) continue;
 			if (!available) {
-				emit({ status: "unavailable", tickets: [] });
+				emit({ status: "unavailable", tickets: [], refreshing: false });
 				continue;
 			}
 			const tickets = await getSupportTickets();
 			if (generation !== startedGeneration) continue;
 			if (tickets === null) {
-				emit({ status: "error", tickets: state.tickets });
+				emit({ status: "error", tickets: state.tickets, refreshing: false });
 			} else {
-				emit({ status: "ready", tickets });
+				emit({ status: "ready", tickets, refreshing: false });
 			}
 		} while (rerunRequested);
 	})().finally(() => {
@@ -90,7 +98,7 @@ export function markTicketReadLocally(ticketId: string) {
 		return;
 	}
 	emit({
-		status: state.status,
+		...state,
 		tickets: state.tickets.map((t) =>
 			t.id === ticketId ? { ...t, unread_count: 0 } : t
 		),

--- a/apps/web/src/lib/support.test.ts
+++ b/apps/web/src/lib/support.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression: sendMessage posts to the conversations manager's mutable
+ * "current ticket". A getMessages for another ticket must not be able to
+ * retarget the manager between a reply's own retarget and its send.
+ */
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((r) => {
+		resolve = r;
+	});
+	return { promise, resolve };
+}
+
+const gate = { current: deferred<void>() };
+const events: string[] = [];
+
+const conversations = {
+	current: null as string | null,
+	isAvailable: () => true,
+	getCurrentTicketId: () => conversations.current,
+	getMessages: vi.fn(async (ticketId: string) => {
+		events.push(`get:${ticketId}`);
+		await gate.current.promise;
+		conversations.current = ticketId;
+		return { results: [] };
+	}),
+	sendMessage: vi.fn(async () => {
+		events.push(`send@${conversations.current}`);
+		return { ticket_id: conversations.current };
+	}),
+};
+
+vi.mock("posthog-js", () => ({ default: { conversations } }));
+
+async function loadSupport() {
+	vi.resetModules();
+	return import("./support");
+}
+
+describe("conversation targeting serialization", () => {
+	beforeEach(() => {
+		conversations.current = null;
+		events.length = 0;
+		gate.current = deferred<void>();
+		conversations.getMessages.mockClear();
+		conversations.sendMessage.mockClear();
+	});
+
+	it("a concurrent getSupportMessages cannot retarget an in-flight reply", async () => {
+		const support = await loadSupport();
+
+		const reply = support.replyToSupportTicket("A", "hi", {});
+		// Fires while reply's retarget is still awaiting the gate.
+		const load = support.getSupportMessages("B");
+		await Promise.resolve();
+		gate.current.resolve();
+
+		expect(await reply).toBe(true);
+		await load;
+		// The reply's retarget + send completed before B's load ran.
+		expect(events).toEqual(["get:A", "send@A", "get:B"]);
+	});
+
+	it("a reply queued behind a new-ticket send still targets its own ticket", async () => {
+		const support = await loadSupport();
+		gate.current.resolve();
+
+		conversations.current = "new-ticket";
+		const created = support.sendSupportMessage("new", {});
+		const reply = support.replyToSupportTicket("A", "hi", {});
+
+		expect(await created).toBe("new-ticket");
+		expect(await reply).toBe(true);
+		expect(events).toEqual(["send@new-ticket", "get:A", "send@A"]);
+	});
+});

--- a/apps/web/src/lib/support.ts
+++ b/apps/web/src/lib/support.ts
@@ -51,24 +51,43 @@ export function waitForSupportAvailable(timeoutMs = 10_000): Promise<boolean> {
 }
 
 /**
+ * sendMessage has no ticket-id parameter — it posts to the manager's mutable
+ * "current ticket" — so every operation that moves that pointer (getMessages,
+ * sendMessage) runs through this chain. Without it, a getMessages landing
+ * between a reply's retarget and its send would post the reply into the wrong
+ * conversation.
+ */
+let conversationChain: Promise<unknown> = Promise.resolve();
+function serialized<T>(op: () => Promise<T>): Promise<T> {
+	const run = conversationChain.then(op, op);
+	conversationChain = run.then(
+		() => undefined,
+		() => undefined
+	);
+	return run;
+}
+
+/**
  * Create a new ticket. Resolves to the ticket id, or null when conversations
  * are unavailable (ad blocker, disabled project, remote config not loaded) or
  * the send fails.
  */
-export async function sendSupportMessage(
+export function sendSupportMessage(
 	message: string,
 	traits: { name?: string; email?: string }
 ): Promise<string | null> {
-	try {
-		const response = await posthog.conversations?.sendMessage(
-			message,
-			traits,
-			true
-		);
-		return response?.ticket_id ?? null;
-	} catch {
-		return null;
-	}
+	return serialized(async () => {
+		try {
+			const response = await posthog.conversations?.sendMessage(
+				message,
+				traits,
+				true
+			);
+			return response?.ticket_id ?? null;
+		} catch {
+			return null;
+		}
+	});
 }
 
 /** All of the user's tickets, newest activity first. */
@@ -86,14 +105,17 @@ export async function getSupportTickets(): Promise<Ticket[] | null> {
 	}
 }
 
-export async function getSupportMessages(
+export function getSupportMessages(
 	ticketId: string
 ): Promise<GetMessagesResponse | null> {
-	try {
-		return (await posthog.conversations?.getMessages(ticketId)) ?? null;
-	} catch {
-		return null;
-	}
+	// getMessages switches the manager's current ticket — serialize it.
+	return serialized(async () => {
+		try {
+			return (await posthog.conversations?.getMessages(ticketId)) ?? null;
+		} catch {
+			return null;
+		}
+	});
 }
 
 export async function markSupportTicketRead(ticketId: string): Promise<boolean> {
@@ -106,26 +128,28 @@ export async function markSupportTicketRead(ticketId: string): Promise<boolean> 
 }
 
 /**
- * Reply into an existing ticket. sendMessage has no ticket-id parameter — it
- * targets the manager's "current ticket", and getMessages(ticketId) is the
- * documented way to switch it, so re-target defensively before sending.
+ * Reply into an existing ticket: re-target via getMessages(ticketId) (the
+ * documented way to switch the current ticket), then send — atomically, so no
+ * other targeting call can move the pointer in between.
  */
-export async function replyToSupportTicket(
+export function replyToSupportTicket(
 	ticketId: string,
 	message: string,
 	traits: { name?: string; email?: string }
 ): Promise<boolean> {
-	try {
-		const conversations = posthog.conversations;
-		if (!conversations) return false;
-		if (conversations.getCurrentTicketId() !== ticketId) {
-			await conversations.getMessages(ticketId);
+	return serialized(async () => {
+		try {
+			const conversations = posthog.conversations;
+			if (!conversations) return false;
+			if (conversations.getCurrentTicketId() !== ticketId) {
+				await conversations.getMessages(ticketId);
+			}
+			const response = await conversations.sendMessage(message, traits, false);
+			return response?.ticket_id === ticketId;
+		} catch {
+			return false;
 		}
-		const response = await conversations.sendMessage(message, traits, false);
-		return response?.ticket_id === ticketId;
-	} catch {
-		return false;
-	}
+	});
 }
 
 /**

--- a/apps/web/src/lib/support.ts
+++ b/apps/web/src/lib/support.ts
@@ -1,0 +1,53 @@
+import posthog from "posthog-js";
+
+/**
+ * PostHog Support (conversations) wrappers. The conversations module loads
+ * async from remote config, so every call is null-guarded — the SDK returns
+ * null/no-ops until available.
+ */
+
+/**
+ * Server-verified ticket ownership (hash from api.support.getConversationsIdentity).
+ * Survives posthog.reset() on sign-out and works cross-device.
+ */
+export function setSupportIdentity(distinctId: string, hash: string) {
+	posthog.setIdentity(distinctId, hash);
+}
+
+export function clearSupportIdentity() {
+	posthog.clearIdentity();
+}
+
+export function isSupportAvailable(): boolean {
+	return posthog.conversations?.isAvailable() ?? false;
+}
+
+/** Open the widget (thread/reply view). */
+export function showSupportWidget() {
+	posthog.conversations?.show();
+}
+
+/**
+ * Suppress the default floating launcher: OneTool's entry points are the
+ * HelpMenu rows, not a chat bubble. The conversations module arrives async
+ * from remote config, so poll until available, then hide. Returns cleanup.
+ */
+export function suppressSupportLauncher(): () => void {
+	const POLL_MS = 500;
+	const GIVE_UP_MS = 30_000;
+	const interval = window.setInterval(() => {
+		if (posthog.conversations?.isAvailable()) {
+			posthog.conversations.hide();
+			window.clearInterval(interval);
+			window.clearTimeout(timeout);
+		}
+	}, POLL_MS);
+	const timeout = window.setTimeout(
+		() => window.clearInterval(interval),
+		GIVE_UP_MS
+	);
+	return () => {
+		window.clearInterval(interval);
+		window.clearTimeout(timeout);
+	};
+}

--- a/apps/web/src/lib/support.ts
+++ b/apps/web/src/lib/support.ts
@@ -28,6 +28,26 @@ export function showSupportWidget() {
 }
 
 /**
+ * Create a new ticket. Resolves null when conversations are unavailable
+ * (ad blocker, disabled project, remote config not loaded) or the send fails.
+ */
+export async function sendSupportMessage(
+	message: string,
+	traits: { name?: string; email?: string }
+): Promise<boolean> {
+	try {
+		const response = await posthog.conversations?.sendMessage(
+			message,
+			traits,
+			true
+		);
+		return response != null;
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Suppress the default floating launcher: OneTool's entry points are the
  * HelpMenu rows, not a chat bubble. The conversations module arrives async
  * from remote config, so poll until available, then hide. Returns cleanup.

--- a/apps/web/src/lib/support.ts
+++ b/apps/web/src/lib/support.ts
@@ -1,10 +1,21 @@
 import posthog from "posthog-js";
+import type { GetMessagesResponse, Ticket } from "posthog-js";
 
 /**
  * PostHog Support (conversations) wrappers. The conversations module loads
  * async from remote config, so every call is null-guarded — the SDK returns
- * null/no-ops until available.
+ * null/no-ops until available. The default floating widget stays disabled in
+ * PostHog project settings; OneTool renders its own UI (/support + dialogs).
  */
+
+export type SupportIntent = "contact" | "bug" | "feature";
+
+/** D13: PostHog Workflows tag tickets by matching this first line. */
+export const SUPPORT_INTENT_PREFIX: Record<SupportIntent, string> = {
+	contact: "Support request",
+	bug: "Bug report",
+	feature: "Feature request",
+};
 
 /**
  * Server-verified ticket ownership (hash from api.support.getConversationsIdentity).
@@ -22,52 +33,133 @@ export function isSupportAvailable(): boolean {
 	return posthog.conversations?.isAvailable() ?? false;
 }
 
-/** Open the widget (thread/reply view). */
-export function showSupportWidget() {
-	posthog.conversations?.show();
+/** Poll until the conversations module is loaded; false when it never arrives (ad blocker). */
+export function waitForSupportAvailable(timeoutMs = 10_000): Promise<boolean> {
+	if (isSupportAvailable()) return Promise.resolve(true);
+	return new Promise((resolve) => {
+		const started = Date.now();
+		const interval = window.setInterval(() => {
+			if (isSupportAvailable()) {
+				window.clearInterval(interval);
+				resolve(true);
+			} else if (Date.now() - started >= timeoutMs) {
+				window.clearInterval(interval);
+				resolve(false);
+			}
+		}, 250);
+	});
 }
 
 /**
- * Create a new ticket. Resolves null when conversations are unavailable
- * (ad blocker, disabled project, remote config not loaded) or the send fails.
+ * Create a new ticket. Resolves to the ticket id, or null when conversations
+ * are unavailable (ad blocker, disabled project, remote config not loaded) or
+ * the send fails.
  */
 export async function sendSupportMessage(
 	message: string,
 	traits: { name?: string; email?: string }
-): Promise<boolean> {
+): Promise<string | null> {
 	try {
 		const response = await posthog.conversations?.sendMessage(
 			message,
 			traits,
 			true
 		);
-		return response != null;
+		return response?.ticket_id ?? null;
+	} catch {
+		return null;
+	}
+}
+
+/** All of the user's tickets, newest activity first. */
+export async function getSupportTickets(): Promise<Ticket[] | null> {
+	try {
+		const response = await posthog.conversations?.getTickets({ limit: 100 });
+		if (!response) return null;
+		return [...response.results].sort(
+			(a, b) =>
+				Date.parse(b.last_message_at ?? b.created_at) -
+				Date.parse(a.last_message_at ?? a.created_at)
+		);
+	} catch {
+		return null;
+	}
+}
+
+export async function getSupportMessages(
+	ticketId: string
+): Promise<GetMessagesResponse | null> {
+	try {
+		return (await posthog.conversations?.getMessages(ticketId)) ?? null;
+	} catch {
+		return null;
+	}
+}
+
+export async function markSupportTicketRead(ticketId: string): Promise<boolean> {
+	try {
+		const response = await posthog.conversations?.markAsRead(ticketId);
+		return response?.success ?? false;
 	} catch {
 		return false;
 	}
 }
 
 /**
- * Suppress the default floating launcher: OneTool's entry points are the
- * HelpMenu rows, not a chat bubble. The conversations module arrives async
- * from remote config, so poll until available, then hide. Returns cleanup.
+ * Reply into an existing ticket. sendMessage has no ticket-id parameter — it
+ * targets the manager's "current ticket", and getMessages(ticketId) is the
+ * documented way to switch it, so re-target defensively before sending.
  */
-export function suppressSupportLauncher(): () => void {
-	const POLL_MS = 500;
-	const GIVE_UP_MS = 30_000;
-	const interval = window.setInterval(() => {
-		if (posthog.conversations?.isAvailable()) {
-			posthog.conversations.hide();
-			window.clearInterval(interval);
-			window.clearTimeout(timeout);
+export async function replyToSupportTicket(
+	ticketId: string,
+	message: string,
+	traits: { name?: string; email?: string }
+): Promise<boolean> {
+	try {
+		const conversations = posthog.conversations;
+		if (!conversations) return false;
+		if (conversations.getCurrentTicketId() !== ticketId) {
+			await conversations.getMessages(ticketId);
 		}
-	}, POLL_MS);
-	const timeout = window.setTimeout(
-		() => window.clearInterval(interval),
-		GIVE_UP_MS
-	);
-	return () => {
-		window.clearInterval(interval);
-		window.clearTimeout(timeout);
-	};
+		const response = await conversations.sendMessage(message, traits, false);
+		return response?.ticket_id === ticketId;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Per-browser ticket → intent map so the /support list can show intent icons
+ * without fetching every thread. Best-effort: tickets created on another
+ * device fall back to a generic label until their thread is opened.
+ */
+const INTENT_STORE_KEY = "onetool.supportTicketIntents";
+
+export function recallTicketIntents(): Record<string, SupportIntent> {
+	try {
+		const raw = window.localStorage.getItem(INTENT_STORE_KEY);
+		return raw ? (JSON.parse(raw) as Record<string, SupportIntent>) : {};
+	} catch {
+		return {};
+	}
+}
+
+export function rememberTicketIntent(ticketId: string, intent: SupportIntent) {
+	try {
+		window.localStorage.setItem(
+			INTENT_STORE_KEY,
+			JSON.stringify({ ...recallTicketIntents(), [ticketId]: intent })
+		);
+	} catch {
+		// Storage unavailable — the list just shows the generic label.
+	}
+}
+
+/** Recover the intent from a ticket's opening message (D13 prefix line). */
+export function intentFromMessage(content: string): SupportIntent | null {
+	const firstLine = content.trimStart().split("\n", 1)[0]?.trim() ?? "";
+	for (const [intent, prefix] of Object.entries(SUPPORT_INTENT_PREFIX)) {
+		if (firstLine === prefix) return intent as SupportIntent;
+	}
+	return null;
 }

--- a/apps/web/src/providers/PostHogProvider.tsx
+++ b/apps/web/src/providers/PostHogProvider.tsx
@@ -4,6 +4,7 @@ import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 import { useEffect } from "react";
 import { env } from "@/env";
+import { suppressSupportLauncher } from "@/lib/support";
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
 	useEffect(() => {
@@ -67,6 +68,8 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
 			// PostHog init can fail (ad blockers, network). Analytics is non-critical.
 			console.error("PostHog initialization failed:", error);
 		}
+		// No floating chat bubble: HelpMenu rows are the only Support entry points.
+		return suppressSupportLauncher();
 	}, []);
 
 	return <PHProvider client={posthog}>{children}</PHProvider>;

--- a/apps/web/src/providers/PostHogProvider.tsx
+++ b/apps/web/src/providers/PostHogProvider.tsx
@@ -4,7 +4,6 @@ import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 import { useEffect } from "react";
 import { env } from "@/env";
-import { suppressSupportLauncher } from "@/lib/support";
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
 	useEffect(() => {
@@ -68,8 +67,8 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
 			// PostHog init can fail (ad blockers, network). Analytics is non-critical.
 			console.error("PostHog initialization failed:", error);
 		}
-		// No floating chat bubble: HelpMenu rows are the only Support entry points.
-		return suppressSupportLauncher();
+		// No floating chat bubble: the widget UI is disabled in PostHog project
+		// settings; OneTool's /support page and dialogs are the only Support UI.
 	}, []);
 
 	return <PHProvider client={posthog}>{children}</PHProvider>;

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -191,6 +191,7 @@ import type * as serviceStatusActions from "../serviceStatusActions.js";
 import type * as skus from "../skus.js";
 import type * as stripeWebhookActions from "../stripeWebhookActions.js";
 import type * as stripeWebhookEvents from "../stripeWebhookEvents.js";
+import type * as support from "../support.js";
 import type * as tasks from "../tasks.js";
 import type * as teamMessages from "../teamMessages.js";
 import type * as usage from "../usage.js";
@@ -387,6 +388,7 @@ declare const fullApi: ApiFromModules<{
   skus: typeof skus;
   stripeWebhookActions: typeof stripeWebhookActions;
   stripeWebhookEvents: typeof stripeWebhookEvents;
+  support: typeof support;
   tasks: typeof tasks;
   teamMessages: typeof teamMessages;
   usage: typeof usage;

--- a/packages/backend/convex/email/branding.test.ts
+++ b/packages/backend/convex/email/branding.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { buildEmailHtml, getOrgInitials, resolveFromEmail } from "./branding";
+import {
+	buildEmailHtml,
+	getOrgInitials,
+	resolveFromEmail,
+	resolveReplyToEmail,
+} from "./branding";
 import { EMAIL_BODY_STYLES } from "./sanitizeHtml";
 
 const base = {
@@ -138,11 +143,18 @@ describe("branding helpers", () => {
 		expect(getOrgInitials("   ")).toBe("?");
 	});
 
-	it("falls back to the support address with no receiving address", () => {
+	it("falls back to the no-reply sender with no receiving address", () => {
 		expect(resolveFromEmail({ receivingAddress: "a@b.test" })).toBe("a@b.test");
 		expect(resolveFromEmail({ receivingAddress: "  " })).toBe(
-			"support@onetool.biz"
+			"no-reply@onetool.biz"
 		);
-		expect(resolveFromEmail({})).toBe("support@onetool.biz");
+		expect(resolveFromEmail({})).toBe("no-reply@onetool.biz");
+	});
+
+	it("falls back to the shared inbound replyTo base with no receiving address", () => {
+		expect(resolveReplyToEmail({ receivingAddress: "a@b.test" })).toBe(
+			"a@b.test"
+		);
+		expect(resolveReplyToEmail({})).toBe("replies@inbound.onetool.biz");
 	});
 });

--- a/packages/backend/convex/email/branding.ts
+++ b/packages/backend/convex/email/branding.ts
@@ -3,15 +3,28 @@
 
 import { sanitizeHtml, EMAIL_BODY_STYLES } from "./sanitizeHtml";
 
-// Canonical fallback when an org has no receiving address configured (rare
+// Fallback sender when an org has no receiving address configured (rare
 // post-migration). Never throws — a missing address must not block sends.
-export const FALLBACK_FROM_EMAIL = "support@onetool.biz";
+// support@onetool.biz is owned by PostHog Support; app mail must not use it.
+export const FALLBACK_FROM_EMAIL = "no-reply@onetool.biz";
+
+// Fallback Reply-To base for the same orgs. Lives on the Resend inbound domain
+// so plus-tokened client replies reach webhook routing — the apex MX is Google,
+// so a support+token@onetool.biz replyTo would dead-end in Gmail.
+export const FALLBACK_REPLY_TO_EMAIL = "replies@inbound.onetool.biz";
 
 export function resolveFromEmail(organization: {
 	receivingAddress?: string;
 }): string {
 	const addr = organization.receivingAddress?.trim();
 	return addr && addr.length > 0 ? addr : FALLBACK_FROM_EMAIL;
+}
+
+export function resolveReplyToEmail(organization: {
+	receivingAddress?: string;
+}): string {
+	const addr = organization.receivingAddress?.trim();
+	return addr && addr.length > 0 ? addr : FALLBACK_REPLY_TO_EMAIL;
 }
 
 // OneTool brand mark, served from the marketing site's public assets. Used for

--- a/packages/backend/convex/email/receivingAddress.ts
+++ b/packages/backend/convex/email/receivingAddress.ts
@@ -10,6 +10,8 @@ const MAX_LOCAL_PART_LENGTH = 24;
 const RESERVED_LOCAL_PARTS = [
 	"support",
 	"noreply",
+	"no-reply",
+	"replies", // shared fallback Reply-To base (FALLBACK_REPLY_TO_EMAIL)
 	"new",
 	"create",
 	"edit",

--- a/packages/backend/convex/lib/automationExec/actions.ts
+++ b/packages/backend/convex/lib/automationExec/actions.ts
@@ -13,7 +13,11 @@ import { getMembership, listMembershipsByOrg } from "../memberships";
 import { celebrateQuoteApproved, celebrateInvoicePaid } from "../celebrations";
 import { insertTeamMessage } from "../../teamMessages";
 import { AUTOMATION_EMAIL_DAILY_CAP, rateLimiter } from "../../rateLimits";
-import { buildEmailHtml, resolveFromEmail } from "../../email/branding";
+import {
+	buildEmailHtml,
+	resolveFromEmail,
+	resolveReplyToEmail,
+} from "../../email/branding";
 import { formatEmailFrom } from "../emailFrom";
 import {
 	getOrCreateOutboundThread,
@@ -2046,7 +2050,7 @@ async function executeSendEmailAction(
 		clientId: client?._id ?? null,
 		subject,
 	});
-	const replyTo = plusTagAddress(fromEmail, threadDocId);
+	const replyTo = plusTagAddress(resolveReplyToEmail(org), threadDocId);
 	const preview = body.substring(0, 100);
 
 	const nodeId = env.currentNodeId ?? "";

--- a/packages/backend/convex/resend.ts
+++ b/packages/backend/convex/resend.ts
@@ -9,7 +9,11 @@ import {
 	plusTagAddress,
 } from "./email/threads";
 import { SERVER_EVENTS, trackServerEvent } from "./lib/posthog";
-import { buildEmailHtml, resolveFromEmail } from "./email/branding";
+import {
+	buildEmailHtml,
+	resolveFromEmail,
+	resolveReplyToEmail,
+} from "./email/branding";
 import { formatEmailFrom } from "./lib/emailFrom";
 import { sanitizeHtml } from "./email/sanitizeHtml";
 
@@ -115,7 +119,7 @@ export const sendClientEmail = userMutation({
 		const message: OutboundMessage = {
 			from: formatEmailFrom(fromName, fromEmail),
 			to: [recipient.email],
-			replyTo: [plusTagAddress(resolveFromEmail(organization), threadDocId)],
+			replyTo: [plusTagAddress(resolveReplyToEmail(organization), threadDocId)],
 			subject: args.subject,
 			html: emailHtml,
 			text: args.messageBody, // text/plain alternative on every send
@@ -309,7 +313,7 @@ export const replyToEmail = userMutation({
 		const message: OutboundMessage = {
 			from: formatEmailFrom(fromName, fromEmail),
 			to: [primaryContact.email],
-			replyTo: [plusTagAddress(resolveFromEmail(organization), threadDocId)],
+			replyTo: [plusTagAddress(resolveReplyToEmail(organization), threadDocId)],
 			subject,
 			html: emailHtml,
 			text: args.messageBody, // text/plain alternative on every send

--- a/packages/backend/convex/resendReceiving.test.ts
+++ b/packages/backend/convex/resendReceiving.test.ts
@@ -8,6 +8,8 @@ import {
 	createTestClientContact,
 } from "./test.helpers";
 import { Id } from "./_generated/dataModel";
+import { plusTagAddress } from "./email/threads";
+import { FALLBACK_REPLY_TO_EMAIL } from "./email/branding";
 
 // resendReceiving.ts constructs the raw Resend SDK client at module load and
 // throws without an API key; stub one before convex-test imports the module.
@@ -199,15 +201,15 @@ describe("resendReceiving.processInboundEmail", () => {
 		expect(second?.threadDocId).toBe(threadDocId);
 	});
 
-	it("routes a plus-tokened reply to the support@ fallback sender instead of dropping it", async () => {
-		// Org WITHOUT a receiving address sends from the shared fallback; the
-		// only routing signal on the reply is the +t<threadDocId> token.
+	// Fallback (no receivingAddress) orgs: the only routing signal on a client
+	// reply is the +t<threadDocId> token. Covers the current replies@inbound
+	// base and the legacy support@ base still present on old sent emails.
+	async function fallbackOrgWithThread(suffix: string) {
 		const { orgId } = await t.run(async (ctx) => {
-			const org = await createTestOrg(ctx, {
-				clerkUserId: "user_fallback_1",
-				clerkOrgId: "org_fallback_1",
+			return await createTestOrg(ctx, {
+				clerkUserId: `user_fallback_${suffix}`,
+				clerkOrgId: `org_fallback_${suffix}`,
 			});
-			return org;
 		});
 		const threadDocId = await t.run(async (ctx) => {
 			return await ctx.db.insert("emailThreads", {
@@ -222,8 +224,13 @@ describe("resendReceiving.processInboundEmail", () => {
 				participantEmails: ["jane@client.com"],
 			});
 		});
+		return { orgId, threadDocId };
+	}
 
-		const tagged = `support+t${threadDocId}@onetool.biz`;
+	it("routes a plus-tokened reply to the replies@inbound fallback base", async () => {
+		const { orgId, threadDocId } = await fallbackOrgWithThread("1");
+
+		const tagged = plusTagAddress(FALLBACK_REPLY_TO_EMAIL, threadDocId);
 		const result = await t.mutation(
 			internal.resendReceiving.processInboundEmail,
 			inboundArgs({
@@ -245,6 +252,31 @@ describe("resendReceiving.processInboundEmail", () => {
 		expect(message?.threadDocId).toBe(threadDocId);
 	});
 
+	it("routes a plus-tokened reply to the legacy support@ base instead of dropping it", async () => {
+		const { orgId, threadDocId } = await fallbackOrgWithThread("2");
+
+		const tagged = `support+t${threadDocId}@onetool.biz`;
+		const result = await t.mutation(
+			internal.resendReceiving.processInboundEmail,
+			inboundArgs({
+				emailId: "re_in_fallback_legacy",
+				from: "Jane Client <jane@client.com>",
+				subject: "Re: Quote",
+				rfcMessageId: "<in-fb-legacy@client.com>",
+				to: [tagged],
+				receivedForAddress: tagged,
+			})
+		);
+		expect(result.success).toBe(true);
+		expect(result.skipped).toBeUndefined();
+
+		const message = await t.run(async (ctx) => {
+			return await findByResendId(ctx, "re_in_fallback_legacy");
+		});
+		expect(message?.orgId).toBe(orgId);
+		expect(message?.threadDocId).toBe(threadDocId);
+	});
+
 	it("still skips untokened mail to the support@ general inbox", async () => {
 		const result = await t.mutation(
 			internal.resendReceiving.processInboundEmail,
@@ -252,6 +284,38 @@ describe("resendReceiving.processInboundEmail", () => {
 				emailId: "re_in_support",
 				to: ["support@onetool.biz"],
 				receivedForAddress: "support@onetool.biz",
+			})
+		);
+		expect(result.success).toBe(true);
+		expect(result.skipped).toBe(true);
+	});
+
+	it("skips untokened mail to the replies@inbound fallback base", async () => {
+		const result = await t.mutation(
+			internal.resendReceiving.processInboundEmail,
+			inboundArgs({
+				emailId: "re_in_replies_untokened",
+				to: [FALLBACK_REPLY_TO_EMAIL],
+				receivedForAddress: FALLBACK_REPLY_TO_EMAIL,
+			})
+		);
+		expect(result.success).toBe(true);
+		expect(result.skipped).toBe(true);
+	});
+
+	it("skips a plus-tokened reply to the replies@inbound base whose thread no longer exists", async () => {
+		const { threadDocId } = await fallbackOrgWithThread("3");
+		await t.run(async (ctx) => {
+			await ctx.db.delete(threadDocId);
+		});
+
+		const tagged = plusTagAddress(FALLBACK_REPLY_TO_EMAIL, threadDocId);
+		const result = await t.mutation(
+			internal.resendReceiving.processInboundEmail,
+			inboundArgs({
+				emailId: "re_in_replies_dead_token",
+				to: [tagged],
+				receivedForAddress: tagged,
 			})
 		);
 		expect(result.success).toBe(true);

--- a/packages/backend/convex/resendReceiving.ts
+++ b/packages/backend/convex/resendReceiving.ts
@@ -11,6 +11,7 @@ import {
 	stripPlusTag,
 	bumpThread,
 } from "./email/threads";
+import { FALLBACK_REPLY_TO_EMAIL } from "./email/branding";
 
 // Validate RESEND_API_KEY before initializing client
 if (!process.env.RESEND_API_KEY) {
@@ -214,15 +215,20 @@ export const processInboundEmail = internalMutation({
 		}
 
 		if (!organization) {
-			// support@onetool.biz is a general inbox, not org-specific.
-			if (baseAddress === "support@onetool.biz") {
+			// Shared fallback bases are only meaningful with a resolvable plus-token:
+			// support@ is the legacy replyTo base (now PostHog's inbox), replies@ is
+			// the current one. Untokened (or dead-token) mail to either has no org.
+			if (
+				baseAddress === "support@onetool.biz" ||
+				baseAddress === FALLBACK_REPLY_TO_EMAIL
+			) {
 				console.log(
-					`Skipping inbound email for support@onetool.biz. From: ${args.from}, Subject: ${args.subject}`
+					`Skipping inbound email to shared address ${baseAddress}. From: ${args.from}, Subject: ${args.subject}`
 				);
 				return {
 					success: true,
 					skipped: true,
-					reason: "General support email - not organization-specific",
+					reason: "Shared fallback address - not organization-specific",
 				};
 			}
 

--- a/packages/backend/convex/resendReceiving.ts
+++ b/packages/backend/convex/resendReceiving.ts
@@ -222,8 +222,9 @@ export const processInboundEmail = internalMutation({
 				baseAddress === "support@onetool.biz" ||
 				baseAddress === FALLBACK_REPLY_TO_EMAIL
 			) {
+				// Don't log sender/subject: inbound mail is third-party PII.
 				console.log(
-					`Skipping inbound email to shared address ${baseAddress}. From: ${args.from}, Subject: ${args.subject}`
+					`Skipping inbound email to shared address ${baseAddress}. Resend email id: ${args.emailId}`
 				);
 				return {
 					success: true,

--- a/packages/backend/convex/support.test.ts
+++ b/packages/backend/convex/support.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { api } from "./_generated/api";
+import { setupConvexTest } from "./test.setup";
+import { createTestOrg, createTestIdentity } from "./test.helpers";
+
+/** Reference HMAC-SHA256 hex, computed independently of the implementation. */
+async function hmacHex(secret: string, message: string): Promise<string> {
+	const encoder = new TextEncoder();
+	const key = await crypto.subtle.importKey(
+		"raw",
+		encoder.encode(secret),
+		{ name: "HMAC", hash: "SHA-256" },
+		false,
+		["sign"]
+	);
+	const signature = await crypto.subtle.sign(
+		"HMAC",
+		key,
+		encoder.encode(message)
+	);
+	return Array.from(new Uint8Array(signature))
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
+}
+
+describe("support.getConversationsIdentity", () => {
+	let t: ReturnType<typeof setupConvexTest>;
+	const originalSecret = process.env.POSTHOG_SECRET_API_TOKEN;
+
+	beforeEach(() => {
+		t = setupConvexTest();
+	});
+
+	afterEach(() => {
+		if (originalSecret === undefined) {
+			delete process.env.POSTHOG_SECRET_API_TOKEN;
+		} else {
+			process.env.POSTHOG_SECRET_API_TOKEN = originalSecret;
+		}
+	});
+
+	async function setup() {
+		const org = await t.run(async (ctx) => createTestOrg(ctx, {}));
+		const asUser = t.withIdentity(
+			createTestIdentity(org.clerkUserId, org.clerkOrgId)
+		);
+		return { ...org, asUser };
+	}
+
+	it("returns the Clerk user id with its HMAC-SHA256 hex hash", async () => {
+		process.env.POSTHOG_SECRET_API_TOKEN = "phs_test_secret";
+		const { asUser, clerkUserId } = await setup();
+
+		const identity = await asUser.query(
+			api.support.getConversationsIdentity,
+			{}
+		);
+		expect(identity).not.toBeNull();
+		expect(identity!.distinctId).toBe(clerkUserId);
+		expect(identity!.hash).toBe(
+			await hmacHex("phs_test_secret", clerkUserId)
+		);
+	});
+
+	it("returns null when the secret env var is unset", async () => {
+		delete process.env.POSTHOG_SECRET_API_TOKEN;
+		const { asUser } = await setup();
+
+		const identity = await asUser.query(
+			api.support.getConversationsIdentity,
+			{}
+		);
+		expect(identity).toBeNull();
+	});
+});

--- a/packages/backend/convex/support.ts
+++ b/packages/backend/convex/support.ts
@@ -1,0 +1,40 @@
+import { userQuery } from "./lib/factories";
+
+/**
+ * PostHog Support identity verification (widget ticket ownership).
+ *
+ * The widget trusts HMAC-SHA256(distinct_id, secret_api_token) computed
+ * server-side, so tickets survive posthog.reset() on sign-out and follow the
+ * user across devices. distinctId must match the client's analytics identify
+ * call (the Clerk user id).
+ */
+export const getConversationsIdentity = userQuery({
+	args: {},
+	handler: async (
+		ctx
+	): Promise<{ distinctId: string; hash: string } | null> => {
+		const secret = process.env.POSTHOG_SECRET_API_TOKEN;
+		// Unset env fails open: the widget falls back to session-based access.
+		if (!secret) return null;
+
+		const encoder = new TextEncoder();
+		const distinctId = ctx.user.externalId;
+		const key = await crypto.subtle.importKey(
+			"raw",
+			encoder.encode(secret),
+			{ name: "HMAC", hash: "SHA-256" },
+			false,
+			["sign"]
+		);
+		const signature = await crypto.subtle.sign(
+			"HMAC",
+			key,
+			encoder.encode(distinctId)
+		);
+		const hash = Array.from(new Uint8Array(signature))
+			.map((b) => b.toString(16).padStart(2, "0"))
+			.join("");
+
+		return { distinctId, hash };
+	},
+});

--- a/packages/help-content/articles/getting-started.ts
+++ b/packages/help-content/articles/getting-started.ts
@@ -673,18 +673,35 @@ export const gettingStartedArticles: HelpArticle[] = [
 					{
 						type: "list",
 						items: [
-							"**Contact support** for questions about anything — your account, billing, or how a feature works.",
+							"**Contact support** for questions about anything: your account, billing, or how a feature works.",
 							"**Report a bug** when something is broken. Tell us what you were trying to do and what happened instead; the technical details (the page you were on, a replay of your session, and any errors) attach automatically, so you don't need screenshots.",
 							"**Request a feature** to tell us what OneTool should do next.",
 						],
 					},
 					{
 						type: "paragraph",
-						text: "The same three actions are in the command palette — press **⌘K** (or **Ctrl+K**) and look under **Support**.",
+						text: "The same three actions are in the command palette: press **⌘K** (or **Ctrl+K**) and look under **Support**.",
 					},
 					{
 						type: "note",
-						text: "A real person reads every message and replies within one business day. Replies arrive by email, and you can also reopen the conversation in the app from the confirmation after you send.",
+						text: "A real person reads every message and replies within one business day. We'll email you when we reply, and the full conversation lives on your Support page in the app.",
+					},
+				],
+			},
+			{
+				heading: "See your requests and our replies",
+				blocks: [
+					{
+						type: "paragraph",
+						text: "Everything you've sent us lives on one page: pick **Your support requests** from the **?** menu (or find it in ⌘K). Each request shows the whole thread, your messages and our replies, and you can reply right from the page.",
+					},
+					{
+						type: "list",
+						items: [
+							"A dot on the **?** icon in the header means we've replied since you last looked.",
+							"Resolved requests are hidden by default. Flip **Show resolved** to see past conversations.",
+							"Use **New request** on the page to start another conversation.",
+						],
 					},
 				],
 			},
@@ -693,7 +710,7 @@ export const gettingStartedArticles: HelpArticle[] = [
 				blocks: [
 					{
 						type: "paragraph",
-						text: "You can always email [support@onetool.biz](mailto:support@onetool.biz) directly — it reaches the same inbox. On the mobile app, open the **Profile** tab and use the rows under **Support**; they start a pre-filled email for you.",
+						text: "You can always email [support@onetool.biz](mailto:support@onetool.biz) directly; it reaches the same inbox. On the mobile app, open the **Profile** tab and use the rows under **Support**; they start a pre-filled email for you.",
 					},
 					{
 						type: "note",
@@ -709,7 +726,7 @@ export const gettingStartedArticles: HelpArticle[] = [
 			},
 			{
 				question: "The in-app form says support chat couldn't load. What now?",
-				answer: "That's usually a browser ad blocker. Email support@onetool.biz instead — it reaches the same place.",
+				answer: "That's usually a browser ad blocker. Email support@onetool.biz instead; it reaches the same place.",
 			},
 		],
 		related: ["mobile-app/onetool-on-iphone-and-ipad"],

--- a/packages/help-content/articles/getting-started.ts
+++ b/packages/help-content/articles/getting-started.ts
@@ -655,4 +655,63 @@ export const gettingStartedArticles: HelpArticle[] = [
 			"client-portal/what-your-clients-see",
 		],
 	},
+	{
+		slug: "get-help-and-share-feedback",
+		title: "Get help and share feedback",
+		subtitle: "Reach a real person for questions, bug reports, and feature ideas without leaving the app.",
+		kind: "howto",
+		availability: "all",
+		keywords: ["support", "contact", "bug", "feedback", "feature request", "help", "email"],
+		sections: [
+			{
+				heading: "Message us from the workspace",
+				blocks: [
+					{
+						type: "paragraph",
+						text: "The fastest way to reach us is the **?** menu in the top-right corner of the workspace. Below the suggested articles you'll find three options under **Get in touch**:",
+					},
+					{
+						type: "list",
+						items: [
+							"**Contact support** for questions about anything — your account, billing, or how a feature works.",
+							"**Report a bug** when something is broken. Tell us what you were trying to do and what happened instead; the technical details (the page you were on, a replay of your session, and any errors) attach automatically, so you don't need screenshots.",
+							"**Request a feature** to tell us what OneTool should do next.",
+						],
+					},
+					{
+						type: "paragraph",
+						text: "The same three actions are in the command palette — press **⌘K** (or **Ctrl+K**) and look under **Support**.",
+					},
+					{
+						type: "note",
+						text: "A real person reads every message and replies within one business day. Replies arrive by email, and you can also reopen the conversation in the app from the confirmation after you send.",
+					},
+				],
+			},
+			{
+				heading: "Email and mobile",
+				blocks: [
+					{
+						type: "paragraph",
+						text: "You can always email [support@onetool.biz](mailto:support@onetool.biz) directly — it reaches the same inbox. On the mobile app, open the **Profile** tab and use the rows under **Support**; they start a pre-filled email for you.",
+					},
+					{
+						type: "note",
+						text: "Please don't include client payment details (card or bank numbers) in support messages.",
+					},
+				],
+			},
+		],
+		faq: [
+			{
+				question: "How fast will I hear back?",
+				answer: "Within one business day. Most messages get a reply sooner.",
+			},
+			{
+				question: "The in-app form says support chat couldn't load. What now?",
+				answer: "That's usually a browser ad blocker. Email support@onetool.biz instead — it reaches the same place.",
+			},
+		],
+		related: ["mobile-app/onetool-on-iphone-and-ipad"],
+	},
 ];


### PR DESCRIPTION
This pull request introduces a new in-app support request and ticketing system for the web workspace, and updates the mobile and privacy policy experiences to clarify support and analytics. The main changes include a new support dialog and ticket view in the web app, a set of mailto-based support options in the mobile app, and privacy policy updates to reflect session replay and support handling.

**Web App: In-App Support System**
- Added a full-featured support dialog and ticketing interface, including ticket list, ticket view, and support message rendering, available throughout the workspace via a new provider. [[1]](diffhunk://#diff-364e3e5da96760752aa44fb3634ea6f2d4aeac89cda845bee9b2dabe809bcfb9R13) [[2]](diffhunk://#diff-364e3e5da96760752aa44fb3634ea6f2d4aeac89cda845bee9b2dabe809bcfb9R42-R44) [[3]](diffhunk://#diff-36c02ae488e3e3e931ea46ebc8ba7b1618e88e14babc46e575614ba59da16bd9R1-R127) [[4]](diffhunk://#diff-3f7f4ef08f20b106e66220b727d419177903933ce48feb809b7bf276c86b39c3R1-R246) [[5]](diffhunk://#diff-73495e21872f7002002499dfd7e8b322d7209f7d6081f22e3c5f7dea81ceed22R1-R140)

**Mobile App: Support Options**
- Added a "Support" section to the profile screen with three mailto-based options: contact support, report a bug, and request a feature. Each option pre-fills the subject and body for the support inbox and tags messages as mobile-originated. [[1]](diffhunk://#diff-1df85d0a829b178db20cd9bdda02c49b8df11d50acf00d469f2c02f71730f2b8L20-R30) [[2]](diffhunk://#diff-1df85d0a829b178db20cd9bdda02c49b8df11d50acf00d469f2c02f71730f2b8R394-R481)

**Privacy Policy Updates**
- Updated the privacy policy to clarify that the web app uses session replay (with form inputs masked and Do Not Track respected), and that support messages (from both web and email) are processed in PostHog's support inbox. The mobile app remains analytics-free. [[1]](diffhunk://#diff-079789fef29abc243e477f5b96e49d25c4314768a1acb6d47de73d14351eafbcL104-R111) [[2]](diffhunk://#diff-079789fef29abc243e477f5b96e49d25c4314768a1acb6d47de73d14351eafbcL281-R291)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-app support for contacting support, reporting bugs, and requesting features.
  * Added a Support page for viewing, replying to, refreshing, and resolving support requests.
  * Added rich-text support message rendering and unread indicators in the Help menu and command palette.
  * Added mobile support contact options with prefilled messages.
* **Documentation**
  * Updated the privacy policy with analytics, session replay, and support-message details.
  * Added guidance for getting help and sharing feedback.
* **Bug Fixes**
  * Improved email sender and reply-to handling for support and automated messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a PostHog-backed support request and ticket experience to the web workspace, mobile mail-based support actions, and corresponding analytics, email-routing, and privacy-policy updates.

- Adds support dialogs, ticket lists, conversation views, unread state, and rich-message rendering.
- Establishes server-verified PostHog Support identity and integrates it with the analytics lifecycle.
- Separates no-reply outbound mail from inbound reply routing and reserves shared receiving addresses.
- Adds mobile support mail links and expands help content and privacy disclosures.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until replies are guaranteed to target the selected support ticket under overlapping ticket operations.

Existing-ticket replies mutate shared current-ticket state and then send in a separate asynchronous step, allowing another ticket operation to retarget the message before submission.

**Files Needing Attention:** apps/web/src/lib/support.ts and apps/web/src/app/(workspace)/support/components/ticket-view.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/lib/support.ts | Adds PostHog Support wrappers; existing-ticket replies have a non-atomic current-ticket targeting race. |
| apps/web/src/app/(workspace)/support/components/ticket-view.tsx | Adds conversation loading, read state, rendering, and replies; navigation permits overlapping operations that expose the reply-target race. |
| apps/web/src/hooks/use-analytics-identity.ts | Adds server-verified Support identity setup, ticket refresh, and sign-out cache reset. |
| packages/backend/convex/support.ts | Generates the authenticated user’s HMAC-backed PostHog conversations identity. |
| packages/backend/convex/resendReceiving.ts | Excludes untokened shared support/reply addresses while preserving token-routed organization replies. |
| packages/backend/convex/email/branding.ts | Separates fallback outbound sender and inbound reply-to address resolution. |
| apps/web/src/providers/PostHogProvider.tsx | Updates PostHog defaults while retaining DNT handling and workspace analytics configuration. |
| apps/mobile/app/(tabs)/profile.tsx | Adds three encoded mailto-based mobile support actions through the existing external-link fallback. |
| apps/web/src/app/(legal)/privacy-policy/page.tsx | Documents session replay, DNT handling, input masking, and PostHog support-message processing. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant U as Workspace user
  participant UI as Support UI
  participant PH as PostHog Support
  participant B as Convex backend
  B-->>UI: Verified conversations identity
  U->>UI: Create support request
  UI->>PH: sendMessage(new ticket)
  PH-->>UI: Ticket ID
  UI->>PH: Refresh ticket list
  U->>UI: Open ticket
  UI->>PH: getMessages(ticketId)
  U->>UI: Submit reply
  UI->>PH: Select current ticket
  UI->>PH: sendMessage(reply)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/src/lib/support.ts:121-124
**Non-atomic reply ticket targeting**

If two ticket operations overlap, `getMessages(ticketId)` can retarget the shared conversations manager between another reply's selection and `sendMessage`, causing that reply to be posted to the wrong conversation. The response check only detects the mismatch after the message has already been submitted.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #340 from xCarter93/f..."](https://github.com/xcarter93/onetool/commit/3ae47c0714d686dda8843a85f9a39a8d8570fecb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56110604)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Client applications](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/client-applications.md)
- Knowledge Base — [Web workspace](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/web-workspace.md)
- Knowledge Base — [Mobile application](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/mobile-application.md)
- Knowledge Base — [Organization security and integrations](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/organization-security-and-integrations.md)
</details>


<!-- /greptile_comment -->