### PR TITLE
Fix PostHogProvider initialization for complete pageview tracking

### DIFF
--- a/apps/web/src/app/(onboarding)/layout.tsx
+++ b/apps/web/src/app/(onboarding)/layout.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 import { ClerkProviderWithTheme } from "@/providers/ClerkProviderWithTheme";
 import ConvexClientProvider from "@/providers/ConvexClientProvider";
-import { PostHogProvider } from "@/providers/PostHogProvider";
 import { ConfirmDialogProvider } from "@/hooks/use-confirm-dialog";
 import { AnalyticsIdentity } from "@/components/analytics-identity";
 
@@ -15,14 +14,12 @@ export default function OnboardingLayout({
 }) {
 	return (
 		<ClerkProviderWithTheme>
-			<PostHogProvider>
-				<ConvexClientProvider>
-					<ConfirmDialogProvider>
-						<AnalyticsIdentity />
-						{children}
-					</ConfirmDialogProvider>
-				</ConvexClientProvider>
-			</PostHogProvider>
+			<ConvexClientProvider>
+				<ConfirmDialogProvider>
+					<AnalyticsIdentity />
+					{children}
+				</ConfirmDialogProvider>
+			</ConvexClientProvider>
 		</ClerkProviderWithTheme>
 	);
 }

--- a/apps/web/src/app/(workspace)/layout.tsx
+++ b/apps/web/src/app/(workspace)/layout.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 import { ClerkProviderWithTheme } from "@/providers/ClerkProviderWithTheme";
 import ConvexClientProvider from "@/providers/ConvexClientProvider";
-import { PostHogProvider } from "@/providers/PostHogProvider";
 import { DynamicTitle } from "@/components/shared/dynamic-title";
 import { ConfirmDialogProvider } from "@/hooks/use-confirm-dialog";
 import { SidebarWithHeader } from "@/components/layout/sidebar-with-header";
@@ -25,31 +24,29 @@ export default function WorkspaceLayout({
 }) {
 	return (
 		<ClerkProviderWithTheme>
-			<PostHogProvider>
-				<ConvexClientProvider>
-					<DynamicTitle />
-					<ConfirmDialogProvider>
-						<div className="workspace-zone min-h-screen md:min-h-min">
-							<AnalyticsIdentity />
+			<ConvexClientProvider>
+				<DynamicTitle />
+				<ConfirmDialogProvider>
+					<div className="workspace-zone min-h-screen md:min-h-min">
+						<AnalyticsIdentity />
 						<CelebrationListener />
-							{/* No ambient blobs / grid overlays here: absolutely-positioned
-							    decorations paint over the static picture-frame background
-							    (but under the card and notches), tinting the frame unevenly. */}
-							<div className="relative bg-background min-h-screen">
-								<ScreenContextProvider>
-									<CurrentRecordProvider>
-										<CreateRecordProvider>
-											<SupportDialogProvider>
-												<SidebarWithHeader>{children}</SidebarWithHeader>
-											</SupportDialogProvider>
-										</CreateRecordProvider>
-									</CurrentRecordProvider>
-								</ScreenContextProvider>
-							</div>
+						{/* No ambient blobs / grid overlays here: absolutely-positioned
+						    decorations paint over the static picture-frame background
+						    (but under the card and notches), tinting the frame unevenly. */}
+						<div className="relative bg-background min-h-screen">
+							<ScreenContextProvider>
+								<CurrentRecordProvider>
+									<CreateRecordProvider>
+										<SupportDialogProvider>
+											<SidebarWithHeader>{children}</SidebarWithHeader>
+										</SupportDialogProvider>
+									</CreateRecordProvider>
+								</CurrentRecordProvider>
+							</ScreenContextProvider>
 						</div>
-					</ConfirmDialogProvider>
-				</ConvexClientProvider>
-			</PostHogProvider>
+					</div>
+				</ConfirmDialogProvider>
+			</ConvexClientProvider>
 		</ClerkProviderWithTheme>
 	);
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Outfit } from "next/font/google";
 import { ThemeProvider } from "@/providers/ThemeProvider";
+import { PostHogProvider } from "@/providers/PostHogProvider";
 import { ToastProvider } from "@/hooks/use-toast";
 import "./globals.css";
 // Portal-only font assets (Caveat for typed-signature canvas rendering).
