### PR TITLE
feat(tours): fix start-blockers, add search/support steps, design pass

### DIFF
--- a/apps/web/src/app/(workspace)/home/page.tsx
+++ b/apps/web/src/app/(workspace)/home/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { useState, useEffect, useRef } from "react";
+import React, { Suspense, useState, useEffect, useRef } from "react";
 import dynamic from "next/dynamic";
+import { useRouter, useSearchParams } from "next/navigation";
 import ActivityFeed from "@/app/(workspace)/home/components/activity-feed";
 import HomeStats from "@/app/(workspace)/home/components/home-stats-real";
 import { NeedsAttention } from "@/app/(workspace)/home/components/needs-attention";
@@ -13,6 +14,7 @@ import { useQuery, useMutation } from "convex/react";
 import { api } from "@onetool/backend/convex/_generated/api";
 import { motion } from "motion/react";
 import { useAutoTimezone } from "@/hooks/use-auto-timezone";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { usePublishScreenContext } from "@/components/assistant/use-screen-context";
 import { SegmentedControl } from "@/components/domain/segmented-control";
 import { LayoutDashboard, CalendarDays } from "lucide-react";
@@ -77,6 +79,10 @@ export default function Page() {
 	const [viewMode, setViewMode] = useState<ViewMode>("dashboard");
 	const [showTourModal, setShowTourModal] = useState(false);
 	const [tourStarted, setTourStarted] = useState(false);
+	// Once the welcome modal has been answered, never re-open it this session —
+	// the hasSeenTour round-trip is slower than the 1s timer below.
+	const tourAnsweredRef = useRef(false);
+	const isMobile = useIsMobile();
 
 	// Get tour context from layout-level provider
 	const tourContext = React.useContext(HomeTourContext);
@@ -106,14 +112,22 @@ export default function Page() {
 
 	// Show tour modal for first-time users
 	useEffect(() => {
-		if (hasSeenTour === false && user && !tourStarted) {
+		if (
+			hasSeenTour === false &&
+			user &&
+			!tourStarted &&
+			!tourAnsweredRef.current &&
+			// The sidebar lives in a closed Sheet below md, so steps 1-4 never
+			// register and the tour cannot start. Desktop-only.
+			!isMobile
+		) {
 			// Small delay to let the page render first
 			const timer = setTimeout(() => {
 				setShowTourModal(true);
 			}, 1000);
 			return () => clearTimeout(timer);
 		}
-	}, [hasSeenTour, user, tourStarted]);
+	}, [hasSeenTour, user, tourStarted, isMobile]);
 
 	// Watch for tour completion/dismissal and call appropriate mutations
 	const prevTourActive = useRef(tourContext?.state.isActive);
@@ -127,6 +141,9 @@ export default function Page() {
 
 			if (allCompleted) {
 				markTourComplete();
+			} else {
+				// Dismissed mid-tour — still "seen", or the welcome modal returns.
+				skipTour();
 			}
 			setTourStarted(false);
 		}
@@ -137,6 +154,7 @@ export default function Page() {
 		tourContext?.state.completedSteps,
 		tourStarted,
 		markTourComplete,
+		skipTour,
 	]);
 
 	// Save view preference to localStorage
@@ -146,18 +164,32 @@ export default function Page() {
 	};
 
 	const handleStartTour = () => {
+		tourAnsweredRef.current = true;
 		setShowTourModal(false);
+		// Dashboard-only steps must be mounted for the tour to register; forced
+		// via state so the saved view preference survives.
+		setViewMode("dashboard");
 		setTourStarted(true);
 	};
 
 	const handleSkipTour = () => {
+		tourAnsweredRef.current = true;
 		setShowTourModal(false);
 	};
 
 	const handleDontShowAgain = async () => {
+		tourAnsweredRef.current = true;
 		setShowTourModal(false);
 		await skipTour();
 	};
