### PR TITLE
Integrate 'many-hats' tagline into landing page components

### DIFF
--- a/apps/web/src/app/components/marketing/sections/final-cta.tsx
+++ b/apps/web/src/app/components/marketing/sections/final-cta.tsx
@@ -153,9 +153,10 @@ export function FinalCta() {
 						</h2>
 
 						<Lede>
-							Add a client, build a quote, send it for signature. You can be
-							doing that ten minutes from now. There is nothing to install, and
-							nobody you have to talk to first.
+							Add a client, build a quote, send it for signature, and hang up a
+							hat or two while you&apos;re at it. You can be doing that ten
+							minutes from now. There is nothing to install, and nobody you
+							have to talk to first.
 						</Lede>
 
 						<div className="mt-7 flex flex-wrap gap-3">

--- a/apps/web/src/app/components/marketing/sections/hero.tsx
+++ b/apps/web/src/app/components/marketing/sections/hero.tsx
@@ -7,6 +7,7 @@ import {
 	at,
 	CheckItem,
 	Container,
+	Eyebrow,
 	GridBackdrop,
 	Lede,
 	PlusCorners,
@@ -92,6 +93,9 @@ export function Hero() {
 					{/* SectionHeading/Lede take className only, so the stagger delay rides
 					    on a wrapper and the primitives keep their own type scale. */}
 					<div className="lp-rise" style={at("60ms")}>
+						<Eyebrow className="mb-4">
+							You wear every hat. You only need OneTool.
+						</Eyebrow>
 						<SectionHeading
 							as="h1"
 							reveal={false}

--- a/apps/web/src/app/components/marketing/sections/one-place.tsx
+++ b/apps/web/src/app/components/marketing/sections/one-place.tsx
@@ -414,8 +414,9 @@ export function OnePlace() {
 					</SectionHeading>
 					<Lede className="max-w-[34rem]">
 						Email, a spreadsheet, a notebook, the group text and a sticky note
-						on the dash. None of them know about each other, so you become the
-						integration.
+						on the dash. A different hat for each one: dispatcher, bookkeeper,
+						scheduler, collections. None of them know about each other, so you
+						become the integration.
 					</Lede>
 
 					<div className="mt-[clamp(40px,6vw,80px)] grid max-w-[30rem] gap-[22px]">

--- a/apps/web/src/app/components/marketing/sections/try-it.tsx
+++ b/apps/web/src/app/components/marketing/sections/try-it.tsx
@@ -442,7 +442,7 @@ export function TryIt() {
 					<Eyebrow>Try it yourself</Eyebrow>
 					<SectionHeading>Run the whole job in 30 seconds.</SectionHeading>
 					<Lede className="max-w-[46rem]">
-						Pick a couple of line items, then send it. You play every part: the
+						Pick a couple of line items, then send it. You wear every hat: the
 						office, the crew and the client. The money lands without a number
 						retyped.
 					</Lede>


### PR DESCRIPTION
This pull request updates several marketing section components to consistently use the "wear every hat" metaphor, clarifying the messaging and improving thematic coherence across the site. It also introduces the `Eyebrow` component to the hero section for an enhanced introductory statement.

**Messaging and Thematic Updates:**
* Updated the `FinalCta`, `OnePlace`, and `TryIt` sections to use "wear every hat" language, replacing previous metaphors and making the messaging more consistent and relatable. [[1]](diffhunk://#diff-1ef72d666c3e6bfdcffe07936eed345c092ce02fb29a8410d65d662779c0fa14L156-R159) [[2]](diffhunk://#diff-75014fb48affe07a82892484b82be177fbd3651e0fd5045fd7ba2425b80e0196L417-R419) [[3]](diffhunk://#diff-336073c71d8caf025aaf8756e4e7ffd944c1d5a5574c5c7a8f5d3b5f0d1ef410L445-R445)

**Component and UI Enhancements:**
* Added the `Eyebrow` component import and included it at the top of the hero section, displaying the new tagline: "You wear every hat. You only need OneTool." [[1]](diffhunk://#diff-b16acfedd2ce00d4d5c3954095e863c224842714e57f0d35ee50153a9495c1d0R10) [[2]](diffhunk://#diff-b16acfedd2ce00d4d5c3954095e863c224842714e57f0d35ee50153a9495c1d0R96-R98)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the landing-page copy to consistently use the “wear every hat” metaphor and adds the tagline to the hero using the existing `Eyebrow` primitive.
- Adds “You wear every hat. You only need OneTool.” above the hero heading.
- Revises the Final CTA, One Place, and Try It messaging for thematic consistency.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The changes are limited to static marketing copy and a type-compatible use of an existing presentational primitive, with no demonstrated build, accessibility, hydration, or runtime regression.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/components/marketing/sections/final-cta.tsx | Extends the closing CTA copy with the new hat metaphor without changing behavior. |
| apps/web/src/app/components/marketing/sections/hero.tsx | Adds a supported `Eyebrow` component above the existing hero heading. |
| apps/web/src/app/components/marketing/sections/one-place.tsx | Revises explanatory marketing copy to enumerate the roles represented by the hat metaphor. |
| apps/web/src/app/components/marketing/sections/try-it.tsx | Replaces the prior “play every part” wording with the consistent “wear every hat” language. |

<sub>Reviews (1): Last reviewed commit: ["copy(landing): thread the many-hats tagl..."](https://github.com/xcarter93/onetool/commit/77267b80e016fcda02ed502fa80aefd48e3bcd41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56679053)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Refined marketing copy across the homepage to emphasize managing multiple business roles with one tool.
  * Added a new hero tagline highlighting the many hats visitors wear.
  * Expanded messaging to reference dispatcher, bookkeeper, scheduler, and collections responsibilities.
  * Added a lighthearted “hang up a hat or two” phrase to the final call to action.
  * Updated the Try It section to reinforce the all-in-one experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->