@@ -25,11 +26,16 @@ export default function RootLayout({
 	return (
 		<html suppressHydrationWarning lang="en">
 			<body className={`${outfit.className} style-nova antialiased`}>
-				<ThemeProvider>
-					<ToastProvider position="top-right" maxToasts={5}>
-						{children}
-					</ToastProvider>
-				</ThemeProvider>
+				{/* Root-level so every surface (marketing, auth, portal, communities,
+				    workspace) gets pageviews; AnalyticsIdentity stays in Clerk-wrapped
+				    layouts since identify() needs auth context. */}
+				<PostHogProvider>
+					<ThemeProvider>
+						<ToastProvider position="top-right" maxToasts={5}>
+							{children}
+						</ToastProvider>
+					</ThemeProvider>
+				</PostHogProvider>
 			</body>
 		</html>
 	);


### PR DESCRIPTION
This pull request refactors where the `PostHogProvider` is included in the application layout. Previously, analytics were only available in the onboarding and workspace sections, but now the provider is moved to the root layout so that all surfaces (including marketing, auth, portal, and communities) have analytics coverage.

**Analytics provider refactor:**

* Removed the `PostHogProvider` wrapper from both the onboarding (`apps/web/src/app/(onboarding)/layout.tsx`) and workspace (`apps/web/src/app/(workspace)/layout.tsx`) layouts. [[1]](diffhunk://#diff-fbe3dcc721255cca4ce741f76e045146cecf5b9c9a1a3e6c5a989b45c5605086L4) [[2]](diffhunk://#diff-fbe3dcc721255cca4ce741f76e045146cecf5b9c9a1a3e6c5a989b45c5605086L18-L25) [[3]](diffhunk://#diff-364e3e5da96760752aa44fb3634ea6f2d4aeac89cda845bee9b2dabe809bcfb9L4) [[4]](diffhunk://#diff-364e3e5da96760752aa44fb3634ea6f2d4aeac89cda845bee9b2dabe809bcfb9L28) [[5]](diffhunk://#diff-364e3e5da96760752aa44fb3634ea6f2d4aeac89cda845bee9b2dabe809bcfb9L52)
* Added the `PostHogProvider` at the root level in `apps/web/src/app/layout.tsx`, ensuring that analytics are available on every page of the app. [[1]](diffhunk://#diff-111ec756d646fc7ecca7118cc675dedf7fde956e903db45ed91fbfd0fc111419R4) [[2]](diffhunk://#diff-111ec756d646fc7ecca7118cc675dedf7fde956e903db45ed91fbfd0fc111419R29-R38)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics coverage and consistency across the application by centralizing analytics at the top level.
  * Prevented duplicate analytics setup in onboarding and workspace areas.
  * Maintained existing authentication, workspace, theme, and notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves PostHog initialization from onboarding and workspace route groups into the main application root to broaden pageview coverage. The portal remains uncovered because it uses a separate root layout.

- Removes duplicate PostHog wrappers from onboarding and workspace layouts.
- Adds one provider around the main root subtree.
- Preserves Clerk-scoped analytics identity components in authenticated layouts.

<h3>Confidence Score: 4/5</h3>

The incomplete portal coverage should be fixed before merging because the stated all-surface pageview behavior is not delivered.

Portal requests bypass the changed root provider through their separate root layout, so the refactor still drops all portal pageviews.

**Files Needing Attention:** apps/web/src/app/layout.tsx and apps/web/src/app/(portal)/layout.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/layout.tsx | Adds the shared PostHog provider, but its claim of portal coverage is invalid because the portal uses another root layout. |
| apps/web/src/app/(onboarding)/layout.tsx | Removes the local PostHog wrapper while preserving identity and data-provider ordering under the main root. |
| apps/web/src/app/(workspace)/layout.tsx | Removes the local PostHog wrapper while retaining the Clerk-scoped analytics identity lifecycle and workspace providers. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Browser --> MainRoot["Main app root layout"]
  Browser --> PortalRoot["Portal root layout"]
  MainRoot --> PostHog["PostHogProvider"]
  PostHog --> Marketing
  PostHog --> Auth
  PostHog --> Onboarding
  PostHog --> Workspace
  PortalRoot --> Portal["Portal routes (no PostHogProvider)"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/src/app/layout.tsx:32
**Portal pageviews remain uninitialized**

When a customer opens a `/portal/c/...` route, the separate portal root layout bypasses this `PostHogProvider`, causing portal navigation to remain absent from pageview analytics despite this refactor's all-surface coverage contract.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(analytics): mount PostHogProvider at..."](https://github.com/xcarter93/onetool/commit/633e4dec520dbe4583984cb9ddd5410b5f816e6c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56887042)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Web workspace](https://app.greptile.com/onetool/-/custom-context/knowledge-base/xcarter93/onetool/-/docs/web-workspace.md)

<!-- /greptile_comment -->