+
+	// Replay entry from the help menu (/home?tour=1).
+	const handleReplayTour = React.useCallback(() => {
+		tourAnsweredRef.current = true;
+		setShowTourModal(false);
+		setViewMode("dashboard");
+		setTourStarted(true);
+	}, []);
 
 	const formatDate = () => {
 		const now = new Date();
@@ -187,6 +219,11 @@ export default function Page() {
 
 			{/* Tour Auto-Start Trigger */}
 			<TourAutoStart tourStarted={tourStarted} />
+
+			{/* Replay entry: /home?tour=1 from the help menu */}
+			<Suspense fallback={null}>
+				<TourReplayWatcher onReplay={handleReplayTour} />
+			</Suspense>
 
 			<div
 				className={`relative p-4 sm:p-6 lg:px-8 lg:pb-8 lg:pt-12 flex flex-col ${
@@ -347,6 +384,21 @@ export default function Page() {
 			</div>
 		</>
 	);
+}
+
+// Consumes the ?tour=1 replay flag, then strips it so a refresh doesn't restart.
+function TourReplayWatcher({ onReplay }: { onReplay: () => void }) {
+	const searchParams = useSearchParams();
+	const router = useRouter();
+	const requested = searchParams.get("tour") === "1";
+
+	React.useEffect(() => {
+		if (!requested) return;
+		router.replace("/home");
+		onReplay();
+	}, [requested, router, onReplay]);
+
+	return null;
 }
 
 // Helper component to auto-start tour after modal closes

--- a/apps/web/src/app/(workspace)/home/page.tsx
+++ b/apps/web/src/app/(workspace)/home/page.tsx
@@ -140,10 +140,10 @@ export default function Page() {
 			);
 
 			if (allCompleted) {
-				markTourComplete();
+				markTourComplete().catch(() => {});
 			} else {
 				// Dismissed mid-tour — still "seen", or the welcome modal returns.
-				skipTour();
+				skipTour().catch(() => {});
 			}
 			setTourStarted(false);
 		}
@@ -180,7 +180,7 @@ export default function Page() {
 	const handleDontShowAgain = async () => {
 		tourAnsweredRef.current = true;
 		setShowTourModal(false);
-		await skipTour();
+		await skipTour().catch(() => {});
 	};
 
 	// Replay entry from the help menu (/home?tour=1).

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -325,13 +325,9 @@
 
 	.tour-element-wrapper[data-tour-active="true"] {
 		z-index: 9999;
-		border-radius: 8px;
-		/* Provide solid background so semi-transparent children render correctly */
-		background-color: #ffffff; /* Light mode: pure white */
-	}
-
-	.dark .tour-element-wrapper[data-tour-active="true"] {
-		background-color: #0a0a0a; /* Dark mode: near-black */
+		border-radius: var(--radius);
+		/* Opaque ground so semi-transparent children don't leak the overlay */
+		background-color: var(--background);
 	}
 
 	/* Disable backdrop-blur effects inside highlighted tour elements
@@ -345,6 +341,7 @@
 	/* Using body data attribute for reliable cross-browser targeting */
 	body[data-tour-step="sidebar-nav"] [data-slot="sidebar-container"],
 	body[data-tour-step="team-switcher"] [data-slot="sidebar-container"],
+	body[data-tour-step="global-search"] [data-slot="sidebar-container"],
 	body[data-tour-step="user-menu"] [data-slot="sidebar-container"] {
 		z-index: 9999 !important;
 	}
@@ -352,12 +349,14 @@
 	/* Also target the sidebar wrapper and inner elements */
 	body[data-tour-step="sidebar-nav"] [data-slot="sidebar-wrapper"],
 	body[data-tour-step="team-switcher"] [data-slot="sidebar-wrapper"],
+	body[data-tour-step="global-search"] [data-slot="sidebar-wrapper"],
 	body[data-tour-step="user-menu"] [data-slot="sidebar-wrapper"] {
 		z-index: 9999 !important;
 	}
 
 	body[data-tour-step="sidebar-nav"] [data-slot="sidebar"],
 	body[data-tour-step="team-switcher"] [data-slot="sidebar"],
+	body[data-tour-step="global-search"] [data-slot="sidebar"],
 	body[data-tour-step="user-menu"] [data-slot="sidebar"] {
 		z-index: 9999 !important;
 	}
@@ -365,9 +364,11 @@
 	/* Prevent overflow clipping of tour outlines in sidebar */
 	body[data-tour-step="sidebar-nav"] [data-slot="sidebar-content"],
 	body[data-tour-step="team-switcher"] [data-slot="sidebar-header"],
+	body[data-tour-step="global-search"] [data-slot="sidebar-header"],
 	body[data-tour-step="user-menu"] [data-slot="sidebar-footer"],
 	body[data-tour-step="sidebar-nav"] [data-sidebar="content"],
 	body[data-tour-step="team-switcher"] [data-sidebar="header"],
+	body[data-tour-step="global-search"] [data-sidebar="header"],
 	body[data-tour-step="user-menu"] [data-sidebar="footer"] {
 		overflow: visible !important;
 	}
@@ -375,6 +376,7 @@
 	/* Ensure the inner sidebar also allows overflow for outlines */
 	body[data-tour-step="sidebar-nav"] [data-slot="sidebar-inner"],
 	body[data-tour-step="team-switcher"] [data-slot="sidebar-inner"],
+	body[data-tour-step="global-search"] [data-slot="sidebar-inner"],
 	body[data-tour-step="user-menu"] [data-slot="sidebar-inner"] {
 		overflow: visible !important;
 	}
@@ -403,7 +405,7 @@
 		content: "";
 		position: absolute;
 		inset: -6px;
-		border-radius: 12px;
+		border-radius: calc(var(--radius) + 4px);
 		border: 3px solid var(--primary);
 		box-shadow:
 			0 0 0 4px color-mix(in oklch, var(--primary) 25%, transparent),
@@ -424,6 +426,12 @@
 			box-shadow:
 				0 0 0 6px color-mix(in oklch, var(--primary) 20%, transparent),
 				0 4px 30px -4px color-mix(in oklch, var(--primary) 50%, transparent);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.tour-element-wrapper[data-tour-active="true"]::after {
+			animation: none;
 		}
 	}
 

--- a/apps/web/src/components/help/help-menu.tsx
+++ b/apps/web/src/components/help/help-menu.tsx
@@ -9,6 +9,7 @@ import {
 	Lightbulb,
 	MessageCircle,
 	MessagesSquare,
+	Route,
 	Sparkles,
 } from "lucide-react";
 import {
@@ -31,6 +32,8 @@ import { DEFAULT_HELP_REFS, getRouteHelpRefs } from "@/lib/help/route-help";
 import { useOptionalSupportDialog } from "@/components/support/support-dialog-provider";
 import type { SupportIntent } from "@/components/support/support-dialog";
 import { supportUnreadCount, useSupportTickets } from "@/lib/support-tickets";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { useIsAdmin } from "@/hooks/use-role-access";
 import { cn } from "@/lib/utils";
 
 const SUPPORT_ROWS: Array<{
@@ -115,6 +118,19 @@ export function HelpMenu() {
 		(!searching ||
 			requestsRowLabel.toLowerCase().includes(query.trim().toLowerCase()));
 
+	// The tour highlights the sidebar (unmounted inside a closed Sheet below md)
+	// and lives on /home, which the proxy keeps admin-only — hidden elsewhere
+	// because the replay would dead-end.
+	const isMobile = useIsMobile();
+	const isAdmin = useIsAdmin();
+	const tourRowLabel = "Take the tour again";
+	const showTourRow =
+		!!openSupport &&
+		!isMobile &&
+		isAdmin &&
+		(!searching ||
+			tourRowLabel.toLowerCase().includes(query.trim().toLowerCase()));
+
 	return (
 		<>
 			<Popover open={open} onOpenChange={handleOpenChange}>
@@ -152,7 +168,9 @@ export function HelpMenu() {
 							onValueChange={setQuery}
 						/>
 						<CommandList>
-							{supportRows.length === 0 && !showRequestsRow && (
+							{supportRows.length === 0 &&
+								!showRequestsRow &&
+								!showTourRow && (
 								<CommandEmpty>No articles match your search.</CommandEmpty>
 							)}
 							{refs.length > 0 && (
@@ -191,7 +209,7 @@ export function HelpMenu() {
 									})}
 								</CommandGroup>
 							)}
-							{(supportRows.length > 0 || showRequestsRow) && (
+							{(supportRows.length > 0 || showRequestsRow || showTourRow) && (
 								<CommandGroup heading="Get in touch">
 									{supportRows.map((row) => (
 										<CommandItem
@@ -244,6 +262,29 @@ export function HelpMenu() {
 													{unreadCount > 0
 														? `${unreadCount} unread ${unreadCount === 1 ? "reply" : "replies"}`
 														: "See your open and past requests"}
+												</span>
+											</span>
+										</CommandItem>
+									)}
+									{showTourRow && (
+										<CommandItem
+											value="tour:replay"
+											onSelect={() => {
+												setOpen(false);
+												setQuery("");
+												router.push("/home?tour=1");
+											}}
+											className="cursor-pointer"
+										>
+											<span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+												<Route className="size-4" aria-hidden="true" />
+											</span>
+											<span className="min-w-0">
+												<span className="block truncate text-sm font-medium text-foreground">
+													{tourRowLabel}
+												</span>
+												<span className="block truncate text-xs text-muted-foreground">
+													Walk through the dashboard tour again
 												</span>
 											</span>
 										</CommandItem>

--- a/apps/web/src/components/layout/app-sidebar.tsx
+++ b/apps/web/src/components/layout/app-sidebar.tsx
@@ -244,7 +244,15 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 				>
 					<TeamSwitcher />
 				</TourElement>
-				<CommandPaletteTrigger />
+				<TourElement<HomeTour>
+					TourContext={HomeTourContext}
+					stepId={HomeTour.GLOBAL_SEARCH}
+					title={HOME_TOUR_CONTENT[HomeTour.GLOBAL_SEARCH].title}
+					description={HOME_TOUR_CONTENT[HomeTour.GLOBAL_SEARCH].description}
+					tooltipPosition={HOME_TOUR_CONTENT[HomeTour.GLOBAL_SEARCH].tooltipPosition}
+				>
+					<CommandPaletteTrigger />
+				</TourElement>
 			</SidebarHeader>
 			<SidebarContent>
 				<TourElement<HomeTour>

--- a/apps/web/src/components/layout/workspace-header.tsx
+++ b/apps/web/src/components/layout/workspace-header.tsx
@@ -7,6 +7,12 @@ import { NotificationBell } from "@/components/layout/notification-bell";
 import { ServiceStatusBadge } from "@/components/layout/service-status-badge";
 import { SettingsPopover } from "@/components/layout/settings-popover";
 import { TrialCountdownPill } from "@/components/layout/trial-countdown-pill";
+import {
+	TourElement,
+	HomeTour,
+	HOME_TOUR_CONTENT,
+	HomeTourContext,
+} from "@/components/tours";
 
 /**
  * Thin workspace navbar. On desktop the picture-frame band above the content
@@ -29,8 +35,19 @@ export function WorkspaceHeader() {
 				<NotchedItem contentClassName="gap-1">
 					<TrialCountdownPill />
 					<ServiceStatusBadge />
-					<HelpMenu />
-					<NotificationBell />
+					<TourElement<HomeTour>
+						TourContext={HomeTourContext}
+						stepId={HomeTour.HELP_SUPPORT}
+						title={HOME_TOUR_CONTENT[HomeTour.HELP_SUPPORT].title}
+						description={HOME_TOUR_CONTENT[HomeTour.HELP_SUPPORT].description}
+						tooltipPosition={
+							HOME_TOUR_CONTENT[HomeTour.HELP_SUPPORT].tooltipPosition
+						}
+						className="flex items-center gap-1"
+					>
+						<HelpMenu />
+						<NotificationBell />
+					</TourElement>
 					<SettingsPopover />
 				</NotchedItem>
 			</div>

--- a/apps/web/src/components/tours/home-tour-context.tsx
+++ b/apps/web/src/components/tours/home-tour-context.tsx
@@ -70,7 +70,7 @@ export const HOME_TOUR_CONTENT: Record<HomeTour, TourStepContent> = {
 	[HomeTour.GLOBAL_SEARCH]: {
 		title: "Search Everything",
 		description:
-			"Jump to any client, project, quote, or invoice from anywhere in the app. Click here or press ⌘K to open it.",
+			"Jump to any client, project, quote, or invoice from anywhere in the app. Click here or press ⌘K (Ctrl+K on Windows) to open it.",
 		tooltipPosition: "right",
 	},
 	[HomeTour.USER_MENU]: {

--- a/apps/web/src/components/tours/home-tour-context.tsx
+++ b/apps/web/src/components/tours/home-tour-context.tsx
@@ -11,6 +11,7 @@ export const enum HomeTour {
 	// Sidebar steps (shown first to orient users)
 	SIDEBAR_NAV = "sidebar-nav",
 	TEAM_SWITCHER = "team-switcher",
+	GLOBAL_SEARCH = "global-search",
 	USER_MENU = "user-menu",
 	// Dashboard steps
 	VIEW_TOGGLE = "view-toggle",
@@ -19,8 +20,9 @@ export const enum HomeTour {
 	CLIENT_MAP = "client-map",
 	TASKS = "tasks",
 	ACTIVITY_FEED = "activity-feed",
-	// Assistant (rendered in the workspace chrome, not the home page)
+	// Workspace chrome (not the home page)
 	ASSISTANT_NOTCH = "assistant-notch",
+	HELP_SUPPORT = "help-support",
 }
 
 // ============================================================================
@@ -30,6 +32,7 @@ export const enum HomeTour {
 export const ORDERED_HOME_TOUR: HomeTour[] = [
 	HomeTour.SIDEBAR_NAV,
 	HomeTour.TEAM_SWITCHER,
+	HomeTour.GLOBAL_SEARCH,
 	HomeTour.USER_MENU,
 	HomeTour.VIEW_TOGGLE,
 	HomeTour.HOME_STATS,
@@ -38,6 +41,7 @@ export const ORDERED_HOME_TOUR: HomeTour[] = [
 	HomeTour.TASKS,
 	HomeTour.ACTIVITY_FEED,
 	HomeTour.ASSISTANT_NOTCH,
+	HomeTour.HELP_SUPPORT,
 ];
 
 // ============================================================================
@@ -54,13 +58,19 @@ export const HOME_TOUR_CONTENT: Record<HomeTour, TourStepContent> = {
 	[HomeTour.SIDEBAR_NAV]: {
 		title: "Navigation Menu",
 		description:
-			"Access all your key areas from here: Clients, Projects, Tasks, Quotes, and Invoices. Click any item to navigate to that section.",
+			"Every area of your workspace lives here: Clients, Projects, Tasks, Quotes, Invoices, Routing, Inbox, Documents, Reports, Automations, Community, and Settings. Click any item to jump straight to it.",
 		tooltipPosition: "right",
 	},
 	[HomeTour.TEAM_SWITCHER]: {
 		title: "Organization Switcher",
 		description:
 			"Switch between different organizations you belong to. You can also access organization settings and create new organizations from here.",
+		tooltipPosition: "right",
+	},
+	[HomeTour.GLOBAL_SEARCH]: {
+		title: "Search Everything",
+		description:
+			"Jump to any client, project, quote, or invoice from anywhere in the app. Click here or press ⌘K to open it.",
 		tooltipPosition: "right",
 	},
 	[HomeTour.USER_MENU]: {
@@ -72,19 +82,19 @@ export const HOME_TOUR_CONTENT: Record<HomeTour, TourStepContent> = {
 	[HomeTour.VIEW_TOGGLE]: {
 		title: "Switch Your View",
 		description:
-			"Toggle between Dashboard and Calendar views. The Calendar gives you a visual timeline of all your tasks and appointments.",
+			"This toggles between the Dashboard you’re looking at now and a full Calendar of your scheduled work. Have a look once the tour finishes — the rest of the tour covers the Dashboard.",
 		tooltipPosition: "left",
 	},
 	[HomeTour.HOME_STATS]: {
 		title: "Your Business at a Glance",
 		description:
-			"Track your key metrics including active clients, projects in progress, pending quotes, and revenue. These update in real-time as you work.",
+			"Total Clients, Projects Completed, Approved Quotes, Invoices Paid, Revenue, and Pending Tasks — all updating in real time as you work.",
 		tooltipPosition: "bottom",
 	},
 	[HomeTour.WEEKLY_CALENDAR]: {
-		title: "Weekly Calendar",
+		title: "Schedule",
 		description:
-			"See your upcoming week at a glance. Tasks and projects appear as bars spanning their scheduled dates. Use the arrows to navigate between weeks.",
+			"Pick a day on the month calendar and the agenda beside it shows the projects and tasks scheduled for it. Dots mark the days that have work on them.",
 		tooltipPosition: "top",
 	},
 	[HomeTour.CLIENT_MAP]: {
@@ -96,7 +106,7 @@ export const HOME_TOUR_CONTENT: Record<HomeTour, TourStepContent> = {
 	[HomeTour.TASKS]: {
 		title: "Needs Attention",
 		description:
-			"Anything running late surfaces here \u2014 overdue tasks and unpaid invoices, most urgent first. Tick a task off inline, or click through to chase an invoice.",
+			"Anything running late surfaces here — overdue tasks, unpaid invoices, and quotes still waiting on a signature, most urgent first. Tick a task off inline, or click through to chase an invoice or quote.",
 		tooltipPosition: "top",
 	},
 	[HomeTour.ACTIVITY_FEED]: {
@@ -108,8 +118,14 @@ export const HOME_TOUR_CONTENT: Record<HomeTour, TourStepContent> = {
 	[HomeTour.ASSISTANT_NOTCH]: {
 		title: "Ask the Assistant",
 		description:
-			"Your AI teammate lives here, on every plan. Ask it to draft a quote, find a client, or explain a report \u2014 it already knows the screen you\u2019re on. Free plans include 10 messages a day.",
+			"Your AI teammate lives here, on every plan. Ask it to draft a quote, find a client, or explain a report — it already knows the screen you’re on. Free plans include 10 messages a day.",
 		tooltipPosition: "top",
+	},
+	[HomeTour.HELP_SUPPORT]: {
+		title: "Help and Notifications",
+		description:
+			"The help menu searches every help article, and it’s also how you report a bug, request a feature, or message support — replies come back to you in the app under “Your support requests.” The bell beside it collects your notifications.",
+		tooltipPosition: "bottom",
 	},
 };
 

--- a/apps/web/src/components/tours/tour-start-modal.tsx
+++ b/apps/web/src/components/tours/tour-start-modal.tsx
@@ -1,11 +1,17 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
-import { createPortal } from "react-dom";
-import { motion, AnimatePresence } from "motion/react";
-import { cn } from "@/lib/utils";
-import { Sparkles, X } from "lucide-react";
+import { useState } from "react";
+import { Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
 
 interface TourStartModalProps {
 	isOpen: boolean;
@@ -14,6 +20,14 @@ interface TourStartModalProps {
 	onDontShowAgain: () => void;
 }
 
+const TOUR_HIGHLIGHTS = [
+	"Navigate the sidebar and switch organizations",
+	"Search anything with ⌘K",
+	"Read your metrics, schedule, client map, and activity",
+	"Stay ahead of overdue work and ask the AI assistant",
+	"Find help and reach support",
+];
+
 export function TourStartModal({
 	isOpen,
 	onStartTour,
@@ -21,235 +35,80 @@ export function TourStartModal({
 	onDontShowAgain,
 }: TourStartModalProps) {
 	const [dontShowAgain, setDontShowAgain] = useState(false);
-	const modalRef = useRef<HTMLDivElement>(null);
-	const previousActiveElement = useRef<HTMLElement | null>(null);
 
-	const handleSkip = useCallback(() => {
+	// Every dismissal path (Skip, Esc, backdrop, close button) honors the
+	// checkbox; starting the tour deliberately does not.
+	const handleSkip = () => {
 		if (dontShowAgain) {
 			onDontShowAgain();
 		} else {
 			onSkip();
 		}
-	}, [dontShowAgain, onDontShowAgain, onSkip]);
-
-	const handleStartTour = () => {
-		onStartTour();
 	};
 
-	// Handle focus management
-	useEffect(() => {
-		if (isOpen) {
-			previousActiveElement.current = document.activeElement as HTMLElement;
+	return (
+		<Dialog
+			open={isOpen}
+			onOpenChange={(open) => {
+				if (!open) handleSkip();
+			}}
+		>
+			<DialogContent className="max-w-md sm:max-w-md">
+				<DialogHeader>
+					<div className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+						<Sparkles className="size-5" aria-hidden="true" />
+					</div>
+					<DialogTitle>Welcome to OneTool</DialogTitle>
+					<DialogDescription>
+						Let us show you around. This quick tour will help you get started
+						with the key features of your dashboard.
+					</DialogDescription>
+				</DialogHeader>
 
-			const focusTimeout = setTimeout(() => {
-				const modalElement = modalRef.current;
-				if (modalElement) {
-					const focusableElements = modalElement.querySelectorAll<HTMLElement>(
-						'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-					);
-					if (focusableElements.length > 0) {
-						focusableElements[0].focus();
-					}
-				}
-			}, 100);
+				<div className="rounded-lg border border-border bg-muted/50 p-4">
+					<p className="mb-3 text-sm font-medium text-foreground">
+						In this tour, you&apos;ll learn how to:
+					</p>
+					<ul className="space-y-2 text-sm text-muted-foreground">
+						{TOUR_HIGHLIGHTS.map((item) => (
+							<li key={item} className="flex items-start gap-2.5">
+								<span
+									aria-hidden="true"
+									className="mt-1.5 size-1.5 shrink-0 rounded-full bg-primary"
+								/>
+								{item}
+							</li>
+						))}
+					</ul>
+				</div>
 
-			return () => {
-				clearTimeout(focusTimeout);
-				if (previousActiveElement.current) {
-					previousActiveElement.current.focus();
-				}
-			};
-		}
-	}, [isOpen]);
-
-	// Handle body scroll lock
-	useEffect(() => {
-		if (isOpen) {
-			const originalOverflow = document.body.style.overflow;
-			document.body.style.overflow = "hidden";
-
-			return () => {
-				document.body.style.overflow = originalOverflow || "";
-			};
-		}
-	}, [isOpen]);
-
-	// Handle escape key
-	useEffect(() => {
-		if (!isOpen) return;
-
-		const handleEscape = (event: KeyboardEvent) => {
-			if (event.key === "Escape") {
-				handleSkip();
-			}
-		};
-
-		document.addEventListener("keydown", handleEscape);
-		return () => document.removeEventListener("keydown", handleEscape);
-	}, [isOpen, handleSkip]);
-
-	if (!isOpen) return null;
-
-	const modalContent = (
-		<AnimatePresence>
-			{isOpen && (
-				<motion.div
-					className="fixed inset-0 z-9999 flex items-center justify-center pointer-events-auto"
-					initial={{ opacity: 0 }}
-					animate={{ opacity: 1 }}
-					exit={{ opacity: 0 }}
-					transition={{ duration: 0.2 }}
-				>
-					{/* Backdrop */}
-					<motion.div
-						className={cn(
-							"absolute inset-0 backdrop-blur-sm",
-							"bg-black/50 dark:bg-black/70"
-						)}
+				<div className="flex flex-col gap-2">
+					<Button onClick={onStartTour} className="w-full justify-center">
+						Start Tour
+					</Button>
+					<Button
 						onClick={handleSkip}
-						initial={{ opacity: 0 }}
-						animate={{ opacity: 1 }}
-						exit={{ opacity: 0 }}
-					/>
-
-					{/* Modal Content */}
-					<motion.div
-						ref={modalRef}
-						className={cn(
-							"relative rounded-2xl shadow-2xl w-full max-w-md mx-4 overflow-hidden",
-							"bg-white dark:bg-gray-900",
-							"border border-gray-200 dark:border-gray-700"
-						)}
-						initial={{ opacity: 0, scale: 0.9, y: 20 }}
-						animate={{ opacity: 1, scale: 1, y: 0 }}
-						exit={{ opacity: 0, scale: 0.9, y: 20 }}
-						transition={{ type: "spring", damping: 25, stiffness: 300 }}
-						role="dialog"
-						aria-modal="true"
-						aria-labelledby="tour-modal-title"
-						tabIndex={-1}
+						variant="ghost"
+						className="w-full justify-center"
 					>
-						{/* Decorative gradient header */}
-						<div className="relative h-32 bg-linear-to-br from-primary via-primary/80 to-primary/60 overflow-hidden">
-							{/* Decorative circles */}
-							<div className="absolute -top-10 -right-10 w-40 h-40 bg-white/10 rounded-full" />
-							<div className="absolute -bottom-5 -left-5 w-24 h-24 bg-white/10 rounded-full" />
+						Skip for now
+					</Button>
+				</div>
 
-							{/* Close button */}
-							<button
-								onClick={handleSkip}
-								aria-label="Close"
-								className={cn(
-									"absolute top-3 right-3 p-2 rounded-full transition-colors",
-									"text-white/80 hover:text-white hover:bg-white/20"
-								)}
-							>
-								<X className="w-5 h-5" />
-							</button>
-
-							{/* Icon */}
-							<div className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2">
-								<div
-									className={cn(
-										"w-16 h-16 rounded-2xl flex items-center justify-center",
-										"bg-white dark:bg-gray-800 shadow-lg",
-										"border-4 border-white dark:border-gray-900"
-									)}
-								>
-									<Sparkles className="w-8 h-8 text-primary" />
-								</div>
-							</div>
-						</div>
-
-						{/* Content */}
-						<div className="px-6 pt-12 pb-6 text-center">
-							<h2
-								id="tour-modal-title"
-								className="text-2xl font-bold text-foreground mb-2"
-							>
-								Welcome to OneTool!
-							</h2>
-							<p className="text-muted-foreground mb-6">
-								Let us show you around! This quick tour will help you get
-								started with the key features of your dashboard.
-							</p>
-
-							{/* What you'll learn */}
-							<div
-								className={cn(
-									"text-left rounded-xl p-4 mb-6",
-									"bg-gray-50 dark:bg-gray-800/50",
-									"border border-gray-100 dark:border-gray-700"
-								)}
-							>
-								<p className="text-sm font-medium text-foreground mb-3">
-									In this tour, you&apos;ll learn how to:
-								</p>
-								<ul className="space-y-2 text-sm text-muted-foreground">
-									<li className="flex items-center gap-2">
-										<div className="w-1.5 h-1.5 rounded-full bg-primary shrink-0" />
-										Navigate using the sidebar menu
-									</li>
-									<li className="flex items-center gap-2">
-										<div className="w-1.5 h-1.5 rounded-full bg-primary shrink-0" />
-										Switch between organizations
-									</li>
-									<li className="flex items-center gap-2">
-										<div className="w-1.5 h-1.5 rounded-full bg-primary shrink-0" />
-										Track your business metrics at a glance
-									</li>
-									<li className="flex items-center gap-2">
-										<div className="w-1.5 h-1.5 rounded-full bg-primary shrink-0" />
-										Stay ahead of overdue work and ask the AI assistant
-									</li>
-								</ul>
-							</div>
-
-							{/* Buttons */}
-							<div className="flex flex-col gap-3">
-								<Button
-									onClick={handleStartTour}
-									size="lg"
-									className="w-full justify-center"
-								>
-									Start Tour
-								</Button>
-								<Button
-									onClick={handleSkip}
-									variant="ghost"
-									size="lg"
-									className="w-full justify-center"
-								>
-									Skip for now
-								</Button>
-							</div>
-
-							{/* Don't show again checkbox */}
-							<div className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-800">
-								<label className="flex items-center justify-center gap-2 cursor-pointer text-sm text-muted-foreground">
-									<input
-										type="checkbox"
-										checked={dontShowAgain}
-										onChange={(e) => setDontShowAgain(e.target.checked)}
-										className={cn(
-											"w-4 h-4 rounded border-gray-300 dark:border-gray-600",
-											"text-primary focus:ring-primary focus:ring-offset-0"
-										)}
-									/>
-									Don&apos;t show this again
-								</label>
-							</div>
-						</div>
-					</motion.div>
-				</motion.div>
-			)}
-		</AnimatePresence>
+				<div className="flex items-center justify-center gap-2 border-t border-border pt-4">
+					<Checkbox
+						id="tour-dont-show-again"
+						checked={dontShowAgain}
+						onCheckedChange={(checked) => setDontShowAgain(checked === true)}
+					/>
+					<Label
+						htmlFor="tour-dont-show-again"
+						className="cursor-pointer text-sm text-muted-foreground"
+					>
+						Don&apos;t show this again
+					</Label>
+				</div>
+			</DialogContent>
+		</Dialog>
 	);
-
-	// Use portal to render at document root
-	if (typeof document !== "undefined") {
-		return createPortal(modalContent, document.body);
-	}
-
-	return null;
 }

--- a/apps/web/src/components/tours/tour-tooltip.tsx
+++ b/apps/web/src/components/tours/tour-tooltip.tsx
@@ -7,10 +7,11 @@ import {
 	useSyncExternalStore,
 } from "react";
 import { createPortal } from "react-dom";
-import { motion } from "motion/react";
+import { motion, useReducedMotion } from "motion/react";
 import { cn } from "@/lib/utils";
-import { ChevronLeft, ChevronRight, X, Keyboard } from "lucide-react";
+import { ChevronLeft, X, Keyboard } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Kbd } from "@/components/ui/kbd";
 
 // Subscribe to viewport size so positioning stays pure and SSR-safe
 function subscribeViewport(callback: () => void) {
@@ -55,6 +56,7 @@ export function TourTooltip({
 		width: 320,
 		height: 280,
 	});
+	const reduceMotion = useReducedMotion();
 
 	// null during SSR/first render; viewport string ("WxH") on the client
 	const viewport = useSyncExternalStore(
@@ -173,15 +175,15 @@ export function TourTooltip({
 			ref={tooltipRef}
 			className="tour-tooltip w-80 max-w-[calc(100vw-2rem)]"
 			style={tooltipStyle}
-			initial={{ opacity: 0, scale: 0.9 }}
+			initial={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.96 }}
 			animate={{ opacity: 1, scale: 1 }}
-			exit={{ opacity: 0, scale: 0.9 }}
-			transition={{ type: "spring", damping: 25, stiffness: 300 }}
+			exit={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.96 }}
+			transition={{ duration: 0.18, ease: [0.23, 1, 0.32, 1] }}
 		>
 			{/* Tooltip content */}
 			<div
 				className={cn(
-					"relative rounded-xl shadow-2xl overflow-hidden",
+					"relative rounded-xl shadow-lg overflow-hidden",
 					"bg-popover text-popover-foreground",
 					"border border-border",
 					"ring-1 ring-primary/20"
@@ -190,10 +192,10 @@ export function TourTooltip({
 				{/* Progress bar at top */}
 				<div className="h-1 bg-muted">
 					<motion.div
-						className="h-full bg-linear-to-r from-primary to-primary/80"
+						className="h-full bg-primary"
 						initial={{ width: 0 }}
 						animate={{ width: `${((currentStep + 1) / totalSteps) * 100}%` }}
-						transition={{ duration: 0.3 }}
+						transition={{ duration: reduceMotion ? 0 : 0.25, ease: [0.23, 1, 0.32, 1] }}
 					/>
 				</div>
 
@@ -252,12 +254,7 @@ export function TourTooltip({
 								<ChevronLeft className="w-4 h-4" />
 							</Button>
 						)}
-						{/* TODO(reui-rebuild): showArrow (hover "→" on non-final steps) dropped — nova Button has no hover-arrow affordance */}
-						<Button
-							onClick={onNext}
-							size="sm"
-							className="shadow-sm! hover:shadow-md!"
-						>
+						<Button onClick={onNext} size="sm">
 							{isLastStep ? "Finish" : "Next"}
 						</Button>
 					</div>
@@ -268,18 +265,18 @@ export function TourTooltip({
 					<div className="flex items-center justify-center gap-4 text-xs text-muted-foreground">
 						<span className="flex items-center gap-1.5">
 							<Keyboard className="w-3 h-3" />
-							<kbd className="px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-mono">
+							<Kbd>
 								←
-							</kbd>
-							<kbd className="px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-mono">
+							</Kbd>
+							<Kbd>
 								→
-							</kbd>
+							</Kbd>
 							<span>Navigate</span>
 						</span>
 						<span className="flex items-center gap-1.5">
-							<kbd className="px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-mono">
+							<Kbd>
 								Esc
-							</kbd>
+							</Kbd>
 							<span>Exit</span>
 						</span>
 					</div>

--- a/packages/help-content/articles/getting-started.ts
+++ b/packages/help-content/articles/getting-started.ts
@@ -216,7 +216,7 @@ export const gettingStartedArticles: HelpArticle[] = [
 				blocks: [
 					{
 						type: "paragraph",
-						text: "Admins land on **Home** after signing in: a dashboard with your key numbers, this week's schedule, a map of client locations, a Needs Attention list of overdue tasks and unpaid invoices, and your most recent client emails with a click-through into the [inbox](/help/inbox/unified-inbox). Members land on **Projects** instead, since Home is an admin view.",
+						text: "Admins land on **Home** after signing in: a dashboard with your key numbers, a schedule calendar with the day's agenda beside it, a map of client locations, a Needs Attention list of overdue tasks, unpaid invoices, and quotes awaiting signature, and your most recent client emails with a click-through into the [inbox](/help/inbox/unified-inbox). Members land on **Projects** instead, since Home is an admin view.",
 					},
 				],
 			},
@@ -693,7 +693,7 @@ export const gettingStartedArticles: HelpArticle[] = [
 				blocks: [
 					{
 						type: "paragraph",
-						text: "Everything you've sent us lives on one page: pick **Your support requests** from the **?** menu (or find it in ⌘K). Each request shows the whole thread, your messages and our replies, and you can reply right from the page.",
+						text: "Everything you've sent us lives on one page: pick **Your support requests** from the **?** menu (or find it in ⌘K). Each request shows the whole thread, your messages and our replies, and you can reply right from the page. **Take the tour again** sits in the same menu on desktop if you'd like another walkthrough of the Home dashboard.",
 					},
 					{
 						type: "list",

--- a/packages/help-content/articles/getting-started.ts
+++ b/packages/help-content/articles/getting-started.ts
@@ -693,7 +693,7 @@ export const gettingStartedArticles: HelpArticle[] = [
 				blocks: [
 					{
 						type: "paragraph",
-						text: "Everything you've sent us lives on one page: pick **Your support requests** from the **?** menu (or find it in ⌘K). Each request shows the whole thread, your messages and our replies, and you can reply right from the page. **Take the tour again** sits in the same menu on desktop if you'd like another walkthrough of the Home dashboard.",
+						text: "Everything you've sent us lives on one page: pick **Your support requests** from the **?** menu (or find it in ⌘K). Each request shows the whole thread, your messages and our replies, and you can reply right from the page. **Take the tour again** sits in the same menu for admins on desktop if you'd like another walkthrough of the Home dashboard.",
 					},
 					{
 						type: "list",


### PR DESCRIPTION
- Fix dead-modal P0s: force dashboard view on tour start, gate welcome modal to desktop; persist skipTour() on mid-tour dismissal
- Add GLOBAL_SEARCH (⌘K) and closing HELP_SUPPORT steps (10 → 12)
- Add "Take the tour again" Help menu row via /home?tour=1 (admin, desktop)
- Correct stale step copy (stats metrics, month schedule, quotes in Needs Attention, full sidebar nav) and start-modal bullets
- Rebuild TourStartModal on ui/dialog + tokens; tooltip motion to charter timing with prefers-reduced-motion; tour CSS onto tokens
- Update getting-started help article to match


Claude-Session: https://claude.ai/code/session_01BmKt8Qzoktqg3jGEHb97qD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a guided home tour covering navigation, dashboard metrics, global search, notifications, and help/support.
  * Added a **Take the tour again** option in the help menu for eligible desktop administrators.
  * Tour progress now supports skipping, dismissing, replaying, and automatically opening the dashboard.

* **Improvements**
  * Improved tour dialogs, tooltips, highlights, and reduced-motion accessibility.
  * Mobile devices no longer display the desktop tour.
  * Updated getting-started documentation with the latest dashboard navigation and tour guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR expands and refreshes the desktop admin home tour while addressing modal and dashboard-view start blockers.
- Adds global-search and help/support steps to the ordered tour.
- Adds a Help-menu replay entry and query-driven replay handling.
- Persists mid-tour dismissal and gates first-run prompts to desktop.
- Rebuilds the start modal and updates tour styling, reduced-motion behavior, copy, and help content.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The desktop eligibility gates, shared-provider target registration, dashboard-forced start, replay lifecycle, and completion persistence remain coherent across the changed tour flow.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/(workspace)/home/page.tsx | Adds desktop gating, dashboard-forced starts, replay-query handling, and completion-versus-dismissal persistence without an accepted defect. |
| apps/web/src/components/tours/home-tour-context.tsx | Extends the ordered tour from ten to twelve steps and refreshes step copy consistently with the new targets. |
| apps/web/src/components/tours/tour-start-modal.tsx | Replaces the custom portal modal with the shared dialog primitives while preserving dismissal choices. |
| apps/web/src/components/help/help-menu.tsx | Adds an admin desktop replay action that navigates to the home tour entry query. |
| apps/web/src/components/layout/app-sidebar.tsx | Registers the existing command-palette trigger as the new global-search tour target. |
| apps/web/src/components/layout/workspace-header.tsx | Registers desktop help and notification controls as the final tour target. |
| apps/web/src/components/tours/tour-tooltip.tsx | Updates tooltip presentation, keyboard styling, timing, and reduced-motion behavior. |
| apps/web/src/app/globals.css | Moves tour highlights to semantic tokens and adds the global-search and reduced-motion styles. |
| packages/help-content/articles/getting-started.ts | Aligns workspace help copy with the current dashboard schedule and attention content. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Eligible desktop admin opens Home] --> B{First visit or replay query?}
    B -- First visit --> C[Show welcome dialog]
    C --> D{Start or dismiss?}
    D -- Start --> E[Force dashboard view]
    D -- Dismiss permanently --> F[Persist tour skipped]
    B -- Replay query --> E
    E --> G[Wait for all tour targets to register]
    G --> H[Run 12 ordered steps]
    H --> I{Finished every step?}
    I -- Yes --> J[Persist tour complete]
    I -- No --> F
```

<sub>Reviews (1): Last reviewed commit: ["feat(tours): fix start-blockers, add sea..."](https://github.com/xcarter93/onetool/commit/a9f91d5deb03f9b41befe44537a95bc5a925282f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56333248)</sub>

**Context used:**

- Knowledge Base — [Client applications](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/client-applications.md)
- Knowledge Base — [Web workspace](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/web-workspace.md)

<!-- /greptile_comment -->